### PR TITLE
[scheduler] Split the `isStartedOrEnded` selector in two

### DIFF
--- a/packages/x-scheduler-headless/src/internals/utils/useEvent.ts
+++ b/packages/x-scheduler-headless/src/internals/utils/useEvent.ts
@@ -1,4 +1,5 @@
 'use client';
+import * as React from 'react';
 import { useStore } from '@base-ui/utils/store';
 import { SchedulerProcessedDate } from '../../models';
 import { useSchedulerStoreContext } from '../../use-scheduler-store-context/useSchedulerStoreContext';
@@ -8,7 +9,11 @@ export function useEvent(parameters: useEvent.Parameters): useEvent.ReturnValue 
   const { start, end } = parameters;
 
   const store = useSchedulerStoreContext();
-  const state = useStore(store, schedulerOccurrenceSelectors.isStartedOrEnded, start, end);
+
+  const started = useStore(store, schedulerOccurrenceSelectors.isStarted, start);
+  const ended = useStore(store, schedulerOccurrenceSelectors.isEnded, end);
+
+  const state = React.useMemo(() => ({ started, ended }), [started, ended]);
 
   return { state };
 }

--- a/packages/x-scheduler-headless/src/scheduler-selectors/schedulerOccurrenceSelectors.test.ts
+++ b/packages/x-scheduler-headless/src/scheduler-selectors/schedulerOccurrenceSelectors.test.ts
@@ -10,70 +10,61 @@ import { processDate } from '../process-date';
 import { schedulerOccurrenceSelectors } from './schedulerOccurrenceSelectors';
 
 describe('schedulerOccurrenceSelectors', () => {
-  describe('isStartedOrEnded', () => {
-    it('should return started=false and ended=false when now is before start', () => {
+  describe('isStarted', () => {
+    it('should return false when now is before start', () => {
       const state = getEventTimelinePremiumStateFromParameters({ events: [] });
       state.nowUpdatedEveryMinute = adapter.date('2025-07-03T08:00:00Z', 'default');
 
       const start = processDate(adapter.date('2025-07-03T10:00:00Z', 'default'), adapter);
-      const end = processDate(adapter.date('2025-07-03T11:00:00Z', 'default'), adapter);
 
-      const result = schedulerOccurrenceSelectors.isStartedOrEnded(state, start, end);
-
-      expect(result.started).to.equal(false);
-      expect(result.ended).to.equal(false);
+      expect(schedulerOccurrenceSelectors.isStarted(state, start)).to.equal(false);
     });
 
-    it('should return started=true and ended=false when now is equal to start', () => {
+    it('should return true when now is equal to start', () => {
       const state = getEventTimelinePremiumStateFromParameters({ events: [] });
       state.nowUpdatedEveryMinute = adapter.date('2025-07-03T10:00:00Z', 'default');
 
       const start = processDate(adapter.date('2025-07-03T10:00:00Z', 'default'), adapter);
-      const end = processDate(adapter.date('2025-07-03T11:00:00Z', 'default'), adapter);
 
-      const result = schedulerOccurrenceSelectors.isStartedOrEnded(state, start, end);
-
-      expect(result.started).to.equal(true);
-      expect(result.ended).to.equal(false);
+      expect(schedulerOccurrenceSelectors.isStarted(state, start)).to.equal(true);
     });
 
-    it('should return started=true and ended=false when now is between start and end', () => {
+    it('should return true when now is after start', () => {
       const state = getEventTimelinePremiumStateFromParameters({ events: [] });
       state.nowUpdatedEveryMinute = adapter.date('2025-07-03T10:30:00Z', 'default');
 
       const start = processDate(adapter.date('2025-07-03T10:00:00Z', 'default'), adapter);
+
+      expect(schedulerOccurrenceSelectors.isStarted(state, start)).to.equal(true);
+    });
+  });
+
+  describe('isEnded', () => {
+    it('should return false when now is before end', () => {
+      const state = getEventTimelinePremiumStateFromParameters({ events: [] });
+      state.nowUpdatedEveryMinute = adapter.date('2025-07-03T10:30:00Z', 'default');
+
       const end = processDate(adapter.date('2025-07-03T11:00:00Z', 'default'), adapter);
 
-      const result = schedulerOccurrenceSelectors.isStartedOrEnded(state, start, end);
-
-      expect(result.started).to.equal(true);
-      expect(result.ended).to.equal(false);
+      expect(schedulerOccurrenceSelectors.isEnded(state, end)).to.equal(false);
     });
 
-    it('should return started=true and ended=false when now is equal to end', () => {
+    it('should return false when now is equal to end', () => {
       const state = getEventTimelinePremiumStateFromParameters({ events: [] });
       state.nowUpdatedEveryMinute = adapter.date('2025-07-03T11:00:00Z', 'default');
 
-      const start = processDate(adapter.date('2025-07-03T10:00:00Z', 'default'), adapter);
       const end = processDate(adapter.date('2025-07-03T11:00:00Z', 'default'), adapter);
 
-      const result = schedulerOccurrenceSelectors.isStartedOrEnded(state, start, end);
-
-      expect(result.started).to.equal(true);
-      expect(result.ended).to.equal(false);
+      expect(schedulerOccurrenceSelectors.isEnded(state, end)).to.equal(false);
     });
 
-    it('should return started=true and ended=true when now is after end', () => {
+    it('should return true when now is after end', () => {
       const state = getEventTimelinePremiumStateFromParameters({ events: [] });
       state.nowUpdatedEveryMinute = adapter.date('2025-07-03T12:00:00Z', 'default');
 
-      const start = processDate(adapter.date('2025-07-03T10:00:00Z', 'default'), adapter);
       const end = processDate(adapter.date('2025-07-03T11:00:00Z', 'default'), adapter);
 
-      const result = schedulerOccurrenceSelectors.isStartedOrEnded(state, start, end);
-
-      expect(result.started).to.equal(true);
-      expect(result.ended).to.equal(true);
+      expect(schedulerOccurrenceSelectors.isEnded(state, end)).to.equal(true);
     });
   });
 

--- a/packages/x-scheduler-headless/src/scheduler-selectors/schedulerOccurrenceSelectors.ts
+++ b/packages/x-scheduler-headless/src/scheduler-selectors/schedulerOccurrenceSelectors.ts
@@ -93,15 +93,18 @@ const occurrencesGroupedByResourceMapSelector = createSelectorMemoized(
 );
 
 export const schedulerOccurrenceSelectors = {
-  // TODO: Pass the occurrence key instead of the start and end dates once the occurrences are stored in the state.
-  isStartedOrEnded: createSelectorMemoized(
+  isStarted: createSelector(
     (state: State) => state.adapter,
     (state: State) => state.nowUpdatedEveryMinute,
-    (adapter, now, start: SchedulerProcessedDate, end: SchedulerProcessedDate) => {
-      return {
-        started: adapter.isBefore(start.value, now) || adapter.isEqual(start.value, now),
-        ended: adapter.isBefore(end.value, now),
-      };
+    (adapter, now, start: SchedulerProcessedDate) => {
+      return adapter.isBefore(start.value, now) || adapter.isEqual(start.value, now);
+    },
+  ),
+  isEnded: createSelector(
+    (state: State) => state.adapter,
+    (state: State) => state.nowUpdatedEveryMinute,
+    (adapter, now, end: SchedulerProcessedDate) => {
+      return adapter.isBefore(end.value, now);
     },
   ),
   groupedByResourceList: occurrencesGroupedByResourceListSelector,


### PR DESCRIPTION
## Summary

This PR refactors the scheduler occurrence selectors to split the combined `isStartedOrEnded` selector into two separate, focused selectors: `isStarted` and `isEnded`. This makes sure we are not changing the returned value of the selector whenever `nowUpdatedEveryMinute` changes

## Changes

### Scheduler Selectors (`schedulerOccurrenceSelectors.ts`)
- Split `isStartedOrEnded` selector into two separate selectors:
  - `isStarted`: Returns whether an event has started (now >= start time)
  - `isEnded`: Returns whether an event has ended (now > end time)
- Changed from `createSelectorMemoized` to `createSelector` for individual selectors
- Each selector now takes a single date parameter instead of both start and end dates

### useEvent Hook (`useEvent.ts`)
- Updated to call both `isStarted` and `isEnded` selectors separately
- Combined results using `React.useMemo` to maintain referential stability
- Added explicit React import for `useMemo`

### Tests (`schedulerOccurrenceSelectors.test.ts`)
- Reorganized test suite to have separate describe blocks for `isStarted` and `isEnded`
- Updated test cases to reflect the new selector signatures
- Simplified test assertions to check individual boolean values

## Benefits

- **Separation of Concerns**: Each selector has a single responsibility
- **Better Memoization**: Components can subscribe to only the state they need
- **Improved Testability**: Easier to test individual concerns
- **Cleaner API**: More intuitive selector names and parameters

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

https://claude.ai/code/session_01JrMc8Ly5VZnVxsY3poMSkK