### PR TITLE
[charts] Refactor `getBarDimensions`

### DIFF
--- a/packages/x-charts/src/BarChart/useBarPlotData.ts
+++ b/packages/x-charts/src/BarChart/useBarPlotData.ts
@@ -98,7 +98,7 @@ export function useBarPlotData(
           dataIndex,
         );
 
-        if (bandDimensions == null || continuousDimensions == null) {
+        if (continuousDimensions == null) {
           continue;
         }
 

--- a/packages/x-charts/src/internals/getBarDimensions.ts
+++ b/packages/x-charts/src/internals/getBarDimensions.ts
@@ -63,7 +63,7 @@ export function getBarDimensions(params: {
     dataIndex,
   );
 
-  if (bandDimensions == null || continuousDimensions == null) {
+  if (continuousDimensions == null) {
     return null;
   }
 


### PR DESCRIPTION
Split `getBarDimensions` in smaller functions to avoid unnecessary computations in `useBarPlotData` (e.g., `getBandSize` only needs to be called once per series).

Also split the bar dimensions into one function for computing band dimensions and another one for continuous dimensions.