### PR TITLE
[DataGridPro] Fix header filter height for `density="compact"`

### DIFF
--- a/packages/x-data-grid-pro/src/components/headerFiltering/GridHeaderFilterCell.tsx
+++ b/packages/x-data-grid-pro/src/components/headerFiltering/GridHeaderFilterCell.tsx
@@ -89,9 +89,9 @@ const StyledInputComponent = styled(GridFilterInputValue, {
     fontSize: '14px',
   },
   [`.${gridClasses['root--densityCompact']} & .${inputBaseClasses.input}`]: {
-    paddingTop: vars.spacing(0.5),
-    paddingBottom: vars.spacing(0.5),
-    height: 23,
+    paddingTop: vars.spacing(0.25),
+    paddingBottom: vars.spacing(0.25),
+    height: 20,
   },
 });
 

--- a/packages/x-data-grid/src/components/containers/GridRootStyles.ts
+++ b/packages/x-data-grid/src/components/containers/GridRootStyles.ts
@@ -396,6 +396,10 @@ export const GridRootStyles = styled('div', {
       minHeight: 'min-content',
       overflow: 'hidden',
     },
+    [`&.${c['root--densityCompact']} .${c['columnHeader--filter']}`]: {
+      paddingTop: 4,
+      paddingBottom: 4,
+    },
     [`& .${c['virtualScroller--hasScrollX']} .${c['columnHeader--last']}`]: {
       overflow: 'hidden',
     },


### PR DESCRIPTION
Even though we set the header filter row height to match compact row height, the styles made it go beyond that, which messed up scrollbar position calculations.

Before: https://mui.com/x/react-data-grid/column-dimensions/#autosizing-header-filters
After: https://deploy-preview-20834--material-ui-x.netlify.app/x/react-data-grid/column-dimensions/#autosizing-header-filters

