### PR TITLE
[data grid] Add missing palette augmentation to x-data-grid-pro and x-data-grid-premium themeAugmentation

### DIFF
--- a/packages/x-data-grid-premium/src/themeAugmentation/overrides.ts
+++ b/packages/x-data-grid-premium/src/themeAugmentation/overrides.ts
@@ -6,4 +6,18 @@ export interface DataGridPremiumComponentNameToClassKey {
 
 declare module '@mui/material/styles' {
   interface ComponentNameToClassKey extends DataGridPremiumComponentNameToClassKey {}
+
+  interface PaletteDataGrid {
+    bg?: string;
+    headerBg?: string;
+    pinnedBg?: string;
+  }
+
+  interface CssVarsPalette {
+    DataGrid: PaletteDataGrid;
+  }
+
+  interface PaletteOptions {
+    DataGrid?: Partial<PaletteDataGrid>;
+  }
 }

--- a/packages/x-data-grid-pro/src/themeAugmentation/overrides.ts
+++ b/packages/x-data-grid-pro/src/themeAugmentation/overrides.ts
@@ -6,4 +6,18 @@ export interface DataGridProComponentNameToClassKey {
 
 declare module '@mui/material/styles' {
   interface ComponentNameToClassKey extends DataGridProComponentNameToClassKey {}
+
+  interface PaletteDataGrid {
+    bg?: string;
+    headerBg?: string;
+    pinnedBg?: string;
+  }
+
+  interface CssVarsPalette {
+    DataGrid: PaletteDataGrid;
+  }
+
+  interface PaletteOptions {
+    DataGrid?: Partial<PaletteDataGrid>;
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #15224

## Problem

The `@mui/x-data-grid` package correctly augments the `@mui/material/styles` module with palette interfaces for CSS variables theme support:

```typescript
interface PaletteDataGrid {
  bg?: string;
  headerBg?: string;
  pinnedBg?: string;
}

interface CssVarsPalette {
  DataGrid: PaletteDataGrid;
}

interface PaletteOptions {
  DataGrid?: Partial<PaletteDataGrid>;
}
```

However, `@mui/x-data-grid-pro` and `@mui/x-data-grid-premium` were **missing these palette augmentations**.

This caused TypeScript users who import `@mui/x-data-grid-pro/themeAugmentation` or `@mui/x-data-grid-premium/themeAugmentation` to lose palette type support that the base `@mui/x-data-grid/themeAugmentation` provided.

## Fix

Added the same `PaletteDataGrid`, `CssVarsPalette`, and `PaletteOptions` interface augmentations to:
- `packages/x-data-grid-pro/src/themeAugmentation/overrides.ts`
- `packages/x-data-grid-premium/src/themeAugmentation/overrides.ts`

This ensures consistent TypeScript theme augmentation behavior across all three DataGrid packages.