### PR TITLE
[DataGridPremium] Fix strategy value computation with row grouping

### DIFF
--- a/packages/x-data-grid-premium/src/hooks/features/dataSource/useGridDataSourcePremium.tsx
+++ b/packages/x-data-grid-premium/src/hooks/features/dataSource/useGridDataSourcePremium.tsx
@@ -63,14 +63,21 @@ export const useGridDataSourcePremium = (
   const aggregationModel = gridAggregationModelSelector(apiRef);
   const groupingModelSize = gridRowGroupingSanitizedModelSelector(apiRef).length;
   const setStrategyAvailability = React.useCallback(() => {
-    const targetStrategy =
+    const currentStrategy =
       props.treeData || (!props.disableRowGrouping && groupingModelSize > 0)
         ? DataSourceRowsUpdateStrategy.GroupedData
         : DataSourceRowsUpdateStrategy.Default;
 
+    const prevStrategy =
+      currentStrategy === DataSourceRowsUpdateStrategy.GroupedData
+        ? DataSourceRowsUpdateStrategy.Default
+        : DataSourceRowsUpdateStrategy.GroupedData;
+
+    apiRef.current.setStrategyAvailability(GridStrategyGroup.DataSource, prevStrategy, () => false);
+
     apiRef.current.setStrategyAvailability(
       GridStrategyGroup.DataSource,
-      targetStrategy,
+      currentStrategy,
       props.dataSource && !props.lazyLoading ? () => true : () => false,
     );
   }, [

--- a/packages/x-data-grid-pro/src/hooks/features/dataSource/useGridDataSourceBasePro.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/dataSource/useGridDataSourceBasePro.ts
@@ -93,13 +93,20 @@ export const useGridDataSourceBasePro = <Api extends GridPrivateApiPro>(
   });
 
   const setStrategyAvailability = React.useCallback(() => {
-    const targetStrategy = props.treeData
+    const currentStrategy = props.treeData
       ? DataSourceRowsUpdateStrategy.GroupedData
       : DataSourceRowsUpdateStrategy.Default;
 
+    const prevStrategy =
+      currentStrategy === DataSourceRowsUpdateStrategy.GroupedData
+        ? DataSourceRowsUpdateStrategy.Default
+        : DataSourceRowsUpdateStrategy.GroupedData;
+
+    apiRef.current.setStrategyAvailability(GridStrategyGroup.DataSource, prevStrategy, () => false);
+
     apiRef.current.setStrategyAvailability(
       GridStrategyGroup.DataSource,
-      targetStrategy,
+      currentStrategy,
       props.dataSource && !props.lazyLoading ? () => true : () => false,
     );
   }, [apiRef, props.dataSource, props.lazyLoading, props.treeData]);


### PR DESCRIPTION
Fixes #20723
- Before: https://stackblitz.com/edit/jajqzkgk-ri1jpwdt?file=src%2FDemo.tsx
- After: https://stackblitz.com/edit/jajqzkgk-iyelr7dp?file=src%2FDemo.tsx

When enabling the row grouping from the flat data, the row grouping strategy was not properly set because flat data strategy wasn't being cleared.

To verify, click "Get active strategy" before and after adding a grouped column and see console output.