### PR TITLE
[charts] Fix WebGL print export canvas stretching

### DIFF
--- a/packages/x-charts-pro/src/internals/plugins/useChartProExport/common.ts
+++ b/packages/x-charts-pro/src/internals/plugins/useChartProExport/common.ts
@@ -42,16 +42,11 @@ export function copyCanvasesContent(original: Element, clone: Element) {
 
         const img = cloneCanvas.ownerDocument.createElement('img');
         img.src = dataURL;
-        img.width = cloneCanvas.width;
-        img.height = cloneCanvas.height;
+        // Use the CSS dimensions (not canvas.width/height which are in device pixels)
+        img.width = originalCanvas.clientWidth;
+        img.height = originalCanvas.clientHeight;
 
-        for (const styleKey in cloneCanvas.style) {
-          if (!Object.hasOwn(img.style, styleKey) || !Object.hasOwn(cloneCanvas.style, styleKey)) {
-            continue;
-          }
-
-          img.style[styleKey] = cloneCanvas.style[styleKey];
-        }
+        img.style.cssText = cloneCanvas.style.cssText;
 
         cloneCanvas.replaceWith(img);
 


### PR DESCRIPTION
## Summary

- Fix canvas-to-image conversion using `canvas.width`/`height` (device pixel buffer dimensions) instead of CSS dimensions, causing images to render 2x too large on high-DPI displays
- Replace broken style copy loop with `cssText` assignment — the `Object.hasOwn` checks never matched any `CSSStyleDeclaration` properties, so no styles were being copied to the replacement `<img>` element

Fixes #21643

## Test plan

- Open a chart with WebGL rendering (e.g., HeatmapPremium)
- Use the export menu → Print
- Verify the WebGL layer stays within the drawing area on both standard and high-DPI displays

🤖 Generated with [Claude Code](https://claude.com/claude-code)