### PR TITLE
[charts-pro] Add border radius to Heatmap

### DIFF
--- a/docs/data/charts/zoom-and-pan/ZoomHeatmap.js
+++ b/docs/data/charts/zoom-and-pan/ZoomHeatmap.js
@@ -80,7 +80,8 @@ export default function ZoomHeatmap() {
           },
         ]}
         series={[{ data: seriesData }]}
-        slots={{ cell: HeatmapCell, tooltip: Tooltip }}
+        borderRadius={4}
+        slots={{ tooltip: Tooltip }}
       />
       <Typography variant="caption">Source: GitHub</Typography>
     </Stack>
@@ -138,8 +139,4 @@ function TooltipContent() {
       </Typography>
     </Stack>
   );
-}
-
-function HeatmapCell({ ownerState, ...props }) {
-  return <rect {...props} rx={4} ry={4} fill={ownerState.color} />;
 }

--- a/docs/data/charts/zoom-and-pan/ZoomHeatmap.tsx
+++ b/docs/data/charts/zoom-and-pan/ZoomHeatmap.tsx
@@ -1,6 +1,6 @@
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
-import { Heatmap, HeatmapCellProps } from '@mui/x-charts-pro/Heatmap';
+import { Heatmap } from '@mui/x-charts-pro/Heatmap';
 import {
   AxisValueFormatterContext,
   HeatmapValueType,
@@ -85,7 +85,8 @@ export default function ZoomHeatmap() {
           },
         ]}
         series={[{ data: seriesData }]}
-        slots={{ cell: HeatmapCell, tooltip: Tooltip }}
+        borderRadius={4}
+        slots={{ tooltip: Tooltip }}
       />
       <Typography variant="caption">Source: GitHub</Typography>
     </Stack>
@@ -143,8 +144,4 @@ function TooltipContent() {
       </Typography>
     </Stack>
   );
-}
-
-function HeatmapCell({ ownerState, ...props }: HeatmapCellProps) {
-  return <rect {...props} rx={4} ry={4} fill={ownerState.color} />;
 }

--- a/docs/pages/x/api/charts/heatmap-plot.json
+++ b/docs/pages/x/api/charts/heatmap-plot.json
@@ -1,5 +1,6 @@
 {
   "props": {
+    "borderRadius": { "type": { "name": "number" } },
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": {
       "type": { "name": "object" },

--- a/docs/pages/x/api/charts/heatmap.json
+++ b/docs/pages/x/api/charts/heatmap.json
@@ -18,6 +18,7 @@
       },
       "required": true
     },
