### PR TITLE
[Data Grid] Prevent default on `Enter` key down

### DIFF
--- a/packages/x-data-grid-pro/src/tests/cellEditing.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/cellEditing.DataGridPro.test.tsx
@@ -864,6 +864,19 @@ describe('<DataGridPro /> - Cell editing', () => {
         fireEvent.keyDown(cell, { key: 'Enter' });
         expect(spiedStartCellEditMode.callCount).to.equal(1);
       });
+
+      it('should prevent the default behavior to avoid the key affecting the edit component', () => {
+        const handleKeyDown = spy((event: React.KeyboardEvent) => event.defaultPrevented);
+        render(
+          <div onKeyDown={handleKeyDown}>
+            <TestCase />
+          </div>,
+        );
+        const cell = getCell(0, 1);
+        fireUserEvent.mousePress(cell);
+        fireEvent.keyDown(cell, { key: 'Enter' });
+        expect(handleKeyDown.returnValues).to.deep.equal([true]);
+      });
     });
 
     describe('by pressing Delete', () => {

--- a/packages/x-data-grid/src/hooks/features/editing/useGridCellEditing.ts
+++ b/packages/x-data-grid/src/hooks/features/editing/useGridCellEditing.ts
@@ -167,6 +167,7 @@ export const useGridCellEditing = (
           reason = GridCellEditStartReasons.pasteKeyDown;
         } else if (event.key === 'Enter') {
           reason = GridCellEditStartReasons.enterKeyDown;
+          event.preventDefault();
         } else if (event.key === 'Backspace' || event.key === 'Delete') {
           reason = GridCellEditStartReasons.deleteKeyDown;
         }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

## Issue

- Open https://mui.com/x/react-data-grid/recipes-editing/#multiline-editing
- Press enter on one of the Bio cell, you will notice that the textarea has new line at the beginning of the edit


https://github.com/user-attachments/assets/58b9af27-fc00-452c-aa79-35c4a97e45cc



## Root cause

When Enter starts edit mode, event.preventDefault() was not called in useGridCellEditing.ts. The unprevented Enter key propagated to the newly rendered textarea, causing the browser to insert a newline.

## Solution

Add event.preventDefault() at line 170 when event.key === 'Enter' starts edit mode.

Added a test to confirm

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
