### PR TITLE
[DataGridPro] Add role="presentation" to detail panel toggle header content

### DIFF
--- a/packages/x-data-grid-pro/src/hooks/features/detailPanel/gridDetailPanelToggleColDef.tsx
+++ b/packages/x-data-grid-pro/src/hooks/features/detailPanel/gridDetailPanelToggleColDef.tsx
@@ -30,5 +30,5 @@ export const GRID_DETAIL_PANEL_TOGGLE_COL_DEF: GridColDef = {
   },
   rowSpanValueGetter: (_, row, __, apiRef) => gridRowIdSelector(apiRef, row),
   renderCell: (params) => <GridDetailPanelToggleCell {...params} />,
-  renderHeader: ({ colDef }) => <div aria-label={colDef.headerName} role='presentation' />,
+  renderHeader: ({ colDef }) => <div aria-label={colDef.headerName} role="presentation" />,
 };


### PR DESCRIPTION
Adds `role="presentation"` to the `renderHeader` output of the detail panel toggle column.

This fixes a bug with ARIA audits, where it throws an error, because presentational elements with `aria-label` are mandatory to have a `role` assigned. (Rule [F59](https://www.w3.org/WAI/WCAG21/Techniques/failures/F59))

Fixes #4771 
Fixes #12515 
Fixes #14285 