+    "borderRadius": { "type": { "name": "number" } },
     "brushConfig": {
       "type": {
         "name": "shape",

--- a/docs/translations/api-docs/charts/heatmap-plot/heatmap-plot.json
+++ b/docs/translations/api-docs/charts/heatmap-plot/heatmap-plot.json
@@ -1,6 +1,7 @@
 {
   "componentDescription": "",
   "propDescriptions": {
+    "borderRadius": { "description": "The border radius of the heatmap cells in pixels." },
     "slotProps": { "description": "The props used for each component slot." },
     "slots": { "description": "Overridable component slots." }
   },

--- a/docs/translations/api-docs/charts/heatmap/heatmap.json
+++ b/docs/translations/api-docs/charts/heatmap/heatmap.json
@@ -1,6 +1,7 @@
 {
   "componentDescription": "",
   "propDescriptions": {
+    "borderRadius": { "description": "The border radius of the heatmap cells in pixels." },
     "brushConfig": { "description": "Configuration for the brush interaction." },
     "colors": { "description": "Color palette used to colorize multiple series." },
     "dataset": {

--- a/packages/x-charts-pro/src/Heatmap/Heatmap.tsx
+++ b/packages/x-charts-pro/src/Heatmap/Heatmap.tsx
@@ -128,6 +128,10 @@ export interface HeatmapProps
    */
   showToolbar?: boolean;
   /**
+   * The border radius of the heatmap cells in pixels.
+   */
+  borderRadius?: number;
+  /**
    * Overridable component slots.
    * @default {}
    */
@@ -194,6 +198,7 @@ const Heatmap = React.forwardRef(function Heatmap(
     enableKeyboardNavigation,
     hideLegend = true,
     showToolbar = false,
+    borderRadius,
   } = props;
 
   const id = useId();
@@ -279,7 +284,7 @@ const Heatmap = React.forwardRef(function Heatmap(
         )}
         <ChartsSurface ref={ref} sx={sx}>
           <g clipPath={`url(#${clipPathId})`}>
-            <HeatmapPlot slots={slots} slotProps={slotProps} />
+            <HeatmapPlot slots={slots} slotProps={slotProps} borderRadius={borderRadius} />
             <FocusedHeatmapCell />
             <ChartsOverlay loading={loading} slots={slots} slotProps={slotProps} />
           </g>
@@ -307,6 +312,10 @@ Heatmap.propTypes = {
       setZoomData: PropTypes.func.isRequired,
     }),
   }),
+  /**
+   * The border radius of the heatmap cells in pixels.
+   */
+  borderRadius: PropTypes.number,
   /**
    * Configuration for the brush interaction.
    */

--- a/packages/x-charts-pro/src/Heatmap/HeatmapItem.tsx
+++ b/packages/x-charts-pro/src/Heatmap/HeatmapItem.tsx
@@ -31,6 +31,10 @@ export interface HeatmapItemProps {
   isHighlighted?: boolean;
   isFaded?: boolean;
   /**
+   * The border radius of the heatmap cell in pixels.
+   */
+  borderRadius?: number;
+  /**
    * The props used for each component slot.
    * @default {}
    */
@@ -69,6 +73,7 @@ function HeatmapItem(props: HeatmapItemProps) {
     value,
     isHighlighted = false,
     isFaded = false,
+    borderRadius,
     slotProps = {},
     slots = {},
     ...other
@@ -98,7 +103,7 @@ function HeatmapItem(props: HeatmapItemProps) {
   const Cell = slots?.cell ?? HeatmapCell;
   const cellProps = useSlotProps({
     elementType: Cell,
-    additionalProps: interactionProps,
+    additionalProps: { ...interactionProps, rx: borderRadius, ry: borderRadius },
     externalForwardedProps: { ...other },
     externalSlotProps: slotProps.cell,
     ownerState,

--- a/packages/x-charts-pro/src/Heatmap/HeatmapPlot.tsx
+++ b/packages/x-charts-pro/src/Heatmap/HeatmapPlot.tsx
@@ -29,11 +29,15 @@ export interface HeatmapPlotProps {
    * @default {}
    */
   slotProps?: HeatmapPlotSlotProps;
+  /**
+   * The border radius of the heatmap cells in pixels.
+   */
+  borderRadius?: number;
 }
 
 const MemoHeatmapItem = React.memo(HeatmapItem);
 
-function HeatmapPlot(props: HeatmapPlotProps) {
+function HeatmapPlot(props: HeatmapPlotProps): React.ReactNode {
   const store = useStore();
   const xScale = useXScale<'band'>();
   const yScale = useYScale<'band'>();
@@ -86,6 +90,7 @@ function HeatmapPlot(props: HeatmapPlotProps) {
               slotProps={props.slotProps}
               isHighlighted={isHighlighted(item)}
               isFaded={isFaded(item)}
+              borderRadius={props.borderRadius}
             />
           );
         })}
@@ -104,6 +109,10 @@ HeatmapPlot.propTypes = {
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |
   // ----------------------------------------------------------------------
+  /**
+   * The border radius of the heatmap cells in pixels.
+   */
+  borderRadius: PropTypes.number,
   /**
    * The props used for each component slot.
    * @default {}


### PR DESCRIPTION
Add border radius to Heatmap so you can add rounded corners to heatmap cells.

<img width="875" height="328" alt="image" src="https://github.com/user-attachments/assets/dee574fd-c0c7-45c9-a7f4-94f812a13dc1" />
