### PR TITLE
[x-license] add 2022 plan version

### DIFF
--- a/packages/x-license/src/utils/licensePlan.ts
+++ b/packages/x-license/src/utils/licensePlan.ts
@@ -1,5 +1,5 @@
 export const PLAN_SCOPES = ['pro', 'premium'] as const;
-export const PLAN_VERSIONS = ['initial', 'Q3-2024', 'Q1-2026'] as const;
+export const PLAN_VERSIONS = ['2022', 'initial', 'Q3-2024', 'Q1-2026'] as const;
 
 export type PlanScope = (typeof PLAN_SCOPES)[number];
 export type PlanVersion = (typeof PLAN_VERSIONS)[number];


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

<img width="728" height="226" alt="Captura de pantalla 2026-03-23 a las 15 11 22" src="https://github.com/user-attachments/assets/251e536a-343b-4b22-a65a-5c2557efc882" />
