### PR TITLE
fix(data-grid): inherit icon fontSize from baseIconButton size

### DIFF
--- a/packages/x-data-grid/src/components/cell/GridActionsCellItem.tsx
+++ b/packages/x-data-grid/src/components/cell/GridActionsCellItem.tsx
@@ -38,6 +38,9 @@ const GridActionsCellItem = forwardRef<HTMLElement, GridActionsCellItemProps>((p
       onClick?.(event);
     };
 
+    const iconButtonSize =
+      (other as any).size ?? (rootProps.slotProps?.baseIconButton as any)?.size ?? 'small';
+
     return (
       <rootProps.slots.baseIconButton
         size="small"
@@ -48,7 +51,7 @@ const GridActionsCellItem = forwardRef<HTMLElement, GridActionsCellItemProps>((p
         {...rootProps.slotProps?.baseIconButton}
         ref={ref as React.RefObject<HTMLButtonElement>}
       >
-        {React.cloneElement(icon!, { fontSize: 'small' })}
+        {React.cloneElement(icon!, { fontSize: iconButtonSize })}
       </rootProps.slots.baseIconButton>
     );
   }


### PR DESCRIPTION
## Problem

The `GridActionsCellItem` component hardcodes `fontSize: 'small'` on the icon, making it impossible to customize the icon size through props or `slotProps.baseIconButton`.

## Solution

The icon's `fontSize` is now derived from the resolved button size, checking (in order):
1. Direct `size` prop on the component
2. `slotProps.baseIconButton.size`
3. Fallback to `'small'` (preserving current default behavior)

This means if you override the button size to `'medium'` or `'large'`, the icon scales accordingly.

Fixes #12900