### PR TITLE
[DataGridPro] Fix number input visibility in header filters

### DIFF
--- a/packages/x-data-grid-pro/src/components/headerFiltering/GridHeaderFilterCell.tsx
+++ b/packages/x-data-grid-pro/src/components/headerFiltering/GridHeaderFilterCell.tsx
@@ -80,7 +80,7 @@ const StyledInputComponent = styled(GridFilterInputValue, {
   flex: 1,
   marginRight: vars.spacing(0.5),
   marginBottom: vars.spacing(-0.25),
-  '& input[type="number"], & input[type="date"], & input[type="datetime-local"]': {
+  '& input[type="date"], & input[type="datetime-local"]': {
     '&[value=""]:not(:focus)': {
       color: 'transparent',
     },


### PR DESCRIPTION
This PR fixes a bug where the value in a number-type header filter would become invisible when the input lost focus without being blurred (e.g., clicking outside the grid or switching tabs).

Fixes #20477
- After: https://stackblitz.com/edit/tdpuogwf-xej3pquq