### PR TITLE
[docs] Update charts v9 migration guide to include premium package

### DIFF
--- a/docs/data/migration/migration-charts-v8/migration-charts-v8.md
+++ b/docs/data/migration/migration-charts-v8/migration-charts-v8.md
@@ -9,7 +9,7 @@ productId: x-charts
 
 ## Introduction
 
-This is a reference guide for upgrading `@mui/x-charts` and `@mui/x-charts-premium` from v8 to v9.
+This is a reference guide for upgrading `@mui/x-charts` from v8 to v9.
 
 <!-- Overall theme of this major, fixing API inconsistencies, improving customization, etc -->
 


### PR DESCRIPTION
Related to #21741. Adds `@mui/x-charts-premium` to the v8 to v9 migration guide alongside the community and pro packages. This ensures users of the premium tier have complete installation and upgrade instructions.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).