### PR TITLE
[charts] Fix cleanup function in useChartInteractionListener to correctly remove event listeners with options

### DIFF
--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartInteractionListener/useChartInteractionListener.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartInteractionListener/useChartInteractionListener.ts
@@ -146,7 +146,7 @@ export const useChartInteractionListener: ChartPlugin<UseChartInteractionListene
       svg?.addEventListener(interaction, callback, options);
 
       return {
-        cleanup: () => svg?.removeEventListener(interaction, callback),
+        cleanup: () => svg?.removeEventListener(interaction, callback, options),
       };
     },
     [svgRef],


### PR DESCRIPTION
Fix cleanup function in useChartInteractionListener to correctly remove event listeners