### PR TITLE
[data grid] Sync component props with theme defaults

### DIFF
--- a/packages/x-data-grid/src/material/index.tsx
+++ b/packages/x-data-grid/src/material/index.tsx
@@ -148,7 +148,10 @@ const BaseSelect = forwardRef<any, P['baseSelect']>(function BaseSelect(props, r
   const theme = useTheme();
   const textFieldDefaults = (theme.components?.MuiTextField?.defaultProps ?? {}) as any;
   const computedSize = (size ?? textFieldDefaults.size) as 'small' | 'medium' | undefined;
-  const computedVariant = (textFieldDefaults.variant ?? 'outlined') as 'standard' | 'filled' | 'outlined';
+  const computedVariant = (textFieldDefaults.variant ?? 'outlined') as
+    | 'standard'
+    | 'filled'
+    | 'outlined';
   const menuProps = {
     PaperProps: {
       onKeyDown,
@@ -158,7 +161,13 @@ const BaseSelect = forwardRef<any, P['baseSelect']>(function BaseSelect(props, r
     menuProps.onClose = onClose;
   }
   return (
-    <MUIFormControl size={computedSize} fullWidth={fullWidth} style={style} disabled={disabled} ref={ref}>
+    <MUIFormControl
+      size={computedSize}
+      fullWidth={fullWidth}
+      style={style}
+      disabled={disabled}
+      ref={ref}
+    >
       <MUIInputLabel id={labelId} htmlFor={id} shrink variant={computedVariant}>
         {label}
       </MUIInputLabel>
@@ -384,7 +393,7 @@ function BaseTextField(props: P['baseTextField']) {
   const { slotProps, material, ...other } = props;
   const theme = useTheme();
   const textFieldDefaults = (theme.components?.MuiTextField?.defaultProps ?? {}) as any;
-  const computedVariant = (other as any).variant ?? (textFieldDefaults.variant ?? 'outlined');
+  const computedVariant = (other as any).variant ?? textFieldDefaults.variant ?? 'outlined';
   const computedSize = (other as any).size ?? textFieldDefaults.size;
   return (
     <MUITextField


### PR DESCRIPTION
This PR makes the grid’s material wrappers honor theme defaults, improving consistency with app-wide MUI configuration.

- `BaseSelect` now reads `MuiTextField.defaultProps` via `useTheme` and applies computed `variant` and `size` to `FormControl`, `InputLabel`, and `Select`.
  - Removed hardcoded `variant="outlined"` and the `notched` prop.
- `BaseTextField` now derives `variant` and `size` from `MuiTextField.defaultProps` when not explicitly provided.

Fixes #20335 