### PR TITLE
[DataGrid] typing for DataGrid columns' `field`

### DIFF
--- a/packages/x-data-grid/src/models/colDef/gridColDef.ts
+++ b/packages/x-data-grid/src/models/colDef/gridColDef.ts
@@ -84,7 +84,7 @@ export interface GridBaseColDef<R extends GridValidRowModel = GridValidRowModel,
   /**
    * The unique identifier of the column. Used to map with [[GridRowModel]] values.
    */
-  field: string;
+  field: keyof R | (string & {});
   /**
    * The title displayed in the column header cell.
    */


### PR DESCRIPTION
Provide strong typing for DataGrid columns' `field` with key of data model in rows and optional `string` type

<img width="764" height="437" alt="image" src="https://github.com/user-attachments/assets/df4647ff-ee15-4d34-9e37-31191909b1c2" />

Related to #18909