### PR TITLE
[DataGrid] Update default `logicOperator` behavior in filtering docs

### DIFF
--- a/docs/data/data-grid/filtering/index.md
+++ b/docs/data/data-grid/filtering/index.md
@@ -67,7 +67,7 @@ const filterModel: GridFilterModel = {
 };
 ```
 
-If no `logicOperator` is provided, the Data Grid will use `GridLogicOperator.Or` by default.
+If no `logicOperator` is provided, the Data Grid will use `GridLogicOperator.And` by default. When the operator is left unchanged in the UI, `onFilterModelChange` can still omit it, so treat an undefined value as `GridLogicOperator.And`.
 
 ### Initialize the filters
 


### PR DESCRIPTION
- Fixed the incorrect default in docs/data/data-grid/filtering/index.md.
- Added a short note that `onFilterModelChange` can omit `logicOperator` until the user toggles it, and that `undefined` should be treated as `GridLogicOperator.And`.

Fixes #20908 