### PR TITLE
[charts-pro] test: image export truncated when page is zoomed out

### DIFF
--- a/test/regressions/index.test.ts
+++ b/test/regressions/index.test.ts
@@ -323,7 +323,7 @@ async function main() {
 
       await download.saveAs(screenshotPath);
 
-      await page.pause();
+      await page.close();
     });
   });
 }


### PR DESCRIPTION
Run argos without the fix from https://github.com/mui/mui-x/pull/21685.