### PR TITLE
[code-infra] Fix contributor generation in changelog

### DIFF
--- a/scripts/changelogUtils.mjs
+++ b/scripts/changelogUtils.mjs
@@ -143,9 +143,21 @@ function getContributors(commits = []) {
     contributors: new Set(),
     team: new Set(),
   };
-  for (const { author } of commits) {
-    if (!author || author.login.endsWith('[bot]')) {
-      break;
+  const warnUsers = new Map();
+  for (const commitItem of commits) {
+    const { author, commit } = commitItem;
+    if (!author || author.login === 'renovate[bot]') {
+      continue;
+    }
+    if (author.login === 'github-actions[bot]') {
+      // extract author name from commit message if the commit is made by github-actions bot
+      const authorNameMatch = commit.message.match(/@([a-zA-Z0-9-]+)/);
+      if (authorNameMatch) {
+        const username = `@${authorNameMatch[1]}`;
+        community.team.add(username);
+        warnUsers.set(commit.message.split('\n')[0].trim(), username);
+      }
+      continue;
     }
     const username = `@${author.login}`;
     if (author.association === 'team') {
@@ -155,6 +167,17 @@ function getContributors(commits = []) {
     } else {
       community.contributors.add(username);
     }
+  }
+  if (warnUsers.size > 0) {
+    console.warn(
+      `The following commits were made by github-actions[bot] and attributed to users based on the commit message:\n${Array.from(
+        warnUsers.entries(),
+      )
+        .map(([commitMessage, username]) => `- ${commitMessage}: ${username}`)
+        .join('\n')}
+Please verify that these attributions are correct. They have been added to the team members group.
+`,
+    );
   }
   return community;
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

Also updated the logic for extracting author from the commit title for cherry-picked PRs.

The output -

```md
Creating changelog for v8.27.4..v8.x when latest tagged version is 'v8.27.5'.
The following commits were made by github-actions[bot] and attributed to users based on the commit message:
- [DataGridPro] Fix sorting not reflected in nested server-side data (@MBilalShafi) (#21641): @MBilalShafi
- [DataGrid] Fix crash when `rows` and `rowModesModel` are updated simultaneously (@michelengelen) (#21684): @michelengelen
- [DataGridPro] Add role="presentation" to detail panel toggle header content (@michelengelen) (#21691): @michelengelen
- [charts] Refactor `LineChart` classes structure (@JCQuintas) (#21672): @JCQuintas
- [charts-pro] Fix image export truncated when page is zoomed out (@bernardobelchior) (#21696): @bernardobelchior
- [docs] Fix `AssistantWithDataSource` demo crashing (@sai6855) (#21631): @sai6855
- [test] Add missing tests for forwarding props to filter operators in DataGrid (@siriwatknp) (#21700): @siriwatknp
- [data-grid] Add missing resizablePanelHandle classes to gridClasses object (@sai6855) (#21632): @sai6855
- [docs] Move Range Bar Chart to existing charts (@bernardobelchior) (#21122): @bernardobelchior
- [data-grid] Refactor headerAlign style calls (@sai6855) (#21633): @sai6855
- [code-infra] Removed `getTeamMembers` function and usage from release script (@michelengelen) (#21608): @michelengelen
- [DataGrid] Fix keyboard navigation with single-row checkbox selection (@mj12albert) (#21529): @mj12albert
- [charts] Refactor `ScatterChart` classes structure (@JCQuintas) (#21706): @JCQuintas
Please verify that these attributions are correct. They have been added to the team members group.

## v8.27.5
<!-- generated comparing v8.27.4..v8.x -->
_Mar 11, 2026_

We'd like to extend a big thank you to the 8 contributors who made this release possible. Here are some highlights ✨:

TODO INSERT HIGHLIGHTS

The following team members contributed to this release:
@arminmeh, @bernardobelchior, @JCQuintas, @MBilalShafi, @michelengelen, @mj12albert, @sai6855, @siriwatknp

### Data Grid
...
```

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
