### PR TITLE
[docs] Improve CLAUDE.md with actionable project context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,28 @@
-# Project guidelines
+# MUI X
 
-Refer to @AGENTS.md
+Advanced React component monorepo: Data Grid, Charts, Date Pickers, Tree View, Scheduler.
+
+Commands for linting, testing, typechecking, and docs: @AGENTS.md
+
+## Open-core model
+
+Community (MIT) → Pro → Premium tiers. Each product follows: `x-<product>` → `x-<product>-pro` → `x-<product>-premium`. Pro/Premium packages re-export and extend community. All pro/premium packages depend on `x-license`.
+
+When adding features, place code in the correct tier package. Community features go in base package; gated features go in pro/premium.
+
+## Key gotchas
+
+- **Docs demos**: only edit `.tsx` files. Run `pnpm docs:typescript:formatted` to regenerate `.js` files. NEVER edit `.js` demo files directly.
+- **After editing component props/types in `packages/`**: run `pnpm proptypes && pnpm docs:api`
+- **After editing code in `packages/x-charts*`**: run `pnpm generate:exports`
+- **Tests use Chai assertions** (not Jest-style): `expect(x).to.equal(y)`, NOT `expect(x).toBe(y)`. Mocking uses Sinon (`spy()`, `stub()`).
+- **Test rendering**: use `createRenderer()` from `@mui/internal-test-utils`, NOT `@testing-library/react` directly.
+- **Test helpers**: `getCell()`, `getRow()`, `getColumnHeaderCell()` etc. are in `test/utils/helperFn.ts`
+- **Environment skip**: `it.skipIf(isJSDOM)` / `it.skipIf(!isJSDOM)` from `test/utils/skipIf`
+- **Date pickers tests**: use `createPickerRenderer()` instead of `createRenderer()`
+- **Markdown demo syntax**: `{{"demo": "DemoName.js"}}` — admonitions: `:::info`, `:::warning`, `:::success`
+- **Codemods**: place in target version directory (e.g., `v9.0.0/`), check `x-codemod/src/util` for helpers
+
+## Shared infrastructure
+
+`x-internals` — shared utilities used by all products. `x-virtualizer` — virtualization. `x-charts-vendor` — vendored D3 deps.


### PR DESCRIPTION
## Summary

Rewrites CLAUDE.md from a 3-line placeholder (`Refer to @AGENTS.md`) into a concise, high-signal guide (~28 lines) for AI coding agents working in this monorepo.

## Process

The file was created using a systematic multi-agent exploration approach:

1. **Launched 6 parallel exploration agents** to research different aspects of the codebase:
   - **Project structure** — packages, build system (code-infra), monorepo tooling (pnpm workspaces + Lerna)
   - **Coding conventions** — component patterns (forwardRef, fastMemo, slots/slotProps, ownerState), state management (centralized store + selectors)
   - **Docs & demos** — Next.js site, demo file conventions (.tsx source → .js generated), markdown syntax
   - **Test patterns** — Vitest + Chai + Sinon stack, createRenderer, co-located tests, helpers
   - **Existing CLAUDE/AGENTS files** — current instructions, CONTRIBUTING.md
   - **Package relationships** — community→pro→premium tiers, x-license gating, dependency chains

2. **Synthesized findings into a first draft** (~94 lines) covering architecture, testing, docs, and code generation.

3. **Applied the `maintain-claude-md` skill guidelines** to ruthlessly trim:
   - Removed architecture patterns section — discoverable from source code
   - Removed test code examples — learnable from existing tests
   - Removed package hierarchy diagram — verbose, discoverable from package.json
   - Removed code generation table — duplicated AGENTS.md content
   - Consolidated all non-obvious gotchas into a single high-density list

4. **Final result: 28 lines** where every line answers: *"Would removing this cause an AI agent to make a mistake?"*

## What's included

- **Open-core model** — tier placement guidance (critical for knowing where to put new code)
- **Key gotchas** — Chai assertions (not Jest), createRenderer (not @testing-library), .tsx-only demo editing, required codegen commands
- **Shared infrastructure** — brief note on x-internals, x-virtualizer, x-charts-vendor
- **`@AGENTS.md` reference** — avoids duplicating command-level instructions