### PR TITLE
[code-infra] Only ignore renovate[bot] in changelog generation script

### DIFF
--- a/scripts/changelogUtils.mjs
+++ b/scripts/changelogUtils.mjs
@@ -194,7 +194,7 @@ async function generateChangelog({
       release,
     })
   )
-    .filter((commit) => !commit.author?.login.endsWith('[bot]'))
+    .filter((commit) => commit.author?.login !== 'renovate[bot]')
     .map((commit) => ({
       ...commit,
       commit: {


### PR DESCRIPTION
Only ignore commits from `renovate[bot]` in changelog generation script. 

Before we were ignoring all commits whose author's logins ended with `[bot]`, which includes `github-actions[bot]`. However, this last bot is the one that creates the cherry-picks, so these commits were wrongly being omitted from the changelog. 