### PR TITLE
[docs] Remove mentions of `mySvgRef`

### DIFF
--- a/docs/data/charts/composition/composition.md
+++ b/docs/data/charts/composition/composition.md
@@ -50,9 +50,7 @@ Notice that the `width` and `height` props are passed to the `ChartsDataProvider
 >
   <ChartsLegend />
   <ChartsLayerContainer>
-    <ChartsSvgLayer>
-      {children}
-    </ChartsSvgLayer>
+    <ChartsSvgLayer>{children}</ChartsSvgLayer>
   </ChartsLayerContainer>
 </ChartsDataProvider>
 ```
@@ -74,9 +72,7 @@ This means that you can't interleave different layers, such as rendering a canva
   height={300}
 >
   <ChartsLegend />
-  <ChartsSurface>
-    {children}
-  </ChartsSurface>
+  <ChartsSurface>{children}</ChartsSurface>
 </ChartsDataProvider>
 ```
 


### PR DESCRIPTION
Remove mentions of `mySvgRef` since the `ChartsSurface` `ref` prop is now an `HTMLDivElement`.

