### PR TITLE
[scheduler] Fix the scheduler default color

### DIFF
--- a/packages/x-scheduler-headless/src/constants/constants.ts
+++ b/packages/x-scheduler-headless/src/constants/constants.ts
@@ -2,9 +2,6 @@ import { SchedulerEventColor, SchedulerEventCreationConfig } from '../models';
 
 export const EVENT_CREATION_PRECISION_MINUTE = 30;
 
-// TODO: Add a color prop to the SchedulerStore and move DEFAULT_EVENT_COLOR there.
-export const DEFAULT_EVENT_COLOR: SchedulerEventColor = 'jade';
-
 export const EVENT_COLORS: SchedulerEventColor[] = [
   'primary',
   'mauve',

--- a/packages/x-scheduler-headless/src/models/resource.ts
+++ b/packages/x-scheduler-headless/src/models/resource.ts
@@ -14,7 +14,7 @@ export interface SchedulerResource {
   title: string;
   /**
    * The color palette used for events assigned to this resource.
-   * Can be overridden per event using the `color` property on the event model. (TODO: not implemented yet)
+   * Can be overridden per event using the `color` property on the event model.
    * @default "jade"
    */
   eventColor?: SchedulerEventColor;

--- a/packages/x-scheduler-headless/src/scheduler-selectors/schedulerOtherSelectors.ts
+++ b/packages/x-scheduler-headless/src/scheduler-selectors/schedulerOtherSelectors.ts
@@ -12,4 +12,8 @@ export const schedulerOtherSelectors = {
   isScopeDialogOpen: createSelector(
     (state: State) => state.pendingUpdateRecurringEventParameters != null,
   ),
+  /**
+   * The default event color used when no color is specified on the event or its resource.
+   */
+  defaultEventColor: createSelector((state: State) => state.eventColor),
 };

--- a/packages/x-scheduler-headless/src/scheduler-selectors/schedulerResourceSelectors.ts
+++ b/packages/x-scheduler-headless/src/scheduler-selectors/schedulerResourceSelectors.ts
@@ -90,4 +90,16 @@ export const schedulerResourceSelectors = {
         )
         .map((resourceId) => resourceId),
   ),
+  /**
+   * Gets the default event color used when no color is specified on the event.
+   */
+  defaultEventColor: createSelector(
+    (state: State, resourceId: SchedulerResourceId | null | undefined) => {
+      if (resourceId == null) {
+        return state.eventColor;
+      }
+
+      return state.processedResourceLookup.get(resourceId)?.eventColor ?? state.eventColor;
+    },
+  ),
 };

--- a/packages/x-scheduler-headless/src/utils/SchedulerStore/SchedulerStore.ts
+++ b/packages/x-scheduler-headless/src/utils/SchedulerStore/SchedulerStore.ts
@@ -30,7 +30,6 @@ import {
   shouldUpdateOccurrencePlaceholder,
 } from './SchedulerStore.utils';
 import { TimeoutManager } from '../TimeoutManager';
-import { DEFAULT_EVENT_COLOR } from '../../constants';
 import { createChangeEventDetails } from '../../base-ui-copy/utils/createBaseUIEventDetails';
 
 const ONE_MINUTE_IN_MS = 60 * 1000;
@@ -119,7 +118,7 @@ export class SchedulerStore<
       areEventsResizable: parameters.areEventsResizable ?? false,
       canDragEventsFromTheOutside: parameters.canDragEventsFromTheOutside ?? false,
       canDropEventsToTheOutside: parameters.canDropEventsToTheOutside ?? false,
-      eventColor: parameters.eventColor ?? DEFAULT_EVENT_COLOR,
+      eventColor: parameters.eventColor ?? 'jade',
       showCurrentTimeIndicator: parameters.showCurrentTimeIndicator ?? true,
       readOnly: parameters.readOnly ?? false,
       eventCreation: parameters.eventCreation ?? true,

