### PR TITLE
[charts] Fix typo in performance note for CustomLineMarks demo

### DIFF
--- a/docs/data/charts/line-demo/line-demo.md
+++ b/docs/data/charts/line-demo/line-demo.md
@@ -53,7 +53,7 @@ Additionally, an uncertainty area is shown to represent the uncertainty of the f
 ## CustomLineMarks
 
 Notice that using another shape than "circle" renders a `<path />` instead of the `<circle />` for mark elements.
-This modification implies a small drop of rendering performances (around +50ms to render 1,000 marks).
+This modification results in a small drop in rendering performance (around 50ms to render 1,000 marks).
 
 {{"demo": "CustomLineMarks.js"}}
 


### PR DESCRIPTION
Updated the number format from 1.000 to 1,000 as intended.