### PR TITLE
[code-infra] Dedupe v8

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -271,7 +271,7 @@ importers:
         version: 7.3.7(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@mui/monorepo':
         specifier: github:mui/material-ui#v7.x
-        version: https://codeload.github.com/mui/material-ui/tar.gz/67acb51e5ffb2c26a17bd809884df348f3057ddc(@babel/core@7.28.5)(@types/express@5.0.3)(eslint@9.39.2)(typescript@5.9.3)(vitest@4.0.16)
+        version: https://codeload.github.com/mui/material-ui/tar.gz/5430aaaa648256beb88f42154051ff448bc62aeb(@babel/core@7.28.5)(@types/express@5.0.3)(eslint@9.39.2)(typescript@5.9.3)(vitest@4.0.16)
       '@mui/utils':
         specifier: 'catalog:'
         version: 7.3.7(@types/react@19.2.7)(react@19.2.3)
@@ -4432,9 +4432,9 @@ packages:
       '@types/react':
         optional: true
 
-  '@mui/monorepo@https://codeload.github.com/mui/material-ui/tar.gz/67acb51e5ffb2c26a17bd809884df348f3057ddc':
-    resolution: {tarball: https://codeload.github.com/mui/material-ui/tar.gz/67acb51e5ffb2c26a17bd809884df348f3057ddc}
-    version: 7.3.8
+  '@mui/monorepo@https://codeload.github.com/mui/material-ui/tar.gz/5430aaaa648256beb88f42154051ff448bc62aeb':
+    resolution: {tarball: https://codeload.github.com/mui/material-ui/tar.gz/5430aaaa648256beb88f42154051ff448bc62aeb}
+    version: 7.3.9
     engines: {node: '>=22.18.0', pnpm: 10.28.2}
 
   '@mui/private-theming@5.17.1':
@@ -14753,7 +14753,7 @@ snapshots:
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)
       '@types/react': 19.2.7
 
-  '@mui/monorepo@https://codeload.github.com/mui/material-ui/tar.gz/67acb51e5ffb2c26a17bd809884df348f3057ddc(@babel/core@7.28.5)(@types/express@5.0.3)(eslint@9.39.2)(typescript@5.9.3)(vitest@4.0.16)':
+  '@mui/monorepo@https://codeload.github.com/mui/material-ui/tar.gz/5430aaaa648256beb88f42154051ff448bc62aeb(@babel/core@7.28.5)(@types/express@5.0.3)(eslint@9.39.2)(typescript@5.9.3)(vitest@4.0.16)':
     dependencies:
       '@netlify/functions': 5.1.2
       '@slack/bolt': 4.6.0(@types/express@5.0.3)


### PR DESCRIPTION
Dedupe v8 as the release is failing: [CircleCI test_static](https://app.circleci.com/pipelines/github/mui/mui-x/121300/workflows/2f7047db-c374-4c1d-bd16-cff5904ee802/jobs/767564)