### PR TITLE
[charts] Remove batch rendering checks in highlight selectors

### DIFF
--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartHighlight/highlightStates.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartHighlight/highlightStates.ts
@@ -1,26 +1,11 @@
 import type { HighlightItemIdentifier, SeriesId } from '../../../../models/seriesType';
-import type {
-  ChartsSeriesConfig,
-  ChartSeriesType,
-  HighlightScope,
-} from '../../../../models/seriesType/config';
+import type { ChartsSeriesConfig, HighlightScope } from '../../../../models/seriesType/config';
 
-const batchRenderingSeries = new Set<SeriesTypeWithBatchRendering>([
-  'bar',
-  'rangeBar',
-  'line',
-] as unknown as SeriesTypeWithBatchRendering[]);
 type SeriesTypeWithBatchRendering =
   | 'bar'
   | 'line'
   // Conditional type to add 'rangeBar' if it exists in ChartsSeriesConfig
   | (ChartsSeriesConfig extends { rangeBar: any } ? 'rangeBar' : never);
-
-export function isBatchRenderingSeriesType(
-  type: ChartSeriesType | undefined,
-): type is SeriesTypeWithBatchRendering {
-  return batchRenderingSeries.has(type as SeriesTypeWithBatchRendering);
-}
 
 export function isSeriesHighlighted<SeriesType extends SeriesTypeWithBatchRendering>(
   scope: Partial<HighlightScope<SeriesType>> | null,

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartHighlight/useChartHighlight.selectors.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartHighlight/useChartHighlight.selectors.ts
@@ -10,7 +10,6 @@ import {
   getSeriesUnfadedDataIndex,
   isSeriesFaded,
   isSeriesHighlighted,
-  isBatchRenderingSeriesType,
 } from './highlightStates';
 import { selectorChartsKeyboardItem } from '../useChartKeyboardNavigation';
 import { selectorChartSeriesProcessed } from '../../corePlugins/useChartSeries/useChartSeries.selectors';
@@ -222,9 +221,6 @@ export const selectorChartIsSeriesHighlighted = createSelector(
     item: HighlightItemIdentifierWithType<SeriesType> | null,
     seriesId: SeriesId,
   ) {
-    if (!isBatchRenderingSeriesType(item?.type)) {
-      return false;
-    }
     return isSeriesHighlighted(scope, item, seriesId);
   },
 );
@@ -237,9 +233,6 @@ export const selectorChartIsSeriesFaded = createSelector(
     item: HighlightItemIdentifierWithType<SeriesType> | null,
     seriesId: SeriesId,
   ) {
-    if (!isBatchRenderingSeriesType(item?.type)) {
-      return false;
-    }
     return isSeriesFaded(scope, item, seriesId);
   },
 );
@@ -252,9 +245,6 @@ export const selectorChartSeriesUnfadedItem = createSelector(
     item: HighlightItemIdentifierWithType<SeriesType> | null,
     seriesId: SeriesId,
   ) {
-    if (!isBatchRenderingSeriesType(item?.type)) {
-      return null;
-    }
     return getSeriesUnfadedDataIndex(scope, item, seriesId);
   },
 );
@@ -267,9 +257,6 @@ export const selectorChartSeriesHighlightedItem = createSelector(
     item: HighlightItemIdentifierWithType<SeriesType> | null,
     seriesId: SeriesId,
   ) {
-    if (!isBatchRenderingSeriesType(item?.type)) {
-      return null;
-    }
     return getSeriesHighlightedDataIndex(scope, item, seriesId);
   },
 );


### PR DESCRIPTION
Related to https://github.com/mui/mui-x/pull/21161#discussion_r2894793545.

Remove batch rendering checks in highlight selectors since it breaks highlighting when using composition. 