### PR TITLE
[data grid] Fix disabled checkbox initial state

### DIFF
--- a/packages/x-data-grid/src/components/columnSelection/GridCellCheckboxRenderer.tsx
+++ b/packages/x-data-grid/src/components/columnSelection/GridCellCheckboxRenderer.tsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import useEventCallback from '@mui/utils/useEventCallback';
+import useEnhancedEffect from '@mui/utils/useEnhancedEffect';
 import { forwardRef } from '@mui/x-internals/forwardRef';
 import { useGridApiContext } from '../../hooks/utils/useGridApiContext';
 import { useGridRootProps } from '../../hooks/utils/useGridRootProps';
@@ -56,7 +57,16 @@ const GridCellCheckboxForwardRef = forwardRef<HTMLInputElement, GridRenderCellPa
       },
     );
 
-    const disabled = !isSelectable;
+    const [disabled, setDisabled] = React.useState(
+      isSelectable === undefined ? undefined : !isSelectable,
+    );
+
+    useEnhancedEffect(() => {
+      if (isSelectable === undefined) {
+        const selectable = apiRef.current.isRowSelectable(id);
+        setDisabled(!selectable);
+      }
+    }, [isSelectable, id, apiRef]);
 
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
       if (disabled) {
@@ -66,7 +76,7 @@ const GridCellCheckboxForwardRef = forwardRef<HTMLInputElement, GridRenderCellPa
       apiRef.current.publishEvent('rowSelectionCheckboxChange', params, event);
     };
 
-    React.useLayoutEffect(() => {
+    useEnhancedEffect(() => {
       if (tabIndex === 0) {
         const element = apiRef.current.getCellElement(id, field);
         if (element) {

--- a/packages/x-data-grid/src/hooks/features/rowSelection/utils.ts
+++ b/packages/x-data-grid/src/hooks/features/rowSelection/utils.ts
@@ -81,7 +81,7 @@ export const checkboxPropsSelector = createSelector(
       columns,
     };
 
-    let isSelectable = true;
+    let isSelectable;
     if (typeof isRowSelectable === 'function') {
       isSelectable = isRowSelectable(rowParams);
     }

--- a/packages/x-data-grid/src/tests/rowSelection.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/rowSelection.DataGrid.test.tsx
@@ -357,51 +357,53 @@ describe('<DataGrid /> - Row selection', () => {
       expect(selectAll).to.have.property('checked', false);
     });
 
-    it('should disable the checkbox if isRowSelectable returns false', () => {
-      render(
-        <TestDataGridSelection isRowSelectable={(params) => params.id === 0} checkboxSelection />,
-      );
-      expect(getRow(0).querySelector('input')?.getAttribute('aria-disabled')).to.equal(null);
-      expect(getRow(1).querySelector('input')?.getAttribute('aria-disabled')).to.equal('true');
-      expect(getRow(1).querySelector('input')?.getAttribute('disabled')).to.equal(null);
-    });
-
-    it('disabled checkboxes cannot be selected', async () => {
-      render(
-        <TestDataGridSelection isRowSelectable={(params) => params.id === 0} checkboxSelection />,
-      );
-
-      const firstCheckbox = getCell(0, 0).querySelector('input');
-      act(() => {
-        firstCheckbox?.click();
+    describe('disabled state', () => {
+      it('should disable the checkbox if isRowSelectable returns false', () => {
+        render(
+          <TestDataGridSelection isRowSelectable={(params) => params.id === 0} checkboxSelection />,
+        );
+        expect(getRow(0).querySelector('input')?.getAttribute('aria-disabled')).to.equal(null);
+        expect(getRow(1).querySelector('input')?.getAttribute('aria-disabled')).to.equal('true');
+        expect(getRow(1).querySelector('input')?.getAttribute('disabled')).to.equal(null);
       });
 
-      expect(getSelectedRowIds()).to.deep.equal([0]);
-      // user.click() doesn't work here because of `pointer-events: none`
-      const secondCheckbox = getCell(1, 0).querySelector('input');
-      act(() => {
-        secondCheckbox?.click();
+      it('disabled checkboxes cannot be selected', async () => {
+        render(
+          <TestDataGridSelection isRowSelectable={(params) => params.id === 0} checkboxSelection />,
+        );
+
+        const firstCheckbox = getCell(0, 0).querySelector('input');
+        act(() => {
+          firstCheckbox?.click();
+        });
+
+        expect(getSelectedRowIds()).to.deep.equal([0]);
+        // user.click() doesn't work here because of `pointer-events: none`
+        const secondCheckbox = getCell(1, 0).querySelector('input');
+        act(() => {
+          secondCheckbox?.click();
+        });
+
+        expect(getSelectedRowIds()).to.deep.equal([0]);
       });
 
-      expect(getSelectedRowIds()).to.deep.equal([0]);
-    });
+      it('disabled checkboxes can be focused', async () => {
+        const { user } = render(
+          <TestDataGridSelection isRowSelectable={(params) => params.id === 0} checkboxSelection />,
+        );
 
-    it('disabled checkboxes can be focused', async () => {
-      const { user } = render(
-        <TestDataGridSelection isRowSelectable={(params) => params.id === 0} checkboxSelection />,
-      );
+        expect(getSelectedRowIds()).to.deep.equal([]);
+        const firstCheckbox = getCell(0, 0).querySelector('input');
+        await user.keyboard('{Tab}');
+        await user.keyboard('{ArrowDown}');
+        expect(document.activeElement).to.equal(firstCheckbox);
 
-      expect(getSelectedRowIds()).to.deep.equal([]);
-      const firstCheckbox = getCell(0, 0).querySelector('input');
-      await user.keyboard('{Tab}');
-      await user.keyboard('{ArrowDown}');
-      expect(document.activeElement).to.equal(firstCheckbox);
-
-      const secondCheckbox = getCell(1, 0).querySelector('input');
-      await user.keyboard('{ArrowDown}');
-      await user.keyboard('[Space]');
-      expect(getSelectedRowIds()).to.deep.equal([]);
-      expect(document.activeElement).to.equal(secondCheckbox);
+        const secondCheckbox = getCell(1, 0).querySelector('input');
+        await user.keyboard('{ArrowDown}');
+        await user.keyboard('[Space]');
+        expect(getSelectedRowIds()).to.deep.equal([]);
+        expect(document.activeElement).to.equal(secondCheckbox);
+      });
     });
 
     it('should select a range with shift pressed when clicking the row', async () => {


### PR DESCRIPTION
Alternative to https://github.com/mui/mui-x/pull/20641

Without strict mode: https://stackblitz.com/edit/mui-datagrid-selection-dlge8v-ngu9snzr?file=src%2FApp.tsx

With strict mode: https://stackblitz.com/edit/mui-datagrid-selection-dlge8v-g9tf7s7s?file=src%2FApp.tsx

With both initially checked/unchecked: https://stackblitz.com/edit/mui-datagrid-selection-dlge8v-gcjnezaa?file=src%2FApp.tsx

Fixes https://github.com/mui/mui-x/issues/20537

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
