### PR TITLE
[DataGrid] Forward rest props in `GridFilterInputMultipleValue`

### DIFF
--- a/packages/x-data-grid/src/components/panel/filterPanel/GridFilterInputMultipleValue.tsx
+++ b/packages/x-data-grid/src/components/panel/filterPanel/GridFilterInputMultipleValue.tsx
@@ -13,7 +13,7 @@ export type GridFilterInputMultipleValueProps = GridFilterInputValueProps<
 };
 
 function GridFilterInputMultipleValue(props: GridFilterInputMultipleValueProps) {
-  const { item, applyValue, type, apiRef, focusElementRef, slotProps } = props;
+  const { item, applyValue, type, apiRef, focusElementRef, slotProps, ...other } = props;
 
   const id = useId();
   const [options, setOptions] = React.useState<string[]>([]);
@@ -76,6 +76,7 @@ function GridFilterInputMultipleValue(props: GridFilterInputMultipleValueProps) 
           inputRef: focusElementRef,
         },
       }}
+      {...other}
       {...slotProps?.root}
     />
   );


### PR DESCRIPTION
**Before**: https://stackblitz.com/edit/bk25mkwc?file=src%2FDemo.tsx
**After**: https://stackblitz.com/edit/57ute3zt?file=src%2FDemo.tsx

## Summary

- Forward `...other` rest props to `BaseAutocomplete` in `GridFilterInputMultipleValue`, matching the existing pattern in `GridFilterInputMultipleSingleSelect`

Fixes #21404

## Context

Both components were created together in #2874 with `...other` forwarded to Autocomplete. During the slotProps refactor in #16174, `...other` was accidentally dropped from `GridFilterInputMultipleValue` while kept in `GridFilterInputMultipleSingleSelect`.

This one-line fix restores the `...other` spread, making both components behave consistently again.