### PR TITLE
[DataGridPro] Fix checkbox column when having pinned columns

### DIFF
--- a/packages/x-data-grid/src/colDef/gridCheckboxSelectionColDef.tsx
+++ b/packages/x-data-grid/src/colDef/gridCheckboxSelectionColDef.tsx
@@ -3,8 +3,7 @@ import { GridHeaderCheckbox } from '../components/columnSelection/GridHeaderChec
 import { GridColDef } from '../models/colDef/gridColDef';
 import { GRID_BOOLEAN_COL_DEF } from './gridBooleanColDef';
 import { gridRowIdSelector } from '../hooks/core/gridPropsSelectors';
-
-export const GRID_CHECKBOX_SELECTION_FIELD = '__check__';
+import { GRID_CHECKBOX_SELECTION_FIELD } from './gridColDef.constants';
 
 export const GRID_CHECKBOX_SELECTION_COL_DEF: GridColDef = {
   ...GRID_BOOLEAN_COL_DEF,

--- a/packages/x-data-grid/src/colDef/gridColDef.constants.ts
+++ b/packages/x-data-grid/src/colDef/gridColDef.constants.ts
@@ -1,0 +1,8 @@
+// Constants used across Grid column definitions and selectors.
+// Keep this file dependency-free to avoid circular imports during module init.
+
+// Special Grid column field identifiers
+export const GRID_CHECKBOX_SELECTION_FIELD = '__check__';
+export const GRID_TREE_DATA_GROUPING_FIELD = '__tree_data_group__';
+export const GRID_ROW_GROUPING_SINGLE_GROUPING_FIELD = '__row_group_by_columns_group__';
+export const GRID_DETAIL_PANEL_TOGGLE_FIELD = '__detail_panel_toggle__';

--- a/packages/x-data-grid/src/colDef/index.ts
+++ b/packages/x-data-grid/src/colDef/index.ts
@@ -11,3 +11,4 @@ export * from './gridNumericOperators';
 export * from './gridSingleSelectOperators';
 export * from './gridStringOperators';
 export * from './gridDefaultColumnTypes';
+export * from './gridColDef.constants';

--- a/packages/x-data-grid/src/hooks/features/columns/gridColumnsSelector.ts
+++ b/packages/x-data-grid/src/hooks/features/columns/gridColumnsSelector.ts
@@ -128,11 +128,11 @@ export const gridVisiblePinnedColumnDefinitionsSelector = createSelectorMemoized
       return EMPTY_PINNED_COLUMN_FIELDS;
     }
     const visiblePinnedFields = filterMissingColumns(model, visibleColumnFields, isRtl);
-    const visiblePinnedColumns = {
+
+    return {
       left: visiblePinnedFields.left.map((field) => columnsState.lookup[field]),
       right: visiblePinnedFields.right.map((field) => columnsState.lookup[field]),
     };
-    return visiblePinnedColumns;
   },
 );
 

--- a/packages/x-data-grid/src/hooks/features/rowSelection/useGridRowSelectionPreProcessors.ts
+++ b/packages/x-data-grid/src/hooks/features/rowSelection/useGridRowSelectionPreProcessors.ts
@@ -5,7 +5,8 @@ import { GridColDef } from '../../../models/colDef/gridColDef';
 import { GridPipeProcessor, useGridRegisterPipeProcessor } from '../../core/pipeProcessing';
 import { getDataGridUtilityClass } from '../../../constants';
 import { DataGridProcessedProps } from '../../../models/props/DataGridProps';
-import { GRID_CHECKBOX_SELECTION_COL_DEF, GRID_CHECKBOX_SELECTION_FIELD } from '../../../colDef';
+import { GRID_CHECKBOX_SELECTION_COL_DEF } from '../../../colDef';
+import { GRID_CHECKBOX_SELECTION_FIELD } from '../../../colDef/gridColDef.constants';
 import { GridPrivateApiCommunity } from '../../../models/api/gridApiCommunity';
 
 type OwnerState = { classes: DataGridProcessedProps['classes'] };
@@ -63,6 +64,68 @@ export const useGridRowSelectionPreProcessors = (
               (field) => field !== GRID_CHECKBOX_SELECTION_FIELD,
             ),
           ];
