### PR TITLE
[docs] Show premium in the overview

### DIFF
--- a/docs/src/modules/components/overview/charts/ChartsCommunityOrPro.tsx
+++ b/docs/src/modules/components/overview/charts/ChartsCommunityOrPro.tsx
@@ -19,7 +19,7 @@ export default function ChartsCommunityOrPro() {
           caption={'Community, Pro and Premium'}
           title={'Three packages for every growing need'}
           description={
-            "Start with the free-forever Community version, then upgrade to Pro or Premium as your needs grow."
+            'Start with the free-forever Community version, then upgrade to Pro or Premium as your needs grow.'
           }
           communityDescription={
             'Free forever under an MIT license. Includes core chart types and building blocks like axes, legends, theming, tooltips, and highlights.'


### PR DESCRIPTION
Add premium card to the overview plans: https://deploy-preview-21343--material-ui-x.netlify.app/x/react-charts/

## Before/after

<img width="981" height="373" alt="image" src="https://github.com/user-attachments/assets/e68327c8-db28-4551-8a1e-30eebd90aa20" />

<img width="981" height="373" alt="image" src="https://github.com/user-attachments/assets/f5a31dce-1dfa-48ae-a1a1-80e055555e11" />
