### PR TITLE
[scheduler] Add tests for the `sortOccurrences` utility

### DIFF
--- a/packages/x-scheduler-headless/src/sort-event-occurrences/sortEventOccurrences.test.ts
+++ b/packages/x-scheduler-headless/src/sort-event-occurrences/sortEventOccurrences.test.ts
@@ -13,13 +13,6 @@ describe('sortEventOccurrences', () => {
     });
 
     it('should sort occurrences by start date (earliest first)', () => {
-      const early = EventBuilder.new().id('early').singleDay('2024-01-15T08:00:00').toOccurrence();
-      const late = EventBuilder.new().id('late').singleDay('2024-01-15T14:00:00').toOccurrence();
-
-      expect(sortEventOccurrences([late, early], adapter)).to.deep.equal([early, late]);
-    });
-
-    it('should sort three occurrences correctly', () => {
       const first = EventBuilder.new().id('first').singleDay('2024-01-15T08:00:00').toOccurrence();
       const second = EventBuilder.new()
         .id('second')


### PR DESCRIPTION
I'm adding more tests to the headless public API :eyes: 