### PR TITLE
[code-infra] Remove x-charts-vendor from nextjs processing

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,8 +33,6 @@
       "@mui/x-charts-pro/*": ["./packages/x-charts-pro/src/*"],
       "@mui/x-charts-premium": ["./packages/x-charts-premium/src"],
       "@mui/x-charts-premium/*": ["./packages/x-charts-premium/src/*"],
-      "@mui/x-charts-vendor": ["./packages/x-charts-vendor"],
-      "@mui/x-charts-vendor/*": ["./packages/x-charts-vendor/build/*"],
       // There is no root import on these packages
       // "@mui/x-scheduler": ["./packages/x-scheduler/src"],
       // "@mui/x-scheduler-premium": ["./packages/x-scheduler-premium/src"],

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -12,8 +12,6 @@
       "@mui/x-charts-pro/*": ["./packages/x-charts-pro/src/*"],
       "@mui/x-charts-premium": ["./packages/x-charts-premium/src"],
       "@mui/x-charts-premium/*": ["./packages/x-charts-premium/src/*"],
-      "@mui/x-charts-vendor": ["./packages/x-charts-vendor"],
-      "@mui/x-charts-vendor/*": ["./packages/x-charts-vendor/*"],
       // There is no root import on these packages
       // "@mui/x-scheduler": ["./packages/x-scheduler/src"],
       // "@mui/x-scheduler-premium": ["./packages/x-scheduler-premium/src"],


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

The files are pre-built during `pnpm install`. So no need for next.js to process it again.

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
