### PR TITLE
[charts] Fix tooltip anchored to item

### DIFF
--- a/packages/x-charts/src/ChartsTooltip/ChartsTooltipContainer.tsx
+++ b/packages/x-charts/src/ChartsTooltip/ChartsTooltipContainer.tsx
@@ -142,7 +142,7 @@ function ChartsTooltipContainer(inProps: ChartsTooltipContainerProps) {
 
     if (itemPosition !== null) {
       // Tooltip position is already handled by the anchor element
-      return () => {};
+      return undefined;
     }
 
     const pointerUpdate = rafThrottle((x: number, y: number) => {


### PR DESCRIPTION
Extracted from #20617

The idea is to put a `rect` inside the SVG and use it as an anchor if we plan to place the tooltip relatively to some SVG coordinates.

If the tooltip follows pointer position we keep using a fake element to anchor the tooltip.


## Demo

Dark mode is the fixed version

https://github.com/user-attachments/assets/412737e1-8423-4152-8a77-49f1320e1fc3

