### PR TITLE
[charts] Use `store.state` over `store.getSnapshot()`

### DIFF
--- a/packages/x-charts-pro/src/ChartZoomSlider/internals/ChartAxisZoomSliderActiveTrack.tsx
+++ b/packages/x-charts-pro/src/ChartZoomSlider/internals/ChartAxisZoomSliderActiveTrack.tsx
@@ -109,7 +109,7 @@ export function ChartAxisZoomSliderActiveTrack({
       }
 
       const point = getSVGPoint(element, event);
-      const pointerZoom = calculateZoomFromPoint(store.getSnapshot(), axisId, point);
+      const pointerZoom = calculateZoomFromPoint(store.state, axisId, point);
 
       if (pointerZoom === null) {
         return;
@@ -131,7 +131,7 @@ export function ChartAxisZoomSliderActiveTrack({
       event.preventDefault();
       activePreviewRect.setPointerCapture(event.pointerId);
 
-      const axisZoomData = selectorChartAxisZoomData(store.getSnapshot(), axisId);
+      const axisZoomData = selectorChartAxisZoomData(store.state, axisId);
       const element = svgRef.current;
 
       if (!axisZoomData || !element) {
@@ -139,7 +139,7 @@ export function ChartAxisZoomSliderActiveTrack({
       }
 
       const point = getSVGPoint(element, event);
-      const pointerDownZoom = calculateZoomFromPoint(store.getSnapshot(), axisId, point);
+      const pointerDownZoom = calculateZoomFromPoint(store.state, axisId, point);
 
       if (pointerDownZoom === null) {
         return;
@@ -170,11 +170,11 @@ export function ChartAxisZoomSliderActiveTrack({
     const point = getSVGPoint(element, event);
 
     instance.setZoomData((prevZoomData) => {
-      const zoomOptions = selectorChartAxisZoomOptionsLookup(store.getSnapshot(), axisId);
+      const zoomOptions = selectorChartAxisZoomOptionsLookup(store.state, axisId);
 
       return prevZoomData.map((zoom) => {
         if (zoom.axisId === axisId) {
-          const newStart = calculateZoomFromPoint(store.getSnapshot(), axisId, point);
+          const newStart = calculateZoomFromPoint(store.state, axisId, point);
 
           if (newStart === null) {
             return zoom;
@@ -201,11 +201,11 @@ export function ChartAxisZoomSliderActiveTrack({
     const point = getSVGPoint(element, event);
 
     instance.setZoomData((prevZoomData) => {
-      const zoomOptions = selectorChartAxisZoomOptionsLookup(store.getSnapshot(), axisId);
+      const zoomOptions = selectorChartAxisZoomOptionsLookup(store.state, axisId);
 
       return prevZoomData.map((zoom) => {
         if (zoom.axisId === axisId) {
-          const newEnd = calculateZoomFromPoint(store.getSnapshot(), axisId, point);
+          const newEnd = calculateZoomFromPoint(store.state, axisId, point);
 
           if (newEnd === null) {
             return zoom;
@@ -231,7 +231,7 @@ export function ChartAxisZoomSliderActiveTrack({
   let endThumbX: number;
   let endThumbY: number;
 
-  const { minStart, maxEnd } = selectorChartAxisZoomOptionsLookup(store.getSnapshot(), axisId);
+  const { minStart, maxEnd } = selectorChartAxisZoomOptionsLookup(store.state, axisId);
   const range = maxEnd - minStart;
   const zoomStart = Math.max(minStart, zoomData.start);
   const zoomEnd = Math.min(zoomData.end, maxEnd);

--- a/packages/x-charts-pro/src/ChartZoomSlider/internals/ChartAxisZoomSliderTrack.tsx
+++ b/packages/x-charts-pro/src/ChartZoomSlider/internals/ChartAxisZoomSliderTrack.tsx
@@ -71,11 +71,7 @@ export function ChartAxisZoomSliderTrack({
     }
 
     const pointerDownPoint = getSVGPoint(element, event);
-    const zoomFromPointerDown = calculateZoomFromPoint(
-      store.getSnapshot(),
-      axisId,
-      pointerDownPoint,
-    );
+    const zoomFromPointerDown = calculateZoomFromPoint(store.state, axisId, pointerDownPoint);
 
     if (zoomFromPointerDown === null) {
       return;
@@ -83,17 +79,13 @@ export function ChartAxisZoomSliderTrack({
 
     const onPointerMove = rafThrottle(function onPointerMove(pointerMoveEvent: PointerEvent) {
       const pointerMovePoint = getSVGPoint(element, pointerMoveEvent);
-      const zoomFromPointerMove = calculateZoomFromPoint(
-        store.getSnapshot(),
-        axisId,
-        pointerMovePoint,
-      );
+      const zoomFromPointerMove = calculateZoomFromPoint(store.state, axisId, pointerMovePoint);
 
       if (zoomFromPointerMove === null) {
         return;
       }
 
-      const zoomOptions = selectorChartAxisZoomOptionsLookup(store.getSnapshot(), axisId);
+      const zoomOptions = selectorChartAxisZoomOptionsLookup(store.state, axisId);
 
       instance.setAxisZoomData(axisId, (prevZoomData) => {
         if (zoomFromPointerMove > zoomFromPointerDown) {

--- a/packages/x-charts-pro/src/SankeyChart/plugins/useSankeyHighlight.ts
+++ b/packages/x-charts-pro/src/SankeyChart/plugins/useSankeyHighlight.ts
@@ -33,7 +33,7 @@ export const useSankeyHighlight: ChartPlugin<UseSankeyHighlightSignature> = ({ s
   });
 
   const setHighlight = useEventCallback((newItem: SankeyHighlightItemData) => {
-    const prevItem = store.getSnapshot().highlight.item;
+    const prevItem = store.state.highlight.item;
 
     if (fastObjectShallowCompare(prevItem, newItem)) {
       return;

--- a/packages/x-charts-pro/src/internals/plugins/useChartProZoom/useChartProZoom.ts
+++ b/packages/x-charts-pro/src/internals/plugins/useChartProZoom/useChartProZoom.ts
@@ -186,10 +186,7 @@ export const useChartProZoom: ChartPlugin<UseChartProZoomSignature> = (pluginDat
     (step: number) => {
       setZoomDataCallback((prev) =>
         prev.map((zoomData) => {
-          const zoomOptions = selectorChartAxisZoomOptionsLookup(
-            store.getSnapshot(),
-            zoomData.axisId,
-          );
+          const zoomOptions = selectorChartAxisZoomOptionsLookup(store.state, zoomData.axisId);
 
           return calculateZoom(zoomData, step, zoomOptions);
         }),

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartClosestPoint/useChartClosestPoint.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartClosestPoint/useChartClosestPoint.ts
@@ -78,8 +78,8 @@ export const useChartClosestPoint: ChartPlugin<UseChartClosestPointSignature> = 
         const xAxisId = aSeries.xAxisId ?? defaultXAxisId;
         const yAxisId = aSeries.yAxisId ?? defaultYAxisId;
 
-        const xAxisZoom = selectorChartAxisZoomData(store.getSnapshot(), xAxisId);
-        const yAxisZoom = selectorChartAxisZoomData(store.getSnapshot(), yAxisId);
+        const xAxisZoom = selectorChartAxisZoomData(store.state, xAxisId);
+        const yAxisZoom = selectorChartAxisZoomData(store.state, yAxisId);
         const maxRadius = voronoiMaxRadius === 'item' ? aSeries.markerSize : voronoiMaxRadius;
 
         const xZoomStart = (xAxisZoom?.start ?? 0) / 100;

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartHighlight/useChartHighlight.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartHighlight/useChartHighlight.ts
@@ -33,7 +33,7 @@ export const useChartHighlight: ChartPlugin<UseChartHighlightSignature> = ({ sto
 
   const clearHighlight = useEventCallback(() => {
     params.onHighlightChange?.(null);
-    const prevHighlight = store.getSnapshot().highlight;
+    const prevHighlight = store.state.highlight;
     if (prevHighlight.item === null || prevHighlight.isControlled) {
       return;
     }
@@ -46,7 +46,7 @@ export const useChartHighlight: ChartPlugin<UseChartHighlightSignature> = ({ sto
   });
 
   const setHighlight = useEventCallback((newItem: HighlightItemData) => {
-    const prevHighlight = store.getSnapshot().highlight;
+    const prevHighlight = store.state.highlight;
 
     if (prevHighlight.isControlled || fastObjectShallowCompare(prevHighlight.item, newItem)) {
       return;

--- a/packages/x-internals/src/store/Store.ts
+++ b/packages/x-internals/src/store/Store.ts
@@ -30,6 +30,10 @@ export class Store<State> {
     };
   };
 
+  /**
+   * Returns the current state snapshot. Meant for usage with `useSyncExternalStore`.
+   * If you want to access the state, use the `state` property instead.
+   */
   getSnapshot = () => {
     return this.state;
   };


### PR DESCRIPTION
Related to https://github.com/mui/mui-x/pull/20457/files#r2603725768.

