### PR TITLE
[pickers] Ensure range values are complete before triggering onAccept

### DIFF
--- a/packages/x-date-pickers/src/internals/hooks/usePicker/hooks/useValueAndOpenStates.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePicker/hooks/useValueAndOpenStates.ts
@@ -119,6 +119,14 @@ export function useValueAndOpenStates<
     }
   });
 
+  const isCompleteRange = (val: unknown): boolean => {
+    if (Array.isArray(val) && val.length === 2) {
+      const [start, end] = val as [unknown, unknown];
+      return start != null && end != null;
+    }
+    return true;
+  };
+
   const setValue = useEventCallback((newValue: TValue, options?: SetValueActionOptions<TError>) => {
     const {
       changeImportance = 'accept',
@@ -135,11 +143,12 @@ export function useValueAndOpenStates<
       // If the value is not controlled and the value has never been modified before,
       // Then clicking on any value (including the one equal to `defaultValue`) should call `onChange` and `onAccept`
       shouldFireOnChange = true;
-      shouldFireOnAccept = changeImportance === 'accept';
+      shouldFireOnAccept = changeImportance === 'accept' && isCompleteRange(newValue);
     } else {
       shouldFireOnChange = !valueManager.areValuesEqual(adapter, newValue, value);
       shouldFireOnAccept =
         changeImportance === 'accept' &&
+        isCompleteRange(newValue) &&
         !valueManager.areValuesEqual(adapter, newValue, state.lastCommittedValue);
     }
 


### PR DESCRIPTION
This change introduces an `isCompleteRange` check within the `useValueAndOpenStates` hook to ensure that the `onAccept` callback is only triggered when a range value is fully defined (i.e., both the start and end values are non-null).

This addresses suggestion 1 from the original issue (reference from https://github.com/mui/mui-x/pull/20782#pullrequestreview-3806467116)

Fixes #17913 