### PR TITLE
[charts] De duplicate keyboard focus handler function

### DIFF
--- a/packages/x-charts/src/BarChart/seriesConfig/bar/keyboardFocusHandler.ts
+++ b/packages/x-charts/src/BarChart/seriesConfig/bar/keyboardFocusHandler.ts
@@ -1,4 +1,4 @@
-import { createKeyboardFocusHandler } from '../../../internals/createKeyboardFocusHandler';
+import { createCommonKeyboardFocusHandler } from '../../../internals/createCommonKeyboardFocusHandler';
 import type { KeyboardFocusHandler } from '../../../internals/plugins/featurePlugins/useChartKeyboardNavigation/keyboardFocusHandler.types';
 import {
   type ComposableCartesianChartSeriesType,
@@ -6,6 +6,6 @@ import {
 } from '../../../internals/commonNextFocusItem';
 
 const keyboardFocusHandler: KeyboardFocusHandler<'bar', ComposableCartesianChartSeriesType> =
-  createKeyboardFocusHandler(composableCartesianSeriesTypes);
+  createCommonKeyboardFocusHandler(composableCartesianSeriesTypes);
 
 export default keyboardFocusHandler;

--- a/packages/x-charts/src/LineChart/seriesConfig/keyboardFocusHandler.ts
+++ b/packages/x-charts/src/LineChart/seriesConfig/keyboardFocusHandler.ts
@@ -1,4 +1,4 @@
-import { createKeyboardFocusHandler } from '../../internals/createKeyboardFocusHandler';
+import { createCommonKeyboardFocusHandler } from '../../internals/createCommonKeyboardFocusHandler';
 import type { KeyboardFocusHandler } from '../../internals/plugins/featurePlugins/useChartKeyboardNavigation/keyboardFocusHandler.types';
 import {
   type ComposableCartesianChartSeriesType,
@@ -6,6 +6,6 @@ import {
 } from '../../internals/commonNextFocusItem';
 
 const keyboardFocusHandler: KeyboardFocusHandler<'line', ComposableCartesianChartSeriesType> =
-  createKeyboardFocusHandler(composableCartesianSeriesTypes);
+  createCommonKeyboardFocusHandler(composableCartesianSeriesTypes);
 
 export default keyboardFocusHandler;

--- a/packages/x-charts/src/PieChart/seriesConfig/keyboardFocusHandler.ts
+++ b/packages/x-charts/src/PieChart/seriesConfig/keyboardFocusHandler.ts
@@ -1,9 +1,9 @@
-import { createKeyboardFocusHandler } from '../../internals/createKeyboardFocusHandler';
+import { createCommonKeyboardFocusHandler } from '../../internals/createCommonKeyboardFocusHandler';
 import type { KeyboardFocusHandler } from '../../internals/plugins/featurePlugins/useChartKeyboardNavigation/keyboardFocusHandler.types';
 
 const outSeriesTypes: Set<'pie'> = new Set(['pie']);
 
 const keyboardFocusHandler: KeyboardFocusHandler<'pie', 'pie'> =
-  createKeyboardFocusHandler(outSeriesTypes);
+  createCommonKeyboardFocusHandler(outSeriesTypes);
 
 export default keyboardFocusHandler;

--- a/packages/x-charts/src/RadarChart/seriesConfig/keyboardFocusHandler.ts
+++ b/packages/x-charts/src/RadarChart/seriesConfig/keyboardFocusHandler.ts
@@ -1,11 +1,9 @@
-import { createKeyboardFocusHandler } from '../../internals/createKeyboardFocusHandler';
+import { createCommonKeyboardFocusHandler } from '../../internals/createCommonKeyboardFocusHandler';
 import type { KeyboardFocusHandler } from '../../internals/plugins/featurePlugins/useChartKeyboardNavigation/keyboardFocusHandler.types';
 
 const outSeriesTypes: Set<'radar'> = new Set(['radar']);
 
-const keyboardFocusHandler: KeyboardFocusHandler<'radar', 'radar'> = createKeyboardFocusHandler(
-  outSeriesTypes,
-  true,
-);
+const keyboardFocusHandler: KeyboardFocusHandler<'radar', 'radar'> =
+  createCommonKeyboardFocusHandler(outSeriesTypes, true);
 
 export default keyboardFocusHandler;

--- a/packages/x-charts/src/ScatterChart/seriesConfig/keyboardFocusHandler.ts
+++ b/packages/x-charts/src/ScatterChart/seriesConfig/keyboardFocusHandler.ts
@@ -1,4 +1,4 @@
-import { createKeyboardFocusHandler } from '../../internals/createKeyboardFocusHandler';
+import { createCommonKeyboardFocusHandler } from '../../internals/createCommonKeyboardFocusHandler';
 import type { KeyboardFocusHandler } from '../../internals/plugins/featurePlugins/useChartKeyboardNavigation/keyboardFocusHandler.types';
 import {
   type ComposableCartesianChartSeriesType,
@@ -6,6 +6,6 @@ import {
 } from '../../internals/commonNextFocusItem';
 
 const keyboardFocusHandler: KeyboardFocusHandler<'scatter', ComposableCartesianChartSeriesType> =
-  createKeyboardFocusHandler(composableCartesianSeriesTypes);
+  createCommonKeyboardFocusHandler(composableCartesianSeriesTypes);
 
 export default keyboardFocusHandler;

--- a/packages/x-charts/src/internals/createCommonKeyboardFocusHandler.ts
+++ b/packages/x-charts/src/internals/createCommonKeyboardFocusHandler.ts
@@ -6,10 +6,12 @@ import {
   createGetPreviousSeriesFocusedItem,
 } from './commonNextFocusItem';
 
-export function createKeyboardFocusHandler<TSeriesType extends Exclude<ChartSeriesType, 'sankey'>>(
-  outSeriesTypes: Set<TSeriesType>,
-  allowCycles?: boolean,
-) {
+/**
+ * Create a keyboard focus handler for common use cases where focused item are defined by the series is and data index.
+ */
+export function createCommonKeyboardFocusHandler<
+  TSeriesType extends Exclude<ChartSeriesType, 'sankey'>,
+>(outSeriesTypes: Set<TSeriesType>, allowCycles?: boolean) {
   const keyboardFocusHandler = (event: KeyboardEvent) => {
     switch (event.key) {
       case 'ArrowRight':


### PR DESCRIPTION
Goal of this PR is to De-duplicate keyboardFocusHandler from 5 different charts, Since exact same code is used in multiple places, i think we can safely create a util out of it and use it across charts. Additionally it also reduced bundle size of 89B. 

<img width="317" height="78" alt="image" src="https://github.com/user-attachments/assets/84aefd4f-e02c-4476-8ab7-af377497cfce" />


