### PR TITLE
[PoC][charts] Enable custom aria description

### DIFF
--- a/packages/x-charts/src/BarChart/seriesConfig/bar/getFocusedValues.ts
+++ b/packages/x-charts/src/BarChart/seriesConfig/bar/getFocusedValues.ts
@@ -1,0 +1,35 @@
+import type { FocusedValuesGetter } from '../../../internals/plugins/featurePlugins/useChartKeyboardNavigation/keyboardFocusValuesGetter.types';
+
+export const getFocusedValues: FocusedValuesGetter<'bar'> = (item, state) => {
+  const series = state.series.defaultizedSeries.bar?.series[item.seriesId];
+
+  const seriesLabel = typeof series?.label === 'function' ? series.label('legend') : series?.label;
+  const seriesValue = series?.data?.[item.dataIndex] ?? null;
+
+  if (series?.layout === 'horizontal') {
+    const axisId = series?.yAxisId;
+
+    const yAxis = state.cartesianAxis?.y.find((axis) => axis.id === axisId);
+    const axisLabel = yAxis?.label;
+    const axisValue = yAxis?.data?.[item.dataIndex!];
+
+    return {
+      axisLabel,
+      axisValue,
+      seriesLabel,
+      seriesValue,
+    };
+  }
+  const axisId = series?.xAxisId;
+
+  const xAxis = state.cartesianAxis?.x.find((axis) => axis.id === axisId);
+  const axisLabel = xAxis?.label;
+  const axisValue = xAxis?.data?.[item.dataIndex!];
+
+  return {
+    axisLabel,
+    axisValue,
+    seriesLabel,
+    seriesValue,
+  };
+};

--- a/packages/x-charts/src/BarChart/seriesConfig/index.ts
+++ b/packages/x-charts/src/BarChart/seriesConfig/index.ts
@@ -4,6 +4,7 @@ import seriesProcessor from './bar/seriesProcessor';
 import legendGetter from './bar/legend';
 import getColor from './bar/getColor';
 import keyboardFocusHandler from './bar/keyboardFocusHandler';
+import { getFocusedValues } from './bar/getFocusedValues';
 import tooltipGetter, { axisTooltipGetter } from './bar/tooltip';
 import tooltipItemPositionGetter from './bar/tooltipPosition';
 import { getSeriesWithDefaultValues } from './bar/getSeriesWithDefaultValues';
@@ -21,6 +22,7 @@ export const barSeriesConfig: ChartSeriesTypeConfig<'bar'> = {
   yExtremumGetter: getExtremumY,
   getSeriesWithDefaultValues,
   keyboardFocusHandler,
+  getFocusedValues,
   identifierSerializer: identifierSerializerSeriesIdDataIndex,
   identifierCleaner: identifierCleanerSeriesIdDataIndex,
 };

--- a/packages/x-charts/src/ChartDataProvider/ChartDataProvider.tsx
+++ b/packages/x-charts/src/ChartDataProvider/ChartDataProvider.tsx
@@ -18,6 +18,7 @@ import {
   ChartsLocalizationProvider,
   type ChartsLocalizationProviderProps,
 } from '../ChartsLocalizationProvider';
+import { ChartsVoiceover } from '../ChartsVoiceover';
 
 export interface ChartDataProviderSlots extends ChartsSlots {}
 
@@ -84,6 +85,7 @@ function ChartDataProvider<
           defaultSlots={defaultSlotsMaterial}
         >
           {children}
+          <ChartsVoiceover />
         </ChartsSlotsProvider>
       </ChartsLocalizationProvider>
     </ChartProvider>

--- a/packages/x-charts/src/ChartsVoiceover/ChartsVoiceover.tsx
+++ b/packages/x-charts/src/ChartsVoiceover/ChartsVoiceover.tsx
@@ -1,0 +1,21 @@
+'use client';
+import { useFocusedItem } from '../hooks/useFocusedItem';
+import { useChartContext } from '../context/ChartProvider';
+
+function ChartsVoiceover() {
+  const { instance } = useChartContext();
+
+  const focusedItem = useFocusedItem();
+
+  const focusedValues = instance?.getFocusedValues?.(focusedItem);
+
+  return (
+    <div>
+      {JSON.stringify(focusedItem)}
+      <br />
+      {JSON.stringify(focusedValues)}
+    </div>
+  );
+}
+
+export { ChartsVoiceover };

--- a/packages/x-charts/src/ChartsVoiceover/index.ts
+++ b/packages/x-charts/src/ChartsVoiceover/index.ts
@@ -1,0 +1,1 @@
+export * from './ChartsVoiceover';

--- a/packages/x-charts/src/index.ts
+++ b/packages/x-charts/src/index.ts
@@ -16,6 +16,7 @@ export * from './ChartsLabel';
 export * from './ChartsLegend';
 export * from './ChartsLocalizationProvider';
 export * from './ChartsAxisHighlight';
+export * from './ChartsVoiceover';
 export * from './BarChart';
 export * from './LineChart';
 export * from './PieChart';

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/seriesConfig.types.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/seriesConfig.types.ts
@@ -14,6 +14,7 @@ import { type GetSeriesWithDefaultValues } from './getSeriesWithDefaultValues.ty
 import { type TooltipItemPositionGetter } from './tooltipItemPositionGetter.types';
 import { type SeriesLayoutGetter } from './seriesLayout.types';
 import { type KeyboardFocusHandler } from '../../../featurePlugins/useChartKeyboardNavigation/keyboardFocusHandler.types';
