### PR TITLE
[charts] Improve type safety in `identifierCleaner`

### DIFF
--- a/packages/x-charts/src/internals/identifierCleaner.ts
+++ b/packages/x-charts/src/internals/identifierCleaner.ts
@@ -1,5 +1,5 @@
-import type { SeriesId, SeriesItemIdentifierWithType } from '../models';
-import type { SeriesTypeWithDataIndex } from '../models/seriesType/config';
+import type { SeriesId } from '../models';
+import type { ChartSeriesType } from '../models/seriesType/config';
 
 /**
  * Cleans an identifier by extracting only type, seriesId, and dataIndex properties.
@@ -10,13 +10,10 @@ import type { SeriesTypeWithDataIndex } from '../models/seriesType/config';
  * properties (like heatmap's xIndex/yIndex) must provide their own cleaner.
  */
 export const identifierCleanerSeriesIdDataIndex = <
-  SeriesType extends SeriesTypeWithDataIndex,
->(identifier: {
-  type: SeriesType;
-  seriesId: SeriesId;
-  dataIndex?: number;
-}): SeriesItemIdentifierWithType<SeriesType> => {
-  // @ts-expect-error we need to trust the output type here, since SeriesType is generic
+  T extends { type: ChartSeriesType; seriesId: SeriesId; dataIndex?: number },
+>(
+  identifier: T,
+): Pick<T, 'type' | 'seriesId' | 'dataIndex'> => {
   return {
     type: identifier.type,
     seriesId: identifier.seriesId,


### PR DESCRIPTION
Related to https://github.com/mui/mui-x/pull/21710#discussion_r2922841642

Improves type-safety of `identifierCleanerSeriesIdDataIndex` to ensure it shows a type error if assigned to series whose item identifier doesn't match. 

If we revert the heatmap identifier to the one before #21710, we see a type-error:

```
../x-charts-pro/src/Heatmap/seriesConfig/index.ts(29,3): error TS2322: Type '<T extends { type: ChartSeriesType; seriesId: SeriesId; dataIndex?: number; }>(identifier: T) => Pick<T, "type" | "seriesId" | "dataIndex">' is not assignable to type 'IdentifierCleaner<"heatmap">'.
  Type 'Pick<HeatmapItemIdentifier, "type" | "seriesId" | "dataIndex">' is missing the following properties from type 'HeatmapItemIdentifier': xIndex, yIndex
```

<img width="1060" height="804" alt="image" src="https://github.com/user-attachments/assets/2fe42811-ca2d-4e07-a7bc-482501ec77c5" />
