### PR TITLE
[charts] Memoize HeatmapItem to avoid re-render when fading/highlighting

### DIFF
--- a/packages/x-charts-pro/src/Heatmap/HeatmapPlot.tsx
+++ b/packages/x-charts-pro/src/Heatmap/HeatmapPlot.tsx
@@ -16,6 +16,8 @@ import { shouldRegisterPointerInteractionsGlobally } from './shouldRegisterPoint
 
 export interface HeatmapPlotProps extends Pick<HeatmapItemProps, 'slots' | 'slotProps'> {}
 
+const MemoHeatmapItem = React.memo(HeatmapItem);
+
 function HeatmapPlot(props: HeatmapPlotProps) {
   const store = useStore();
   const xScale = useXScale<'band'>();
@@ -55,7 +57,7 @@ function HeatmapPlot(props: HeatmapPlotProps) {
           };
 
           return (
-            <HeatmapItem
+            <MemoHeatmapItem
               key={`${xIndex}_${yIndex}`}
               width={xScale.bandwidth()}
               height={yScale.bandwidth()}


### PR DESCRIPTION
Memoize `HeatmapItem` to avoid re-render when fading/highlighting. This works well because in `HeatmapPlot` we're only either providing primitives or `slots/slotProps` which are unchanged from the user input.

I was noticing some slowdown in the docs. 

Before (no memo):

https://github.com/user-attachments/assets/a2752b5b-e275-40e8-a238-59f3e7a13cb1

After (memo):

https://github.com/user-attachments/assets/d7374e4d-cb22-42e4-a826-48ef994d6ea5

