### PR TITLE
[scheduler] fix drag and drop on day cells (month and week view)

### DIFF
--- a/packages/x-scheduler-headless/src/calendar-grid/day-cell/useDayCellDropTarget.ts
+++ b/packages/x-scheduler-headless/src/calendar-grid/day-cell/useDayCellDropTarget.ts
@@ -74,7 +74,9 @@ export function useDayCellDropTarget(parameters: useDayCellDropTarget.Parameters
 
       // Move a Time Grid Event into the Day Grid
       if (data.source === 'CalendarGridTimeEvent') {
-        const cursorDate = adapter.addMilliseconds(data.start, data.initialCursorPositionInEventMs);
+        const cursorDate = adapter.startOfDay(
+          adapter.addMilliseconds(data.start, data.initialCursorPositionInEventMs),
+        );
         const offset = adapter.differenceInDays(value, cursorDate);
         return getDataFromInside(
           data,

--- a/packages/x-scheduler-headless/src/calendar-grid/day-event/CalendarGridDayEvent.tsx
+++ b/packages/x-scheduler-headless/src/calendar-grid/day-event/CalendarGridDayEvent.tsx
@@ -75,7 +75,9 @@ export const CalendarGridDayEvent = React.forwardRef(function CalendarGridDayEve
     const elementPosition = ref.current.getBoundingClientRect();
     const positionX = (clientX - elementPosition.x) / ref.current.offsetWidth;
 
-    return adapter.addDays(eventStartInRow, Math.ceil(positionX * eventDayLengthInRow) - 1);
+    return adapter.startOfDay(
+      adapter.addDays(eventStartInRow, Math.ceil(positionX * eventDayLengthInRow) - 1),
+    );
   });
 
   const firstEventOfSeries = schedulerEventSelectors.processedEvent(store.state, eventId)!;


### PR DESCRIPTION
Issue #21163 

I was reviewing the month view for the styles cleanup ✅, everything was fixed but I found a bug =>

When dragging events in the day grid, the placeholder appeared one cell behind the cursor. This happened because `differenceInDays` (from date-fns) truncates toward zero, and the dates being compared had different time components:
  - **Cell values** are at midnight (e.g., `Sat 00:00`) — set by `getDayList` via `adapter.startOfDay()`
  - **Dragged day / cursor date** retained the event's time (e.g., `Fri 10:00`)
This caused incorrect offsets: differenceInDays(Sat 00:00, Fri 10:00) = 0.58 → truncated to 0 (should be 1)

Video:
https://github.com/user-attachments/assets/ffc774ba-f225-4cd2-a0f2-152683d21470

  Two code paths were affected:
  1. **Day grid → day grid** (dragging an event in Month View)
  2. **Time grid → day grid** (dragging a time event to the Week View's all-day section)

Now:
https://github.com/user-attachments/assets/b1dde0c0-bb30-4bba-a5b8-72cb3351b26e

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
