### PR TITLE
[tree view] Fix `props.id` not passed to the root element

### DIFF
--- a/packages/x-tree-view-pro/src/RichTreeViewPro/RichTreeViewPro.test.tsx
+++ b/packages/x-tree-view-pro/src/RichTreeViewPro/RichTreeViewPro.test.tsx
@@ -1,4 +1,5 @@
-import { createRenderer } from '@mui/internal-test-utils';
+import * as React from 'react';
+import { createRenderer, screen } from '@mui/internal-test-utils';
 import {
   RichTreeViewPro,
   richTreeViewProClasses as classes,
@@ -16,4 +17,10 @@ describe('<RichTreeViewPro />', () => {
     muiName: 'MuiRichTreeViewPro',
     skip: ['componentProp', 'componentsProp', 'themeVariants'],
   }));
+
+  it('should pass the id prop to the root element', () => {
+    render(<RichTreeViewPro id="test-id" items={[{ id: '1', label: 'Item 1' }]} />);
+
+    expect(screen.getByRole('tree')).to.have.attribute('id', 'test-id');
+  });
 });

--- a/packages/x-tree-view/src/RichTreeView/RichTreeView.test.tsx
+++ b/packages/x-tree-view/src/RichTreeView/RichTreeView.test.tsx
@@ -1,4 +1,5 @@
-import { createRenderer } from '@mui/internal-test-utils';
+import * as React from 'react';
+import { createRenderer, screen } from '@mui/internal-test-utils';
 import { RichTreeView, richTreeViewClasses as classes } from '@mui/x-tree-view/RichTreeView';
 import { describeConformance } from 'test/utils/describeConformance';
 
@@ -13,4 +14,10 @@ describe('<RichTreeView />', () => {
     muiName: 'MuiRichTreeView',
     skip: ['componentProp', 'componentsProp', 'themeVariants'],
   }));
+
+  it('should pass the id prop to the root element', () => {
+    render(<RichTreeView id="test-id" items={[{ id: '1', label: 'Item 1' }]} />);
+
+    expect(screen.getByRole('tree')).to.have.attribute('id', 'test-id');
+  });
 });

--- a/packages/x-tree-view/src/SimpleTreeView/SimpleTreeView.test.tsx
+++ b/packages/x-tree-view/src/SimpleTreeView/SimpleTreeView.test.tsx
@@ -1,5 +1,7 @@
-import { createRenderer } from '@mui/internal-test-utils';
+import * as React from 'react';
+import { createRenderer, screen } from '@mui/internal-test-utils';
 import { SimpleTreeView, simpleTreeViewClasses as classes } from '@mui/x-tree-view/SimpleTreeView';
+import { TreeItem } from '@mui/x-tree-view/TreeItem';
 import { describeConformance } from 'test/utils/describeConformance';
 
 describe('<SimpleTreeView />', () => {
@@ -13,4 +15,14 @@ describe('<SimpleTreeView />', () => {
     muiName: 'MuiSimpleTreeView',
     skip: ['componentProp', 'componentsProp', 'themeVariants'],
   }));
+
+  it('should pass the id prop to the root element', () => {
+    render(
+      <SimpleTreeView id="test-id">
+        <TreeItem itemId="1" label="Item 1" />
+      </SimpleTreeView>,
+    );
+
+    expect(screen.getByRole('tree')).to.have.attribute('id', 'test-id');
+  });
 });

--- a/packages/x-tree-view/src/internals/plugins/id/selectors.ts
+++ b/packages/x-tree-view/src/internals/plugins/id/selectors.ts
@@ -2,18 +2,22 @@ import { createSelector } from '@mui/x-internals/store';
 import { MinimalTreeViewState } from '../../MinimalTreeViewStore';
 import { TreeViewItemId } from '../../../models';
 
+const treeIdSelector = createSelector(
+  (state: MinimalTreeViewState<any, any>) => state.providedTreeId ?? state.treeId,
+);
+
 export const idSelectors = {
   /**
    * Get the id attribute of the tree view.
    */
-  treeId: createSelector((state: MinimalTreeViewState<any, any>) => state.treeId),
+  treeId: treeIdSelector,
   /**
    * Generate the id attribute (i.e.: the `id` attribute passed to the DOM element) of a Tree Item.
    * If the user explicitly defined an id attribute, it will be returned.
    * Otherwise, the method creates a unique id for the item based on the Tree View id attribute and the item `itemId`
    */
   treeItemIdAttribute: createSelector(
-    (state: MinimalTreeViewState<any, any>) => state.treeId,
+    treeIdSelector,
     (treeId, itemId: TreeViewItemId, providedIdAttribute: string | undefined) => {
       if (providedIdAttribute != null) {
         return providedIdAttribute;


### PR DESCRIPTION
Manual cherry-pick of #20891 for v8 (I forgot to add the label)