### PR TITLE
[docs] Remove stabilized experimental feature from demo

### DIFF
--- a/docs/data/charts/references/ReferenceOverview.js
+++ b/docs/data/charts/references/ReferenceOverview.js
@@ -105,7 +105,6 @@ export default function ReferenceOverview() {
 
       <ChartsDataProviderPro
         height={300}
-        experimentalFeatures={{ preferStrictDomainInLineCharts: true }}
         dataset={usaUnemploymentAndGdp}
         series={[
           {

--- a/docs/data/charts/references/ReferenceOverview.tsx
+++ b/docs/data/charts/references/ReferenceOverview.tsx
@@ -116,7 +116,6 @@ export default function ReferenceOverview() {
 
       <ChartsDataProviderPro
         height={300}
-        experimentalFeatures={{ preferStrictDomainInLineCharts: true }}
         dataset={usaUnemploymentAndGdp}
         series={[
           {


### PR DESCRIPTION
## Summary

- Remove `preferStrictDomainInLineCharts` from the Reference Overview demo's `experimentalFeatures` prop, as it has been stabilized and is no longer part of `LineExperimentalFeatures`