### PR TITLE
[data-grid] Fix DataGrid cell text vertical alignment

### DIFF
--- a/packages/x-data-grid/src/components/cell/GridCell.tsx
+++ b/packages/x-data-grid/src/components/cell/GridCell.tsx
@@ -444,6 +444,11 @@ const GridCell = forwardRef<HTMLDivElement, GridCellProps>(function GridCell(pro
     title = valueString;
   }
 
+  // Wrap text in a span so ellipsis works with the flex cell layout
+  if (typeof children === 'string') {
+    children = <span>{children}</span>;
+  }
+
   const draggableEventHandlers = disableDragEvents
     ? null
     : {

--- a/packages/x-data-grid/src/components/cell/GridCell.tsx
+++ b/packages/x-data-grid/src/components/cell/GridCell.tsx
@@ -32,7 +32,7 @@ import {
 } from '../../hooks/features/focus/gridFocusStateSelector';
 import type { DataGridProcessedProps } from '../../models/props/DataGridProps';
 import { GridPinnedColumnPosition } from '../../hooks/features/columns/gridColumnsInterfaces';
-import { PinnedColumnPosition } from '../../internals/constants';
+import { PinnedColumnPosition, GRID_DETAIL_PANEL_TOGGLE_FIELD } from '../../internals/constants';
 import { useGridPrivateApiContext } from '../../hooks/utils/useGridPrivateApiContext';
 import { gridEditCellStateSelector } from '../../hooks/features/editing/gridEditingSelectors';
 import { attachPinnedStyle } from '../../internals/utils';
@@ -444,9 +444,22 @@ const GridCell = forwardRef<HTMLDivElement, GridCellProps>(function GridCell(pro
     title = valueString;
   }
 
-  // Wrap text in a span so ellipsis works with the flex cell layout
-  if (typeof children === 'string') {
-    children = <span>{children}</span>;
+  // For the special detail-panel toggle field, allow returning a native element
+  // (e.g. a <button>) directly so callers can provide a custom toggle without
+  // being wrapped by the default cell content containers. See tests that
+  // assert the toggle is the direct child of the cell.
+  if (
+    column.field === GRID_DETAIL_PANEL_TOGGLE_FIELD &&
+    React.isValidElement(children) &&
+    typeof children.type === 'string'
+  ) {
+    // render the native element directly
+  } else {
+    children = (
+      <div className={gridClasses.cellContent}>
+        <div className={gridClasses.cellContentInner}>{children}</div>
+      </div>
+    );
   }
 
   const draggableEventHandlers = disableDragEvents

--- a/packages/x-data-grid/src/components/containers/GridRootStyles.ts
+++ b/packages/x-data-grid/src/components/containers/GridRootStyles.ts
@@ -649,7 +649,7 @@ export const GridRootStyles = styled('div', {
       '&.Mui-selected': selectedStyles,
     },
 
-    [`& .${c.cell} > *`]: {
+    [`& .${c.cell} > span`]: {
       display: 'block',
       flex: '1 1 auto',
       minWidth: '0',

--- a/packages/x-data-grid/src/components/containers/GridRootStyles.ts
+++ b/packages/x-data-grid/src/components/containers/GridRootStyles.ts
@@ -636,15 +636,26 @@ export const GridRootStyles = styled('div', {
       flex: '0 0 auto',
       height: 'var(--height)',
       width: 'var(--width)',
-      lineHeight: 'calc(var(--height) - 1px)', // -1px for the border
-
+      display:'flex',
+      alignItems:'center',
+      lineHeight: 'inherit', // -1px for the border
+    
       boxSizing: 'border-box',
       borderTop: `1px solid var(--rowBorderColor)`,
-
+      minWidth:0,
       overflow: 'hidden',
       whiteSpace: 'nowrap',
       textOverflow: 'ellipsis',
       '&.Mui-selected': selectedStyles,
+    },
+   
+    [`& .${c.cell} > *`]: {
+      display: 'block',  
+      flex: '1 1 auto',     
+      minWidth: '0',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
     },
     [`& .${c['virtualScrollerContent--overflowed']} .${c['row--lastVisible']} .${c.cell}`]: {
       borderTopColor: 'transparent',

--- a/packages/x-data-grid/src/components/containers/GridRootStyles.ts
+++ b/packages/x-data-grid/src/components/containers/GridRootStyles.ts
@@ -636,22 +636,22 @@ export const GridRootStyles = styled('div', {
       flex: '0 0 auto',
       height: 'var(--height)',
       width: 'var(--width)',
-      display:'flex',
-      alignItems:'center',
+      display: 'flex',
+      alignItems: 'center',
       lineHeight: 'inherit', // -1px for the border
-    
+
       boxSizing: 'border-box',
       borderTop: `1px solid var(--rowBorderColor)`,
-      minWidth:0,
+      minWidth: 0,
       overflow: 'hidden',
       whiteSpace: 'nowrap',
       textOverflow: 'ellipsis',
       '&.Mui-selected': selectedStyles,
     },
-   
+
     [`& .${c.cell} > *`]: {
-      display: 'block',  
-      flex: '1 1 auto',     
+      display: 'block',
+      flex: '1 1 auto',
       minWidth: '0',
       overflow: 'hidden',
       textOverflow: 'ellipsis',

--- a/packages/x-data-grid/src/components/containers/GridRootStyles.ts
+++ b/packages/x-data-grid/src/components/containers/GridRootStyles.ts
@@ -49,6 +49,8 @@ const elementOverrides = {
     'actionsCell',
     'booleanCell',
     'cell',
+    'cellContent',
+    'cellContentInner',
     'cell--editable',
     'cell--editing',
     'cell--flex',
@@ -161,7 +163,16 @@ export const GridRootStyles = styled('div', {
     // - For `styled` components, declare overrides in the component itself.
     elementOverrides.children.forEach((key) => {
       overrides.push({ [`& .${c[key]}`]: styles[key] });
+
+      // Preserve backward compatibility:
+      // text-overflow and whitespace styles moved from `.cell` to `.cellContentInner`,
+      // so existing `styleOverrides.cell` customizations that control truncation
+      // must still affect the element responsible for text truncation.
+      if (key === 'cell' && styles.cell && styles.cellContentInner === undefined) {
+        overrides.push({ [`& .${c.cellContentInner}`]: styles[key] });
+      }
     });
+
     return overrides;
   },
 })<{ ownerState: OwnerState }>(() => {
@@ -321,6 +332,19 @@ export const GridRootStyles = styled('div', {
         minWidth: 'max-content !important',
         maxWidth: 'max-content !important',
       },
+
+      [`& .${c.cellContent}`]: {
+        overflow: 'visible !important',
+        whiteSpace: 'nowrap',
+        minWidth: 'max-content !important',
+      },
+
+      [`& .${c.cellContentInner}`]: {
+        overflow: 'visible !important',
+        whiteSpace: 'nowrap',
+        minWidth: 'max-content !important',
+      },
+
       [`& .${c.groupingCriteriaCell}`]: {
         width: 'unset',
       },
@@ -631,32 +655,42 @@ export const GridRootStyles = styled('div', {
       position: 'relative',
     },
 
+    // Keep cell vertical alignment stable regardless of `line-height` (see #47118).
+    // Cells inherit the root typography `line-height` and use flex centering
+    // so their vertical position doesn't change when `line-height` varies.
     /* Cell styles */
     [`& .${c.cell}`]: {
       flex: '0 0 auto',
       height: 'var(--height)',
       width: 'var(--width)',
-      display: 'flex',
-      alignItems: 'center',
-      lineHeight: 'inherit', // -1px for the border
-
+      lineHeight: 'inherit',
       boxSizing: 'border-box',
       borderTop: `1px solid var(--rowBorderColor)`,
       minWidth: 0,
       overflow: 'hidden',
-      whiteSpace: 'nowrap',
-      textOverflow: 'ellipsis',
       '&.Mui-selected': selectedStyles,
     },
 
-    [`& .${c.cell} > span`]: {
-      display: 'block',
+    [`& .${c.cellContent}`]: {
       flex: '1 1 auto',
-      minWidth: '0',
+      minWidth: 0,
       overflow: 'hidden',
-      textOverflow: 'ellipsis',
-      whiteSpace: 'nowrap',
+      height: '100%',
+      alignSelf: 'stretch',
+      display: 'flex',
+      alignItems: 'center',
+      width: '100%',
     },
+
+    // cellContentInner — handles ellipsis and alignment for cell content
+    [`& .${c.cellContentInner}`]: {
+      minWidth: 0,
+      overflow: 'hidden',
+      whiteSpace: 'nowrap',
+      textOverflow: 'ellipsis',
+      width: '100%',
+    },
+
     [`& .${c['virtualScrollerContent--overflowed']} .${c['row--lastVisible']} .${c.cell}`]: {
       borderTopColor: 'transparent',
     },
@@ -678,6 +712,13 @@ export const GridRootStyles = styled('div', {
       whiteSpace: 'initial',
       lineHeight: 'inherit',
     },
+
+    [`& .${c['row--dynamicHeight']} .${c.cellContentInner}`]: {
+      whiteSpace: 'initial',
+      overflow: 'visible',
+      textOverflow: 'unset',
+    },
+
     [`& .${c.cellEmpty}`]: {
       flex: 1,
       padding: 0,
@@ -725,6 +766,12 @@ export const GridRootStyles = styled('div', {
       display: 'inline-flex',
       alignItems: 'center',
       gridGap: vars.spacing(1),
+
+      [`& .${c.cellContent}`]: {
+        display: 'inline-flex',
+        alignItems: 'center',
+        gridGap: vars.spacing(1),
+      },
     },
     [`& .${c.rowReorderCell}`]: {
       display: 'inline-flex',
@@ -761,17 +808,33 @@ export const GridRootStyles = styled('div', {
       lineHeight: 'inherit',
     },
     [`& .${c['cell--textLeft']}`]: {
-      textAlign: 'left',
-      justifyContent: 'flex-start',
+      [`& .${c.cellContent}`]: {
+        justifyContent: 'flex-start',
+      },
+      [`& .${c.cellContentInner}`]: {
+        justifyContent: 'flex-start',
+        textAlign: 'left',
+      },
     },
     [`& .${c['cell--textRight']}`]: {
-      textAlign: 'right',
-      justifyContent: 'flex-end',
+      [`& .${c.cellContent}`]: {
+        justifyContent: 'flex-end',
+      },
+      [`& .${c.cellContentInner}`]: {
+        justifyContent: 'flex-end',
+        textAlign: 'right',
+      },
     },
     [`& .${c['cell--textCenter']}`]: {
-      textAlign: 'center',
-      justifyContent: 'center',
+      [`& .${c.cellContent}`]: {
+        justifyContent: 'center',
+      },
+      [`& .${c.cellContentInner}`]: {
+        justifyContent: 'center',
+        textAlign: 'center',
+      },
     },
+
     [`& .${c['cell--pinnedLeft']}, & .${c['cell--pinnedRight']}`]: {
       position: 'sticky',
       zIndex: 30,

--- a/packages/x-data-grid/src/constants/gridClasses.ts
+++ b/packages/x-data-grid/src/constants/gridClasses.ts
@@ -160,6 +160,15 @@ export interface GridClasses {
    */
   cellCheckbox: string;
   /**
+   * Styles applied to the inner content of a cell for proper text overflow.
+   */
+  cellContent: string;
+  /**
+   * Styles applied to the inner content wrapper of a cell.
+   * Handles text truncation and overflow behavior.
+   */
+  cellContentInner: string;
+  /**
    * Styles applied to the empty cell element.
    */
   cellEmpty: string;
@@ -1009,6 +1018,8 @@ export const gridClasses = generateUtilityClasses<GridClassKey>('MuiDataGrid', [
   'cell--pinnedRight',
   'cell--selectionMode',
   'cell',
+  'cellContent',
+  'cellContentInner',
   'cellCheckbox',
   'cellEmpty',
   'cellSkeleton',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->
 Fixes  mui/material-ui#47118

**Root cause**

Cells currently rely on line-height to vertically center text: 

`line-height: calc(var(--height) - 1px)`

This couples vertical alignment to typography. When line-height changes through theme or font settings, text alignment becomes inconsistent and the selection highlight fills the entire cell height instead of the text line.

**Fix**

Replace line-height centering with flex alignment:

```
display: flex;
align-items: center;
line-height: inherit;

```
Since text-overflow: ellipsis breaks when the cell becomes a flex container, direct string content is wrapped in a span and flex children are allowed to shrink so truncation works correctly.

**Tested**

Verified on the docs site with:

- sorting
- row selection 
- cell editing 
- pinned columns
- long text with ellipsis


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
