### PR TITLE
[docs] Move Range Bar Chart to existing charts

### DIFF
--- a/docs/src/modules/components/ChartComponentsGrid.js
+++ b/docs/src/modules/components/ChartComponentsGrid.js
@@ -60,6 +60,11 @@ function getComponents() {
       href: '/x/react-charts/sankey/',
       pro: true,
     },
+    {
+      title: 'Range Bar Chart',
+      href: '/x/react-charts/range-bar/',
+      premium: true,
+    },
   ];
 }
 

--- a/docs/src/modules/components/ChartComponentsUpcoming.js
+++ b/docs/src/modules/components/ChartComponentsUpcoming.js
@@ -17,11 +17,6 @@ function getComponents() {
       href: 'https://github.com/mui/mui-x/issues/17275',
     },
     {
-      title: 'Range Bar',
-      href: 'https://github.com/mui/mui-x/issues/20350',
-      premium: true,
-    },
-    {
       title: 'Range Area',
       href: 'https://github.com/mui/mui-x/issues/13988',
       premium: true,


### PR DESCRIPTION
Move Range Bar Chart to existing charts. I had forgotten to do it when implementing it in #20275.

Needs to be cherry-picked to v8.

<img width="1269" height="1322" alt="localhost_3001_x_react-charts_" src="https://github.com/user-attachments/assets/f8828117-7263-43a3-a546-1fc86cef359b" />
