### PR TITLE
[charts-pro] Move heatmap highlight handling to plot component

### DIFF
--- a/packages/x-charts-pro/src/Heatmap/HeatmapItem.tsx
+++ b/packages/x-charts-pro/src/Heatmap/HeatmapItem.tsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
 import useSlotProps from '@mui/utils/useSlotProps';
 import composeClasses from '@mui/utils/composeClasses';
-import { useItemHighlighted } from '@mui/x-charts/hooks';
 import { useInteractionItemProps, type SeriesId } from '@mui/x-charts/internals';
 import { type HeatmapClasses, getHeatmapUtilityClass } from './heatmapClasses';
 
@@ -28,6 +27,8 @@ export interface HeatmapItemProps {
   x: number;
   y: number;
   color: string;
+  isHighlighted?: boolean;
+  isFaded?: boolean;
   /**
    * The props used for each component slot.
    * @default {}
@@ -74,13 +75,19 @@ const useUtilityClasses = (ownerState: HeatmapItemOwnerState) => {
  * @ignore - internal component.
  */
 function HeatmapItem(props: HeatmapItemProps) {
-  const { seriesId, dataIndex, color, value, slotProps = {}, slots = {}, ...other } = props;
-
-  const interactionProps = useInteractionItemProps({ type: 'heatmap', seriesId, dataIndex });
-  const { isFaded, isHighlighted } = useItemHighlighted({
+  const {
     seriesId,
     dataIndex,
-  });
+    color,
+    value,
+    isHighlighted = false,
+    isFaded = false,
+    slotProps = {},
+    slots = {},
+    ...other
+  } = props;
+
+  const interactionProps = useInteractionItemProps({ type: 'heatmap', seriesId, dataIndex });
 
   const ownerState = {
     seriesId,

--- a/packages/x-charts-pro/src/Heatmap/HeatmapPlot.tsx
+++ b/packages/x-charts-pro/src/Heatmap/HeatmapPlot.tsx
@@ -1,16 +1,26 @@
 'use client';
 import PropTypes from 'prop-types';
 import { useXScale, useYScale, useZColorScale } from '@mui/x-charts/hooks';
+import {
+  type HighlightItemData,
+  selectorChartsIsFadedCallback,
+  selectorChartsIsHighlightedCallback,
+  useStore,
+} from '@mui/x-charts/internals';
 import { useHeatmapSeriesContext } from '../hooks/useHeatmapSeries';
 import { HeatmapItem, type HeatmapItemProps } from './HeatmapItem';
 
 export interface HeatmapPlotProps extends Pick<HeatmapItemProps, 'slots' | 'slotProps'> {}
 
 function HeatmapPlot(props: HeatmapPlotProps) {
+  const store = useStore();
   const xScale = useXScale<'band'>();
   const yScale = useYScale<'band'>();
   const colorScale = useZColorScale()!;
   const series = useHeatmapSeriesContext();
+
+  const isHighlighted = store.use(selectorChartsIsHighlightedCallback);
+  const isFaded = store.use(selectorChartsIsFadedCallback);
 
   const xDomain = xScale.domain();
   const yDomain = yScale.domain();
@@ -26,9 +36,16 @@ function HeatmapPlot(props: HeatmapPlotProps) {
         const x = xScale(xDomain[xIndex]);
         const y = yScale(yDomain[yIndex]);
         const color = colorScale?.(value);
+
         if (x === undefined || y === undefined || !color) {
           return null;
         }
+
+        const item: HighlightItemData = {
+          seriesId: seriesToDisplay.id,
+          dataIndex,
+        };
+
         return (
           <HeatmapItem
             key={`${xIndex}_${yIndex}`}
@@ -42,6 +59,8 @@ function HeatmapPlot(props: HeatmapPlotProps) {
             value={value}
             slots={props.slots}
             slotProps={props.slotProps}
+            isHighlighted={isHighlighted(item)}
+            isFaded={isFaded(item)}
           />
         );
       })}


### PR DESCRIPTION
Part of https://github.com/mui/mui-x/issues/20702.

Improves heatmap performance with large datasets since each `HeatmapItem` will now call less hooks. 