### PR TITLE
[l10n] Fix Czech (csCZ) locale: sort/filter labels are swapped

### DIFF
--- a/packages/x-data-grid/src/locales/csCZ.ts
+++ b/packages/x-data-grid/src/locales/csCZ.ts
@@ -138,7 +138,7 @@ const csCZGrid: Partial<GridLocaleText> = {
   columnMenuManageColumns: 'Spravovat sloupce',
   columnMenuFilter: 'Filtr',
   columnMenuHideColumn: 'Skrýt',
-  columnMenuUnsort: 'Zrušit filtry',
+  columnMenuUnsort: 'Zrušit řazení',
   columnMenuSortAsc: 'Seřadit vzestupně',
   columnMenuSortDesc: 'Seřadit sestupně',
   // columnMenuManagePivot: 'Manage pivot',
@@ -155,7 +155,7 @@ const csCZGrid: Partial<GridLocaleText> = {
     return `${count} ${pluralForm}`;
   },
   columnHeaderFiltersLabel: 'Zobrazit filtry',
-  columnHeaderSortIconLabel: 'Filtrovat',
+  columnHeaderSortIconLabel: 'Řadit',
 
   // Rows selected footer text
   footerRowSelected: (count) => {


### PR DESCRIPTION
Two translation errors in the Czech (csCZ) locale where sort and filter labels are swapped: KeyCurrent (wrong)FixedcolumnHeaderSortIconLabel'Filtrovat' (= Filter)'Řadit' (= Sort)columnMenuUnsort'Zrušit filtry' (= Clear filters)'Zrušit řazení' (= Clear sorting) Other sort-related keys (columnMenuSortAsc: 'Seřadit vzestupně', columnMenuSortDesc: 'Seřadit sestupně') are correct, confirming this is a typo.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
