### PR TITLE
[DataGrid] Prevent unnecessary row selection checkbox rerendering

### DIFF
--- a/packages/x-data-grid/src/components/columnSelection/GridCellCheckboxRenderer.tsx
+++ b/packages/x-data-grid/src/components/columnSelection/GridCellCheckboxRenderer.tsx
@@ -8,7 +8,7 @@ import { forwardRef } from '@mui/x-internals/forwardRef';
 import { useGridApiContext } from '../../hooks/utils/useGridApiContext';
 import { useGridRootProps } from '../../hooks/utils/useGridRootProps';
 import { getDataGridUtilityClass } from '../../constants/gridClasses';
-import { useGridSelector } from '../../hooks/utils/useGridSelector';
+import { useGridSelector, objectShallowCompare } from '../../hooks/utils/useGridSelector';
 import { checkboxPropsSelector } from '../../hooks/features/rowSelection/utils';
 import type { DataGridProcessedProps } from '../../models/props/DataGridProps';
 import type { GridRowSelectionCheckboxParams } from '../../models/params/gridRowSelectionCheckboxParams';
@@ -54,6 +54,7 @@ const GridCellCheckboxForwardRef = forwardRef<HTMLInputElement, GridRenderCellPa
         groupId: id,
         autoSelectParents: rootProps.rowSelectionPropagation?.parents ?? false,
       },
+      objectShallowCompare,
     );
 
     const disabled = !isSelectable;


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/21556

Props selector returns an object with boolean flags.

https://github.com/user-attachments/assets/440a19e8-0768-42ba-9e4d-670afda18906

