### PR TITLE
[charts-pro] Handle edge case in export image

### DIFF
--- a/packages/x-charts-pro/src/internals/plugins/useChartProExport/exportImage.ts
+++ b/packages/x-charts-pro/src/internals/plugins/useChartProExport/exportImage.ts
@@ -90,8 +90,7 @@ export async function exportImage(
   if (canvas.width === 0 || canvas.height === 0) {
     doc.body.removeChild(iframe);
     throw new Error(
-      `MUI X Charts: Cannot export an image with zero width or height. Width: ${canvas.width}px. Height: ${canvas.height}px.\n` +
-        'If this happens, please open an issue at github.com/mui/mui-x with a reproduction of the problem.',
+      `MUI X Charts: Cannot export an image with zero width or height. Width: ${canvas.width}px. Height: ${canvas.height}px.`,
     );
   }
 


### PR DESCRIPTION
When the iframe's body style is set to certain values (e.g., `display: 'flex'`), the body won't have an intrinsic size, causing the resulting canvas to have a height of 0px, which causes `toBlob` to return null.

You can reproduce this issue in [our docs](https://mui.com/x/react-charts/export/) as follows:


https://github.com/user-attachments/assets/91b39800-2164-4aa6-b576-10d5672727db

