### PR TITLE
Data source: apply server-side sorting when row grouping is enabled

### DIFF
--- a/packages/x-data-grid/src/hooks/features/dataSource/useGridDataSourceBase.ts
+++ b/packages/x-data-grid/src/hooks/features/dataSource/useGridDataSourceBase.ts
@@ -324,9 +324,30 @@ export const useGridDataSourceBase = <Api extends GridPrivateApiCommunity>(
     cache,
     events: {
       strategyAvailabilityChange: handleStrategyActivityChange,
-      sortModelChange: runIf(standardRowsUpdateStrategyActive, () => debouncedFetchRows()),
-      filterModelChange: runIf(standardRowsUpdateStrategyActive, () => debouncedFetchRows()),
-      paginationModelChange: runIf(standardRowsUpdateStrategyActive, () => debouncedFetchRows()),
+      sortModelChange: runIf(standardRowsUpdateStrategyActive, () => {
+        // When using the grouped data strategy, keeping children expanded can prevent the grid from
+        // reflecting changes in the returned row order (e.g. after server-side sorting).
+        // We prefer correctness of ordering for sort/filter/pagination changes.
+        if (currentStrategy === DataSourceRowsUpdateStrategy.GroupedData) {
+          debouncedFetchRows(undefined, { keepChildrenExpanded: false, skipCache: true });
+          return;
+        }
+        debouncedFetchRows();
+      }),
+      filterModelChange: runIf(standardRowsUpdateStrategyActive, () => {
+        if (currentStrategy === DataSourceRowsUpdateStrategy.GroupedData) {
+          debouncedFetchRows(undefined, { keepChildrenExpanded: false, skipCache: true });
+          return;
+        }
+        debouncedFetchRows();
+      }),
+      paginationModelChange: runIf(standardRowsUpdateStrategyActive, () => {
+        if (currentStrategy === DataSourceRowsUpdateStrategy.GroupedData) {
+          debouncedFetchRows(undefined, { keepChildrenExpanded: false, skipCache: true });
+          return;
+        }
+        debouncedFetchRows();
+      }),
     },
   };
 };


### PR DESCRIPTION
Fixes #20974.

When using the grouped data update strategy, keepChildrenExpanded can prevent the grid from reflecting the updated row order returned by dataSource.getRows() after sort/filter/pagination changes.

This change forces keepChildrenExpanded=false (and skipCache=true) for those events when the grouped strategy is active, ensuring the returned ordering is applied.

Also adds a regression test in the Premium data source suite.
