### PR TITLE
[data-grid-pro] Add regression tests for onRowSelectionModelChange reason in lazy loading mode

### DIFF
--- a/packages/x-data-grid-pro/src/tests/rowSelection.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/rowSelection.DataGridPro.test.tsx
@@ -3,6 +3,7 @@ import { spy } from 'sinon';
 import { type RefObject } from '@mui/x-internals/types';
 import {
   getCell,
+  getColumnHeaderCell,
   getColumnValues,
   getRows,
   includeRowSelection,
@@ -1378,6 +1379,49 @@ describe('<DataGridPro /> - Row selection', () => {
         type: 'exclude',
         ids: new Set(),
       });
+    });
+  });
+
+  describe('lazy loading: onRowSelectionModelChange reason', () => {
+    function TestLazyLoadingSelection(props: Partial<DataGridProProps>) {
+      return (
+        <div style={{ width: 300, height: 300 }}>
+          <DataGridPro
+            columns={[{ field: 'id' }, { field: 'name' }]}
+            rows={[
+              { id: 1, name: 'Alice' },
+              { id: 2, name: 'Bob' },
+              { id: 3, name: 'Charlie' },
+            ]}
+            rowCount={3}
+            rowsLoadingMode="server"
+            paginationMode="server"
+            sortingMode="server"
+            filterMode="server"
+            checkboxSelection
+            disableVirtualization
+            {...props}
+          />
+        </div>
+      );
+    }
+
+    it('should pass reason="singleRowSelection" when a row checkbox is clicked (lazy loading)', async () => {
+      const onRowSelectionModelChange = spy();
+      const { user } = render(
+        <TestLazyLoadingSelection onRowSelectionModelChange={onRowSelectionModelChange} />,
+      );
+      await user.click(getCell(0, 0).querySelector('input')!);
+      expect(onRowSelectionModelChange.lastCall.args[1].reason).to.equal('singleRowSelection');
+    });
+
+    it('should pass reason="multipleRowsSelection" when the "Select all" header checkbox is clicked (lazy loading)', async () => {
+      const onRowSelectionModelChange = spy();
+      const { user } = render(
+        <TestLazyLoadingSelection onRowSelectionModelChange={onRowSelectionModelChange} />,
+      );
+      await user.click(getColumnHeaderCell(0).querySelector('input')!);
+      expect(onRowSelectionModelChange.lastCall.args[1].reason).to.equal('multipleRowsSelection');
     });
   });
 });


### PR DESCRIPTION
Closes #18443

## Problem

When lazy loading is applied (`rowsLoadingMode='server'`), `onRowSelectionModelChange` was not receiving a `reason` parameter for:
- Clicking an individual row checkbox (`reason` should be `'singleRowSelection'`)
- Clicking the "Select All" header checkbox (`reason` should be `'multipleRowsSelection'`)

The root cause was that `setRowSelectionModel` calls in user-interaction paths were missing the `reason` argument. This has since been fixed in the selection hooks, but there were no regression tests specifically covering the lazy loading scenario.

## Fix

Add two test cases to `rowSelection.DataGridPro.test.tsx` that verify the `reason` is correctly passed via `onRowSelectionModelChange` when `rowsLoadingMode='server'` is applied:

1. **Single row checkbox click** → `reason: 'singleRowSelection'`
2. **"Select all" header checkbox click** → `reason: 'multipleRowsSelection'`

These tests prevent future regressions of the issue specifically in lazy loading mode.