--- a/packages/x-scheduler-headless/src/utils/SchedulerStore/SchedulerStore.types.ts
+++ b/packages/x-scheduler-headless/src/utils/SchedulerStore/SchedulerStore.types.ts
@@ -220,7 +220,7 @@ export interface SchedulerParameters<TEvent extends object, TResource extends ob
   /**
    * The color palette used for all events.
    * Can be overridden per resource using the `eventColor` property on the resource model.
-   * Can be overridden per event using the `color` property on the event model. (TODO: not implemented yet)
+   * Can be overridden per event using the `color` property on the event model.
    * @default "jade"
    */
   eventColor?: SchedulerEventColor;

--- a/packages/x-scheduler/src/internals/components/event-popover/EventPopover.test.tsx
+++ b/packages/x-scheduler/src/internals/components/event-popover/EventPopover.test.tsx
@@ -15,13 +15,11 @@ import {
   SchedulerResourceId,
   SchedulerOccurrencePlaceholderCreation,
 } from '@mui/x-scheduler-headless/models';
-import { DEFAULT_EVENT_COLOR } from '@mui/x-scheduler-headless/constants';
 import { Popover } from '@base-ui-components/react/popover';
 import { EventCalendarStoreContext } from '@mui/x-scheduler-headless/use-event-calendar-store-context';
 import { EventCalendarProvider } from '@mui/x-scheduler-headless/event-calendar-provider';
 import { SchedulerEvent } from '@mui/x-scheduler/models';
 import { EventPopoverContent } from './EventPopover';
-import { getColorClassName } from '../../utils/color-utils';
 import { RecurringScopeDialog } from '../scope-dialog/ScopeDialog';
 
 const DEFAULT_EVENT: SchedulerEvent = EventBuilder.new()
