### PR TITLE
[code-infra] Update code-infra CircleCI orb to fix pnpm dedupe issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  code-infra: https://raw.githubusercontent.com/mui/mui-public/877573f0cfcf5da40f459e69bdd9667a7c12addd/.circleci/orbs/code-infra.yml
+  code-infra: https://raw.githubusercontent.com/mui/mui-public/b3e30c8c80b8a7add749bec88ff3c37cde2d05fb/.circleci/orbs/code-infra.yml
 
 parameters:
   browserstack-force:


### PR DESCRIPTION
[Explanation](https://mui-org.slack.com/archives/C042YB5RB3N/p1772465027573989).

Basically, `pnpm dedupe` was running against master instead of `v8.x`, which is why https://github.com/mui/mui-x/pull/21607 is failing in [test_static](https://app.circleci.com/pipelines/github/mui/mui-x/121300/workflows/2f7047db-c374-4c1d-bd16-cff5904ee802/jobs/767564).