### PR TITLE
[charts-premium] Fix wrong `defaultSlots` in premium charts

### DIFF
--- a/packages/x-charts-premium/src/ChartDataProviderPremium/ChartDataProviderPremium.tsx
+++ b/packages/x-charts-premium/src/ChartDataProviderPremium/ChartDataProviderPremium.tsx
@@ -8,9 +8,9 @@ import {
   type ChartProviderProps,
   ChartsSlotsProvider,
   type ChartSeriesConfig,
-  defaultSlotsMaterial,
 } from '@mui/x-charts/internals';
 import { ChartsLocalizationProvider } from '@mui/x-charts/ChartsLocalizationProvider';
+import { defaultSlotsMaterial } from '@mui/x-charts-pro/internals';
 import { useLicenseVerifier } from '@mui/x-license/useLicenseVerifier';
 import {
   type ChartsSlotPropsPro,

--- a/packages/x-charts-pro/src/internals/index.ts
+++ b/packages/x-charts-pro/src/internals/index.ts
@@ -5,3 +5,4 @@ export type { PreviewPlotProps } from '../ChartZoomSlider/internals/previews/Pre
 export { defaultSeriesConfigPro } from '../ChartDataProviderPro/ChartDataProviderPro';
 export type { ProPluginsPerSeriesType } from '../context/ChartProApi';
 export { useHeatmapProps } from '../Heatmap/useHeatmapProps';
+export { defaultSlotsMaterial } from './material';


### PR DESCRIPTION
Fix wrong `defaultSlots` in premium charts. The `defaultSlotsMaterial` from the community package are missing some components that are required for the `ChartsToolbarPro` to render, which was causing a crash when rendering a `HeatmapPremium` with `showToolbar={true}`.

Reproduction:

<details>

<summary>Code</summary>

```tsx
import Box from '@mui/material/Box';
import { HeatmapValueType } from '@mui/x-charts-pro/models';
import type {} from '@mui/x-charts-pro/themeAugmentation';
import { HeatmapPremium } from '@mui/x-charts-premium/HeatmapPremium';

export const data: HeatmapValueType[] = [
  [0, 0, 10],
  [0, 1, 20],
  [0, 2, 40],
  [0, 3, 90],
  [0, 4, 70],
  [1, 0, 30],
  [1, 1, 50],
  [1, 2, 10],
  [1, 3, 70],
  [1, 4, 40],
  [2, 0, 50],
  [2, 1, 20],
  [2, 2, 90],
  [2, 3, 20],
  [2, 4, 70],
  [3, 0, 40],
  [3, 1, 50],
  [3, 2, 20],
  [3, 3, 70],
  [3, 4, 90],
];

export default function BasicHeatmap() {
  return (
    <Box sx={{ width: '100%', maxWidth: 400 }}>
      <HeatmapPremium
        xAxis={[{ data: [1, 2, 3, 4] }]}
        yAxis={[{ data: ['A', 'B', 'C', 'D', 'E'] }]}
        series={[{ data, highlightScope: { fade: 'series', highlight: 'item' } }]}
        height={300}
        showToolbar
      />
    </Box>
  );
}
```

</details>

