### PR TITLE
[code-infra] Set BASE_BRANCH env var in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  code-infra: https://raw.githubusercontent.com/mui/mui-public/0eed58c5bf2f7f3bfa60887e07808b0d6b4a078b/.circleci/orbs/code-infra.yml
+  code-infra: https://raw.githubusercontent.com/mui/mui-public/48198a7131b2ee621cc13bc7729cc41c72f370e7/.circleci/orbs/code-infra.yml
 
 parameters:
   browserstack-force:
@@ -50,6 +50,11 @@ default-job: &default-job
     # expose it globally otherwise we have to thread it from each job to the install command
     BROWSERSTACK_FORCE: << pipeline.parameters.browserstack-force >>
     COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
+    # Used by the code-infra orb to diff against the correct base branch for dedupe and prettier checks
+    # #target-branch-reference
+    # Replace `master` with the new branch `vX.x` when creating the first PR on the vX.x branch
+    # For example, when creating v9 from v8, `master -> v8.x`
+    BASE_BRANCH: master
   working_directory: /tmp/mui
   executor: code-infra/mui-node
 # CircleCI has disabled the cache across forks for security reasons.


### PR DESCRIPTION
Sets `BASE_BRANCH=master` in the `default-job` environment block so that the shared orb's `pnpm-dedupe` and `prettier` commands diff against the correct base branch.

Companion to https://github.com/mui/mui-public/pull/1156.