### PR TITLE
[x-license] merge `@mui/x-telemetry` into `@mui/x-license`

### DIFF
--- a/docs/data/charts/bars/BarScatterCompostion.js
+++ b/docs/data/charts/bars/BarScatterCompostion.js
@@ -5,7 +5,7 @@ import { ScatterPlot } from '@mui/x-charts/ScatterChart';
 import { ChartsXAxis } from '@mui/x-charts/ChartsXAxis';
 import { ChartsYAxis } from '@mui/x-charts/ChartsYAxis';
 import { ChartsGrid } from '@mui/x-charts/ChartsGrid';
-import { ChartDataProvider } from '@mui/x-charts/ChartDataProvider';
+import { ChartsDataProvider } from '@mui/x-charts/ChartsDataProvider';
 import { ChartsSurface } from '@mui/x-charts/ChartsSurface';
 import { ChartsTooltip } from '@mui/x-charts/ChartsTooltip';
 import { legendClasses, ChartsLegend } from '@mui/x-charts/ChartsLegend';
@@ -62,7 +62,7 @@ export default function BarScatterCompostion() {
       <Typography variant="h6">
         GDP growth rate comparison (2024 vs 2010-19 Avg)
       </Typography>
-      <ChartDataProvider
+      <ChartsDataProvider
         dataset={GDPdata}
         series={[
           {
@@ -102,7 +102,7 @@ export default function BarScatterCompostion() {
           <ChartsXAxis axisId="bar" />
           <ChartsYAxis />
         </ChartsSurface>
-      </ChartDataProvider>
+      </ChartsDataProvider>
     </Box>
   );
 }

--- a/docs/data/charts/bars/BarScatterCompostion.tsx
+++ b/docs/data/charts/bars/BarScatterCompostion.tsx
@@ -5,7 +5,7 @@ import { ScatterPlot } from '@mui/x-charts/ScatterChart';
 import { ChartsXAxis } from '@mui/x-charts/ChartsXAxis';
 import { ChartsYAxis } from '@mui/x-charts/ChartsYAxis';
 import { ChartsGrid } from '@mui/x-charts/ChartsGrid';
-import { ChartDataProvider } from '@mui/x-charts/ChartDataProvider';
+import { ChartsDataProvider } from '@mui/x-charts/ChartsDataProvider';
 import { ChartsSurface } from '@mui/x-charts/ChartsSurface';
 import { ChartsTooltip } from '@mui/x-charts/ChartsTooltip';
 import { legendClasses, ChartsLegend } from '@mui/x-charts/ChartsLegend';
@@ -64,7 +64,7 @@ export default function BarScatterCompostion() {
       <Typography variant="h6">
         GDP growth rate comparison (2024 vs 2010-19 Avg)
       </Typography>
-      <ChartDataProvider
+      <ChartsDataProvider
         dataset={GDPdata}
         series={[
           {
@@ -104,7 +104,7 @@ export default function BarScatterCompostion() {
           <ChartsXAxis axisId="bar" />
           <ChartsYAxis />
         </ChartsSurface>
-      </ChartDataProvider>
+      </ChartsDataProvider>
     </Box>
   );
 }

--- a/docs/data/charts/brush/BrushScatterList.js
+++ b/docs/data/charts/brush/BrushScatterList.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ChartDataProvider } from '@mui/x-charts/ChartDataProvider';
+import { ChartsDataProvider } from '@mui/x-charts/ChartsDataProvider';
 import { ChartsSurface } from '@mui/x-charts/ChartsSurface';
 import { ScatterPlot } from '@mui/x-charts/ScatterChart';
 import { ChartsAxis } from '@mui/x-charts/ChartsAxis';
@@ -131,7 +131,7 @@ export default function BrushScatterList() {
         Drag to select points on the scatter chart. Selected points will be displayed
         below.
       </Typography>
-      <ChartDataProvider
+      <ChartsDataProvider
         series={[
           {
             type: 'scatter',
@@ -149,7 +149,7 @@ export default function BrushScatterList() {
           <ChartContent />
         </ChartsSurface>
         <SelectedPointsList />
-      </ChartDataProvider>
+      </ChartsDataProvider>
     </Box>
   );
 }

--- a/docs/data/charts/brush/BrushScatterList.tsx
+++ b/docs/data/charts/brush/BrushScatterList.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ChartDataProvider } from '@mui/x-charts/ChartDataProvider';
+import { ChartsDataProvider } from '@mui/x-charts/ChartsDataProvider';
 import { ChartsSurface } from '@mui/x-charts/ChartsSurface';
 import { ScatterPlot } from '@mui/x-charts/ScatterChart';
 import { ChartsAxis } from '@mui/x-charts/ChartsAxis';
@@ -131,7 +131,7 @@ export default function BrushScatterList() {
         Drag to select points on the scatter chart. Selected points will be displayed
         below.
       </Typography>
-      <ChartDataProvider
+      <ChartsDataProvider
         series={[
           {
             type: 'scatter',
@@ -149,7 +149,7 @@ export default function BrushScatterList() {
           <ChartContent />
         </ChartsSurface>
         <SelectedPointsList />
-      </ChartDataProvider>
+      </ChartsDataProvider>
     </Box>
   );
 }

--- a/docs/data/charts/components/HtmlLegend.js
+++ b/docs/data/charts/components/HtmlLegend.js
@@ -1,6 +1,6 @@
 import Box from '@mui/material/Box';
 import { useLegend } from '@mui/x-charts/hooks';
-import { ChartDataProvider } from '@mui/x-charts/ChartDataProvider';
+import { ChartsDataProvider } from '@mui/x-charts/ChartsDataProvider';
 import { ChartsSurface } from '@mui/x-charts/ChartsSurface';
 import { BarPlot } from '@mui/x-charts/BarChart';
 import { ChartsXAxis } from '@mui/x-charts/ChartsXAxis';
@@ -46,7 +46,7 @@ const veryLongText =
 export default function HtmlLegend() {
   return (
     <Box sx={{ height: 400, display: 'flex', flexDirection: 'column' }}>
-      <ChartDataProvider
+      <ChartsDataProvider
         series={[
           { label: 'First Series', type: 'bar', data: [100, 200] },
           { label: veryLongText, type: 'bar', data: [45, 333] },
@@ -59,7 +59,7 @@ export default function HtmlLegend() {
           <ChartsYAxis />
         </ChartsSurface>
         <MyCustomLegend />
-      </ChartDataProvider>
+      </ChartsDataProvider>
     </Box>
   );
 }

--- a/docs/data/charts/components/HtmlLegend.tsx
+++ b/docs/data/charts/components/HtmlLegend.tsx
@@ -1,6 +1,6 @@
 import Box from '@mui/material/Box';
 import { useLegend } from '@mui/x-charts/hooks';
-import { ChartDataProvider } from '@mui/x-charts/ChartDataProvider';
+import { ChartsDataProvider } from '@mui/x-charts/ChartsDataProvider';
 import { ChartsSurface } from '@mui/x-charts/ChartsSurface';
 import { BarPlot } from '@mui/x-charts/BarChart';
 import { ChartsXAxis } from '@mui/x-charts/ChartsXAxis';
@@ -46,7 +46,7 @@ const veryLongText =
 export default function HtmlLegend() {
   return (
     <Box sx={{ height: 400, display: 'flex', flexDirection: 'column' }}>
-      <ChartDataProvider
+      <ChartsDataProvider
         series={[
           { label: 'First Series', type: 'bar', data: [100, 200] },
           { label: veryLongText, type: 'bar', data: [45, 333] },
@@ -59,7 +59,7 @@ export default function HtmlLegend() {
           <ChartsYAxis />
         </ChartsSurface>
         <MyCustomLegend />
-      </ChartDataProvider>
+      </ChartsDataProvider>
     </Box>
   );
 }

--- a/docs/data/charts/components/HtmlLegend.tsx.preview
+++ b/docs/data/charts/components/HtmlLegend.tsx.preview
@@ -1,4 +1,4 @@
-<ChartDataProvider
+<ChartsDataProvider
   series={[
     { label: 'First Series', type: 'bar', data: [100, 200] },
     { label: veryLongText, type: 'bar', data: [45, 333] },
@@ -11,4 +11,4 @@
     <ChartsYAxis />
   </ChartsSurface>
   <MyCustomLegend />
-</ChartDataProvider>
+</ChartsDataProvider>

--- a/docs/data/charts/components/SeriesDemo.js
+++ b/docs/data/charts/components/SeriesDemo.js
@@ -4,7 +4,7 @@ import { ChartsYAxis } from '@mui/x-charts/ChartsYAxis';
 import { LinePlot } from '@mui/x-charts/LineChart';
 import { useLineSeries, useXAxis, useXScale, useYScale } from '@mui/x-charts/hooks';
 import { ChartsSurface } from '@mui/x-charts/ChartsSurface';
-import { ChartDataProvider } from '@mui/x-charts/ChartDataProvider';
+import { ChartsDataProvider } from '@mui/x-charts/ChartsDataProvider';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 
@@ -83,7 +83,7 @@ function PointLabel({ x, y, placement, color }) {
 export default function SeriesDemo() {
   return (
     <Box sx={{ position: 'relative', width: '100%' }}>
-      <ChartDataProvider
+      <ChartsDataProvider
         xAxis={[{ id: 'x', data: [1, 2, 3, 5, 8, 10], height: 28 }]}
         series={[
           { id: 'a', type: 'line', data: [4, 6, 4, 9, 3, 5] },
@@ -98,7 +98,7 @@ export default function SeriesDemo() {
           <ChartsYAxis />
         </ChartsSurface>
         <ExtremaLabels />
-      </ChartDataProvider>
+      </ChartsDataProvider>
     </Box>
   );
 }

--- a/docs/data/charts/components/SeriesDemo.tsx
+++ b/docs/data/charts/components/SeriesDemo.tsx
@@ -4,7 +4,7 @@ import { ChartsYAxis } from '@mui/x-charts/ChartsYAxis';
 import { LinePlot } from '@mui/x-charts/LineChart';
 import { useLineSeries, useXAxis, useXScale, useYScale } from '@mui/x-charts/hooks';
 import { ChartsSurface } from '@mui/x-charts/ChartsSurface';
-import { ChartDataProvider } from '@mui/x-charts/ChartDataProvider';
+import { ChartsDataProvider } from '@mui/x-charts/ChartsDataProvider';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import { DefaultizedLineSeriesType } from '@mui/x-charts/models';
@@ -98,7 +98,7 @@ function PointLabel({
 export default function SeriesDemo() {
   return (
     <Box sx={{ position: 'relative', width: '100%' }}>
-      <ChartDataProvider
+      <ChartsDataProvider
         xAxis={[{ id: 'x', data: [1, 2, 3, 5, 8, 10], height: 28 }]}
         series={[
           { id: 'a', type: 'line', data: [4, 6, 4, 9, 3, 5] },
@@ -113,7 +113,7 @@ export default function SeriesDemo() {
           <ChartsYAxis />
         </ChartsSurface>
         <ExtremaLabels />
-      </ChartDataProvider>
+      </ChartsDataProvider>
     </Box>
   );
 }

--- a/docs/data/charts/components/SeriesDemo.tsx.preview
+++ b/docs/data/charts/components/SeriesDemo.tsx.preview
@@ -1,4 +1,4 @@
-<ChartDataProvider
+<ChartsDataProvider
   xAxis={[{ id: 'x', data: [1, 2, 3, 5, 8, 10], height: 28 }]}
   series={[
     { id: 'a', type: 'line', data: [4, 6, 4, 9, 3, 5] },
@@ -13,4 +13,4 @@
     <ChartsYAxis />
   </ChartsSurface>
   <ExtremaLabels />
-</ChartDataProvider>
+</ChartsDataProvider>

--- a/docs/data/charts/composition/LegendTooltipComposition.js
+++ b/docs/data/charts/composition/LegendTooltipComposition.js
@@ -1,4 +1,4 @@
-import { ChartDataProvider } from '@mui/x-charts/ChartDataProvider';
+import { ChartsDataProvider } from '@mui/x-charts/ChartsDataProvider';
 import { ChartsSurface } from '@mui/x-charts/ChartsSurface';
 import { LinePlot, MarkPlot } from '@mui/x-charts/LineChart';
 import { ChartsLegend } from '@mui/x-charts/ChartsLegend';
@@ -30,7 +30,7 @@ export default function LegendTooltipComposition() {
         alignItems: 'center',
       }}
     >
-      <ChartDataProvider
+      <ChartsDataProvider
         height={300}
         series={[{ type: 'line', data: pData, label: 'Sales Data', showMark: true }]}
         xAxis={[{ scaleType: 'point', data: xLabels }]}
@@ -46,7 +46,7 @@ export default function LegendTooltipComposition() {
           <MarkPlot />
           <ChartsAxisHighlight x="line" />
         </ChartsSurface>
-      </ChartDataProvider>
+      </ChartsDataProvider>
     </Box>
   );
 }

--- a/docs/data/charts/composition/LegendTooltipComposition.tsx
+++ b/docs/data/charts/composition/LegendTooltipComposition.tsx
@@ -1,4 +1,4 @@
-import { ChartDataProvider } from '@mui/x-charts/ChartDataProvider';
+import { ChartsDataProvider } from '@mui/x-charts/ChartsDataProvider';
 import { ChartsSurface } from '@mui/x-charts/ChartsSurface';
 import { LinePlot, MarkPlot } from '@mui/x-charts/LineChart';
 import { ChartsLegend } from '@mui/x-charts/ChartsLegend';
@@ -30,7 +30,7 @@ export default function LegendTooltipComposition() {
         alignItems: 'center',
       }}
     >
-      <ChartDataProvider
+      <ChartsDataProvider
         height={300}
         series={[{ type: 'line', data: pData, label: 'Sales Data', showMark: true }]}
         xAxis={[{ scaleType: 'point', data: xLabels }]}
@@ -46,7 +46,7 @@ export default function LegendTooltipComposition() {
           <MarkPlot />
           <ChartsAxisHighlight x="line" />
         </ChartsSurface>
-      </ChartDataProvider>
+      </ChartsDataProvider>
     </Box>
   );
 }

--- a/docs/data/charts/export/ExportCompositionNoSnap.js
+++ b/docs/data/charts/export/ExportCompositionNoSnap.js
@@ -5,7 +5,7 @@ import { ChartsXAxis } from '@mui/x-charts/ChartsXAxis';
 import { useChartRootRef } from '@mui/x-charts/hooks';
 import Button from '@mui/material/Button';
 import { Stack } from '@mui/system';
-import { ChartDataProviderPro } from '@mui/x-charts-pro/ChartDataProviderPro';
+import { ChartsDataProviderPro } from '@mui/x-charts-pro/ChartsDataProviderPro';
 import { ChartsSurface } from '@mui/x-charts/ChartsSurface';
 import { ChartsYAxis } from '@mui/x-charts/ChartsYAxis';
 import { ChartsLegend } from '@mui/x-charts/ChartsLegend';
@@ -37,7 +37,7 @@ export default function ExportCompositionNoSnap() {
       >
         Print
       </Button>
-      <ChartDataProviderPro
+      <ChartsDataProviderPro
         apiRef={apiRef}
         height={300}
         series={[
@@ -75,7 +75,7 @@ export default function ExportCompositionNoSnap() {
           </ChartsSurface>
           <ChartsLegend direction="horizontal" />
         </CustomChartWrapper>
-      </ChartDataProviderPro>
+      </ChartsDataProviderPro>
     </Stack>
   );
 }

--- a/docs/data/charts/export/ExportCompositionNoSnap.tsx
+++ b/docs/data/charts/export/ExportCompositionNoSnap.tsx
@@ -5,7 +5,7 @@ import { ChartsXAxis } from '@mui/x-charts/ChartsXAxis';
 import { useChartRootRef } from '@mui/x-charts/hooks';
 import Button from '@mui/material/Button';
 import { Stack } from '@mui/system';
-import { ChartDataProviderPro } from '@mui/x-charts-pro/ChartDataProviderPro';
+import { ChartsDataProviderPro } from '@mui/x-charts-pro/ChartsDataProviderPro';
 import { ChartsSurface } from '@mui/x-charts/ChartsSurface';
 import { ChartsYAxis } from '@mui/x-charts/ChartsYAxis';
 import { ChartsLegend } from '@mui/x-charts/ChartsLegend';
@@ -37,7 +37,7 @@ export default function ExportCompositionNoSnap() {
       >
         Print
       </Button>
-      <ChartDataProviderPro
+      <ChartsDataProviderPro
         apiRef={apiRef}
         height={300}
         series={[
@@ -75,7 +75,7 @@ export default function ExportCompositionNoSnap() {
           </ChartsSurface>
           <ChartsLegend direction="horizontal" />
         </CustomChartWrapper>
-      </ChartDataProviderPro>
+      </ChartsDataProviderPro>
     </Stack>
   );
 }

--- a/docs/data/charts/hooks/UseAxes.js
+++ b/docs/data/charts/hooks/UseAxes.js
@@ -3,7 +3,7 @@ import { useYAxes, useXAxis, useLineSeries } from '@mui/x-charts/hooks';
 import { LinePlot } from '@mui/x-charts/LineChart';
 import { ChartsXAxis } from '@mui/x-charts/ChartsXAxis';
 import { ChartsYAxis } from '@mui/x-charts/ChartsYAxis';
-import { ChartDataProvider } from '@mui/x-charts/ChartDataProvider';
+import { ChartsDataProvider } from '@mui/x-charts/ChartsDataProvider';
 import { ChartsSurface } from '@mui/x-charts/ChartsSurface';
 import { useTheme } from '@mui/material/styles';
 
@@ -119,7 +119,7 @@ function AxisRangeIndicators() {
 export default function UseAxes() {
   return (
     <div style={{ width: '100%' }}>
-      <ChartDataProvider
+      <ChartsDataProvider
         dataset={dataset}
         xAxis={[
           {
@@ -180,7 +180,7 @@ export default function UseAxes() {
           <ChartsYAxis axisId="rainfall" />
           <AxisRangeIndicators />
         </ChartsSurface>
-      </ChartDataProvider>
+      </ChartsDataProvider>
     </div>
   );
 }

--- a/docs/data/charts/hooks/UseAxes.tsx
+++ b/docs/data/charts/hooks/UseAxes.tsx
@@ -3,7 +3,7 @@ import { useYAxes, useXAxis, useLineSeries } from '@mui/x-charts/hooks';
 import { LinePlot } from '@mui/x-charts/LineChart';
 import { ChartsXAxis } from '@mui/x-charts/ChartsXAxis';
 import { ChartsYAxis } from '@mui/x-charts/ChartsYAxis';
-import { ChartDataProvider } from '@mui/x-charts/ChartDataProvider';
+import { ChartsDataProvider } from '@mui/x-charts/ChartsDataProvider';
 import { ChartsSurface } from '@mui/x-charts/ChartsSurface';
 import { useTheme } from '@mui/material/styles';
 
@@ -123,7 +123,7 @@ function AxisRangeIndicators() {
 export default function UseAxes() {
   return (
     <div style={{ width: '100%' }}>
-      <ChartDataProvider
+      <ChartsDataProvider
         dataset={dataset}
         xAxis={[
           {
@@ -184,7 +184,7 @@ export default function UseAxes() {
           <ChartsYAxis axisId="rainfall" />
           <AxisRangeIndicators />
         </ChartsSurface>
-      </ChartDataProvider>
+      </ChartsDataProvider>
     </div>
   );
 }

--- a/docs/data/charts/hooks/UseDataset.js
+++ b/docs/data/charts/hooks/UseDataset.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useDataset } from '@mui/x-charts/hooks';
-import { ChartDataProvider } from '@mui/x-charts/ChartDataProvider';
+import { ChartsDataProvider } from '@mui/x-charts/ChartsDataProvider';
 import { ChartsSurface } from '@mui/x-charts/ChartsSurface';
 import { LineHighlightPlot, LinePlot } from '@mui/x-charts/LineChart';
 import { ChartsXAxis } from '@mui/x-charts/ChartsXAxis';
@@ -86,7 +86,7 @@ function DatasetStats() {
 
 export default function UseDataset() {
   return (
-    <ChartDataProvider
+    <ChartsDataProvider
       dataset={dataset}
       xAxis={[{ dataKey: 'month', scaleType: 'point' }]}
       series={[
@@ -119,6 +119,6 @@ export default function UseDataset() {
           <ChartsLegend direction="horizontal" />
         </Box>
       </Box>
-    </ChartDataProvider>
+    </ChartsDataProvider>
   );
 }

--- a/docs/data/charts/hooks/UseDataset.tsx
+++ b/docs/data/charts/hooks/UseDataset.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useDataset } from '@mui/x-charts/hooks';
-import { ChartDataProvider } from '@mui/x-charts/ChartDataProvider';
+import { ChartsDataProvider } from '@mui/x-charts/ChartsDataProvider';
 import { ChartsSurface } from '@mui/x-charts/ChartsSurface';
 import { LineHighlightPlot, LinePlot } from '@mui/x-charts/LineChart';
 import { ChartsXAxis } from '@mui/x-charts/ChartsXAxis';
@@ -86,7 +86,7 @@ function DatasetStats() {
 
 export default function UseDataset() {
   return (
-    <ChartDataProvider
+    <ChartsDataProvider
       dataset={dataset}
       xAxis={[{ dataKey: 'month', scaleType: 'point' }]}
       series={[
@@ -119,6 +119,6 @@ export default function UseDataset() {
           <ChartsLegend direction="horizontal" />
         </Box>
       </Box>
-    </ChartDataProvider>
+    </ChartsDataProvider>
   );
 }

--- a/docs/data/charts/hooks/UseDatasetAdvanced.js
+++ b/docs/data/charts/hooks/UseDatasetAdvanced.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useDataset } from '@mui/x-charts/hooks';
-import { ChartDataProvider } from '@mui/x-charts/ChartDataProvider';
+import { ChartsDataProvider } from '@mui/x-charts/ChartsDataProvider';
 import { ChartsSurface } from '@mui/x-charts/ChartsSurface';
 import { BarPlot } from '@mui/x-charts/BarChart';
 import { ChartsXAxis } from '@mui/x-charts/ChartsXAxis';
@@ -149,7 +149,7 @@ export default function UseDatasetAdvanced() {
   }, []);
 
   return (
-    <ChartDataProvider
+    <ChartsDataProvider
       dataset={dataset}
       xAxis={[{ id: 'x-axis-id', dataKey: 'product', scaleType: 'band' }]}
       series={[
@@ -181,6 +181,6 @@ export default function UseDatasetAdvanced() {
           onHighlightedIndexChange={setHighlightedIndexCallback}
         />
       </Box>
-    </ChartDataProvider>
+    </ChartsDataProvider>
   );
 }

--- a/docs/data/charts/hooks/UseDatasetAdvanced.tsx
+++ b/docs/data/charts/hooks/UseDatasetAdvanced.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useDataset } from '@mui/x-charts/hooks';
-import { ChartDataProvider } from '@mui/x-charts/ChartDataProvider';
+import { ChartsDataProvider } from '@mui/x-charts/ChartsDataProvider';
 import { ChartsSurface } from '@mui/x-charts/ChartsSurface';
 import { BarPlot } from '@mui/x-charts/BarChart';
 import { ChartsXAxis } from '@mui/x-charts/ChartsXAxis';
@@ -157,7 +157,7 @@ export default function UseDatasetAdvanced() {
   }, []);
 
   return (
-    <ChartDataProvider
+    <ChartsDataProvider
       dataset={dataset}
       xAxis={[{ id: 'x-axis-id', dataKey: 'product', scaleType: 'band' }]}
       series={[
@@ -189,6 +189,6 @@ export default function UseDatasetAdvanced() {
           onHighlightedIndexChange={setHighlightedIndexCallback}
         />
       </Box>
-    </ChartDataProvider>
+    </ChartsDataProvider>
   );
 }

--- a/docs/data/charts/hooks/UseSeries.js
+++ b/docs/data/charts/hooks/UseSeries.js
@@ -4,7 +4,7 @@ import { BarPlot } from '@mui/x-charts/BarChart';
 import { LinePlot } from '@mui/x-charts/LineChart';
 import { ChartsXAxis } from '@mui/x-charts/ChartsXAxis';
 import { ChartsYAxis } from '@mui/x-charts/ChartsYAxis';
-import { ChartDataProvider } from '@mui/x-charts/ChartDataProvider';
+import { ChartsDataProvider } from '@mui/x-charts/ChartsDataProvider';
 import { ChartsSurface } from '@mui/x-charts/ChartsSurface';
 
 const barData = [4, 3, 5, 7, 2];
@@ -44,7 +44,7 @@ function MaxLineOnEachSeries() {
 export default function UseSeries() {
   return (
     <div>
-      <ChartDataProvider
+      <ChartsDataProvider
         series={[
           {
             data: barData,
@@ -78,7 +78,7 @@ export default function UseSeries() {
           <ChartsYAxis />
           <MaxLineOnEachSeries />
         </ChartsSurface>
-      </ChartDataProvider>
+      </ChartsDataProvider>
     </div>
   );
 }

--- a/docs/data/charts/hooks/UseSeries.tsx
+++ b/docs/data/charts/hooks/UseSeries.tsx
@@ -4,7 +4,7 @@ import { BarPlot } from '@mui/x-charts/BarChart';
 import { LinePlot } from '@mui/x-charts/LineChart';
 import { ChartsXAxis } from '@mui/x-charts/ChartsXAxis';
 import { ChartsYAxis } from '@mui/x-charts/ChartsYAxis';
-import { ChartDataProvider } from '@mui/x-charts/ChartDataProvider';
+import { ChartsDataProvider } from '@mui/x-charts/ChartsDataProvider';
 import { ChartsSurface } from '@mui/x-charts/ChartsSurface';
 
 const barData = [4, 3, 5, 7, 2] as const;
@@ -44,7 +44,7 @@ function MaxLineOnEachSeries() {
 export default function UseSeries() {
   return (
     <div>
-      <ChartDataProvider
+      <ChartsDataProvider
         series={[
           {
             data: barData,
@@ -79,7 +79,7 @@ export default function UseSeries() {
           <ChartsYAxis />
           <MaxLineOnEachSeries />
         </ChartsSurface>
-      </ChartDataProvider>
+      </ChartsDataProvider>
     </div>
   );
 }

--- a/docs/data/charts/legend/LegendClick.js
+++ b/docs/data/charts/legend/LegendClick.js
@@ -8,7 +8,7 @@ import UndoOutlinedIcon from '@mui/icons-material/UndoOutlined';
 import { ChartsLegend, PiecewiseColorLegend } from '@mui/x-charts/ChartsLegend';
 
 import { HighlightedCode } from '@mui/docs/HighlightedCode';
-import { ChartDataProvider } from '@mui/x-charts/ChartDataProvider';
+import { ChartsDataProvider } from '@mui/x-charts/ChartsDataProvider';
 
 const pieSeries = [
   {
@@ -70,22 +70,22 @@ export default function LegendClick() {
         }}
       >
         <Typography>Chart Legend</Typography>
-        <ChartDataProvider series={barSeries} width={400} height={60}>
+        <ChartsDataProvider series={barSeries} width={400} height={60}>
           <ChartsLegend
             direction="horizontal"
             // @ts-ignore
             onItemClick={(event, context, index) => setItemData([context, index])}
           />
-        </ChartDataProvider>
+        </ChartsDataProvider>
         <Typography>Pie Chart Legend</Typography>
-        <ChartDataProvider series={pieSeries} width={400} height={60}>
+        <ChartsDataProvider series={pieSeries} width={400} height={60}>
           <ChartsLegend
             direction="horizontal"
             onItemClick={(event, context, index) => setItemData([context, index])}
           />
-        </ChartDataProvider>
+        </ChartsDataProvider>
         <Typography>Piecewise Color Legend</Typography>
-        <ChartDataProvider
+        <ChartsDataProvider
           // @ts-ignore
           series={lineSeries}
           width={400}
@@ -109,7 +109,7 @@ export default function LegendClick() {
             // @ts-ignore
             onItemClick={(event, context, index) => setItemData([context, index])}
           />
-        </ChartDataProvider>
+        </ChartsDataProvider>
       </Box>
 
       <Stack direction="column" sx={{ width: { xs: '100%', md: '40%' } }}>

--- a/docs/data/charts/legend/LegendClick.tsx
+++ b/docs/data/charts/legend/LegendClick.tsx
@@ -8,7 +8,7 @@ import UndoOutlinedIcon from '@mui/icons-material/UndoOutlined';
 import { ChartsLegend, PiecewiseColorLegend } from '@mui/x-charts/ChartsLegend';
 
 import { HighlightedCode } from '@mui/docs/HighlightedCode';
-import { ChartDataProvider } from '@mui/x-charts/ChartDataProvider';
+import { ChartsDataProvider } from '@mui/x-charts/ChartsDataProvider';
 
 const pieSeries = [
   {
@@ -70,22 +70,22 @@ export default function LegendClick() {
         }}
       >
         <Typography>Chart Legend</Typography>
-        <ChartDataProvider series={barSeries} width={400} height={60}>
+        <ChartsDataProvider series={barSeries} width={400} height={60}>
           <ChartsLegend
             direction="horizontal"
             // @ts-ignore
             onItemClick={(event, context, index) => setItemData([context, index])}
           />
-        </ChartDataProvider>
+        </ChartsDataProvider>
         <Typography>Pie Chart Legend</Typography>
-        <ChartDataProvider series={pieSeries} width={400} height={60}>
+        <ChartsDataProvider series={pieSeries} width={400} height={60}>
           <ChartsLegend
             direction="horizontal"
             onItemClick={(event, context, index) => setItemData([context, index])}
           />
-        </ChartDataProvider>
+        </ChartsDataProvider>
         <Typography>Piecewise Color Legend</Typography>
-        <ChartDataProvider
+        <ChartsDataProvider
           // @ts-ignore
           series={lineSeries}
           width={400}
@@ -109,7 +109,7 @@ export default function LegendClick() {
             // @ts-ignore
             onItemClick={(event, context, index) => setItemData([context, index])}
           />
-        </ChartDataProvider>
+        </ChartsDataProvider>
       </Box>
 
       <Stack direction="column" sx={{ width: { xs: '100%', md: '40%' } }}>

--- a/docs/data/charts/legend/LegendLabelPositions.js
+++ b/docs/data/charts/legend/LegendLabelPositions.js
@@ -4,7 +4,7 @@ import {
   piecewiseColorDefaultLabelFormatter,
   PiecewiseColorLegend,
 } from '@mui/x-charts/ChartsLegend';
-import { ChartDataProvider } from '@mui/x-charts/ChartDataProvider';
+import { ChartsDataProvider } from '@mui/x-charts/ChartsDataProvider';
 import { ChartsAxesGradients } from '@mui/x-charts/internals';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
@@ -17,7 +17,7 @@ export default function LegendLabelPositions() {
       : '';
 
   return (
-    <ChartDataProvider
+    <ChartsDataProvider
       series={[]}
       width={200}
       height={200}
@@ -240,6 +240,6 @@ export default function LegendLabelPositions() {
       <svg width={0} height={0}>
         <ChartsAxesGradients />
       </svg>
-    </ChartDataProvider>
+    </ChartsDataProvider>
   );
 }

--- a/docs/data/charts/legend/LegendLabelPositions.tsx
+++ b/docs/data/charts/legend/LegendLabelPositions.tsx
@@ -5,7 +5,7 @@ import {
   PiecewiseColorLegend,
   PiecewiseLabelFormatterParams,
 } from '@mui/x-charts/ChartsLegend';
-import { ChartDataProvider } from '@mui/x-charts/ChartDataProvider';
+import { ChartsDataProvider } from '@mui/x-charts/ChartsDataProvider';
 import { ChartsAxesGradients } from '@mui/x-charts/internals';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
@@ -18,7 +18,7 @@ export default function LegendLabelPositions() {
       : '';
 
   return (
-    <ChartDataProvider
+    <ChartsDataProvider
       series={[]}
       width={200}
       height={200}
@@ -241,6 +241,6 @@ export default function LegendLabelPositions() {
       <svg width={0} height={0}>
         <ChartsAxesGradients />
       </svg>
-    </ChartDataProvider>
+    </ChartsDataProvider>
   );
 }

--- a/docs/data/charts/lines/LineOverview.js
+++ b/docs/data/charts/lines/LineOverview.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import { alpha, useTheme } from '@mui/material/styles';
-import { ChartDataProviderPro } from '@mui/x-charts-pro/ChartDataProviderPro';
+import { ChartsDataProviderPro } from '@mui/x-charts-pro/ChartsDataProviderPro';
 import { ChartsSurface } from '@mui/x-charts-pro/ChartsSurface';
 import { LinePlot } from '@mui/x-charts-pro/LineChart';
 import { ChartsXAxis } from '@mui/x-charts-pro/ChartsXAxis';
@@ -93,7 +93,7 @@ export default function LineOverview() {
         US unemployment rate comparison with GDP per capita
       </Typography>
 
-      <ChartDataProviderPro
+      <ChartsDataProviderPro
         height={300}
         experimentalFeatures={{ preferStrictDomainInLineCharts: true }}
         dataset={usaUnemploymentAndGdp}
@@ -177,7 +177,7 @@ export default function LineOverview() {
           <ChartZoomSlider />
         </ChartsSurface>
         <ChartsTooltip />
-      </ChartDataProviderPro>
+      </ChartsDataProviderPro>
 
       <Typography
         variant="caption"

--- a/docs/data/charts/lines/LineOverview.tsx
+++ b/docs/data/charts/lines/LineOverview.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import { alpha, useTheme } from '@mui/material/styles';
-import { ChartDataProviderPro } from '@mui/x-charts-pro/ChartDataProviderPro';
+import { ChartsDataProviderPro } from '@mui/x-charts-pro/ChartsDataProviderPro';
 import { ChartsSurface } from '@mui/x-charts-pro/ChartsSurface';
 import { LinePlot } from '@mui/x-charts-pro/LineChart';
 import { ChartsXAxis } from '@mui/x-charts-pro/ChartsXAxis';
@@ -99,7 +99,7 @@ export default function LineOverview() {
         US unemployment rate comparison with GDP per capita
       </Typography>
 
-      <ChartDataProviderPro
+      <ChartsDataProviderPro
         height={300}
         experimentalFeatures={{ preferStrictDomainInLineCharts: true }}
         dataset={usaUnemploymentAndGdp}
@@ -183,7 +183,7 @@ export default function LineOverview() {
           <ChartZoomSlider />
         </ChartsSurface>
         <ChartsTooltip />
-      </ChartDataProviderPro>
+      </ChartsDataProviderPro>
 
       <Typography
         variant="caption"

--- a/docs/data/charts/range-bar/RangeBarProjectSchedule.js
+++ b/docs/data/charts/range-bar/RangeBarProjectSchedule.js
@@ -18,7 +18,7 @@ import { rainbowSurgePalette } from '@mui/x-charts/colorPalettes';
 import { ChartsWrapper } from '@mui/x-charts-pro/ChartsWrapper';
 import { ChartsSurface } from '@mui/x-charts-pro/ChartsSurface';
 import { ScatterPlot } from '@mui/x-charts/ScatterChart';
-import { ChartDataProviderPremium } from '@mui/x-charts-premium/ChartDataProviderPremium';
+import { ChartsDataProviderPremium } from '@mui/x-charts-premium/ChartsDataProviderPremium';
 
 const importantHappeningsLabels = [
   'Exploratory archaeology digs begin.',
@@ -215,7 +215,7 @@ export default function RangeBarProjectSchedule() {
   ];
 
   return (
-    <ChartDataProviderPremium
+    <ChartsDataProviderPremium
       dataset={bigDigDataset}
       xAxis={xAxis}
       yAxis={yAxis}
@@ -253,7 +253,7 @@ export default function RangeBarProjectSchedule() {
           ]}
         />
       </ChartsWrapper>
-    </ChartDataProviderPremium>
+    </ChartsDataProviderPremium>
   );
 }
 

--- a/docs/data/charts/range-bar/RangeBarProjectSchedule.tsx
+++ b/docs/data/charts/range-bar/RangeBarProjectSchedule.tsx
@@ -18,7 +18,7 @@ import { rainbowSurgePalette } from '@mui/x-charts/colorPalettes';
 import { ChartsWrapper } from '@mui/x-charts-pro/ChartsWrapper';
 import { ChartsSurface } from '@mui/x-charts-pro/ChartsSurface';
 import { ScatterPlot, ScatterSeries } from '@mui/x-charts/ScatterChart';
-import { ChartDataProviderPremium } from '@mui/x-charts-premium/ChartDataProviderPremium';
+import { ChartsDataProviderPremium } from '@mui/x-charts-premium/ChartsDataProviderPremium';
 
 const importantHappeningsLabels = [
   'Exploratory archaeology digs begin.',
@@ -213,7 +213,7 @@ export default function RangeBarProjectSchedule() {
   ];
 
   return (
-    <ChartDataProviderPremium
+    <ChartsDataProviderPremium
       dataset={bigDigDataset}
       xAxis={xAxis}
       yAxis={yAxis}
@@ -251,7 +251,7 @@ export default function RangeBarProjectSchedule() {
           ]}
         />
       </ChartsWrapper>
-    </ChartDataProviderPremium>
+    </ChartsDataProviderPremium>
   );
 }
 

--- a/packages/x-charts/src/ChartsLegend/ChartsLegend.test.tsx
+++ b/packages/x-charts/src/ChartsLegend/ChartsLegend.test.tsx
@@ -1,6 +1,6 @@
 import { createRenderer, describeConformance } from '@mui/internal-test-utils';
 import { ChartsLegend, legendClasses } from '@mui/x-charts/ChartsLegend';
-import { ChartDataProvider } from '@mui/x-charts/ChartDataProvider';
+import { ChartsDataProvider } from '@mui/x-charts/ChartsDataProvider';
 import { ChartsSurface } from '@mui/x-charts/ChartsSurface';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 
@@ -13,7 +13,7 @@ describe('<ChartsLegend />', () => {
     render: (node) =>
       render(node, {
         wrapper: ({ children }) => (
-          <ChartDataProvider
+          <ChartsDataProvider
             height={50}
             width={50}
             series={[
@@ -28,7 +28,7 @@ describe('<ChartsLegend />', () => {
             {/* https://github.com/mui/material-ui/blob/c0620e333641deda56f3cd68c7c3736098ee818c/packages-internal/test-utils/src/describeConformance.tsx#L257 */}
             {children}
             <ChartsSurface />
-          </ChartDataProvider>
+          </ChartsDataProvider>
         ),
       }),
     muiName: 'MuiChartsLegend',

--- a/packages/x-charts/src/ChartsLegend/ContinuousColorLegend.test.tsx
+++ b/packages/x-charts/src/ChartsLegend/ContinuousColorLegend.test.tsx
@@ -1,6 +1,6 @@
 import { createRenderer, describeConformance } from '@mui/internal-test-utils';
 import { ContinuousColorLegend, continuousColorLegendClasses } from '@mui/x-charts/ChartsLegend';
-import { ChartDataProvider } from '@mui/x-charts/ChartDataProvider';
+import { ChartsDataProvider } from '@mui/x-charts/ChartsDataProvider';
 import { ChartsSurface } from '@mui/x-charts/ChartsSurface';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 
@@ -13,7 +13,7 @@ describe('<ContinuousColorLegend />', () => {
     render: (node) =>
       render(node, {
         wrapper: ({ children }) => (
-          <ChartDataProvider
+          <ChartsDataProvider
             height={50}
             width={50}
             series={[
@@ -38,7 +38,7 @@ describe('<ContinuousColorLegend />', () => {
             {/* https://github.com/mui/material-ui/blob/c0620e333641deda56f3cd68c7c3736098ee818c/packages-internal/test-utils/src/describeConformance.tsx#L257 */}
             {children}
             <ChartsSurface />
-          </ChartDataProvider>
+          </ChartsDataProvider>
         ),
       }),
     muiName: 'MuiContinuousColorLegend',

--- a/packages/x-charts/src/ChartsLegend/PiecewiseColorLegend.test.tsx
+++ b/packages/x-charts/src/ChartsLegend/PiecewiseColorLegend.test.tsx
@@ -1,6 +1,6 @@
 import { createRenderer, describeConformance, screen } from '@mui/internal-test-utils';
 import { PiecewiseColorLegend, piecewiseColorLegendClasses } from '@mui/x-charts/ChartsLegend';
-import { ChartDataProvider } from '@mui/x-charts/ChartDataProvider';
+import { ChartsDataProvider } from '@mui/x-charts/ChartsDataProvider';
 import { ChartsSurface } from '@mui/x-charts/ChartsSurface';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 
@@ -13,7 +13,7 @@ describe('<PiecewiseColorLegend />', () => {
     render: (node) =>
       render(node, {
         wrapper: ({ children }) => (
-          <ChartDataProvider
+          <ChartsDataProvider
             height={50}
             width={50}
             series={[
@@ -37,7 +37,7 @@ describe('<PiecewiseColorLegend />', () => {
             {/* https://github.com/mui/material-ui/blob/c0620e333641deda56f3cd68c7c3736098ee818c/packages-internal/test-utils/src/describeConformance.tsx#L257 */}
             {children}
             <ChartsSurface />
-          </ChartDataProvider>
+          </ChartsDataProvider>
         ),
       }),
     muiName: 'MuiPiecewiseColorLegend',
@@ -51,7 +51,7 @@ describe('<PiecewiseColorLegend />', () => {
 
   it('should apply inline-start class when labelPosition="inline-start"', () => {
     render(
-      <ChartDataProvider
+      <ChartsDataProvider
         height={50}
         width={50}
         series={[
@@ -73,7 +73,7 @@ describe('<PiecewiseColorLegend />', () => {
       >
         <PiecewiseColorLegend labelPosition="inline-start" />
         <ChartsSurface />
-      </ChartDataProvider>,
+      </ChartsDataProvider>,
     );
 
     expect(screen.getByRole('list').className).contains(piecewiseColorLegendClasses.inlineStart);
@@ -81,7 +81,7 @@ describe('<PiecewiseColorLegend />', () => {
 
   it('should apply inline-end class when labelPosition="inline-end"', () => {
     render(
-      <ChartDataProvider
+      <ChartsDataProvider
         height={50}
         width={50}
         series={[
@@ -103,7 +103,7 @@ describe('<PiecewiseColorLegend />', () => {
       >
         <PiecewiseColorLegend labelPosition="inline-end" />
         <ChartsSurface />
-      </ChartDataProvider>,
+      </ChartsDataProvider>,
     );
 
     expect(screen.getByRole('list').className).contains(piecewiseColorLegendClasses.inlineEnd);

--- a/packages/x-charts/src/hooks/useSkipAnimation.test.tsx
+++ b/packages/x-charts/src/hooks/useSkipAnimation.test.tsx
@@ -19,7 +19,11 @@ function UseSkipAnimation({ localSkipAnimation }: { localSkipAnimation?: boolean
 }
 
 const createMatchMedia = (matches: boolean) => () =>
-  ({ matches, addEventListener: () => {}, removeEventListener: () => {} }) as any;
+  ({
+    matches,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  }) as any;
 
 describe('useSkipAnimation', () => {
   const { render } = createRenderer();

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxis.axisHighlight.test.tsx
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxis.axisHighlight.test.tsx
@@ -1,7 +1,7 @@
 import { vi } from 'vitest';
 import { createRenderer, waitFor } from '@mui/internal-test-utils';
 import { isJSDOM } from 'test/utils/skipIf';
-import { ChartDataProvider } from '@mui/x-charts/ChartDataProvider';
+import { ChartsDataProvider } from '@mui/x-charts/ChartsDataProvider';
 import { ChartsSurface } from '@mui/x-charts/ChartsSurface';
 import { ChartsAxisHighlight, chartsAxisHighlightClasses } from '@mui/x-charts/ChartsAxisHighlight';
 import { useChartCartesianAxis } from './useChartCartesianAxis';
@@ -15,7 +15,7 @@ describe.skipIf(isJSDOM)('useChartCartesianAxis - axis highlight', () => {
   it('should call onHighlightedAxisChange when crossing any value', async () => {
     const onHighlightedAxisChange = vi.fn();
     const { user, container } = render(
-      <ChartDataProvider<'bar', [UseChartInteractionSignature, UseChartCartesianAxisSignature]>
+      <ChartsDataProvider<'bar', [UseChartInteractionSignature, UseChartCartesianAxisSignature]>
         plugins={[useChartInteraction, useChartCartesianAxis]}
         xAxis={[{ id: 'x-axis', scaleType: 'band', data: ['A', 'B'], position: 'none' }]}
         yAxis={[{ id: 'y-axis', min: 0, max: 1, data: [0, 0.5], position: 'none' }]}
@@ -25,7 +25,7 @@ describe.skipIf(isJSDOM)('useChartCartesianAxis - axis highlight', () => {
         onHighlightedAxisChange={onHighlightedAxisChange}
       >
         <ChartsSurface />
-      </ChartDataProvider>,
+      </ChartsDataProvider>,
     );
 
     const svg = container.querySelector('svg')!;
@@ -73,7 +73,7 @@ describe.skipIf(isJSDOM)('useChartCartesianAxis - axis highlight', () => {
   it('should call onHighlightedAxisChange when axis got modified', async () => {
     const onHighlightedAxisChange = vi.fn();
     const { user, setProps, container } = render(
-      <ChartDataProvider<'bar', [UseChartInteractionSignature, UseChartCartesianAxisSignature]>
+      <ChartsDataProvider<'bar', [UseChartInteractionSignature, UseChartCartesianAxisSignature]>
         plugins={[useChartInteraction, useChartCartesianAxis]}
         xAxis={[{ id: 'x-axis', scaleType: 'band', data: ['A', 'B'], position: 'none' }]}
         yAxis={[{ position: 'none' }]}
@@ -83,7 +83,7 @@ describe.skipIf(isJSDOM)('useChartCartesianAxis - axis highlight', () => {
         onHighlightedAxisChange={onHighlightedAxisChange}
       >
         <ChartsSurface />
-      </ChartDataProvider>,
+      </ChartsDataProvider>,
     );
 
     const svg = container.querySelector('svg')!;
@@ -108,7 +108,7 @@ describe.skipIf(isJSDOM)('useChartCartesianAxis - axis highlight', () => {
   it('should not call onHighlightedAxisChange when axis got modified but highlighted item stay the same', async () => {
     const onHighlightedAxisChange = vi.fn();
     const { user, setProps, container } = render(
-      <ChartDataProvider<'bar', [UseChartInteractionSignature, UseChartCartesianAxisSignature]>
+      <ChartsDataProvider<'bar', [UseChartInteractionSignature, UseChartCartesianAxisSignature]>
         plugins={[useChartInteraction, useChartCartesianAxis]}
         xAxis={[{ id: 'x-axis', scaleType: 'band', data: ['A', 'B'], position: 'none' }]}
         yAxis={[{ position: 'none' }]}
@@ -118,7 +118,7 @@ describe.skipIf(isJSDOM)('useChartCartesianAxis - axis highlight', () => {
         onHighlightedAxisChange={onHighlightedAxisChange}
       >
         <ChartsSurface />
-      </ChartDataProvider>,
+      </ChartsDataProvider>,
     );
 
     const svg = container.querySelector('svg')!;
@@ -140,7 +140,7 @@ describe.skipIf(isJSDOM)('useChartCartesianAxis - axis highlight', () => {
   it('should call onHighlightedAxisChange when highlighted axis got removed', async () => {
     const onHighlightedAxisChange = vi.fn();
     const { user, setProps, container } = render(
-      <ChartDataProvider<'bar', [UseChartInteractionSignature, UseChartCartesianAxisSignature]>
+      <ChartsDataProvider<'bar', [UseChartInteractionSignature, UseChartCartesianAxisSignature]>
         plugins={[useChartInteraction, useChartCartesianAxis]}
         xAxis={[{ id: 'x-axis', scaleType: 'band', data: ['A', 'B'], position: 'none' }]}
         yAxis={[{ position: 'none' }]}
@@ -150,7 +150,7 @@ describe.skipIf(isJSDOM)('useChartCartesianAxis - axis highlight', () => {
         onHighlightedAxisChange={onHighlightedAxisChange}
       >
         <ChartsSurface />
-      </ChartDataProvider>,
+      </ChartsDataProvider>,
     );
 
     const svg = container.querySelector('svg')!;
@@ -174,7 +174,7 @@ describe.skipIf(isJSDOM)('useChartCartesianAxis - axis highlight', () => {
 
   it('should allow to highlight axes without data', async () => {
     const { user, container } = render(
-      <ChartDataProvider<'bar', [UseChartInteractionSignature, UseChartCartesianAxisSignature]>
+      <ChartsDataProvider<'bar', [UseChartInteractionSignature, UseChartCartesianAxisSignature]>
         plugins={[useChartInteraction, useChartCartesianAxis]}
         xAxis={[{ id: 'x-axis', scaleType: 'band', data: ['A', 'B'], position: 'none' }]}
         yAxis={[{ position: 'none', min: 0, max: 100 }]}
@@ -185,7 +185,7 @@ describe.skipIf(isJSDOM)('useChartCartesianAxis - axis highlight', () => {
         <ChartsSurface>
           <ChartsAxisHighlight y="line" />
         </ChartsSurface>
-      </ChartDataProvider>,
+      </ChartsDataProvider>,
     );
 
     const svg = container.querySelector('svg')!;
@@ -199,7 +199,7 @@ describe.skipIf(isJSDOM)('useChartCartesianAxis - axis highlight', () => {
 
   it('should allow to highlight axes with data', async () => {
     const { user, container } = render(
-      <ChartDataProvider<'bar', [UseChartInteractionSignature, UseChartCartesianAxisSignature]>
+      <ChartsDataProvider<'bar', [UseChartInteractionSignature, UseChartCartesianAxisSignature]>
         plugins={[useChartInteraction, useChartCartesianAxis]}
         xAxis={[{ id: 'x-axis', scaleType: 'band', data: ['A', 'B'], position: 'none' }]}
         yAxis={[{ position: 'none', min: 0, max: 100 }]}
@@ -210,7 +210,7 @@ describe.skipIf(isJSDOM)('useChartCartesianAxis - axis highlight', () => {
         <ChartsSurface>
           <ChartsAxisHighlight x="line" />
         </ChartsSurface>
-      </ChartDataProvider>,
+      </ChartsDataProvider>,
     );
 
     const svg = container.querySelector('svg')!;

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartPolarAxis/useChartPolarAxis.test.tsx
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartPolarAxis/useChartPolarAxis.test.tsx
@@ -1,6 +1,6 @@
 import { createRenderer } from '@mui/internal-test-utils';
 import { isJSDOM } from 'test/utils/skipIf';
-import { ChartDataProvider } from '@mui/x-charts/ChartDataProvider';
+import { ChartsDataProvider } from '@mui/x-charts/ChartsDataProvider';
 import { type UseChartPolarAxisSignature } from './useChartPolarAxis.types';
 import { useChartPolarAxis } from './useChartPolarAxis';
 
@@ -17,7 +17,7 @@ describe('useChartPolarAxis', () => {
 
     expect(() =>
       render(
-        <ChartDataProvider<'radar', [UseChartPolarAxisSignature]>
+        <ChartsDataProvider<'radar', [UseChartPolarAxisSignature]>
           rotationAxis={[
             { scaleType: 'band', id: 'qwerty', data: ['a', 'b', 'c'] },
             { scaleType: 'band', id: 'qwerty', data: ['a', 'b', 'c'] },
@@ -42,7 +42,7 @@ describe('useChartPolarAxis', () => {
 
       expect(() =>
         render(
-          <ChartDataProvider<'radar', [UseChartPolarAxisSignature]>
+          <ChartsDataProvider<'radar', [UseChartPolarAxisSignature]>
             rotationAxis={[{ scaleType: 'band', id: 'qwerty', data: ['a', 'b', 'c'] }]}
             radiusAxis={[{ id: 'qwerty' }]}
             height={100}

--- a/packages/x-codemod/src/v9.0.0/charts/preset-safe/index.ts
+++ b/packages/x-codemod/src/v9.0.0/charts/preset-safe/index.ts
@@ -2,6 +2,7 @@ import { JsCodeShiftAPI, JsCodeShiftFileInfo } from '../../../types';
 import * as renameIdToSeriesId from '../rename-id-to-series-id';
 import * as renameChartApiImport from '../rename-chart-api-import';
 import * as renameChartContainer from '../rename-chart-container';
+import * as renameChartDataProvider from '../rename-chart-data-provider';
 import * as replaceHeatmapHideLegend from '../replace-heatmap-hide-legend-false';
 import * as replaceShowMarkDefault from '../replace-show-mark-default';
 
@@ -12,6 +13,7 @@ const allModules = [
   renameIdToSeriesId,
   renameChartApiImport,
   renameChartContainer,
+  renameChartDataProvider,
 ];
 
 export default function transformer(file: JsCodeShiftFileInfo, api: JsCodeShiftAPI, options: any) {

--- a/packages/x-codemod/src/v9.0.0/charts/rename-chart-data-provider/actual-nested-imports.spec.tsx
+++ b/packages/x-codemod/src/v9.0.0/charts/rename-chart-data-provider/actual-nested-imports.spec.tsx
@@ -1,0 +1,43 @@
+// @ts-nocheck
+import { ChartDataProvider } from '@mui/x-charts/ChartDataProvider';
+import { ChartDataProviderPro } from '@mui/x-charts-pro/ChartDataProviderPro';
+import { ChartDataProviderPremium } from '@mui/x-charts-premium/ChartDataProviderPremium';
+import {
+  ChartDataProviderProps,
+  ChartDataProviderSlots,
+  ChartDataProviderSlotProps,
+} from '@mui/x-charts/ChartDataProvider';
+import {
+  ChartDataProviderProProps,
+  ChartDataProviderProSlots,
+  ChartDataProviderProSlotProps,
+} from '@mui/x-charts-pro/ChartDataProviderPro';
+import {
+  ChartDataProviderPremiumProps,
+  ChartDataProviderPremiumSlots,
+  ChartDataProviderPremiumSlotProps,
+} from '@mui/x-charts-premium/ChartDataProviderPremium';
+import { ChartDataProvider as AliasedProvider } from '@mui/x-charts/ChartDataProvider';
+
+function App() {
+  const props: ChartDataProviderProps = {};
+  const proProps: ChartDataProviderProProps = {};
+  const premiumProps: ChartDataProviderPremiumProps = {};
+
+  return (
+    <div>
+      <ChartDataProvider>
+        <div />
+      </ChartDataProvider>
+      <ChartDataProviderPro>
+        <div />
+      </ChartDataProviderPro>
+      <ChartDataProviderPremium>
+        <div />
+      </ChartDataProviderPremium>
+      <AliasedProvider>
+        <div />
+      </AliasedProvider>
+    </div>
+  );
+}

--- a/packages/x-codemod/src/v9.0.0/charts/rename-chart-data-provider/actual-root-imports.spec.tsx
+++ b/packages/x-codemod/src/v9.0.0/charts/rename-chart-data-provider/actual-root-imports.spec.tsx
@@ -1,0 +1,24 @@
+// @ts-nocheck
+import { ChartDataProvider, ChartDataProviderProps } from '@mui/x-charts';
+import { ChartDataProviderPro, ChartDataProviderProProps } from '@mui/x-charts-pro';
+import { ChartDataProviderPremium, ChartDataProviderPremiumProps } from '@mui/x-charts-premium';
+
+function App() {
+  const props: ChartDataProviderProps = {};
+  const proProps: ChartDataProviderProProps = {};
+  const premiumProps: ChartDataProviderPremiumProps = {};
+
+  return (
+    <div>
+      <ChartDataProvider>
+        <div />
+      </ChartDataProvider>
+      <ChartDataProviderPro>
+        <div />
+      </ChartDataProviderPro>
+      <ChartDataProviderPremium>
+        <div />
+      </ChartDataProviderPremium>
+    </div>
+  );
+}

--- a/packages/x-codemod/src/v9.0.0/charts/rename-chart-data-provider/expected-nested-imports.spec.tsx
+++ b/packages/x-codemod/src/v9.0.0/charts/rename-chart-data-provider/expected-nested-imports.spec.tsx
@@ -1,0 +1,43 @@
+// @ts-nocheck
+import { ChartsDataProvider } from '@mui/x-charts/ChartsDataProvider';
+import { ChartsDataProviderPro } from '@mui/x-charts-pro/ChartsDataProviderPro';
+import { ChartsDataProviderPremium } from '@mui/x-charts-premium/ChartsDataProviderPremium';
+import {
+  ChartsDataProviderProps,
+  ChartsDataProviderSlots,
+  ChartsDataProviderSlotProps,
+} from '@mui/x-charts/ChartsDataProvider';
+import {
+  ChartsDataProviderProProps,
+  ChartsDataProviderProSlots,
+  ChartsDataProviderProSlotProps,
+} from '@mui/x-charts-pro/ChartsDataProviderPro';
+import {
+  ChartsDataProviderPremiumProps,
+  ChartsDataProviderPremiumSlots,
+  ChartsDataProviderPremiumSlotProps,
+} from '@mui/x-charts-premium/ChartsDataProviderPremium';
+import { ChartsDataProvider as AliasedProvider } from '@mui/x-charts/ChartsDataProvider';
+
+function App() {
+  const props: ChartsDataProviderProps = {};
+  const proProps: ChartsDataProviderProProps = {};
+  const premiumProps: ChartsDataProviderPremiumProps = {};
+
+  return (
+    <div>
+      <ChartsDataProvider>
+        <div />
+      </ChartsDataProvider>
+      <ChartsDataProviderPro>
+        <div />
+      </ChartsDataProviderPro>
+      <ChartsDataProviderPremium>
+        <div />
+      </ChartsDataProviderPremium>
+      <AliasedProvider>
+        <div />
+      </AliasedProvider>
+    </div>
+  );
+}

--- a/packages/x-codemod/src/v9.0.0/charts/rename-chart-data-provider/expected-root-imports.spec.tsx
+++ b/packages/x-codemod/src/v9.0.0/charts/rename-chart-data-provider/expected-root-imports.spec.tsx
@@ -1,0 +1,24 @@
+// @ts-nocheck
+import { ChartsDataProvider, ChartsDataProviderProps } from '@mui/x-charts';
+import { ChartsDataProviderPro, ChartsDataProviderProProps } from '@mui/x-charts-pro';
+import { ChartsDataProviderPremium, ChartsDataProviderPremiumProps } from '@mui/x-charts-premium';
+
+function App() {
+  const props: ChartsDataProviderProps = {};
+  const proProps: ChartsDataProviderProProps = {};
+  const premiumProps: ChartsDataProviderPremiumProps = {};
+
+  return (
+    <div>
+      <ChartsDataProvider>
+        <div />
+      </ChartsDataProvider>
+      <ChartsDataProviderPro>
+        <div />
+      </ChartsDataProviderPro>
+      <ChartsDataProviderPremium>
+        <div />
+      </ChartsDataProviderPremium>
+    </div>
+  );
+}

--- a/packages/x-codemod/src/v9.0.0/charts/rename-chart-data-provider/index.ts
+++ b/packages/x-codemod/src/v9.0.0/charts/rename-chart-data-provider/index.ts
@@ -1,0 +1,86 @@
+import path from 'path';
+import type { JsCodeShiftAPI, JsCodeShiftFileInfo } from '../../../types';
+import readFile from '../../../util/readFile';
+import { renameImports } from '../../../util/renameImports';
+
+export default function transformer(file: JsCodeShiftFileInfo, api: JsCodeShiftAPI, options: any) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  const printOptions = options.printOptions || {
+    quote: 'single',
+    trailingComma: true,
+  };
+
+  renameImports({
+    j,
+    root,
+    packageNames: ['@mui/x-charts', '@mui/x-charts-pro', '@mui/x-charts-premium'],
+    imports: [
+      {
+        oldEndpoint: 'ChartDataProvider',
+        newEndpoint: 'ChartsDataProvider',
+        importsMapping: {
+          ChartDataProvider: 'ChartsDataProvider',
+          ChartDataProviderProps: 'ChartsDataProviderProps',
+          ChartDataProviderSlots: 'ChartsDataProviderSlots',
+          ChartDataProviderSlotProps: 'ChartsDataProviderSlotProps',
+        },
+      },
+    ],
+  });
+
+  renameImports({
+    j,
+    root,
+    packageNames: ['@mui/x-charts-pro', '@mui/x-charts-premium'],
+    imports: [
+      {
+        oldEndpoint: 'ChartDataProviderPro',
+        newEndpoint: 'ChartsDataProviderPro',
+        importsMapping: {
+          ChartDataProviderPro: 'ChartsDataProviderPro',
+          ChartDataProviderProProps: 'ChartsDataProviderProProps',
+          ChartDataProviderProSlots: 'ChartsDataProviderProSlots',
+          ChartDataProviderProSlotProps: 'ChartsDataProviderProSlotProps',
+        },
+      },
+    ],
+  });
+
+  renameImports({
+    j,
+    root,
+    packageNames: ['@mui/x-charts-premium'],
+    imports: [
+      {
+        oldEndpoint: 'ChartDataProviderPremium',
+        newEndpoint: 'ChartsDataProviderPremium',
+        importsMapping: {
+          ChartDataProviderPremium: 'ChartsDataProviderPremium',
+          ChartDataProviderPremiumProps: 'ChartsDataProviderPremiumProps',
+          ChartDataProviderPremiumSlots: 'ChartsDataProviderPremiumSlots',
+          ChartDataProviderPremiumSlotProps: 'ChartsDataProviderPremiumSlotProps',
+        },
+      },
+    ],
+  });
+
+  return root.toSource(printOptions);
+}
+
+export const testConfig = () => ({
+  name: 'rename-chart-data-provider',
+  specFiles: [
+    {
+      name: 'nested-imports',
+      actual: readFile(path.join(import.meta.dirname, 'actual-nested-imports.spec.tsx')),
+      expected: readFile(path.join(import.meta.dirname, 'expected-nested-imports.spec.tsx')),
+    },
+    {
+      name: 'root-imports',
+      actual: readFile(path.join(import.meta.dirname, 'actual-root-imports.spec.tsx')),
+      expected: readFile(path.join(import.meta.dirname, 'expected-root-imports.spec.tsx')),
+    },
+  ],
+});

--- a/packages/x-codemod/src/v9.0.0/charts/rename-chart-data-provider/rename-chart-data-provider.test.ts
+++ b/packages/x-codemod/src/v9.0.0/charts/rename-chart-data-provider/rename-chart-data-provider.test.ts
@@ -1,0 +1,32 @@
+import jscodeshift from 'jscodeshift';
+import transform, { testConfig } from './index';
+
+const allFiles = [testConfig].map((config) => config().specFiles).flat();
+
+describe('v9.0.0/charts', () => {
+  describe(`${testConfig.name}`, () => {
+    describe.each(allFiles)('$name', (file) => {
+      it('transforms code as needed', () => {
+        const actual = transform(
+          { source: file.actual },
+          { jscodeshift: jscodeshift.withParser('tsx') },
+          {},
+        );
+
+        const expected = file.expected;
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
+      });
+
+      it('should be idempotent', () => {
+        const actual = transform(
+          { source: file.expected },
+          { jscodeshift: jscodeshift.withParser('tsx') },
+          {},
+        );
+
+        const expected = file.expected;
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Contains #21470 & #21485 (I need the content of both PRs in this merge).

## Summary

**Merge `@mui/x-telemetry` into `@mui/x-license`**: Telemetry source files now live under `src/telemetry/` within `x-license`. The `@mui/x-telemetry` package has been deleted entirely, simplifying the dependency graph since `x-license` was its only consumer.

### What changed

- Moved all telemetry source files into `packages/x-license/src/telemetry/`, preserving the original directory structure (`runtime/`, `postinstall/`).
- Updated internal imports in `x-license` (`index.ts`, `useLicenseVerifier.ts`) to use relative paths instead of `@mui/x-telemetry`.
- Moved telemetry dependencies (`@fingerprintjs/fingerprintjs`, `ci-info`, `is-docker`, `node-machine-id`) into `x-license`'s `package.json`.
- Added the `postinstall` script to `x-license` (via `packageScripts` + `addPackageScripts.js`), adjusting path resolution for the deeper nesting.
- Updated `docs/pages/_app.js` to import `muiXTelemetrySettings` from `@mui/x-license` instead of `@mui/x-telemetry`.
- Created `telemetry-env.d.ts` to extend the `MUIEnv` interface with telemetry-specific environment variables.
- Excluded `src/telemetry/postinstall/**` from `tsconfig.build.json` (postinstall runs at install time, not in the browser, no `.d.ts` needed).
- Removed `@mui/x-telemetry` references from root `tsconfig.json`, `tsconfig.prod.json`, `eslint.config.mjs`, `vitest.shared.mts`, and `scripts/printPkgPrNewPublishDirs.mts`.
- Deleted `packages/x-telemetry/` entirely.

<img width="1473" height="857" alt="log" src="https://github.com/user-attachments/assets/c49fdb1c-722e-43d7-b310-05fae99006a9" />

<img width="1180" height="556" alt="db" src="https://github.com/user-attachments/assets/56f5a371-7822-4a4b-b1e0-3d1d467c6343" />


## Changelog

### `@mui/x-license`

- Merge `@mui/x-telemetry` into `@mui/x-license`; telemetry source files now live under `src/telemetry/`

### `@mui/x-telemetry`

- This package has been removed. Use `@mui/x-license` instead.