+        }
+      }
+
+      // Ensure the checkbox selection column is visually the first column by pinning it to the
+      // left edge when it is auto-inserted due to `checkboxSelection`.
+      // Note: We no longer consider RTL here; we always use the left side.
+      // Respect explicit user pinning (left or right) and avoid re-applying if already pinned first.
+      // Update the pinnedColumns slice directly via setState.
+      const api = apiRef.current as any;
+      const pinned = api?.state?.pinnedColumns;
+
+      if (pinned) {
+        const left: string[] = Array.isArray(pinned.left) ? pinned.left : [];
+        const right: string[] = Array.isArray(pinned.right) ? pinned.right : [];
+
+        if (shouldHaveSelectionColumn) {
+          const alreadyPinned =
+            left.includes(GRID_CHECKBOX_SELECTION_FIELD) || right.includes(GRID_CHECKBOX_SELECTION_FIELD);
+
+          // Only auto-pin the checkbox to the LEFT edge if there are other pinned columns
+          // on the left already. Otherwise, keep it unpinned.
+          const leftWithoutCheckbox = left.filter((f) => f !== GRID_CHECKBOX_SELECTION_FIELD);
+
+          if (!alreadyPinned && leftWithoutCheckbox.length > 0) {
+            const newLeft = [GRID_CHECKBOX_SELECTION_FIELD, ...leftWithoutCheckbox];
+            const newRight = right;
+
+            const changed =
+              newLeft.length !== left.length || newLeft[0] !== left[0];
+
+            if (changed) {
+              api.setState((state: any) => ({
+                ...state,
+                pinnedColumns: { left: newLeft, right: newRight },
+              }));
+            }
+          } else if (alreadyPinned && left.includes(GRID_CHECKBOX_SELECTION_FIELD) && leftWithoutCheckbox.length === 0) {
+            // If the checkbox is pinned on the LEFT but would be alone on that edge,
+            // unpin it from the left to avoid a solitary pinned checkbox.
+            const newLeft = left.filter((f) => f !== GRID_CHECKBOX_SELECTION_FIELD);
+            const newRight = right;
+
+            const changed = newLeft.length !== left.length;
+            if (changed) {
+              api.setState((state: any) => ({
+                ...state,
+                pinnedColumns: { left: newLeft, right: newRight },
+              }));
+            }
+          }
+          // If it's already pinned (possibly by the user) or there are no other left pinned columns,
+          // we do nothing: respect explicit user pinning and avoid pinning when alone.
+        } else {
+          // Checkbox selection disabled: clean up any leftover pinning of the checkbox column.
+          const newLeft = left.filter((f) => f !== GRID_CHECKBOX_SELECTION_FIELD);
+          const newRight = right.filter((f) => f !== GRID_CHECKBOX_SELECTION_FIELD);
+          if (newLeft.length !== left.length || newRight.length !== right.length) {
+            api.setState((state: any) => ({
+              ...state,
+              pinnedColumns: { left: newLeft, right: newRight },
+            }));
+          }
         }
       }
 

--- a/packages/x-data-grid/src/internals/constants.ts
+++ b/packages/x-data-grid/src/internals/constants.ts
@@ -1,6 +1,8 @@
-export const GRID_TREE_DATA_GROUPING_FIELD = '__tree_data_group__';
-export const GRID_ROW_GROUPING_SINGLE_GROUPING_FIELD = '__row_group_by_columns_group__';
-export const GRID_DETAIL_PANEL_TOGGLE_FIELD = '__detail_panel_toggle__';
+export {
+  GRID_TREE_DATA_GROUPING_FIELD,
+  GRID_ROW_GROUPING_SINGLE_GROUPING_FIELD,
+  GRID_DETAIL_PANEL_TOGGLE_FIELD,
+} from '../colDef/gridColDef.constants';
 export enum PinnedColumnPosition {
   NONE,
   LEFT,


### PR DESCRIPTION
This fixes the checkbox column not being added to the pinned columns.

This also introduces a new `gridColDef.constants.ts` file that was added to prevent a circular reference. I moved more constant values that are similar in nature to the file, but wanted to check if this is fine with the team as well or if we should use the `internals/constants.ts` file instead.

Fixes #17807 