### PR TITLE
[code-infra] Only run charts test if only charts file are impacted

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ jobs:
 
             if [[ -z "$NON_CHARTS_FILES" ]]; then
               echo "Only charts-related files changed. Filtering browser tests to x-charts* projects."
-              echo 'export BROWSER_TEST_PROJECT_FILTER="--project \"x-charts*\""' >> "$BASH_ENV"
+              echo 'export BROWSER_TEST_PROJECT_FILTER=" ./packages/x-charts*"' >> "$BASH_ENV"
             else
               echo "Non-charts files changed. Running all browser tests."
             fi


### PR DESCRIPTION
The PR compare the branch state with its common ancestor with master branche.

If modified files are only in 

- `packages/x-charts*`: the charts packages
- `docs`: should never break test, plus it's full of auto-generated files
- `scripts/x-charts*`: to catch when we export new components/types

The the test-browser should run with `--project \"x-charts*"`

It should reduce the CI time for charts PR (can be extended to other packages)

It should not impact tests on the master branch because by definition, there is no change between master and master :)


- Tests without filtering: 20min https://app.circleci.com/pipelines/github/mui/mui-x/120198/workflows/e4dbfeb5-322f-4315-abf0-26659d2a87ca/jobs/758816
- Tests with filtering: 3min https://app.circleci.com/pipelines/github/mui/mui-x/120284/workflows/9aeeb194-cde7-4998-a6c1-e837c5abf8f3/jobs/759444