### PR TITLE
[charts] Remove duplicated types

### DIFF
--- a/packages/x-charts/src/hooks/useInteractionItemProps.ts
+++ b/packages/x-charts/src/hooks/useInteractionItemProps.ts
@@ -5,7 +5,8 @@ import { type SeriesItemIdentifierWithData } from '../models';
 import { useChartContext } from '../context/ChartProvider';
 import type { UseChartHighlightSignature } from '../internals/plugins/featurePlugins/useChartHighlight';
 import type { UseChartInteractionSignature } from '../internals/plugins/featurePlugins/useChartInteraction';
-import type { ChartSeriesType, ChartItemIdentifier } from '../models/seriesType/config';
+import type { ChartSeriesType } from '../models/seriesType/config';
+import type { SeriesItemIdentifier } from '../models/seriesType';
 import type { ChartInstance } from '../internals/plugins/models';
 import type { UseChartTooltipSignature } from '../internals/plugins/featurePlugins/useChartTooltip';
 
@@ -74,7 +75,7 @@ export function getInteractionItemProps(
   instance: ChartInstance<
     [UseChartInteractionSignature, UseChartHighlightSignature, UseChartTooltipSignature]
   >,
-  item: ChartItemIdentifier<ChartSeriesType>,
+  item: SeriesItemIdentifier<ChartSeriesType>,
 ): {
   onPointerEnter?: () => void;
   onPointerLeave?: () => void;

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartTooltip/useChartTooltip.selectors.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartTooltip/useChartTooltip.selectors.ts
@@ -1,9 +1,6 @@
 import { createSelector, createSelectorMemoized } from '@mui/x-internals/store';
-import type {
-  ChartItemIdentifier,
-  ChartSeriesDefaultized,
-  ChartSeriesType,
-} from '../../../../models/seriesType/config';
+import type { SeriesItemIdentifier } from '../../../../models/seriesType';
+import type { ChartSeriesDefaultized, ChartSeriesType } from '../../../../models/seriesType/config';
 import {
   type ProcessedSeries,
   selectorChartSeriesConfig,
@@ -78,7 +75,7 @@ const selectorChartsTooltipAxisConfig = createSelectorMemoized(
   selectorChartRadiusAxis,
   selectorChartSeriesProcessed,
   function selectorChartsTooltipAxisConfig<T extends ChartSeriesType>(
-    identifier: ChartItemIdentifier<T> | null,
+    identifier: SeriesItemIdentifier<T> | null,
     { axis: xAxis, axisIds: xAxisIds }: ComputeResult<ChartsXAxisProps>,
     { axis: yAxis, axisIds: yAxisIds }: ComputeResult<ChartsYAxisProps>,
     rotationAxes: ComputePolarResult<ChartsRotationAxisProps>,
@@ -128,7 +125,7 @@ export const selectorChartsTooltipItemPosition = createSelectorMemoized(
   selectorChartsTooltipAxisConfig,
 
   function selectorChartsTooltipItemPosition<T extends ChartSeriesType>(
-    identifier: ChartItemIdentifier<T> | null,
+    identifier: SeriesItemIdentifier<T> | null,
     drawingArea: ChartDrawingArea,
     seriesConfig: ChartSeriesConfig<T>,
     series: ProcessedSeries<T>,

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartTooltip/useChartTooltip.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartTooltip/useChartTooltip.ts
@@ -2,11 +2,12 @@ import useEventCallback from '@mui/utils/useEventCallback';
 import { fastObjectShallowCompare } from '@mui/x-internals/fastObjectShallowCompare';
 import type { ChartPlugin } from '../../models';
 import type { UseChartTooltipSignature } from './useChartTooltip.types';
-import type { ChartItemIdentifier, ChartSeriesType } from '../../../../models/seriesType/config';
+import type { SeriesItemIdentifier } from '../../../../models/seriesType';
+import type { ChartSeriesType } from '../../../../models/seriesType/config';
 
 export const useChartTooltip: ChartPlugin<UseChartTooltipSignature> = ({ store }) => {
   const removeTooltipItem = useEventCallback(function removeTooltipItem(
-    itemToRemove?: ChartItemIdentifier<ChartSeriesType>,
+    itemToRemove?: SeriesItemIdentifier<ChartSeriesType>,
   ) {
     const prevItem = store.state.tooltip.item;
 
@@ -27,7 +28,7 @@ export const useChartTooltip: ChartPlugin<UseChartTooltipSignature> = ({ store }
   });
 
   const setTooltipItem = useEventCallback(function setTooltipItem(
-    newItem: ChartItemIdentifier<ChartSeriesType>,
+    newItem: SeriesItemIdentifier<ChartSeriesType>,
   ) {
     if (!fastObjectShallowCompare(store.state.tooltip.item, newItem)) {
       store.set('tooltip', { item: newItem });

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartTooltip/useChartTooltip.types.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartTooltip/useChartTooltip.types.ts
@@ -1,20 +1,21 @@
 import type { ChartPluginSignature } from '../../models';
-import type { ChartItemIdentifier, ChartSeriesType } from '../../../../models/seriesType/config';
+import type { SeriesItemIdentifier } from '../../../../models/seriesType';
+import type { ChartSeriesType } from '../../../../models/seriesType/config';
 
 export interface UseChartTooltipInstance {
   /**
    * Setter for the item the user is pointing at.
-   * @param {ChartItemIdentifier} newItem The identifier of the item.
+   * @param {SeriesItemIdentifier} newItem The identifier of the item.
    */
-  setTooltipItem: (newItem: ChartItemIdentifier<ChartSeriesType>) => void;
+  setTooltipItem: (newItem: SeriesItemIdentifier<ChartSeriesType>) => void;
   /**
    * Remove the item the user was pointing at.
    * - If `itemToRemove` is provided, it removes the item only if it matches the current one.
    *   Otherwise it assumes the item got already updated and does nothing.
    * - If `itemToRemove` is not provided, it removes the current item unconditionally.
-   * @param {ChartItemIdentifier} itemToRemove The identifier of the item.
+   * @param {SeriesItemIdentifier} itemToRemove The identifier of the item.
    */
-  removeTooltipItem: (itemToRemove?: ChartItemIdentifier<ChartSeriesType>) => void;
+  removeTooltipItem: (itemToRemove?: SeriesItemIdentifier<ChartSeriesType>) => void;
 }
 
 export interface UseChartTooltipState {
@@ -22,7 +23,7 @@ export interface UseChartTooltipState {
     /**
      * The item currently under the pointer.
      */
-    item: null | ChartItemIdentifier<ChartSeriesType>;
+    item: null | SeriesItemIdentifier<ChartSeriesType>;
   };
 }
 

--- a/packages/x-charts/src/internals/plugins/models/seriesConfig/tooltipGetter.types.ts
+++ b/packages/x-charts/src/internals/plugins/models/seriesConfig/tooltipGetter.types.ts
@@ -1,5 +1,5 @@
+import type { SeriesItemIdentifier } from '../../../../models/seriesType';
 import type {
-  ChartItemIdentifier,
   ChartSeriesDefaultized,
   ChartSeriesType,
   ChartsSeriesConfig,
@@ -20,7 +20,7 @@ export interface ItemTooltip<T extends ChartSeriesType> {
   /**
    * An object that identifies the item to display.
    */
-  identifier: ChartItemIdentifier<T>;
+  identifier: SeriesItemIdentifier<T>;
   /**
    * The color associated with the item.
    */
@@ -78,7 +78,7 @@ export type TooltipGetter<TSeriesType extends ChartSeriesType> = (params: {
   series: ChartSeriesDefaultized<TSeriesType>;
   axesConfig: TooltipGetterAxesConfig;
   getColor: ColorGetter<TSeriesType>;
-  identifier: ChartItemIdentifier<TSeriesType> | null;
+  identifier: SeriesItemIdentifier<TSeriesType> | null;
 }) =>
   | (TSeriesType extends 'radar'
       ? ItemTooltipWithMultipleValues<TSeriesType>

--- a/packages/x-charts/src/internals/plugins/models/seriesConfig/tooltipItemPositionGetter.types.ts
+++ b/packages/x-charts/src/internals/plugins/models/seriesConfig/tooltipItemPositionGetter.types.ts
@@ -1,4 +1,5 @@
-import type { ChartItemIdentifier, ChartSeriesType } from '../../../../models/seriesType/config';
+import type { SeriesItemIdentifier } from '../../../../models/seriesType';
+import type { ChartSeriesType } from '../../../../models/seriesType/config';
 import {
   type ChartsRotationAxisProps,
   type ChartsRadiusAxisProps,
@@ -20,7 +21,7 @@ export type TooltipItemPositionGetter<TSeriesType extends ChartSeriesType> = (pa
   series: ProcessedSeries<TSeriesType>;
   axesConfig: TooltipPositionGetterAxesConfig;
   drawingArea: ChartDrawingArea;
-  identifier: ChartItemIdentifier<TSeriesType> | null;
+  identifier: SeriesItemIdentifier<TSeriesType> | null;
   seriesLayout: SeriesLayout<TSeriesType>;
   /**
    * The preferred placement of the tooltip related to the element.

--- a/packages/x-charts/src/models/seriesType/config.ts
+++ b/packages/x-charts/src/models/seriesType/config.ts
@@ -130,12 +130,6 @@ export type ChartSeriesLayout<T extends ChartSeriesType> = ChartsSeriesConfig[T]
   ? ChartsSeriesConfig[T]['seriesLayout']
   : never;
 
-export type ChartItemIdentifier<T extends ChartSeriesType> =
-  ChartsSeriesConfig[T]['itemIdentifier'];
-
-export type ChartItemIdentifierWithData<T extends ChartSeriesType> =
-  ChartsSeriesConfig[T]['itemIdentifierWithData'];
-
 export type DatasetElementType<T> = {
   [key: string]: T;
 };


### PR DESCRIPTION
I noticed the definition of types for item identifiers are duplicated