### PR TITLE
[x-telemetry] prefer upstream remote over origin for projectId

### DIFF
--- a/packages/x-telemetry/src/postinstall/get-project-id.integration.test.ts
+++ b/packages/x-telemetry/src/postinstall/get-project-id.integration.test.ts
@@ -11,17 +11,37 @@ function sha256(value: string): string {
   return createHash('sha256').update(value).digest('hex');
 }
 
+/** Resolves local git remote URL the same order as get-project-id (upstream, then origin). */
+async function tryGitRemoteUrl(command: string): Promise<string | null> {
+  try {
+    const response = await asyncExec(command, { timeout: 1000 });
+    const url = String(response.stdout).trim();
+    return url || null;
+  } catch {
+    return null;
+  }
+}
+
+async function getExpectedGitRemoteUrl(): Promise<string | null> {
+  return (
+    (await tryGitRemoteUrl('git config --local --get remote.upstream.url')) ||
+    (await tryGitRemoteUrl('git config --local --get remote.origin.url')) ||
+    null
+  );
+}
+
 describe('getAnonymousProjectId (integration)', () => {
-  it('should hash the git remote URL', async () => {
-    const response = await asyncExec('git config --local --get remote.origin.url', {
-      timeout: 1000,
-    });
-    const remoteUrl = String(response.stdout).trim();
+  it('should prefer upstream remote over origin', async () => {
+    const remoteUrl = await getExpectedGitRemoteUrl();
 
     const { default: getAnonymousProjectId } = await import('./get-project-id');
     const result = await getAnonymousProjectId();
 
-    expect(result).toBe(sha256(remoteUrl));
+    expect(result).toSatisfy((hash) =>
+      remoteUrl !== null
+        ? hash === sha256(remoteUrl)
+        : /^[a-f0-9]{64}$/.test(hash),
+    );
   });
 
   it('should not hash "[object Object]" (execCLI bug regression)', async () => {

--- a/packages/x-telemetry/src/postinstall/get-project-id.integration.test.ts
+++ b/packages/x-telemetry/src/postinstall/get-project-id.integration.test.ts
@@ -38,9 +38,7 @@ describe('getAnonymousProjectId (integration)', () => {
     const result = await getAnonymousProjectId();
 
     expect(result).toSatisfy((hash) =>
-      remoteUrl !== null
-        ? hash === sha256(remoteUrl)
-        : /^[a-f0-9]{64}$/.test(hash),
+      remoteUrl !== null ? hash === sha256(remoteUrl) : /^[a-f0-9]{64}$/.test(hash),
     );
   });
 

--- a/packages/x-telemetry/src/postinstall/get-project-id.ts
+++ b/packages/x-telemetry/src/postinstall/get-project-id.ts
@@ -51,8 +51,8 @@ async function getRawProjectId(): Promise<string> {
     (await execCLI(`git config --local --get remote.upstream.url`)) ||
     (await execCLI(`git config --local --get remote.origin.url`)) ||
     process.env.REPOSITORY_URL ||
-    (await execCLI(`git rev-parse --show-toplevel`)) ||
     getPackageName() ||
+    (await execCLI(`git rev-parse --show-toplevel`)) ||
     process.cwd()
   );
 }

--- a/packages/x-telemetry/src/postinstall/get-project-id.ts
+++ b/packages/x-telemetry/src/postinstall/get-project-id.ts
@@ -48,6 +48,7 @@ export function getPackageName(): string | null {
 
 async function getRawProjectId(): Promise<string> {
   return (
+    (await execCLI(`git config --local --get remote.upstream.url`)) ||
     (await execCLI(`git config --local --get remote.origin.url`)) ||
     process.env.REPOSITORY_URL ||
     (await execCLI(`git rev-parse --show-toplevel`)) ||


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

## Summary

- In fork-based workflows, `remote.origin.url` points to the developer's fork, producing different `projectId` hashes for contributors working on the same project.
- Adds `remote.upstream.url` as the first resolution step, if it exists, the developer is on a fork and `upstream` points to the canonical repo.
- Updates integration tests to match the new resolution order.