### PR TITLE
[charts] Fix tooltip blink between node and pointer anchor

### DIFF
--- a/packages/x-charts/src/ChartsTooltip/ChartsTooltipContainer.tsx
+++ b/packages/x-charts/src/ChartsTooltip/ChartsTooltipContainer.tsx
@@ -288,6 +288,8 @@ function ChartsTooltipContainer(inProps: ChartsTooltipContainerProps) {
         {isOpen && (
           <ChartsTooltipRoot
             {...other}
+            // The key is here to make sure the tooltip uses the new anchor immediately.
+            key={itemPosition ? 'charts-anchored' : 'charts-pointer'}
             className={classes?.root}
             open={isOpen}
             placement={


### PR DESCRIPTION
Fix #21306


I realised the tooltip anchor itself the the  `itemPosition` ref even if it's null.

To convince yourself, do the following modification, and you will see the tooltip blink somewhere else.
```diff
- left: itemPosition?.x ?? 0,
+ left: itemPosition?.x ?? 200,
top: itemPosition?.y ?? 0,
```


The issue probably comes from the fact we swich a ref to another one. And the anchor update is done in a second render step. Leading to an incponsistent intermediate state that renders the pointer tooltip, while anchoring it to the previous ref.


In the PR I use `key` to force react recognising it's a new component.


Fun fact, I found this because I tried the following setup, and noticed that the tooltip blink on the `anchorRef.current` while being blue


```jsx
itemPosition
	? ChartsTooltipRoot anchorEl={anchorRef.current}>{children}</ChartsTooltipRoot>
	: ChartsTooltipRoot anchorEl={pointerAnchorEl} sx={{ backgroundColor: 'blue'}}>{children}</ChartsTooltipRoot>
```




