### PR TITLE
[charts-premium] Fix wrong `defaultSlots` in premium charts

### DIFF
--- a/packages/x-charts-premium/src/ChartDataProviderPremium/ChartDataProviderPremium.tsx
+++ b/packages/x-charts-premium/src/ChartDataProviderPremium/ChartDataProviderPremium.tsx
@@ -8,9 +8,9 @@ import {
   type ChartProviderProps,
   ChartsSlotsProvider,
   type ChartSeriesConfig,
-  defaultSlotsMaterial,
 } from '@mui/x-charts/internals';
 import { ChartsLocalizationProvider } from '@mui/x-charts/ChartsLocalizationProvider';
+import { defaultSlotsMaterial } from '@mui/x-charts-pro/internals';
 import { useLicenseVerifier } from '@mui/x-license/useLicenseVerifier';
 import {
   type ChartsSlotPropsPro,

--- a/packages/x-charts-pro/src/internals/index.ts
+++ b/packages/x-charts-pro/src/internals/index.ts
@@ -4,3 +4,4 @@ export { seriesPreviewPlotMap } from '../ChartZoomSlider/internals/seriesPreview
 export type { PreviewPlotProps } from '../ChartZoomSlider/internals/previews/PreviewPlot.types';
 export { defaultSeriesConfigPro } from '../ChartDataProviderPro/ChartDataProviderPro';
 export type { ProPluginsPerSeriesType } from '../context/ChartProApi';
+export { defaultSlotsMaterial } from './material';


### PR DESCRIPTION
Related to https://github.com/mui/mui-x/pull/21034.

Cherry-pick https://github.com/mui/mui-x/commit/b87efeaa7699cb644219f7e10a576c8f24032768.