### PR TITLE
[data-grid] Fix pinned cells becoming transparent on row hover in older WebKit

### DIFF
--- a/packages/x-data-grid/src/components/containers/GridRootStyles.ts
+++ b/packages/x-data-grid/src/components/containers/GridRootStyles.ts
@@ -227,12 +227,7 @@ export const GridRootStyles = styled('div', {
     [`& .${c['cell--pinnedLeft']}, & .${c['cell--pinnedRight']}`]: {
       backgroundColor,
       '&.Mui-selected': {
-        backgroundColor: mix(
-          backgroundColor,
-          selectedBackground,
-          selectedOpacity,
-          backgroundColor,
-        ),
+        backgroundColor: mix(backgroundColor, selectedBackground, selectedOpacity, backgroundColor),
         '&:hover': {
           backgroundColor: mix(
             backgroundColor,

--- a/packages/x-data-grid/src/components/containers/GridRootStyles.ts
+++ b/packages/x-data-grid/src/components/containers/GridRootStyles.ts
@@ -186,6 +186,11 @@ export const GridRootStyles = styled('div', {
     hover: vars.colors.interactive.hover,
     selected: selectedColor,
     selectedHover: selectedColor,
+    // For pinned cells: fall back to the solid pinned background so older WebKit
+    // (no color-mix support) doesn't render them as transparent on hover (see #18273).
+    pinnedHover: pinnedBackground,
+    pinnedSelected: pinnedBackground,
+    pinnedSelectedHover: pinnedBackground,
   };
 
   const hoverBackground = mix(baseBackground, hoverColor, hoverOpacity, fallbackColors.hover);
@@ -206,21 +211,19 @@ export const GridRootStyles = styled('div', {
     pinnedBackground,
     hoverColor,
     hoverOpacity,
-    // Fall back to the solid pinned background so older WebKit (no color-mix support)
-    // doesn't render pinned cells as transparent on row hover (see #18273).
-    pinnedBackground,
+    fallbackColors.pinnedHover,
   );
   const pinnedSelectedBackground = mix(
     pinnedBackground,
     selectedColor,
     selectedOpacity,
-    pinnedBackground,
+    fallbackColors.pinnedSelected,
   );
   const pinnedSelectedHoverBackground = mix(
     pinnedBackground,
     selectedHoverColor,
     selectedHoverOpacity,
-    pinnedBackground,
+    fallbackColors.pinnedSelectedHover,
   );
 
   const getPinnedBackgroundStyles = (backgroundColor: string) => ({

--- a/packages/x-data-grid/src/components/containers/GridRootStyles.ts
+++ b/packages/x-data-grid/src/components/containers/GridRootStyles.ts
@@ -206,19 +206,21 @@ export const GridRootStyles = styled('div', {
     pinnedBackground,
     hoverColor,
     hoverOpacity,
-    fallbackColors.hover,
+    // Fall back to the solid pinned background so older WebKit (no color-mix support)
+    // doesn't render pinned cells as transparent on row hover (see #18273).
+    pinnedBackground,
   );
   const pinnedSelectedBackground = mix(
     pinnedBackground,
     selectedColor,
     selectedOpacity,
-    fallbackColors.selected,
+    pinnedBackground,
   );
   const pinnedSelectedHoverBackground = mix(
     pinnedBackground,
     selectedHoverColor,
     selectedHoverOpacity,
-    fallbackColors.selectedHover,
+    pinnedBackground,
   );
 
   const getPinnedBackgroundStyles = (backgroundColor: string) => ({
@@ -229,14 +231,14 @@ export const GridRootStyles = styled('div', {
           backgroundColor,
           selectedBackground,
           selectedOpacity,
-          fallbackColors.selected,
+          backgroundColor,
         ),
         '&:hover': {
           backgroundColor: mix(
             backgroundColor,
             selectedHoverBackground,
             selectedHoverOpacity,
-            fallbackColors.selectedHover,
+            backgroundColor,
           ),
         },
       },


### PR DESCRIPTION
Fixes #18273

## Problem

In older WebKit-based browsers (e.g. Safari 17.6) that don't support `color-mix()`, the pinned cell background colors are computed with a nearly-transparent fallback (the raw hover/selected overlay color). When a row is hovered, this overwrites the pinned cell's solid `background`, making pinned columns visually transparent and letting the row behind them bleed through.

## Fix

Change the fallback values for `pinnedHoverBackground`, `pinnedSelectedBackground`, and `pinnedSelectedHoverBackground` from the overlay colors to `pinnedBackground` itself. In browsers that don't support `color-mix()`, pinned cells will keep their solid background during hover/selection — no blending effect, but no transparency either.

The existing `mix()` function already handles the `color-mix()` support check; only the fallback string needed updating.