### PR TITLE
[charts] Add candlestick page to sidebar navigation

### DIFF
--- a/docs/data/pages.ts
+++ b/docs/data/pages.ts
@@ -648,11 +648,6 @@ const pages: MuiPage[] = [
             plan: 'pro',
           },
           {
-            pathname: '/x/react-charts/candlestick',
-            plan: 'premium',
-            unstable: true,
-          },
-          {
             pathname: '/x/react-charts-funnel',
             title: 'Funnel',
             plan: 'pro',
@@ -662,6 +657,11 @@ const pages: MuiPage[] = [
             ],
           },
           { pathname: '/x/react-charts/sankey', plan: 'pro' },
+          {
+            pathname: '/x/react-charts/candlestick',
+            plan: 'premium',
+            unstable: true,
+          },
           {
             pathname: '/x/react-charts/#planned-charts',
             title: 'Future Components',


### PR DESCRIPTION
## Summary
- Adds the candlestick chart page to the docs sidebar navigation
- Marked as `premium` plan and `unstable` (preview)
- Placed after sankey, before the "Future Components" section

## Changelog

- Release `Candlestick` charts in unstable mode. Use `import { Unstable_CandlestickPlot } from '@mui/x-charts-premium'` to start using.