### PR TITLE
[x-license] Fix process.env.MUI_VERSION not being replaced during build

### DIFF
--- a/mui-env.d.ts
+++ b/mui-env.d.ts
@@ -3,6 +3,7 @@ export {}; // Ensure this file is treated as a module to avoid global scope TS e
 declare global {
   interface MUIEnv {
     NODE_ENV?: string;
+    MUI_VERSION?: string;
   }
 
   interface Process {

--- a/packages/x-charts-premium/src/ChartsDataProviderPremium/ChartsDataProviderPremium.tsx
+++ b/packages/x-charts-premium/src/ChartsDataProviderPremium/ChartsDataProviderPremium.tsx
@@ -23,7 +23,7 @@ import { useChartsDataProviderPremiumProps } from './useChartsDataProviderPremiu
 
 const packageInfo = {
   releaseDate: '__RELEASE_INFO__',
-  version: (process.env as any).MUI_VERSION,
+  version: process.env.MUI_VERSION!,
   name: 'x-charts-premium' as const,
 };
 

--- a/packages/x-charts-pro/src/ChartsDataProviderPro/ChartsDataProviderPro.tsx
+++ b/packages/x-charts-pro/src/ChartsDataProviderPro/ChartsDataProviderPro.tsx
@@ -23,7 +23,7 @@ import { ChartsWatermark } from '../internals/ChartsWatermark';
 
 const packageInfo = {
   releaseDate: '__RELEASE_INFO__',
-  version: (process.env as any).MUI_VERSION,
+  version: process.env.MUI_VERSION!,
   name: 'x-charts-pro' as const,
 };
 

--- a/packages/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
+++ b/packages/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
@@ -61,7 +61,7 @@ const configuration: GridConfiguration<GridPrivateApiPremium, DataGridPremiumPro
 };
 const packageInfo = {
   releaseDate: '__RELEASE_INFO__',
-  version: (process.env as any).MUI_VERSION,
+  version: process.env.MUI_VERSION!,
   name: 'x-data-grid-premium' as const,
 };
 const watermark = <Watermark packageInfo={packageInfo} />;

--- a/packages/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
+++ b/packages/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
@@ -37,7 +37,7 @@ const configuration: GridConfiguration<GridPrivateApiPro> = {
 };
 const packageInfo = {
   releaseDate: '__RELEASE_INFO__',
-  version: (process.env as any).MUI_VERSION,
+  version: process.env.MUI_VERSION!,
   name: 'x-data-grid-pro' as const,
 };
 const watermark = <Watermark packageInfo={packageInfo} />;

--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
@@ -65,7 +65,7 @@ import { dateRangePickerDay2Classes } from '../DateRangePickerDay2';
 
 const packageInfo = {
   releaseDate: '__RELEASE_INFO__',
-  version: (process.env as any).MUI_VERSION,
+  version: process.env.MUI_VERSION!,
   name: 'x-date-pickers-pro' as const,
 };
 

--- a/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.tsx
@@ -276,7 +276,7 @@ const DateRangePickerDayRaw = React.forwardRef(function DateRangePickerDay(
 
   useLicenseVerifier({
     releaseDate: '__RELEASE_INFO__',
-    version: (process.env as any).MUI_VERSION,
+    version: process.env.MUI_VERSION!,
     name: 'x-date-pickers-pro',
   });
   const adapter = usePickerAdapter();

--- a/packages/x-date-pickers-pro/src/internals/hooks/useDesktopRangePicker/useDesktopRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/internals/hooks/useDesktopRangePicker/useDesktopRangePicker.tsx
@@ -34,7 +34,7 @@ export const useDesktopRangePicker = <
 }: UseDesktopRangePickerParams<TView, TEnableAccessibleFieldDOMStructure, TExternalProps>) => {
   useLicenseVerifier({
     releaseDate: '__RELEASE_INFO__',
-    version: (process.env as any).MUI_VERSION,
+    version: process.env.MUI_VERSION!,
     name: 'x-date-pickers-pro',
   });
 

--- a/packages/x-date-pickers-pro/src/internals/hooks/useMobileRangePicker/useMobileRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/internals/hooks/useMobileRangePicker/useMobileRangePicker.tsx
@@ -38,7 +38,7 @@ export const useMobileRangePicker = <
 }: UseMobileRangePickerParams<TView, TEnableAccessibleFieldDOMStructure, TExternalProps>) => {
   useLicenseVerifier({
     releaseDate: '__RELEASE_INFO__',
-    version: (process.env as any).MUI_VERSION,
+    version: process.env.MUI_VERSION!,
     name: 'x-date-pickers-pro',
   });
 

--- a/packages/x-scheduler-premium/src/event-calendar-premium/EventCalendarPremium.tsx
+++ b/packages/x-scheduler-premium/src/event-calendar-premium/EventCalendarPremium.tsx
@@ -20,7 +20,7 @@ import { EventCalendarPremiumProps } from './EventCalendarPremium.types';
 
 const packageInfo = {
   releaseDate: '__RELEASE_INFO__',
-  version: (process.env as any).MUI_VERSION,
+  version: process.env.MUI_VERSION!,
   name: 'x-scheduler-premium' as const,
 };
 const watermark = <Watermark packageInfo={packageInfo} />;

--- a/packages/x-scheduler-premium/src/event-timeline-premium/EventTimelinePremium.tsx
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/EventTimelinePremium.tsx
@@ -25,7 +25,7 @@ import { EventTimelinePremiumStyledContext } from './EventTimelinePremiumStyledC
 
 const packageInfo = {
   releaseDate: '__RELEASE_INFO__',
-  version: (process.env as any).MUI_VERSION,
+  version: process.env.MUI_VERSION!,
   name: 'x-scheduler-premium' as const,
 };
 const watermark = <Watermark packageInfo={packageInfo} />;

--- a/packages/x-tree-view-pro/src/RichTreeViewPro/RichTreeViewPro.tsx
+++ b/packages/x-tree-view-pro/src/RichTreeViewPro/RichTreeViewPro.tsx
@@ -67,7 +67,7 @@ type RichTreeViewProComponent = (<R extends {}, Multiple extends boolean | undef
 
 const packageInfo = {
   releaseDate: '__RELEASE_INFO__',
-  version: (process.env as any).MUI_VERSION,
+  version: process.env.MUI_VERSION!,
   name: 'x-tree-view-pro' as const,
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

## Summary

- The `(process.env as any).MUI_VERSION` pattern prevented `babel-plugin-transform-inline-environment-variables` from replacing the value during build. The `as any` TypeScript cast wraps the AST node in a `TSAsExpression`, which the Babel plugin doesn't recognize. By the time the TS preset strips the cast, the env var plugin has already run.
- This caused `packageVersion` to be `undefined` in published npm packages, making `parseInt(undefined)` return `NaN`, so the `NotValidForPackage` license check (`packageMajorVersion >= 9`) was always skipped.
- Replaced `(process.env as any).MUI_VERSION` with `process.env.MUI_VERSION!` in all 11 affected files and added `MUI_VERSION` to the `MUIEnv` type in `mui-env.d.ts`.

**Before:**
<img width="573" height="252" alt="before" src="https://github.com/user-attachments/assets/5c1de552-4707-4d2f-83d8-c7dcf9c2fdc2" />

**After:**
<img width="683" height="284" alt="after" src="https://github.com/user-attachments/assets/310e64c2-d73f-4799-86cb-5d3c3c3416a0" />


## Test plan

- [x] Run `pnpm --filter @mui/x-data-grid-pro build` and verify `version: "9.0.0-alpha.3"` in `build/DataGridPro/DataGridPro.js` (not `process.env.MUI_VERSION`)
- [x] Run typechecks: `pnpm --filter "@mui/x-data-grid*" run typescript`, `pnpm --filter "@mui/x-charts*" run typescript`, `pnpm --filter "@mui/x-date-pickers*" run typescript`, `pnpm --filter "@mui/x-tree-view*" run typescript`
- [ ] Test with a V8 license key on a V9 package and confirm `NotValidForPackage` status is returned
