### PR TITLE
[charts-premium] Fix links in comments for chart containers and data providers

### DIFF
--- a/packages/x-charts-premium/src/ChartContainerPremium/ChartContainerPremium.tsx
+++ b/packages/x-charts-premium/src/ChartContainerPremium/ChartContainerPremium.tsx
@@ -38,7 +38,7 @@ type ChartContainerPremiumComponent = <
  *
  * API:
  *
- * - [ChartContainer API](https://mui.com/x/api/charts/chart-container/)
+ * - [ChartContainerPremium API](https://mui.com/x/api/charts/chart-container-premium/)
  *
  * @example
  * ```jsx

--- a/packages/x-charts-premium/src/ChartDataProviderPremium/ChartDataProviderPremium.tsx
+++ b/packages/x-charts-premium/src/ChartDataProviderPremium/ChartDataProviderPremium.tsx
@@ -62,11 +62,11 @@ export const defaultSeriesConfigPremium: ChartSeriesConfig<
  *
  * API:
  *
- * - [ChartDataProviderPro API](https://mui.com/x/api/charts/chart-data-provider/)
+ * - [ChartDataProviderPremium API](https://mui.com/x/api/charts/chart-data-provider-premium/)
  *
  * @example
  * ```jsx
- * <ChartDataProviderPro
+ * <ChartDataProviderPremium
  *   series={[{ label: "Label", type: "bar", data: [10, 20] }]}
  *   xAxis={[{ data: ["A", "B"], scaleType: "band", id: "x-axis" }]}
  * >
@@ -75,7 +75,7 @@ export const defaultSeriesConfigPremium: ChartSeriesConfig<
  *      <ChartsXAxis axisId="x-axis" />
  *   </ChartsSurface>
  *   {'Custom Legend Component'}
- * </ChartDataProviderPro>
+ * </ChartDataProviderPremium>
  * ```
  */
 function ChartDataProviderPremium<

--- a/packages/x-charts-pro/src/ChartContainerPro/ChartContainerPro.tsx
+++ b/packages/x-charts-pro/src/ChartContainerPro/ChartContainerPro.tsx
@@ -34,7 +34,7 @@ type ChartContainerProComponent = <
  *
  * API:
  *
- * - [ChartContainer API](https://mui.com/x/api/charts/chart-container/)
+ * - [ChartContainerPro API](https://mui.com/x/api/charts/chart-container-pro/)
  *
  * @example
  * ```jsx

--- a/packages/x-charts-pro/src/ChartDataProviderPro/ChartDataProviderPro.tsx
+++ b/packages/x-charts-pro/src/ChartDataProviderPro/ChartDataProviderPro.tsx
@@ -57,7 +57,7 @@ export const defaultSeriesConfigPro: ChartSeriesConfig<'bar' | 'scatter' | 'line
  *
  * API:
  *
- * - [ChartDataProviderPro API](https://mui.com/x/api/charts/chart-data-provider/)
+ * - [ChartDataProviderPro API](https://mui.com/x/api/charts/chart-data-provider-pro/)
  *
  * @example
  * ```jsx


### PR DESCRIPTION
Fix links in comments for chart containers and data providers since they pointed to the community components.