### PR TITLE
[DataGrid] Exclude `ServerSideLazyLoadingRevalidation` from argos

### DIFF
--- a/test/regressions/testsBySuite.ts
+++ b/test/regressions/testsBySuite.ts
@@ -26,7 +26,7 @@ const docsImports = import.meta.glob<React.ComponentType>(
     '!docsx/data/data-grid/filtering/RemoveBuiltInOperators', // Needs interaction
     '!docsx/data/data-grid/filtering/CustomRatingOperator', // Needs interaction
     '!docsx/data/data-grid/filtering/CustomInputComponent', // Needs interaction
-    '!docsx/data/data-grid/server-side-data/ServerSideLazyLoadingRevalidation',
+    '!docsx/data/data-grid/server-side-data/ServerSideLazyLoadingRevalidation', // Flashes cause flaky argos screenshots
     '!docsx/data/date-pickers/date-calendar/DateCalendarServerRequest', // Has random behavior (TODO: Use seeded random)
     '!docsx/data/charts/tooltip/Custom*', // Composition example
     '!docsx/data/charts/tooltip/Item*', // Composition example


### PR DESCRIPTION
Flashes in https://deploy-preview-21628--material-ui-x.netlify.app/x/react-data-grid/server-side-data/lazy-loading/#dynamically-updated-datasets demo is causing argos to fail in multiple PR's, Opened PR to remove it from argos

Check CI's of https://github.com/mui/mui-x/pull/21733, https://github.com/mui/mui-x/pull/21628, https://github.com/mui/mui-x/pull/21738