### PR TITLE
[charts] Fix multiple exports of `HighlightScope`

### DIFF
--- a/packages/x-charts/src/context/index.ts
+++ b/packages/x-charts/src/context/index.ts
@@ -1,8 +1,8 @@
 export type {
-  HighlightScope,
   FadeOptions,
   HighlightItemData,
   HighlightOptions,
 } from '../internals/plugins/featurePlugins/useChartHighlight';
+export type { HighlightScope } from '../models/seriesType/config';
 export * from './useChartApiContext';
 export type { ChartApi } from './ChartApi';

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartHighlight/createIsFaded.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartHighlight/createIsFaded.ts
@@ -1,5 +1,4 @@
-import { type ChartSeriesType } from '../../../../models/seriesType/config';
-import { type HighlightScope } from './highlightConfig.types';
+import { type HighlightScope, type ChartSeriesType } from '../../../../models/seriesType/config';
 import { type HighlightItemData } from './useChartHighlight.types';
 
 function alwaysFalse(): boolean {

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartHighlight/createIsHighlighted.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartHighlight/createIsHighlighted.ts
@@ -1,5 +1,4 @@
-import { type ChartSeriesType } from '../../../../models/seriesType/config';
-import { type HighlightScope } from './highlightConfig.types';
+import { type ChartSeriesType, type HighlightScope } from '../../../../models/seriesType/config';
 import { type HighlightItemData } from './useChartHighlight.types';
 
 function alwaysFalse(): boolean {

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartHighlight/highlightConfig.types.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartHighlight/highlightConfig.types.ts
@@ -20,5 +20,3 @@ export type CommonHighlightScope = {
    */
   fade?: FadeOptions;
 };
-
-export type { HighlightScope } from '../../../../models/seriesType/config';

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartHighlight/useChartHighlight.selectors.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartHighlight/useChartHighlight.selectors.ts
@@ -1,9 +1,8 @@
 import { createSelector, createSelectorMemoized } from '@mui/x-internals/store';
 import { type SeriesId } from '../../../../models/seriesType/common';
-import { type ChartSeriesType } from '../../../../models/seriesType/config';
+import { type ChartSeriesType, type HighlightScope } from '../../../../models/seriesType/config';
 import { type ChartRootSelector } from '../../utils/selectors';
 import { type HighlightItemData, type UseChartHighlightSignature } from './useChartHighlight.types';
-import { type HighlightScope } from './highlightConfig.types';
 import { createIsHighlighted } from './createIsHighlighted';
 import { createIsFaded } from './createIsFaded';
 import {


### PR DESCRIPTION
[This commit](https://github.com/mui/mui-x/commit/2dd0028d3a4561fea60ac117920ebc8611b0bdb3) in master is failing due to this issue. 

```
/tmp/mui/packages/x-charts/src/internals/index.ts
  40:1  error  Multiple exports of name 'HighlightScope'  import/export
  89:1  error  Multiple exports of name 'HighlightScope'  import/export
```

Now we only import `HighlightScope` from `src/models/seriesType/config.ts`