### PR TITLE
[charts] Add `shouldShowFirstTick` to ordinal time ticks

### DIFF
--- a/packages/x-charts/src/hooks/useTicks.ts
+++ b/packages/x-charts/src/hooks/useTicks.ts
@@ -171,6 +171,15 @@ function getTimeTicks<T extends { toString(): string }>(
   }
 
   const ticks: { index: number; formatter: (d: Date) => string }[] = [];
+
+  for (let i = startFrequencyIndex; i <= endFrequencyIndex; i += 1) {
+    const date = domain[0];
+    if (date instanceof Date && ticksFrequencies[i].shouldShowFirstTick(date)) {
+      ticks.push({ index: 0, formatter: ticksFrequencies[i].format });
+      break;
+    }
+  }
+
   for (let tickIndex = Math.max(1, startIndex); tickIndex <= endIndex; tickIndex += 1) {
     for (let i = startFrequencyIndex; i <= endFrequencyIndex; i += 1) {
       const prevDate = domain[tickIndex - 1];

--- a/packages/x-charts/src/models/timeTicks.ts
+++ b/packages/x-charts/src/models/timeTicks.ts
@@ -17,6 +17,12 @@ export type TickFrequencyDefinition = {
    */
   isTick: (prev: Date, value: Date) => boolean;
   /**
+   * Decides whether the first tick should be shown depending on its value.
+   * @param {Date} value The first tick value.
+   * @returns {boolean} Whether the first tick should be shown or not.
+   */
+  shouldShowFirstTick: (value: Date) => boolean;
+  /**
    * Format the tick value for display.
    * @param {Date} date The tick value to format.
    * @returns {string} The formatted date string.

--- a/packages/x-charts/src/utils/timeTicks.ts
+++ b/packages/x-charts/src/utils/timeTicks.ts
@@ -19,17 +19,22 @@ export const tickFrequencies: Record<TickFrequency, TickFrequencyDefinition> = {
   years: {
     getTickNumber: yearNumber,
     isTick: (prev: Date, value: Date) => value.getFullYear() !== prev.getFullYear(),
+    shouldShowFirstTick: () => true,
     format: (d: Date) => d.getFullYear().toString(),
   },
   quarterly: {
     getTickNumber: (from: Date, to: Date) => Math.floor(monthNumber(from, to) / 3),
     isTick: (prev: Date, value: Date) =>
       value.getMonth() !== prev.getMonth() && value.getMonth() % 3 === 0,
+    shouldShowFirstTick(value: Date) {
+      return value.getMonth() % 3 === 0;
+    },
     format: new Intl.DateTimeFormat('default', { month: 'short' }).format,
   },
   months: {
     getTickNumber: monthNumber,
     isTick: (prev: Date, value: Date) => value.getMonth() !== prev.getMonth(),
+    shouldShowFirstTick: () => true,
     format: new Intl.DateTimeFormat('default', { month: 'short' }).format,
   },
   biweekly: {
@@ -37,22 +42,28 @@ export const tickFrequencies: Record<TickFrequency, TickFrequencyDefinition> = {
     isTick: (prev: Date, value: Date) =>
       (value.getDay() < prev.getDay() || dayNumber(value, prev) > 7) &&
       Math.floor(value.getDate() / 7) % 2 === 1,
+    shouldShowFirstTick(value: Date) {
+      return Math.floor(value.getDate() / 7) % 2 === 1;
+    },
     format: new Intl.DateTimeFormat('default', { day: 'numeric' }).format,
   },
   weeks: {
     getTickNumber: (from: Date, to: Date) => dayNumber(from, to) / 7,
     isTick: (prev: Date, value: Date) =>
       value.getDay() < prev.getDay() || dayNumber(value, prev) >= 7,
+    shouldShowFirstTick: () => true,
     format: new Intl.DateTimeFormat('default', { day: 'numeric' }).format,
   },
   days: {
     getTickNumber: dayNumber,
     isTick: (prev: Date, value: Date) => value.getDate() !== prev.getDate(),
+    shouldShowFirstTick: () => true,
     format: new Intl.DateTimeFormat('default', { day: 'numeric' }).format,
   },
   hours: {
     getTickNumber: hourNumber,
     isTick: (prev: Date, value: Date) => value.getHours() !== prev.getHours(),
+    shouldShowFirstTick: () => true,
     format: new Intl.DateTimeFormat('default', { hour: '2-digit', minute: '2-digit' }).format,
   },
 };


### PR DESCRIPTION
Add `shouldShowFirstTick` to ordinal time ticks so users can customize whether to show the first tick when using `ordinalTimeTicks`. 

Also changed the default behavior so that the first tick is shown in all tick frequencies (some depending on a condition).
This, plus `shouldShowFirstTick` being mandatory is what constitutes a breaking change. 

TODO: Add tests
