### PR TITLE
[scheduler] Optimize `MonthViewCell` by using `isCurrentDay` selector

### DIFF
--- a/packages/x-scheduler/src/month-view/month-view-row/MonthViewCell.tsx
+++ b/packages/x-scheduler/src/month-view/month-view-row/MonthViewCell.tsx
@@ -179,18 +179,15 @@ export const MonthViewCell = React.forwardRef(function MonthViewCell(
     eventCalendarOccurrencePlaceholderSelectors.isCreatingInDayCell,
     day.value,
   );
+  const isToday = useStore(store, schedulerNowSelectors.isCurrentDay, day.value);
   const placeholder = CalendarGrid.usePlaceholderInDay(day.value, row);
 
   // Ref hooks
   const cellRef = React.useRef<HTMLDivElement | null>(null);
   const handleRef = useMergedRefs(ref, cellRef);
 
-  // Selector hooks
-  const now = useStore(store, schedulerNowSelectors.nowUpdatedEveryMinute);
-
   const isCurrentMonth = adapter.isSameMonth(day.value, visibleDate);
   const isFirstDayOfMonth = adapter.isSameDay(day.value, adapter.startOfMonth(day.value));
-  const isToday = adapter.isSameDay(day.value, now);
 
   const visibleOccurrences =
     day.withPosition.length > maxEvents


### PR DESCRIPTION
## Summary
This PR optimizes the `MonthViewCell` component by replacing a direct store selector call with a more efficient selector that accepts the day value as a parameter.

## Changes
- Removed the `nowUpdatedEveryMinute` selector call that was fetching the current time for every cell render
- Replaced it with the `isCurrentDay` selector that directly compares the cell's day value against the current day
- This reduces unnecessary store subscriptions and improves performance by eliminating an intermediate variable

## Benefits
- **Performance**: Reduces the number of store subscriptions and re-renders
- **Clarity**: The intent is clearer - we're checking if a specific day is today, not fetching the current time
- **Efficiency**: Delegates the comparison logic to the selector, following better separation of concerns

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

https://claude.ai/code/session_01Y8YVYJ6WCrcAqZ4p6X1wsv