### PR TITLE
[code-infra] Remove `stylelint-config-tailwindcss`

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,6 @@
     "stream-browserify": "^3.0.0",
     "string-replace-loader": "^3.2.0",
     "stylelint": "^16.26.0",
-    "stylelint-config-tailwindcss": "^1.0.0",
     "terser-webpack-plugin": "^5.3.14",
     "tsx": "catalog:",
     "typescript": "^5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -458,9 +458,6 @@ importers:
       stylelint:
         specifier: ^16.26.0
         version: 16.26.0(typescript@5.9.3)
-      stylelint-config-tailwindcss:
-        specifier: ^1.0.0
-        version: 1.0.0(stylelint@16.26.0(typescript@5.9.3))(tailwindcss@4.1.13)
       terser-webpack-plugin:
         specifier: ^5.3.14
         version: 5.3.14(@swc/core@1.13.5)(esbuild@0.27.1)(webpack@5.101.3(@swc/core@1.13.5)(esbuild@0.27.1))
@@ -11380,12 +11377,6 @@ packages:
     peerDependencies:
       stylelint: ^16.23.0
 
-  stylelint-config-tailwindcss@1.0.0:
-    resolution: {integrity: sha512-e6WUBJeLdOZ0sy8FZ1jk5Zy9iNGqqJbrMwnnV0Hpaw/yin6QO3gVv/zvyqSty8Yg6nEB5gqcyJbN387TPhEa7Q==}
-    peerDependencies:
-      stylelint: '>=13.13.1'
-      tailwindcss: '>=2.2.16'
-
   stylelint@16.26.0:
     resolution: {integrity: sha512-Y/3AVBefrkqqapVYH3LBF5TSDZ1kw+0XpdKN2KchfuhMK6lQ85S4XOG4lIZLcrcS4PWBmvcY6eS2kCQFz0jukQ==}
     engines: {node: '>=18.12.0'}
@@ -11445,9 +11436,6 @@ packages:
   table@6.9.0:
     resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
     engines: {node: '>=10.0.0'}
-
-  tailwindcss@4.1.13:
-    resolution: {integrity: sha512-i+zidfmTqtwquj4hMEwdjshYYgMbOrPzb9a0M3ZgNa0JMoZeFC6bxZvO8yr8ozS6ix2SDz0+mvryPeBs2TFE+w==}
 
   tapable@0.1.10:
     resolution: {integrity: sha512-jX8Et4hHg57mug1/079yitEKWGB3LCwoxByLsNim89LABq8NqgiX+6iYVOsq0vX8uJHkU+DZ5fnq95f800bEsQ==}
@@ -23156,11 +23144,6 @@ snapshots:
       stylelint: 16.26.0(typescript@5.9.3)
       stylelint-config-recommended: 17.0.0(stylelint@16.26.0(typescript@5.9.3))
 
-  stylelint-config-tailwindcss@1.0.0(stylelint@16.26.0(typescript@5.9.3))(tailwindcss@4.1.13):
-    dependencies:
-      stylelint: 16.26.0(typescript@5.9.3)
-      tailwindcss: 4.1.13
-
   stylelint@16.26.0(typescript@5.9.3):
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
@@ -23260,8 +23243,6 @@ snapshots:
       slice-ansi: 4.0.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-
-  tailwindcss@4.1.13: {}
 
   tapable@0.1.10: {}
 


### PR DESCRIPTION
Remove `stylelint-config-tailwindcss` as it seems unused. 

Only Base UI uses it ([search results](https://github.com/search?q=org%3Amui%20stylelint-config-tailwindcss&type=code)), but we don't depend on it for stylelint config.