### PR TITLE
[code-infra] Set BASE_BRANCH env var in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,6 +154,27 @@ jobs:
     steps:
       - checkout
       - install-deps
+      - run:
+          name: Resolve base branch
+          command: |
+            BASE_BRANCH="master"
+            if [[ -n "${CIRCLE_PULL_REQUEST}" ]]; then
+              PR_NUMBER="${CIRCLE_PULL_REQUEST##*/}"
+              REPO_SLUG="${CIRCLE_PULL_REQUEST#https://github.com/}"
+              REPO_SLUG="${REPO_SLUG%/pull/*}"
+              FETCHED_BASE=$(curl -sf "https://api.github.com/repos/${REPO_SLUG}/pulls/${PR_NUMBER}" | jq -r '.base.ref // empty')
+              if [[ -n "${FETCHED_BASE}" ]]; then
+                BASE_BRANCH="${FETCHED_BASE}"
+              fi
+            fi
+            echo "Resolved base branch: ${BASE_BRANCH}"
+            git fetch origin "${BASE_BRANCH}" --depth 1
+            if [[ $(git diff --name-status "${BASE_BRANCH:-master}" | grep -E 'pnpm-workspace\.yaml|pnpm-lock.yaml|package\.json') == "" ]];
+            then
+              echo "No changes to dependencies detected. Skipping..."
+            else
+              pnpm dedupe --check
+            fi
       - code-infra/check-static-changes
       - run:
           name: Generate PropTypes


### PR DESCRIPTION
Sets `BASE_BRANCH=v8.x` in the `default-job` environment block so that the shared orb's `pnpm-dedupe` and `prettier` commands diff against the correct base branch.

Also updates the orb hash to `48198a7131b2ee621cc13bc7729cc41c72f370e7`.

Companion to https://github.com/mui/mui-public/pull/1156 and https://github.com/mui/mui-x/pull/21548.