+import { type FocusedValuesGetter } from '../../../featurePlugins/useChartKeyboardNavigation/keyboardFocusValuesGetter.types';
 import { type IdentifierSerializer } from './identifierSerializer.types';
 import { type IdentifierCleaner } from './identifierCleaner.types';
 import { type GetItemAtPosition } from './getItemAtPosition.types';
@@ -38,7 +39,8 @@ export type ChartSeriesTypeConfig<TSeriesType extends ChartSeriesType> = {
   tooltipGetter: TooltipGetter<TSeriesType>;
   tooltipItemPositionGetter?: TooltipItemPositionGetter<TSeriesType>;
   getSeriesWithDefaultValues: GetSeriesWithDefaultValues<TSeriesType>;
-  keyboardFocusHandler?: KeyboardFocusHandler<TSeriesType>;
+  keyboardFocusHandler: KeyboardFocusHandler<TSeriesType>;
+  getFocusedValues?: FocusedValuesGetter<TSeriesType>;
   /**
    * A function to serialize the series item identifier into a unique string.
    * @param {SeriesItemIdentifier<TSeriesType>} identifier The series item identifier.

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/keyboardFocusValuesGetter.types.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/keyboardFocusValuesGetter.types.ts
@@ -1,0 +1,22 @@
+import type {
+  CartesianChartSeriesType,
+  ChartSeriesType,
+} from '../../../../models/seriesType/config';
+import type { FocusedItemIdentifier, FocusedItemValues } from '../../../../models/seriesType';
+import type { UseChartKeyboardNavigationSignature } from './useChartKeyboardNavigation.types';
+import type { ChartState } from '../../models/chart';
+import type { UseChartCartesianAxisSignature } from '../useChartCartesianAxis';
+
+export type FocusedValuesGetter<TSeriesType extends ChartSeriesType> = (
+  currentItem: FocusedItemIdentifier<TSeriesType>,
+  state: TSeriesType extends CartesianChartSeriesType
+    ? Pick<
+        ChartState<
+          [UseChartKeyboardNavigationSignature],
+          [UseChartCartesianAxisSignature],
+          TSeriesType
+        >,
+        'series' | 'cartesianAxis'
+      >
+    : Pick<ChartState<[UseChartKeyboardNavigationSignature], [], TSeriesType>, 'series'>,
+) => FocusedItemValues<TSeriesType>;

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.ts
@@ -8,6 +8,7 @@ import type { ChartPlugin } from '../../models';
 import type { UseChartKeyboardNavigationSignature } from './useChartKeyboardNavigation.types';
 import type { ChartSeriesType } from '../../../../models/seriesType/config';
 import type { FocusedItemUpdater } from './keyboardFocusHandler.types';
+import type { FocusedItemIdentifier } from '../../../../models';
 
 export const useChartKeyboardNavigation: ChartPlugin<UseChartKeyboardNavigationSignature> = ({
   params,
@@ -94,7 +95,20 @@ export const useChartKeyboardNavigation: ChartPlugin<UseChartKeyboardNavigationS
     }
   }, [store, params.enableKeyboardNavigation]);
 
-  return {};
+  const getFocusedValues = useEventCallback(
+    <SeriesType extends ChartSeriesType>(itemParams?: FocusedItemIdentifier<SeriesType>) => {
+      const item = itemParams;
+
+      if (item == null) {
+        return null;
+      }
+
+      const seriesConfig = selectorChartSeriesConfig(store.state);
+
+      return seriesConfig[item.type].getFocusedValues?.(item, store.state) ?? null;
+    },
+  );
+  return { instance: { getFocusedValues } };
 };
 
 useChartKeyboardNavigation.getInitialState = (params) => ({

--- a/packages/x-charts/src/models/seriesType/index.ts
+++ b/packages/x-charts/src/models/seriesType/index.ts
@@ -27,6 +27,29 @@ export type FocusedItemIdentifier<T extends ChartSeriesType = ChartSeriesType> =
     ? DefaultizedProps<ChartsSeriesConfig[T]['itemIdentifier'], 'xIndex' | 'yIndex'>
     : ChartsSeriesConfig[T]['itemIdentifier'];
 
+export type FocusedItemValues<T extends ChartSeriesType = ChartSeriesType> = T extends
+  | 'line'
+  | 'bar'
+  | 'radar'
+  ? {
+      axisLabel?: string;
+      axisValue?: { toString(): string };
+      seriesLabel?: string;
+      seriesValue?: ChartsSeriesConfig[T]['valueType'];
+    }
+  : T extends 'scatter'
+    ? {
+        xLabel?: string;
+        xValue?: ChartsSeriesConfig['scatter']['valueType']['x'];
+        yLabel?: string;
+        yValue?: ChartsSeriesConfig['scatter']['valueType']['y'];
+        zLabel?: string;
+        zValue?: ChartsSeriesConfig['scatter']['valueType']['z'];
+        seriesLabel?: string;
+        seriesValue?: { toString(): string };
+      }
+    : null;
+
 export { type SeriesId } from './common';
 export type { CartesianChartSeriesType, StackableChartSeriesType } from './config';
 export * from './line';


### PR DESCRIPTION
This is a MVP for arial label generation

To let user create their own voiceover description, they need to get the data and labels.

Each charts is different. 

- bar, line, and radar need:  series + 1 axis: `` `${series.label} is ${series.value} in ${axis.value}` ``
- scatter needs: series + 2 or 3 axes `` `${series.value.x} ${xAxis.label} for ${series.vlue.y} ${yAxis.label}` ``
- sankey: is fully custom ``type==='link' `${value} from ${source.label} to ${target.label}` : `${label}` ``

This PR is just to discuss how do we get the data. A similar problem occurs for the item tooltip. For now, we solved it by adding edge-cases handler, and for series too specific create a dedicated hook.