### PR TITLE
[data grid] Fix virtualization crash by preventing out-of-bounds focusedVirtualCell indices

### DIFF
--- a/packages/x-virtualizer/src/features/virtualization/virtualization.ts
+++ b/packages/x-virtualizer/src/features/virtualization/virtualization.ts
@@ -424,11 +424,18 @@ function useVirtualization(store: Store<BaseState>, params: ParamsWithDefaults, 
     let virtualRowIndex = -1;
     const focusedVirtualCell = params.focusedVirtualCell?.();
     if (!isPinnedSection && focusedVirtualCell) {
-      if (focusedVirtualCell.rowIndex < firstRowToRender) {
+      if (
+        focusedVirtualCell.rowIndex < firstRowToRender &&
+        focusedVirtualCell.rowIndex >= 0 &&
+        focusedVirtualCell.rowIndex < rowModels.length
+      ) {
         rowIndexes.unshift(focusedVirtualCell.rowIndex);
         virtualRowIndex = focusedVirtualCell.rowIndex;
       }
-      if (focusedVirtualCell.rowIndex > lastRowToRender) {
+      if (
+        focusedVirtualCell.rowIndex > lastRowToRender &&
+        focusedVirtualCell.rowIndex < rowModels.length
+      ) {
         rowIndexes.push(focusedVirtualCell.rowIndex);
         virtualRowIndex = focusedVirtualCell.rowIndex;
       }


### PR DESCRIPTION
Cherry-pick of https://github.com/mui/mui-x/pull/20927

The original pull request was missing `v8.x` label, and therefore wasn't cherry-picked automatically