### PR TITLE
[docs] Remove copy pasted `aria-label`

### DIFF
--- a/docs/data/charts/axis/SymlogBars.tsx.preview
+++ b/docs/data/charts/axis/SymlogBars.tsx.preview
@@ -6,7 +6,7 @@
   fullWidth
 >
   {['bar', 'area'].map((type) => (
-    <ToggleButton key={type} value={type} aria-label="left aligned">
+    <ToggleButton key={type} value={type}  >
       {type}
     </ToggleButton>
   ))}

--- a/docs/data/charts/axis/SymlogScale.js
+++ b/docs/data/charts/axis/SymlogScale.js
@@ -24,7 +24,7 @@ export default function SymlogScale() {
         fullWidth
       >
         {['bar', 'area'].map((type) => (
-          <ToggleButton key={type} value={type} aria-label="left aligned">
+          <ToggleButton key={type} value={type}>
             {type}
           </ToggleButton>
         ))}

--- a/docs/data/charts/axis/SymlogScale.tsx
+++ b/docs/data/charts/axis/SymlogScale.tsx
@@ -24,7 +24,7 @@ export default function SymlogScale() {
         fullWidth
       >
         {['bar', 'area'].map((type) => (
-          <ToggleButton key={type} value={type} aria-label="left aligned">
+          <ToggleButton key={type} value={type}>
             {type}
           </ToggleButton>
         ))}

--- a/docs/data/charts/axis/SymlogScale.tsx.preview
+++ b/docs/data/charts/axis/SymlogScale.tsx.preview
@@ -6,7 +6,7 @@
   fullWidth
 >
   {['bar', 'area'].map((type) => (
-    <ToggleButton key={type} value={type} aria-label="left aligned">
+    <ToggleButton key={type} value={type}>
       {type}
     </ToggleButton>
   ))}

--- a/docs/data/charts/highlighting/ControlledHighlight.js
+++ b/docs/data/charts/highlighting/ControlledHighlight.js
@@ -54,7 +54,7 @@ export default function ControlledHighlight() {
             fullWidth
           >
             {['A', 'B'].map((type) => (
-              <ToggleButton key={type} value={type} aria-label="left aligned">
+              <ToggleButton key={type} value={type}>
                 Series {type}
               </ToggleButton>
             ))}

--- a/docs/data/charts/highlighting/ControlledHighlight.tsx
+++ b/docs/data/charts/highlighting/ControlledHighlight.tsx
@@ -55,7 +55,7 @@ export default function ControlledHighlight() {
             fullWidth
           >
             {['A', 'B'].map((type) => (
-              <ToggleButton key={type} value={type} aria-label="left aligned">
+              <ToggleButton key={type} value={type}>
                 Series {type}
               </ToggleButton>
             ))}

--- a/docs/data/charts/highlighting/ElementHighlights.js
+++ b/docs/data/charts/highlighting/ElementHighlights.js
@@ -109,7 +109,7 @@ export default function ElementHighlights() {
           fullWidth
         >
           {['bar', 'line', 'scatter', 'pie'].map((type) => (
-            <ToggleButton key={type} value={type} aria-label="left aligned">
+            <ToggleButton key={type} value={type}>
               {type}
             </ToggleButton>
           ))}

--- a/docs/data/charts/highlighting/ElementHighlights.tsx
+++ b/docs/data/charts/highlighting/ElementHighlights.tsx
@@ -109,7 +109,7 @@ export default function ElementHighlights() {
           fullWidth
         >
           {['bar', 'line', 'scatter', 'pie'].map((type) => (
-            <ToggleButton key={type} value={type} aria-label="left aligned">
+            <ToggleButton key={type} value={type}>
               {type}
             </ToggleButton>
           ))}

--- a/docs/data/charts/zoom-and-pan/ZoomSliderPreview.js
+++ b/docs/data/charts/zoom-and-pan/ZoomSliderPreview.js
@@ -146,7 +146,7 @@ export default function ZoomSliderPreview() {
         fullWidth
       >
         {['bar', 'line', 'area', 'scatter'].map((type) => (
-          <ToggleButton key={type} value={type} aria-label="left aligned">
+          <ToggleButton key={type} value={type}>
             {type}
           </ToggleButton>
         ))}

--- a/docs/data/charts/zoom-and-pan/ZoomSliderPreview.tsx
+++ b/docs/data/charts/zoom-and-pan/ZoomSliderPreview.tsx
@@ -153,7 +153,7 @@ export default function ZoomSliderPreview() {
         fullWidth
       >
         {['bar', 'line', 'area', 'scatter'].map((type) => (
-          <ToggleButton key={type} value={type} aria-label="left aligned">
+          <ToggleButton key={type} value={type}>
             {type}
           </ToggleButton>
         ))}


### PR DESCRIPTION
Just noticed we tend to copy the aria label from MUI demo without updating it