### PR TITLE
[internal] Add information about codemods to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ To generate `.js` files, run `pnpm docs:typescript:formatted`.
 
 ## Codemods
 
-Codemods are run by consumers of the MUI X libraries to migrate to newer versions of the libraries.
+Codemods are run by consumers of the MUI X libraries to migrate to newer versions of the libraries.
 
 ### Versioning
 


### PR DESCRIPTION
When using Claude Code, the codemods for migrating from v8 to v9 were being placed in v9's directory, so I thought it would make sense to explain it in `AGENTS.md` to avoid similar issues in the future.

Also, they were writing all code from scratch, so added a suggestion to use our utils.