### PR TITLE
[code-infra] Update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-packages/x-charts* @mui/xcharts
-docs/data/charts @mui/xcharts @prakhargupta1
+packages/x-charts* @JCQuintas @alexfauquette @bernardobelchior
+docs/data/charts @JCQuintas @alexfauquette @bernardobelchior
 CHANGELOG.md @mui/explore @mui/xcharts @mui/xgrid @mui/infra


### PR DESCRIPTION
Do we want to keep using `@mui/charts` or go back to usernames? 