### PR TITLE
[internal] Fix the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Release highlight ✨:
 
 ### Data Grid
 
+#### `@mui/x-data-grid-premium@8.26.1` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link 'Premium plan')
+
 - [DataGridPremium] Fix type import (#21033) @arminmeh
 
 ## 8.26.0


### PR DESCRIPTION
Only the premium package was published, so we shouldn't show others with version 8.26.1.
I have updated the release already https://github.com/mui/mui-x/releases/tag/v8.26.1