### PR TITLE
[code-infra] Upgrade test_unit to large resource class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,7 @@ jobs:
 
   test_unit:
     <<: *default-job
+    resource_class: large
     steps:
       - checkout
       - install-deps:
@@ -100,7 +101,12 @@ jobs:
           name: Test JSDOM
           command: |
             # Fully saturate all the available CPUs by splitting the tests in 1 shard per CPU
-            pnpm exec concurrently "pnpm test:unit:jsdom --reporter=blob  --reporter=dot --shard=1/2" "pnpm test:unit:jsdom --reporter=blob  --reporter=dot --shard=2/2" || TEST_EXIT_CODE=$?
+            pnpm exec concurrently \
+              "pnpm test:unit:jsdom --reporter=blob --reporter=dot --shard=1/4" \
+              "pnpm test:unit:jsdom --reporter=blob --reporter=dot --shard=2/4" \
+              "pnpm test:unit:jsdom --reporter=blob --reporter=dot --shard=3/4" \
+              "pnpm test:unit:jsdom --reporter=blob --reporter=dot --shard=4/4" \
+              || TEST_EXIT_CODE=$?
             pnpm exec vitest run --merge-reports
             # Reports merged, we can now exit with the stored code
             exit ${TEST_EXIT_CODE:-0}


### PR DESCRIPTION
## Summary

From https://github.com/mui/mui-public/issues/1157
The job was made capable of scaling linearly by CPU in https://github.com/mui/mui-x/pull/20179

- Upgrade `test_unit` CircleCI job to `resource_class: large` (4 vCPUs)
- Split test shards from 2 to 4 to fully utilize the additional CPUs

This drops the job runtime by about 40% (this PR run compared to average runtime on master over last 30 days)