### PR TITLE
[code-infra] Github action to sync title and label

### DIFF
--- a/.github/workflows/prs-check-label-title-sync.yml
+++ b/.github/workflows/prs-check-label-title-sync.yml
@@ -1,8 +1,8 @@
-name: Sync label and title
+name: Check PR labels and title sync
 
 on:
   pull_request:
-    types: [opened, reopened, labeled, unlabeled, edited]
+    types: [opened, reopened, labeled, unlabeled, edited, synchronize]
 
 permissions: {}
 
@@ -10,35 +10,50 @@ jobs:
   check_label_title_sync:
     runs-on: ubuntu-latest
     name: Check label and title sync
-    permissions:
-      pull-requests: read
     steps:
       - name: Check label matches title
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
-            const { data: pr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number,
-            });
-
+            const pr = context.payload.pull_request;
             const title = pr.title.toLowerCase();
-            const existingLabels = pr.labels?.map((label) => label.name.toLowerCase()) || [];
+            const existingLabels =
+              pr.labels?.map((label) => label.name.toLowerCase()) || [];
+            const titleLabels = Array.from(
+              title.matchAll(/(?:\[([^\]]+)\])/g),
+              (match) => match[1]
+            );
+            const expectedLabelsFromTitle = titleLabels
+              .map((label) => {
+                if (label.endsWith("-pro")) {
+                  return "plan: Pro";
+                }
+                if (label.endsWith("-premium")) {
+                  return "plan: Premium";
+                }
+                if (label === "docs") {
+                  return "docs";
+                }
+                return null;
+              })
+              .filter(Boolean);
 
-            // Determine expected label from title
-            let expectedLabel = null;
-            if (title.includes('-pro]')) {
-              expectedLabel = 'plan: Pro';
-            } else if (title.includes('-premium]')) {
-              expectedLabel = 'plan: Premium';
+            if (expectedLabelsFromTitle.length === 0) {
+              return;
             }
 
-            // If title has a plan indicator, verify the label is present
-            if (expectedLabel) {
-              if (!existingLabels.includes(expectedLabel.toLowerCase())) {
-                core.setFailed(`PR title contains "${expectedLabel.includes('pro') ? '-pro' : '-premium'}" but missing "${expectedLabel}" label. Please add the appropriate label.`);
-                return;
-              }
-              core.info(`✓ Label "${expectedLabel}" matches title`);
+            const missingLabels = expectedLabelsFromTitle.filter(
+              (label) => !existingLabels.includes(label)
+            );
+
+            if (
+              missingLabels.length > 0
+            ) {
+              core.setFailed(
+                `Title indicates labels that are missing: [${missingLabels.join(
+                  ", "
+                )}]. Please add them to the PR labels.`
+              );
+            } else {
+              core.info('No missing labels detected based on title.');
             }


### PR DESCRIPTION
Currently, it only looks for plan related label and fails the CI if the label is not present if the title contains `-pro]` or `-premium]`. This is in an effort to simplify unified changelog generation script.


<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
