### PR TITLE
[scheduler] Memoize resource visibility checking in `getOccurrencesFromEvents`

### DIFF
--- a/packages/x-scheduler-headless/src/internals/utils/event-utils.ts
+++ b/packages/x-scheduler-headless/src/internals/utils/event-utils.ts
@@ -106,10 +106,7 @@ export function getOccurrencesFromEvents(parameters: GetOccurrencesFromEventsPar
 
   for (const event of events) {
     // STEP 1: Skip events from resources that are not visible
-    if (
-      event.resource &&
-      checkResourceVisibility(event.resource) === false
-    ) {
+    if (event.resource && checkResourceVisibility(event.resource) === false) {
       continue;
     }
 


### PR DESCRIPTION
We where walking the resource tree for every event, event if lots of event had the same resource.