### PR TITLE
[code-infra] Add `MUI_TEST_ENV` global

### DIFF
--- a/test/setupVitest.ts
+++ b/test/setupVitest.ts
@@ -10,6 +10,8 @@ import { clearWarningsCache } from '@mui/x-internals/warning';
 import setupVitest from '@mui/internal-test-utils/setupVitest';
 import { configure, isJsdom } from '@mui/internal-test-utils';
 
+(globalThis as any).MUI_TEST_ENV = true;
+
 setupVitest({ emotion: true });
 
 configure({


### PR DESCRIPTION
Prepare for core update of https://github.com/mui/material-ui/pull/47692

Some of the tests rely on core libraries altering behavior when `NODE_ENV` is `test`. We want to avoid introducing unknown env vars in the bundles, but we still want to keep test behavior in there, we opted for replacing

```tsx
if (process.env.NODE === 'test') {
```
with
```tsx
if (process.env.NODE !== 'production' && globalThis.MUI_TEST_ENV) {
```

That way X tests can still rely on core test behavior without impacting any bundle size

Eventually we'll move to https://github.com/mui/mui-x/pull/21121, but we need core libraries updated first