@@ -275,9 +273,7 @@ describe('<EventPopoverContent />', () => {
     );
 
     expect(screen.getByRole('button', { name: /resource/i }).textContent).to.match(/NoColor/i);
-    expect(document.querySelector('.ResourceLegendColor')).to.have.class(
-      getColorClassName(DEFAULT_EVENT_COLOR),
-    );
+    expect(document.querySelector('.ResourceLegendColor')).to.have.class('palette-jade');
   });
 
   it('should fallback to "No resource" with default color when the event has no resource', async () => {
@@ -309,9 +305,7 @@ describe('<EventPopoverContent />', () => {
 
     expect(screen.getByRole('button', { name: /resource/i }).textContent).to.match(/no resource/i);
 
-    expect(document.querySelector('.ResourceLegendColor')).to.have.class(
-      getColorClassName(DEFAULT_EVENT_COLOR),
-    );
+    expect(document.querySelector('.ResourceLegendColor')).to.have.class('palette-jade');
 
     await user.click(screen.getByRole('button', { name: /save changes/i }));
 

--- a/packages/x-scheduler/src/internals/components/event-popover/ReadonlyContent.tsx
+++ b/packages/x-scheduler/src/internals/components/event-popover/ReadonlyContent.tsx
@@ -4,7 +4,6 @@ import { Calendar } from 'lucide-react';
 import { useStore } from '@base-ui-components/utils/store';
 import { SchedulerEventOccurrence } from '@mui/x-scheduler-headless/models';
 import { useSchedulerStoreContext } from '@mui/x-scheduler-headless/use-scheduler-store-context';
-import { DEFAULT_EVENT_COLOR } from '@mui/x-scheduler-headless/constants';
 import {
   schedulerEventSelectors,
   schedulerRecurringEventSelectors,
@@ -66,12 +65,7 @@ export default function ReadonlyContent(props: ReadonlyContentProps) {
               />
             )}
 
-            <span
-              className={clsx(
-                'ResourceLegendColor',
-                getColorClassName(color ?? DEFAULT_EVENT_COLOR),
-              )}
-            />
+            <span className={clsx('ResourceLegendColor', getColorClassName(color))} />
           </div>
           <p
             className={clsx('EventPopoverResourceTitle', 'LinesClamp')}

--- a/packages/x-scheduler/src/internals/components/event-popover/ResourceMenu.tsx
+++ b/packages/x-scheduler/src/internals/components/event-popover/ResourceMenu.tsx
@@ -3,9 +3,12 @@ import * as React from 'react';
 import clsx from 'clsx';
 import { CheckIcon, ChevronDown } from 'lucide-react';
 import { Menu } from '@base-ui-components/react/menu';
-import { DEFAULT_EVENT_COLOR, EVENT_COLORS } from '@mui/x-scheduler-headless/constants';
+import { EVENT_COLORS } from '@mui/x-scheduler-headless/constants';
 import { useSchedulerStoreContext } from '@mui/x-scheduler-headless/use-scheduler-store-context';
-import { schedulerResourceSelectors } from '@mui/x-scheduler-headless/scheduler-selectors';
+import {
+  schedulerOtherSelectors,
+  schedulerResourceSelectors,
+} from '@mui/x-scheduler-headless/scheduler-selectors';
 import { SchedulerEventColor, SchedulerResourceId } from '@mui/x-scheduler-headless/models';
 import { useStore } from '@base-ui-components/utils/store';
 import { useTranslations } from '../../utils/TranslationsContext';
@@ -27,13 +30,18 @@ interface ResourceMenuTriggerContentProps {
 interface ResourceOptionType {
   label: string;
   value: string | null;
-  eventColor?: SchedulerEventColor;
+  eventColor: SchedulerEventColor;
 }
 
 function ResourceMenuTriggerContent(props: ResourceMenuTriggerContentProps) {
   const { resource, color } = props;
 
-  const resourceColor = resource?.eventColor || DEFAULT_EVENT_COLOR;
+  const store = useSchedulerStoreContext();
+  const resourceColor = useStore(
+    store,
+    schedulerResourceSelectors.defaultEventColor,
+    resource?.value,
+  );
 
   return (
     <div className="EventPopoverResourceLegendContainer">
@@ -55,17 +63,18 @@ export default function ResourceMenu(props: ResourceSelectProps) {
 
   // Selector hooks
   const resources = useStore(store, schedulerResourceSelectors.processedResourceFlatList);
+  const eventDefaultColor = useStore(store, schedulerOtherSelectors.defaultEventColor);
 
   const resourcesOptions = React.useMemo((): ResourceOptionType[] => {
     return [
-      { label: translations.labelNoResource, value: null, eventColor: DEFAULT_EVENT_COLOR },
+      { label: translations.labelNoResource, value: null, eventColor: eventDefaultColor },
       ...resources.map((resource) => ({
         label: resource.title,
         value: resource.id,
-        eventColor: resource.eventColor,
+        eventColor: resource.eventColor ?? eventDefaultColor,
       })),
     ];
-  }, [resources, translations.labelNoResource]);
+  }, [resources, translations.labelNoResource, eventDefaultColor]);
 
   const resource = React.useMemo(
     () =>
@@ -106,7 +115,7 @@ export default function ResourceMenu(props: ResourceSelectProps) {
                       <span
                         className={clsx(
                           'ResourceLegendColor',
-                          getColorClassName(resourceOption.eventColor ?? DEFAULT_EVENT_COLOR),
+                          getColorClassName(resourceOption.eventColor),
                         )}
                       />
                       <span className="EventPopoverSelectItemText">{resourceOption.label}</span>
@@ -133,12 +142,7 @@ export default function ResourceMenu(props: ResourceSelectProps) {
                     className="EventPopoverColorMenuItem"
                     aria-label={colorOption}
                   >
-                    <div
-                      className={clsx(
-                        'ColorRadioItemCircle',
-                        getColorClassName(colorOption ?? DEFAULT_EVENT_COLOR),
-                      )}
-                    >
+                    <div className={clsx('ColorRadioItemCircle', getColorClassName(colorOption))}>
                       <Menu.RadioItemIndicator className="CheckboxIndicator">
                         <CheckIcon size={14} strokeWidth={1.5} />
                       </Menu.RadioItemIndicator>

--- a/packages/x-scheduler/src/internals/components/resource-legend/ResourceLegend.tsx
+++ b/packages/x-scheduler/src/internals/components/resource-legend/ResourceLegend.tsx
@@ -9,7 +9,6 @@ import { useStableCallback } from '@base-ui-components/utils/useStableCallback';
 import { useEventCalendarStoreContext } from '@mui/x-scheduler-headless/use-event-calendar-store-context';
 import { schedulerResourceSelectors } from '@mui/x-scheduler-headless/scheduler-selectors';
 import { SchedulerResource } from '@mui/x-scheduler-headless/models';
-import { DEFAULT_EVENT_COLOR } from '@mui/x-scheduler-headless/constants';
 import { ResourceLegendProps } from './ResourceLegend.types';
 import { useTranslations } from '../../utils/TranslationsContext';
 import { getColorClassName } from '../../utils/color-utils';
@@ -18,15 +17,12 @@ import './ResourceLegend.css';
 function ResourceLegendItem(props: { resource: SchedulerResource }) {
   const { resource } = props;
   const translations = useTranslations();
+  const store = useEventCalendarStoreContext();
+  const eventColor = useStore(store, schedulerResourceSelectors.defaultEventColor, resource.id);
 
   return (
     <label className="ResourceLegendItem">
-      <span
-        className={clsx(
-          'ResourceLegendColor',
-          getColorClassName(resource.eventColor ?? DEFAULT_EVENT_COLOR),
-        )}
-      />
+      <span className={clsx('ResourceLegendColor', getColorClassName(eventColor))} />
       <span className="ResourceLegendName">{resource.title}</span>
       <Checkbox.Root
         className={clsx('NeutralTextButton', 'Button', 'ResourceLegendButton')}

--- a/packages/x-scheduler/src/timeline/content/timeline-title-cell/TimelineTitleCell.tsx
+++ b/packages/x-scheduler/src/timeline/content/timeline-title-cell/TimelineTitleCell.tsx
@@ -1,22 +1,22 @@
 import clsx from 'clsx';
+import { useStore } from '@base-ui-components/utils/store';
 import { Timeline as TimelinePrimitive } from '@mui/x-scheduler-headless/timeline';
-import { DEFAULT_EVENT_COLOR } from '@mui/x-scheduler-headless/constants';
 import { SchedulerResource } from '@mui/x-scheduler-headless/models';
+import { schedulerResourceSelectors } from '@mui/x-scheduler-headless/scheduler-selectors';
+import { useTimelineStoreContext } from '@mui/x-scheduler-headless/use-timeline-store-context';
 import { getColorClassName } from '../../../internals/utils/color-utils';
 
 export default function TimelineTitleCell({ resource }: { resource: SchedulerResource }) {
+  const store = useTimelineStoreContext();
+  const eventColor = useStore(store, schedulerResourceSelectors.defaultEventColor, resource.id);
+
   return (
     <TimelinePrimitive.Row className="TimelineRow">
       <TimelinePrimitive.Cell
         className={clsx('TimelineCell', 'TimelineTitleCell')}
         id={`TimelineTitleCell-${resource.id}`}
       >
-        <span
-          className={clsx(
-            'ResourceLegendColor',
-            getColorClassName(resource.eventColor ?? DEFAULT_EVENT_COLOR),
-          )}
-        />
+        <span className={clsx('ResourceLegendColor', getColorClassName(eventColor))} />
 
         {resource.title}
       </TimelinePrimitive.Cell>


### PR DESCRIPTION
I removed fallback to the hardcoded `jade` value that would have been buggy when `props.eventColor` is set.