### PR TITLE
[charts] Use dedicated shape for line charts without `showMark`

### DIFF
--- a/docs/data/charts/lines/LineOverview.js
+++ b/docs/data/charts/lines/LineOverview.js
@@ -4,7 +4,7 @@ import Box from '@mui/material/Box';
 import { alpha, useTheme } from '@mui/material/styles';
 import { ChartsDataProviderPro } from '@mui/x-charts-pro/ChartsDataProviderPro';
 import { ChartsSurface } from '@mui/x-charts-pro/ChartsSurface';
-import { LinePlot } from '@mui/x-charts-pro/LineChart';
+import { LineHighlightPlot, LinePlot } from '@mui/x-charts-pro/LineChart';
 import { ChartsXAxis } from '@mui/x-charts-pro/ChartsXAxis';
 import { ChartsYAxis } from '@mui/x-charts-pro/ChartsYAxis';
 import { useDrawingArea, useXScale } from '@mui/x-charts-pro/hooks';
@@ -174,6 +174,7 @@ export default function LineOverview() {
           <ChartsYAxis axisId="unemployment-axis" label="Unemployment Rate" />
           <ChartsYAxis axisId="gdp-axis" label="GDP per capita in US$" />
           <ChartsAxisHighlight x="line" />
+          <LineHighlightPlot />
           <ChartZoomSlider />
         </ChartsSurface>
         <ChartsTooltip />

--- a/docs/data/charts/lines/LineOverview.tsx
+++ b/docs/data/charts/lines/LineOverview.tsx
@@ -4,7 +4,7 @@ import Box from '@mui/material/Box';
 import { alpha, useTheme } from '@mui/material/styles';
 import { ChartsDataProviderPro } from '@mui/x-charts-pro/ChartsDataProviderPro';
 import { ChartsSurface } from '@mui/x-charts-pro/ChartsSurface';
-import { LinePlot } from '@mui/x-charts-pro/LineChart';
+import { LineHighlightPlot, LinePlot } from '@mui/x-charts-pro/LineChart';
 import { ChartsXAxis } from '@mui/x-charts-pro/ChartsXAxis';
 import { ChartsYAxis } from '@mui/x-charts-pro/ChartsYAxis';
 import { useDrawingArea, useXScale } from '@mui/x-charts-pro/hooks';
@@ -180,6 +180,7 @@ export default function LineOverview() {
           <ChartsYAxis axisId="unemployment-axis" label="Unemployment Rate" />
           <ChartsYAxis axisId="gdp-axis" label="GDP per capita in US$" />
           <ChartsAxisHighlight x="line" />
+          <LineHighlightPlot />
           <ChartZoomSlider />
         </ChartsSurface>
         <ChartsTooltip />

--- a/packages/x-charts/src/LineChart/LineHighlightPlot.tsx
+++ b/packages/x-charts/src/LineChart/LineHighlightPlot.tsx
@@ -124,8 +124,7 @@ function LineHighlightPlot(props: LineHighlightPlotProps) {
                 color={colorGetter(highlightedIndex)}
                 x={x}
                 y={y}
-                shape={shape}
-                {...(!showMark ? { shape: 'circle', r: 4 } : {})}
+                {...(!showMark ? { shape: 'circle', r: 4 } : { shape })}
                 {...slotProps?.lineHighlight}
               />
             );

--- a/packages/x-charts/src/LineChart/LineHighlightPlot.tsx
+++ b/packages/x-charts/src/LineChart/LineHighlightPlot.tsx
@@ -83,7 +83,8 @@ function LineHighlightPlot(props: LineHighlightPlotProps) {
               visibleStackedData,
               data,
               disableHighlight,
-              shape = 'circle',
+              shape,
+              showMark,
             } = series[seriesId];
 
             if (disableHighlight || data[highlightedIndex] == null) {
@@ -124,6 +125,7 @@ function LineHighlightPlot(props: LineHighlightPlotProps) {
                 x={x}
                 y={y}
                 shape={shape}
+                {...(!showMark ? { shape: 'circle', r: 4 } : {})}
                 {...slotProps?.lineHighlight}
               />
             );

--- a/packages/x-charts/src/models/seriesType/line.ts
+++ b/packages/x-charts/src/models/seriesType/line.ts
@@ -119,7 +119,7 @@ export type LineItemIdentifier = {
 
 export interface DefaultizedLineSeriesType extends DefaultizedProps<
   LineSeriesType,
-  CommonDefaultizedProps | 'color'
+  CommonDefaultizedProps | 'color' | 'shape'
 > {
   hidden: boolean;
 }


### PR DESCRIPTION
Follow up on #21713

When using axis highlight with a line chart that does not have marks, it feels weird to see large shape for each series

- The fact that each series has a dedicated shape is useless because it does not relate to the tooltip/legend
- The fact the shapes are that big is to fully cover the default marks. When we know that marks are not render, we can reduce a bit the size of the highlight