### PR TITLE
[scheduler] Fix horizontal scrolling on Event Timeline Premium

### DIFF
--- a/packages/x-scheduler-premium/src/event-timeline-premium/content/EventTimelinePremiumContent.tsx
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/content/EventTimelinePremiumContent.tsx
@@ -38,7 +38,7 @@ const EventTimelinePremiumGrid = styled(TimelineGrid.Root, {
 })({
   height: '100%',
   display: 'grid',
-  gridTemplateColumns: 'minmax(100px, auto) 1fr',
+  gridTemplateColumns: 'minmax(100px, auto) minmax(0, 1fr)',
   gridTemplateRows: 'auto repeat(var(--row-count, 0), auto) minmax(auto, 1fr)',
   alignItems: 'stretch',
 });


### PR DESCRIPTION
**What was happening:** The grid layout uses two columns — a title column and a content column. The content column was defined as 1fr, which in CSS Grid is shorthand for minmax(auto, 1fr). The auto minimum means the track expands to fit the content's intrinsic width (the wide timeline headers). This caused the entire grid to overflow its container. Since the EventsSubGridWrapper (which has overflowX: auto) ended up being as wide as its content, no scrollbar was triggered. The root element's overflow: hidden then simply clipped the excess — making horizontal scroll impossible.

**What the fix does:** Changing to minmax(0, 1fr) sets the column minimum to 0 instead of auto, so the column is constrained to the available space. The timeline content now properly overflows inside the EventsSubGridWrapper, which triggers the horizontal scrollbar as intended.

All 988 existing tests continue to pass.