### PR TITLE
[docs-infra] Fix current version detection logic

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -245,26 +245,29 @@ function AppWrapper(props) {
   const pageContextValue = React.useMemo(() => {
     const { activePage, activePageParents } = findActivePage(pages, router.pathname);
     const languagePrefix = pageProps.userLanguage === 'en' ? '' : `/${pageProps.userLanguage}`;
-    const productIdSubpathMap = {
-      introduction: '/x/introduction',
-      'x-data-grid': '/x/react-data-grid',
-      'x-date-pickers': '/x/react-date-pickers',
-      'x-charts': '/x/react-charts',
-      'x-tree-view': '/x/react-tree-view',
+    const productIdMap = {
+      introduction: { subpath: '/x/introduction', version: process.env.LIB_VERSION },
+      'x-data-grid': { subpath: '/x/react-data-grid', version: process.env.DATA_GRID_VERSION },
+      'x-date-pickers': {
+        subpath: '/x/react-date-pickers',
+        version: process.env.DATE_PICKERS_VERSION,
+      },
+      'x-charts': { subpath: '/x/react-charts', version: process.env.CHARTS_VERSION },
+      'x-tree-view': { subpath: '/x/react-tree-view', version: process.env.TREE_VIEW_VERSION },
     };
 
     const getVersionOptions = (id, versions) =>
       versions.map((version) => {
-        if (version === process.env.LIB_VERSION) {
+        if (version === productIdMap[id].version) {
           return {
             current: true,
             text: `v${version}`,
-            href: `${languagePrefix}${productIdSubpathMap[id]}/`,
+            href: `${languagePrefix}${productIdMap[id].subpath}/`,
           };
         }
         return {
           text: version,
-          href: `https://${version}.mui.com${languagePrefix}${productIdSubpathMap[id]}/`,
+          href: `https://${version}.mui.com${languagePrefix}${productIdMap[id].subpath}/`,
         };
       });
 


### PR DESCRIPTION
Currently, `LIB_VERSION` is used to establish current version for each product.
But if the package version bump is skipped, and package version doesn't match root package.json anymore – it doesn't work as expected.
This happened with our latest release (8.27.2), where x-data-grid version stays at 8.27.1, and x-charts version stays at 8.27.0:
- Introduction: https://699848452f0dbb000893f434--material-ui-x.netlify.app/x/introduction/
  ✅ Correctly shows 8.27.2 in version selector
- Pickers: https://699848452f0dbb000893f434--material-ui-x.netlify.app/x/react-date-pickers/
  ✅ Correctly shows 8.27.2 in version selector
- Data Grid: https://699848452f0dbb000893f434--material-ui-x.netlify.app/x/react-data-grid/
  ❌ Incorrectly shows `next` as current version
- Charts: https://699848452f0dbb000893f434--material-ui-x.netlify.app/x/react-charts/
  ❌ Incorrectly shows `next` as current version
  
Preview: https://deploy-preview-21415--material-ui-x.netlify.app/x/introduction/