### PR TITLE
[pickers] Fixes invalid date tests

### DIFF
--- a/packages/x-date-pickers/src/DateField/tests/invalidStateKeyboard.DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/invalidStateKeyboard.DateField.test.tsx
@@ -20,16 +20,28 @@ describeAdapters(
       await view.user.keyboard('00');
       await view.user.tab();
 
+      const inputRoot = getFieldInputRoot();
+
       // Should be invalid now
-      expect(getFieldInputRoot()).to.have.attribute('aria-invalid', 'true');
+      expect(inputRoot).to.have.attribute('aria-invalid', 'true');
 
-      // Move to year and spin
+      await view.selectSectionAsync('day');
+
+      // Returns to valid after refocusing (incomplete date)
+      expect(inputRoot).to.have.attribute('aria-invalid', 'false');
+      await view.user.keyboard('05');
+
       await view.selectSectionAsync('year');
-      await view.user.keyboard('[ArrowUp][ArrowUp][ArrowDown]');
-      await view.user.tab();
+      await view.user.keyboard('2025');
 
-      // Still invalid, must not flash to valid between spins
-      expect(getFieldInputRoot()).to.have.attribute('aria-invalid', 'true');
+      // Should now be invalid
+      expect(inputRoot).to.have.attribute('aria-invalid', 'true');
+
+      // Spin using keypress
+      await view.user.keyboard('[ArrowUp][ArrowUp][ArrowDown]');
+
+      // Should still be invalid despite cycling 3 times, must not flash to valid between spins
+      expect(inputRoot).to.have.attribute('aria-invalid', 'true');
 
       view.unmount();
     });
@@ -41,16 +53,29 @@ describeAdapters(
       const input = getTextbox();
 
       await view.selectSectionAsync('month');
-      await view.user.keyboard('0');
+      await view.user.keyboard('00');
       await view.user.tab();
 
+      // Should be invalid now
       expect(input).to.have.attribute('aria-invalid', 'true');
+
+      await view.selectSectionAsync('day');
+
+      // Returns to valid after refocusing (incomplete date)
+      expect(input).to.have.attribute('aria-invalid', 'false');
+      await view.user.keyboard('05');
 
       // Move to year and spin using keypress
       await view.selectSectionAsync('year');
+      await view.user.keyboard('2025');
+
+      // Should now be invalid
+      expect(input).to.have.attribute('aria-invalid', 'true');
+
       await view.user.keyboard('[ArrowUp][ArrowUp][ArrowDown]');
       await view.user.tab();
 
+      // Should still be invalid despite cycling 3 times, must not flash to valid between spins
       expect(input).to.have.attribute('aria-invalid', 'true');
 
       view.unmount();


### PR DESCRIPTION
Fixes the regression tests for `DateField` invalid-state handling during keyboard spin. Ensures `aria-invalid` remains `true` while spinning year when another section (e.g., month "00") keeps the value invalid.

The tests now consistently pass locally:
<img width="1317" height="696" alt="Screenshot 2025-12-09 at 15 37 12" src="https://github.com/user-attachments/assets/15e8e51b-7193-4fae-8dd2-622214983732" />
