### PR TITLE
[code-infra] Ignore flaky regression test

### DIFF
--- a/test/regressions/testsBySuite.ts
+++ b/test/regressions/testsBySuite.ts
@@ -26,7 +26,8 @@ const docsImports = import.meta.glob<React.ComponentType>(
     '!docsx/data/data-grid/filtering/RemoveBuiltInOperators', // Needs interaction
     '!docsx/data/data-grid/filtering/CustomRatingOperator', // Needs interaction
     '!docsx/data/data-grid/filtering/CustomInputComponent', // Needs interaction
-    '!docsx/data/date-pickers/date-calendar/DateCalendarServerRequest', // Has random behavior (TODO: Use seeded random)
+    '!docsx/data/data-grid/server-side-data/ServerSideLazyLoadingRevalidation.', // Has random behavior
+    '!docsx/data/date-pickers/date-calendar/DateCalendarServerRequest', // Has random behavior
     '!docsx/data/charts/tooltip/Custom*', // Composition example
     '!docsx/data/charts/tooltip/Item*', // Composition example
     '!docsx/data/charts/tooltip/AxisFormatter',


### PR DESCRIPTION
Test periodically load data from "fake server" but we can't control when the SS will be taken, so we might as well just remove it. 