### PR TITLE
[DataGrid] Fix skeleton overlay backdrop issue

### DIFF
--- a/packages/x-data-grid/src/components/base/GridOverlays.tsx
+++ b/packages/x-data-grid/src/components/base/GridOverlays.tsx
@@ -94,7 +94,10 @@ export function GridOverlayWrapper(props: React.PropsWithChildren<GridOverlaysPr
         className={classes.inner}
         style={{
           height,
-          width: dimensions.viewportOuterSize.width,
+          width:
+            props.loadingOverlayVariant === 'skeleton'
+              ? Math.max(dimensions.viewportOuterSize.width, dimensions.columnsTotalWidth)
+              : dimensions.viewportOuterSize.width,
         }}
         {...props}
       />


### PR DESCRIPTION
Fixes #21781

Fix preview: https://deploy-preview-21951--material-ui-x.netlify.app/x/react-data-grid/overlays/#skeleton