### PR TITLE
[charts-pro] Remove styled from heatmap cell

### DIFF
--- a/packages/x-charts-pro/src/Heatmap/HeatmapItem.tsx
+++ b/packages/x-charts-pro/src/Heatmap/HeatmapItem.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { styled } from '@mui/material/styles';
 import useSlotProps from '@mui/utils/useSlotProps';
 import composeClasses from '@mui/utils/composeClasses';
 import { useInteractionItemProps, type SeriesId } from '@mui/x-charts/internals';
@@ -58,19 +57,6 @@ export interface HeatmapCellProps extends React.ComponentPropsWithRef<'rect'> {
   ownerState: HeatmapItemOwnerState;
 }
 
-const HeatmapCell = styled('rect', {
-  name: 'MuiHeatmap',
-  slot: 'Cell',
-  overridesResolver: (_, styles) => styles.arc, // FIXME: Inconsistent naming with slot
-})<{ ownerState: HeatmapItemOwnerState }>(({ ownerState }) => ({
-  filter:
-    (ownerState.isHighlighted && 'saturate(120%)') ||
-    (ownerState.isFaded && 'saturate(80%)') ||
-    undefined,
-  fill: ownerState.color,
-  shapeRendering: 'crispEdges',
-}));
-
 const useUtilityClasses = (ownerState: HeatmapItemOwnerState) => {
   const { classes, seriesId, isFaded, isHighlighted } = ownerState;
   const slots = {
@@ -78,6 +64,20 @@ const useUtilityClasses = (ownerState: HeatmapItemOwnerState) => {
   };
   return composeClasses(slots, getHeatmapUtilityClass, classes);
 };
+
+function HeatmapCell({ ownerState, ...props }: HeatmapCellProps) {
+  const { isHighlighted, isFaded, color } = ownerState;
+
+  let filter: React.CSSProperties['filter'] = undefined;
+
+  if (isHighlighted) {
+    filter = 'saturate(120%)';
+  } else if (isFaded) {
+    filter = 'saturate(80%)';
+  }
+
+  return <rect filter={filter} fill={color} shapeRendering="crispEdges" {...props} />;
+}
 
 /**
  * @ignore - internal component.

--- a/packages/x-charts-pro/src/Heatmap/seriesConfig/extremums.ts
+++ b/packages/x-charts-pro/src/Heatmap/seriesConfig/extremums.ts
@@ -1,9 +1,7 @@
-import { type CartesianExtremumGetter } from '@mui/x-charts/internals';
+import { type CartesianExtremumGetter, findMinMax } from '@mui/x-charts/internals';
 
 export const getBaseExtremum: CartesianExtremumGetter<'heatmap'> = (params) => {
   const { axis } = params;
 
-  const minX = Math.min(...(axis.data ?? []));
-  const maxX = Math.max(...(axis.data ?? []));
-  return [minX, maxX];
+  return findMinMax(axis.data ?? []);
 };


### PR DESCRIPTION
Related to https://github.com/mui/mui-x/issues/20702.

Remove `styled` from heatmap cell as it had significant impact on heatmap performance when using large datasets. 