### PR TITLE
[data grid] Fix pagination state with unknown row count when controlled by `paginationMeta`

### DIFF
--- a/packages/x-data-grid/src/components/GridPagination.tsx
+++ b/packages/x-data-grid/src/components/GridPagination.tsx
@@ -31,16 +31,17 @@ function GridPagination() {
 
   const { paginationMode, loading } = rootProps;
 
-  const disabled = rowCount === -1 && paginationMode === 'server' && loading;
+  const unknownRowCount = rowCount == null || rowCount === -1;
+  const disabled = unknownRowCount && paginationMode === 'server' && loading;
 
   const lastPage = React.useMemo(() => Math.max(0, pageCount - 1), [pageCount]);
 
   const computedPage = React.useMemo(() => {
-    if (rowCount === -1) {
+    if (unknownRowCount) {
       return paginationModel.page;
     }
     return paginationModel.page <= lastPage ? paginationModel.page : lastPage;
-  }, [lastPage, paginationModel.page, rowCount]);
+  }, [lastPage, paginationModel.page, unknownRowCount]);
 
   const handlePageSizeChange = React.useCallback(
     (pageSize: number) => {
@@ -98,7 +99,7 @@ function GridPagination() {
   return (
     <GridPaginationRoot
       as={rootProps.slots.basePagination}
-      count={rowCount}
+      count={rowCount ?? -1}
       page={computedPage}
       rowsPerPageOptions={pageSizeOptions}
       rowsPerPage={paginationModel.pageSize}

--- a/packages/x-data-grid/src/constants/localeTextConstants.ts
+++ b/packages/x-data-grid/src/constants/localeTextConstants.ts
@@ -196,11 +196,12 @@ export const GRID_DEFAULT_LOCALE_TEXT: GridLocaleText = {
   // Pagination
   paginationRowsPerPage: 'Rows per page:',
   paginationDisplayedRows: ({ from, to, count, estimated }) => {
+    const unknownRowCount = count == null || count === -1;
     if (!estimated) {
-      return `${from}–${to} of ${count !== -1 ? count : `more than ${to}`}`;
+      return `${from}–${to} of ${!unknownRowCount ? count : `more than ${to}`}`;
     }
     const estimatedLabel = estimated && estimated > to ? `around ${estimated}` : `more than ${to}`;
-    return `${from}–${to} of ${count !== -1 ? count : estimatedLabel}`;
+    return `${from}–${to} of ${!unknownRowCount ? count : estimatedLabel}`;
   },
   paginationItemAriaLabel: (type) => {
     if (type === 'first') {

--- a/packages/x-data-grid/src/hooks/features/pagination/gridPaginationUtils.ts
+++ b/packages/x-data-grid/src/hooks/features/pagination/gridPaginationUtils.ts
@@ -10,7 +10,7 @@ export const getPageCount = (rowCount: number, pageSize: number, page: number): 
     return Math.ceil(rowCount / pageSize);
   }
 
-  if (rowCount === -1) {
+  if (rowCount === -1 || rowCount == null) {
     // With unknown row-count, we can assume a page after the current one
     return page + 2;
   }

--- a/packages/x-data-grid/src/internals/utils/propValidation.ts
+++ b/packages/x-data-grid/src/internals/utils/propValidation.ts
@@ -37,6 +37,7 @@ export const propValidatorsDataGrid: PropValidator<DataGridProcessedProps>[] = [
     (props.paginationMode === 'server' &&
       props.rowCount == null &&
       !props.dataSource &&
+      !props.paginationMeta &&
       [
         "MUI X: The `rowCount` prop must be passed using `paginationMode='server'`",
         'For more detail, see http://mui.com/components/data-grid/pagination/#index-based-pagination',

--- a/packages/x-data-grid/src/locales/beBY.ts
+++ b/packages/x-data-grid/src/locales/beBY.ts
@@ -231,11 +231,12 @@ const beBYGrid: Partial<GridLocaleText> = {
   //   count,
   //   estimated
   // }) => {
+  //   const unknownRowCount = count == null || count === -1;
   //   if (!estimated) {
-  //     return `${from}–${to} of ${count !== -1 ? count : `more than ${to}`}`;
+  //     return `${from}–${to} of ${!unknownRowCount ? count : `more than ${to}`}`;
   //   }
   //   const estimatedLabel = estimated && estimated > to ? `around ${estimated}` : `more than ${to}`;
-  //   return `${from}–${to} of ${count !== -1 ? count : estimatedLabel}`;
+  //   return `${from}–${to} of ${!unknownRowCount ? count : estimatedLabel}`;
   // },
   paginationItemAriaLabel: (type) => {
     if (type === 'first') {

--- a/packages/x-data-grid/src/locales/bgBG.ts
+++ b/packages/x-data-grid/src/locales/bgBG.ts
@@ -200,11 +200,12 @@ const bgBGGrid: Partial<GridLocaleText> = {
   //   count,
   //   estimated
   // }) => {
+  //   const unknownRowCount = count == null || count === -1;
   //   if (!estimated) {
-  //     return `${from}–${to} of ${count !== -1 ? count : `more than ${to}`}`;
+  //     return `${from}–${to} of ${!unknownRowCount ? count : `more than ${to}`}`;
   //   }
   //   const estimatedLabel = estimated && estimated > to ? `around ${estimated}` : `more than ${to}`;
-  //   return `${from}–${to} of ${count !== -1 ? count : estimatedLabel}`;
+  //   return `${from}–${to} of ${!unknownRowCount ? count : estimatedLabel}`;
   // },
   paginationItemAriaLabel: (type) => {
     if (type === 'first') {

--- a/packages/x-data-grid/src/locales/bnBD.ts
+++ b/packages/x-data-grid/src/locales/bnBD.ts
@@ -202,11 +202,12 @@ const bnBDGrid: Partial<GridLocaleText> = {
   //   count,
   //   estimated
   // }) => {
+  //   const unknownRowCount = count == null || count === -1;
   //   if (!estimated) {
-  //     return `${from}–${to} of ${count !== -1 ? count : `more than ${to}`}`;
+  //     return `${from}–${to} of ${!unknownRowCount ? count : `more than ${to}`}`;
   //   }
   //   const estimatedLabel = estimated && estimated > to ? `around ${estimated}` : `more than ${to}`;
-  //   return `${from}–${to} of ${count !== -1 ? count : estimatedLabel}`;
+  //   return `${from}–${to} of ${!unknownRowCount ? count : estimatedLabel}`;
   // },
   paginationItemAriaLabel: (type) => {
     if (type === 'first') {

--- a/packages/x-data-grid/src/locales/daDK.ts
+++ b/packages/x-data-grid/src/locales/daDK.ts
@@ -200,11 +200,12 @@ const daDKGrid: Partial<GridLocaleText> = {
   //   count,
   //   estimated
   // }) => {
+  //   const unknownRowCount = count == null || count === -1;
   //   if (!estimated) {
-  //     return `${from}–${to} of ${count !== -1 ? count : `more than ${to}`}`;
+  //     return `${from}–${to} of ${!unknownRowCount ? count : `more than ${to}`}`;
   //   }
   //   const estimatedLabel = estimated && estimated > to ? `around ${estimated}` : `more than ${to}`;
-  //   return `${from}–${to} of ${count !== -1 ? count : estimatedLabel}`;
+  //   return `${from}–${to} of ${!unknownRowCount ? count : estimatedLabel}`;
   // },
   paginationItemAriaLabel: (type) => {
     if (type === 'first') {

--- a/packages/x-data-grid/src/locales/elGR.ts
+++ b/packages/x-data-grid/src/locales/elGR.ts
@@ -202,11 +202,12 @@ const elGRGrid: Partial<GridLocaleText> = {
   //   count,
   //   estimated
   // }) => {
+  //   const unknownRowCount = count == null || count === -1;
   //   if (!estimated) {
-  //     return `${from}–${to} of ${count !== -1 ? count : `more than ${to}`}`;
+  //     return `${from}–${to} of ${!unknownRowCount ? count : `more than ${to}`}`;
   //   }
   //   const estimatedLabel = estimated && estimated > to ? `around ${estimated}` : `more than ${to}`;
-  //   return `${from}–${to} of ${count !== -1 ? count : estimatedLabel}`;
+  //   return `${from}–${to} of ${!unknownRowCount ? count : estimatedLabel}`;
   // },
   paginationItemAriaLabel: (type) => {
     if (type === 'first') {

--- a/packages/x-data-grid/src/locales/faIR.ts
+++ b/packages/x-data-grid/src/locales/faIR.ts
@@ -202,11 +202,12 @@ const faIRGrid: Partial<GridLocaleText> = {
   //   count,
   //   estimated
   // }) => {
+  //   const unknownRowCount = count == null || count === -1;
   //   if (!estimated) {
-  //     return `${from}–${to} of ${count !== -1 ? count : `more than ${to}`}`;
+  //     return `${from}–${to} of ${!unknownRowCount ? count : `more than ${to}`}`;
   //   }
   //   const estimatedLabel = estimated && estimated > to ? `around ${estimated}` : `more than ${to}`;
-  //   return `${from}–${to} of ${count !== -1 ? count : estimatedLabel}`;
+  //   return `${from}–${to} of ${!unknownRowCount ? count : estimatedLabel}`;
   // },
   paginationItemAriaLabel: (type) => {
     if (type === 'first') {

--- a/packages/x-data-grid/src/locales/fiFI.ts
+++ b/packages/x-data-grid/src/locales/fiFI.ts
@@ -202,11 +202,12 @@ const fiFIGrid: Partial<GridLocaleText> = {
   //   count,
   //   estimated
   // }) => {
+  //   const unknownRowCount = count == null || count === -1;
   //   if (!estimated) {
-  //     return `${from}–${to} of ${count !== -1 ? count : `more than ${to}`}`;
+  //     return `${from}–${to} of ${!unknownRowCount ? count : `more than ${to}`}`;
   //   }
   //   const estimatedLabel = estimated && estimated > to ? `around ${estimated}` : `more than ${to}`;
-  //   return `${from}–${to} of ${count !== -1 ? count : estimatedLabel}`;
+  //   return `${from}–${to} of ${!unknownRowCount ? count : estimatedLabel}`;
   // },
   paginationItemAriaLabel: (type) => {
     if (type === 'first') {

--- a/packages/x-data-grid/src/locales/huHU.ts
+++ b/packages/x-data-grid/src/locales/huHU.ts
@@ -197,11 +197,12 @@ const huHUGrid: Partial<GridLocaleText> = {
   //   count,
   //   estimated
   // }) => {
+  //   const unknownRowCount = count == null || count === -1;
   //   if (!estimated) {
-  //     return `${from}–${to} of ${count !== -1 ? count : `more than ${to}`}`;
+  //     return `${from}–${to} of ${!unknownRowCount ? count : `more than ${to}`}`;
   //   }
   //   const estimatedLabel = estimated && estimated > to ? `around ${estimated}` : `more than ${to}`;
-  //   return `${from}–${to} of ${count !== -1 ? count : estimatedLabel}`;
+  //   return `${from}–${to} of ${!unknownRowCount ? count : estimatedLabel}`;
   // },
   paginationItemAriaLabel: (type) => {
     if (type === 'first') {

--- a/packages/x-data-grid/src/locales/hyAM.ts
+++ b/packages/x-data-grid/src/locales/hyAM.ts
@@ -220,11 +220,12 @@ const hyAMGrid: Partial<GridLocaleText> = {
   //   count,
   //   estimated
   // }) => {
+  //   const unknownRowCount = count == null || count === -1;
   //   if (!estimated) {
-  //     return `${from}–${to} of ${count !== -1 ? count : `more than ${to}`}`;
+  //     return `${from}–${to} of ${!unknownRowCount ? count : `more than ${to}`}`;
   //   }
   //   const estimatedLabel = estimated && estimated > to ? `around ${estimated}` : `more than ${to}`;
-  //   return `${from}–${to} of ${count !== -1 ? count : estimatedLabel}`;
+  //   return `${from}–${to} of ${!unknownRowCount ? count : estimatedLabel}`;
   // },
   // paginationItemAriaLabel: type => {
   //   if (type === 'first') {

--- a/packages/x-data-grid/src/locales/isIS.ts
+++ b/packages/x-data-grid/src/locales/isIS.ts
@@ -200,11 +200,12 @@ const isISGrid: Partial<GridLocaleText> = {
   //   count,
   //   estimated
   // }) => {
+  //   const unknownRowCount = count == null || count === -1;
   //   if (!estimated) {
-  //     return `${from}–${to} of ${count !== -1 ? count : `more than ${to}`}`;
+  //     return `${from}–${to} of ${!unknownRowCount ? count : `more than ${to}`}`;
   //   }
   //   const estimatedLabel = estimated && estimated > to ? `around ${estimated}` : `more than ${to}`;
-  //   return `${from}–${to} of ${count !== -1 ? count : estimatedLabel}`;
+  //   return `${from}–${to} of ${!unknownRowCount ? count : estimatedLabel}`;
   // },
   paginationItemAriaLabel: (type) => {
     if (type === 'first') {

--- a/packages/x-data-grid/src/locales/nlNL.ts
+++ b/packages/x-data-grid/src/locales/nlNL.ts
@@ -202,11 +202,12 @@ const nlNLGrid: Partial<GridLocaleText> = {
   //   count,
   //   estimated
   // }) => {
+  //   const unknownRowCount = count == null || count === -1;
   //   if (!estimated) {
-  //     return `${from}–${to} of ${count !== -1 ? count : `more than ${to}`}`;
+  //     return `${from}–${to} of ${!unknownRowCount ? count : `more than ${to}`}`;
   //   }
   //   const estimatedLabel = estimated && estimated > to ? `around ${estimated}` : `more than ${to}`;
-  //   return `${from}–${to} of ${count !== -1 ? count : estimatedLabel}`;
+  //   return `${from}–${to} of ${!unknownRowCount ? count : estimatedLabel}`;
   // },
   paginationItemAriaLabel: (type) => {
     if (type === 'first') {

--- a/packages/x-data-grid/src/locales/roRO.ts
+++ b/packages/x-data-grid/src/locales/roRO.ts
@@ -202,11 +202,12 @@ const roROGrid: Partial<GridLocaleText> = {
   //   count,
   //   estimated
   // }) => {
+  //   const unknownRowCount = count == null || count === -1;
   //   if (!estimated) {
-  //     return `${from}–${to} of ${count !== -1 ? count : `more than ${to}`}`;
+  //     return `${from}–${to} of ${!unknownRowCount ? count : `more than ${to}`}`;
   //   }
   //   const estimatedLabel = estimated && estimated > to ? `around ${estimated}` : `more than ${to}`;
-  //   return `${from}–${to} of ${count !== -1 ? count : estimatedLabel}`;
+  //   return `${from}–${to} of ${!unknownRowCount ? count : estimatedLabel}`;
   // },
   paginationItemAriaLabel: (type) => {
     if (type === 'first') {

--- a/packages/x-data-grid/src/locales/ruRU.ts
+++ b/packages/x-data-grid/src/locales/ruRU.ts
@@ -232,11 +232,12 @@ const ruRUGrid: Partial<GridLocaleText> = {
   //   count,
   //   estimated
   // }) => {
+  //   const unknownRowCount = count == null || count === -1;
   //   if (!estimated) {
-  //     return `${from}–${to} of ${count !== -1 ? count : `more than ${to}`}`;
+  //     return `${from}–${to} of ${!unknownRowCount ? count : `more than ${to}`}`;
   //   }
   //   const estimatedLabel = estimated && estimated > to ? `around ${estimated}` : `more than ${to}`;
-  //   return `${from}–${to} of ${count !== -1 ? count : estimatedLabel}`;
+  //   return `${from}–${to} of ${!unknownRowCount ? count : estimatedLabel}`;
   // },
   paginationItemAriaLabel: (type) => {
     if (type === 'first') {

--- a/packages/x-data-grid/src/locales/svSE.ts
+++ b/packages/x-data-grid/src/locales/svSE.ts
@@ -202,11 +202,12 @@ const svSEGrid: Partial<GridLocaleText> = {
   //   count,
   //   estimated
   // }) => {
+  //   const unknownRowCount = count == null || count === -1;
   //   if (!estimated) {
-  //     return `${from}–${to} of ${count !== -1 ? count : `more than ${to}`}`;
+  //     return `${from}–${to} of ${!unknownRowCount ? count : `more than ${to}`}`;
   //   }
   //   const estimatedLabel = estimated && estimated > to ? `around ${estimated}` : `more than ${to}`;
-  //   return `${from}–${to} of ${count !== -1 ? count : estimatedLabel}`;
+  //   return `${from}–${to} of ${!unknownRowCount ? count : estimatedLabel}`;
   // },
   paginationItemAriaLabel: (type) => {
     if (type === 'first') {

--- a/packages/x-data-grid/src/locales/trTR.ts
+++ b/packages/x-data-grid/src/locales/trTR.ts
@@ -197,11 +197,12 @@ const trTRGrid: Partial<GridLocaleText> = {
   //   count,
   //   estimated
   // }) => {
+  //   const unknownRowCount = count == null || count === -1;
   //   if (!estimated) {
-  //     return `${from}–${to} of ${count !== -1 ? count : `more than ${to}`}`;
+  //     return `${from}–${to} of ${!unknownRowCount ? count : `more than ${to}`}`;
   //   }
   //   const estimatedLabel = estimated && estimated > to ? `around ${estimated}` : `more than ${to}`;
-  //   return `${from}–${to} of ${count !== -1 ? count : estimatedLabel}`;
+  //   return `${from}–${to} of ${!unknownRowCount ? count : estimatedLabel}`;
   // },
   paginationItemAriaLabel: (type) => {
     if (type === 'first') {

--- a/packages/x-data-grid/src/locales/ukUA.ts
+++ b/packages/x-data-grid/src/locales/ukUA.ts
@@ -232,11 +232,12 @@ const ukUAGrid: Partial<GridLocaleText> = {
   //   count,
   //   estimated
   // }) => {
+  //   const unknownRowCount = count == null || count === -1;
   //   if (!estimated) {
-  //     return `${from}–${to} of ${count !== -1 ? count : `more than ${to}`}`;
+  //     return `${from}–${to} of ${!unknownRowCount ? count : `more than ${to}`}`;
   //   }
   //   const estimatedLabel = estimated && estimated > to ? `around ${estimated}` : `more than ${to}`;
-  //   return `${from}–${to} of ${count !== -1 ? count : estimatedLabel}`;
+  //   return `${from}–${to} of ${!unknownRowCount ? count : estimatedLabel}`;
   // },
   paginationItemAriaLabel: (type) => {
     if (type === 'first') {

--- a/packages/x-data-grid/src/locales/urPK.ts
+++ b/packages/x-data-grid/src/locales/urPK.ts
@@ -200,11 +200,12 @@ const urPKGrid: Partial<GridLocaleText> = {
   //   count,
   //   estimated
   // }) => {
+  //   const unknownRowCount = count == null || count === -1;
   //   if (!estimated) {
-  //     return `${from}–${to} of ${count !== -1 ? count : `more than ${to}`}`;
+  //     return `${from}–${to} of ${!unknownRowCount ? count : `more than ${to}`}`;
   //   }
   //   const estimatedLabel = estimated && estimated > to ? `around ${estimated}` : `more than ${to}`;
-  //   return `${from}–${to} of ${count !== -1 ? count : estimatedLabel}`;
+  //   return `${from}–${to} of ${!unknownRowCount ? count : estimatedLabel}`;
   // },
   paginationItemAriaLabel: (type) => {
     if (type === 'first') {

--- a/packages/x-data-grid/src/locales/viVN.ts
+++ b/packages/x-data-grid/src/locales/viVN.ts
@@ -200,11 +200,12 @@ const viVNGrid: Partial<GridLocaleText> = {
   //   count,
   //   estimated
   // }) => {
+  //   const unknownRowCount = count == null || count === -1;
   //   if (!estimated) {
-  //     return `${from}–${to} of ${count !== -1 ? count : `more than ${to}`}`;
+  //     return `${from}–${to} of ${!unknownRowCount ? count : `more than ${to}`}`;
   //   }
   //   const estimatedLabel = estimated && estimated > to ? `around ${estimated}` : `more than ${to}`;
-  //   return `${from}–${to} of ${count !== -1 ? count : estimatedLabel}`;
+  //   return `${from}–${to} of ${!unknownRowCount ? count : estimatedLabel}`;
   // },
   paginationItemAriaLabel: (type) => {
     if (type === 'first') {


### PR DESCRIPTION
Preview: https://stackblitz.com/edit/mz7lzksi?file=src%2FDemo.tsx

Made it work when `rowCount` is not explicitly specified, technically `rowCount={-1}` could work as well but looks sketchy

Fixes https://github.com/mui/mui-x/issues/20667

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
