### PR TITLE
[docs] Update v9 migration guides to install next tag

### DIFF
--- a/docs/data/migration/migration-charts-v8/migration-charts-v8.md
+++ b/docs/data/migration/migration-charts-v8/migration-charts-v8.md
@@ -89,14 +89,14 @@ This affects: `BarElement`, `BarLabel`, `LineElement`, `AreaElement`, `MarkEleme
 
 ## Start using the new release
 
-In `package.json`, change the version of the charts package to `latest`.
+In `package.json`, change the version of the charts package to `next`.
 
 ```diff
 -"@mui/x-charts": "^8.x.x",
-+"@mui/x-charts": "latest",
++"@mui/x-charts": "next",
 
 -"@mui/x-charts-pro": "^8.x.x",
-+"@mui/x-charts-pro": "latest",
++"@mui/x-charts-pro": "next",
 ```
 
 Since `v9` is a major release, it contains changes that affect the public API.

--- a/docs/data/migration/migration-pickers-v8/migration-pickers-v8.md
+++ b/docs/data/migration/migration-pickers-v8/migration-pickers-v8.md
@@ -13,14 +13,14 @@ This is a reference guide for upgrading `@mui/x-date-pickers` from v8 to v9.
 
 ## Start using the new release
 
-In `package.json`, change the version of the date pickers package to `latest`.
+In `package.json`, change the version of the date pickers package to `next`.
 
 ```diff
 -"@mui/x-date-pickers": "8.x.x",
-+"@mui/x-date-pickers": "latest",
++"@mui/x-date-pickers": "next",
 
 -"@mui/x-date-pickers-pro": "8.x.x",
-+"@mui/x-date-pickers-pro": "latest",
++"@mui/x-date-pickers-pro": "next",
 ```
 
 Since `v9` is a major release, it contains changes that affect the public API.

--- a/docs/data/migration/migration-tree-view-v8/migration-tree-view-v8.md
+++ b/docs/data/migration/migration-tree-view-v8/migration-tree-view-v8.md
@@ -13,14 +13,14 @@ This is a reference guide for upgrading `@mui/x-tree-view` from v8 to v9.
 
 ## Start using the new release
 
-In `package.json`, change the version of the Tree View package to `latest`.
+In `package.json`, change the version of the Tree View package to `next`.
 
 ```diff
 -"@mui/x-tree-view": "8.x.x",
-+"@mui/x-tree-view": "latest",
++"@mui/x-tree-view": "next",
 
 -"@mui/x-tree-view-pro": "8.x.x",
-+"@mui/x-tree-view-pro": "latest",
++"@mui/x-tree-view-pro": "next",
 ```
 
 The `v9` major release contains changes that affect the public API.


### PR DESCRIPTION
Updates the v8 to v9 migration guides for Charts, Date Pickers, and Tree View to consistently use the `next` tag instead of `latest` when upgrading packages, matching the Data Grid migration guide.
