### PR TITLE
[charts] Rename `TickItemType` to `TickItem`

### DIFF
--- a/packages/x-charts/src/ChartsXAxis/getVisibleLabels.tsx
+++ b/packages/x-charts/src/ChartsXAxis/getVisibleLabels.tsx
@@ -1,12 +1,12 @@
 'use client';
-import { type TickItemType } from '../hooks/useTicks';
+import { type TickItem } from '../hooks/useTicks';
 import { type ChartsXAxisProps, type ComputedXAxis } from '../models/axis';
 import { getMinXTranslation } from '../internals/geometry';
 import { type ChartsTextStyle } from '../internals/getWordsByLines';
 import { batchMeasureStrings } from '../internals/domUtils';
 
 /* Returns a set of indices of the tick labels that should be visible.  */
-export function getVisibleLabels<T extends TickItemType>(
+export function getVisibleLabels<T extends TickItem>(
   xTicks: T[],
   {
     tickLabelStyle: style,
@@ -79,7 +79,7 @@ export function getVisibleLabels<T extends TickItemType>(
   );
 }
 
-function getTickLabelSize<T extends TickItemType>(
+function getTickLabelSize<T extends TickItem>(
   sizeMap: Map<string | number, { width: number; height: number }>,
   tick: T,
 ) {
@@ -101,7 +101,7 @@ function getTickLabelSize<T extends TickItemType>(
   return { width, height };
 }
 
-function measureTickLabels<T extends TickItemType>(ticks: T[], style: ChartsTextStyle | undefined) {
+function measureTickLabels<T extends TickItem>(ticks: T[], style: ChartsTextStyle | undefined) {
   const strings = new Set<string>();
 
   for (const tick of ticks) {

--- a/packages/x-charts/src/ChartsXAxis/shortenLabels.ts
+++ b/packages/x-charts/src/ChartsXAxis/shortenLabels.ts
@@ -1,18 +1,18 @@
 import { clampAngle } from '../internals/clampAngle';
 import { doesTextFitInRect, ellipsize } from '../internals/ellipsize';
 import { getStringSize } from '../internals/domUtils';
-import { type TickItemType } from '../hooks/useTicks';
+import { type TickItem } from '../hooks/useTicks';
 import { type ChartsXAxisProps } from '../models/axis';
 import { type ChartDrawingArea } from '../hooks/useDrawingArea';
 
 export function shortenLabels(
-  visibleLabels: Set<TickItemType>,
+  visibleLabels: Set<TickItem>,
   drawingArea: Pick<ChartDrawingArea, 'left' | 'width' | 'right'>,
   maxHeight: number,
   isRtl: boolean,
   tickLabelStyle: ChartsXAxisProps['tickLabelStyle'],
 ) {
-  const shortenedLabels = new Map<TickItemType, string>();
+  const shortenedLabels = new Map<TickItem, string>();
   const angle = clampAngle(tickLabelStyle?.angle ?? 0);
 
   // Multiplying the space available to the left of the text position by leftBoundFactor returns the max width of the text.

--- a/packages/x-charts/src/ChartsYAxis/shortenLabels.tsx
+++ b/packages/x-charts/src/ChartsYAxis/shortenLabels.tsx
@@ -3,17 +3,17 @@ import { clampAngle } from '../internals/clampAngle';
 import { doesTextFitInRect, ellipsize } from '../internals/ellipsize';
 import { getStringSize } from '../internals/domUtils';
 import { type ChartDrawingArea } from '../hooks';
-import { type TickItemType } from '../hooks/useTicks';
+import { type TickItem } from '../hooks/useTicks';
 import { type ChartsYAxisProps } from '../models';
 
 export function shortenLabels(
-  visibleLabels: TickItemType[],
+  visibleLabels: TickItem[],
   drawingArea: Pick<ChartDrawingArea, 'top' | 'height' | 'bottom'>,
   maxWidth: number,
   isRtl: boolean,
   tickLabelStyle: ChartsYAxisProps['tickLabelStyle'],
 ) {
-  const shortenedLabels = new Map<TickItemType, string>();
+  const shortenedLabels = new Map<TickItem, string>();
   const angle = clampAngle(tickLabelStyle?.angle ?? 0);
 
   let topBoundFactor = 1;

--- a/packages/x-charts/src/hooks/useTicks.ts
+++ b/packages/x-charts/src/hooks/useTicks.ts
@@ -62,7 +62,7 @@ const offsetRatio = {
   middle: 0.5,
 } as const;
 
-export type TickItemType = {
+export type TickItem = {
   /**
    * This property is undefined only if it's the tick closing the last band
    */
@@ -328,7 +328,7 @@ export function getTicks(options: GetTicksOptions) {
     typeof tickInterval === 'object' ? tickInterval : getDefaultTicks(scale, tickNumber);
 
   // Ticks inside the drawing area
-  const visibleTicks: TickItemType[] = [];
+  const visibleTicks: TickItem[] = [];
 
   for (let i = 0; i < ticks.length; i += 1) {
     const value = ticks[i];
@@ -371,7 +371,7 @@ function getDefaultTicks(scale: D3ContinuousScale, tickNumber: number) {
 
 export function useTicks(
   options: Omit<GetTicksOptions, 'isInside'> & { direction: 'x' | 'y' },
-): TickItemType[] {
+): TickItem[] {
   const {
     scale,
     tickNumber,


### PR DESCRIPTION
Precursor to https://github.com/mui/mui-x/pull/20935.

I'm renaming this now because we'll export this type in #20935.

Cherry-picking because we probably want the feature in #20935 in v8.