### PR TITLE
[docs] Document how to customize voiceover announcement

### DIFF
--- a/docs/data/charts/accessibility/accessibility.md
+++ b/docs/data/charts/accessibility/accessibility.md
@@ -82,7 +82,7 @@ Charts use a proxy strategy to support screen reader when user navigate with key
 
 The description of the focused element is localized.
 You can customize it by using [localization key](/x/react-charts/localization/#localize-text).
-The `[type]Description` localization keys are functions for a given series type, for example, `pieDescription` for pie charts. 
+The `[type]Description` localization keys are functions for a given series type, for example, `pieDescription` for pie charts.
 These functions receives values related to the focused item, and should return the description to display.
 
 ### Composition


### PR DESCRIPTION
Fix #13113

I was considering adding to series a method to override the entire message generation. But when writing the docs, I realised this might add to much complexity for users compared to what they need.
