### PR TITLE
[data-grid] Refactor GridScrollAreaRawRoot's overridesResolver to use elementOverrides

### DIFF
--- a/packages/x-data-grid/src/components/GridScrollArea.tsx
+++ b/packages/x-data-grid/src/components/GridScrollArea.tsx
@@ -45,16 +45,24 @@ const useUtilityClasses = (ownerState: OwnerState) => {
   return composeClasses(slots, getDataGridUtilityClass, classes);
 };
 
+const elementOverrides = [
+  'scrollArea--left',
+  'scrollArea--right',
+  'scrollArea--up',
+  'scrollArea--down',
+] as const;
+
 const GridScrollAreaRawRoot = styled('div', {
   name: 'MuiDataGrid',
   slot: 'ScrollArea',
-  overridesResolver: (props, styles) => [
-    { [`&.${gridClasses['scrollArea--left']}`]: styles['scrollArea--left'] },
-    { [`&.${gridClasses['scrollArea--right']}`]: styles['scrollArea--right'] },
-    { [`&.${gridClasses['scrollArea--up']}`]: styles['scrollArea--up'] },
-    { [`&.${gridClasses['scrollArea--down']}`]: styles['scrollArea--down'] },
-    styles.scrollArea,
-  ],
+  overridesResolver: (props, styles) => {
+    const overrides = [styles.scrollArea];
+    elementOverrides.forEach((key) => {
+      overrides.push({ [`&.${gridClasses[key]}`]: styles[key] });
+    });
+
+    return overrides;
+  },
 })<{ ownerState: OwnerState }>(() => ({
   position: 'absolute',
   zIndex: 101,


### PR DESCRIPTION


<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
