### PR TITLE
[internal] Remove checks for `materialVersion >= 6`

### DIFF
--- a/packages/x-date-pickers/src/internals/components/PickerFieldUI.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickerFieldUI.tsx
@@ -7,7 +7,6 @@ import MuiTextField, { TextFieldProps } from '@mui/material/TextField';
 import MuiIconButton, { IconButtonProps } from '@mui/material/IconButton';
 import MuiInputAdornment, { InputAdornmentProps } from '@mui/material/InputAdornment';
 import { SvgIconProps } from '@mui/material/SvgIcon';
-import { major as materialMajor } from '@mui/material/version';
 import useSlotProps from '@mui/utils/useSlotProps';
 import { MakeOptional, SlotComponentPropsFromProps } from '@mui/x-internals/types';
 import { FieldOwnerState } from '../../models';
@@ -43,10 +42,9 @@ export const cleanFieldResponse = <
       openPickerAriaLabel,
       ...other
     } = fieldResponse;
-    const mergedInputProps =
-      materialMajor >= 6 && other?.slotProps?.input
-        ? mergeSlotProps(other?.slotProps?.input, InputProps)
-        : noop;
+    const mergedInputProps = other?.slotProps?.input
+      ? mergeSlotProps(other?.slotProps?.input, InputProps)
+      : noop;
 
     return {
       clearable,
@@ -56,7 +54,7 @@ export const cleanFieldResponse = <
       openPickerAriaLabel,
       textFieldProps: {
         ...other,
-        ...(materialMajor >= 6 && other?.slotProps?.input
+        ...(other?.slotProps?.input
           ? {
               slotProps: {
                 ...other?.slotProps,
@@ -89,14 +87,12 @@ export const cleanFieldResponse = <
     ...other
   } = fieldResponse;
 
-  const mergedInputProps =
-    materialMajor >= 6 && other?.slotProps?.input
-      ? mergeSlotProps(other?.slotProps?.input, InputProps)
-      : noop;
-  const mergedHtmlInputProps =
-    materialMajor >= 6 && other?.slotProps?.htmlInput
-      ? mergeSlotProps(other?.slotProps?.htmlInput, inputProps)
-      : noop;
+  const mergedInputProps = other?.slotProps?.input
+    ? mergeSlotProps(other?.slotProps?.input, InputProps)
+    : noop;
+  const mergedHtmlInputProps = other?.slotProps?.htmlInput
+    ? mergeSlotProps(other?.slotProps?.htmlInput, inputProps)
+    : noop;
   return {
     clearable,
     onClear,
@@ -105,7 +101,7 @@ export const cleanFieldResponse = <
     openPickerAriaLabel,
     textFieldProps: {
       ...other,
-      ...(materialMajor >= 6 && (other?.slotProps?.input || other?.slotProps?.htmlInput)
+      ...(other?.slotProps?.input || other?.slotProps?.htmlInput
         ? {
             slotProps: {
               ...other?.slotProps,
@@ -253,8 +249,9 @@ export function PickerFieldUI<
 
   const additionalTextFieldInputProps: PickersTextFieldProps['InputProps'] = {};
   const textFieldInputProps = resolveComponentProps(
-    ((materialMajor >= 6 && (textFieldProps as TextFieldProps)?.slotProps?.input) ??
-      textFieldProps.InputProps) as PickersTextFieldProps['InputProps'] | undefined,
+    ((textFieldProps as TextFieldProps)?.slotProps?.input ?? textFieldProps.InputProps) as
+      | PickersTextFieldProps['InputProps']
+      | undefined,
     ownerState,
   );
 
@@ -331,28 +328,26 @@ export function PickerFieldUI<
     ];
   }
 
-  const resolvedTextFieldInputProps =
-    materialMajor >= 6 && (textFieldProps as TextFieldProps)?.slotProps?.input
-      ? resolveComponentProps(
-          mergeSlotProps(textFieldInputProps, additionalTextFieldInputProps),
-          ownerState,
-        )
-      : {
-          ...textFieldInputProps,
-          ...additionalTextFieldInputProps,
-        };
+  const resolvedTextFieldInputProps = (textFieldProps as TextFieldProps)?.slotProps?.input
+    ? resolveComponentProps(
+        mergeSlotProps(textFieldInputProps, additionalTextFieldInputProps),
+        ownerState,
+      )
+    : {
+        ...textFieldInputProps,
+        ...additionalTextFieldInputProps,
+      };
 
   // We need to resolve the `inputProps` since we are messing with those props in this component.
-  textFieldProps.inputProps =
-    materialMajor >= 6 && (textFieldProps as TextFieldProps)?.slotProps?.htmlInput
-      ? resolveComponentProps(
-          (textFieldProps as TextFieldProps).slotProps!.htmlInput as any,
-          ownerState,
-        )
-      : textFieldProps.inputProps;
+  textFieldProps.inputProps = (textFieldProps as TextFieldProps)?.slotProps?.htmlInput
+    ? resolveComponentProps(
+        (textFieldProps as TextFieldProps).slotProps!.htmlInput as any,
+        ownerState,
+      )
+    : textFieldProps.inputProps;
 
   // Remove the `input` slotProps to avoid them overriding the manually resolved `InputProps`.
-  // Relevant on `materialMajor >= 6` since `slotProps` would take precedence.
+  // `slotProps` would take precedence over `InputProps`.
   delete (textFieldProps as TextFieldProps)?.slotProps?.input;
   if (fieldResponse.enableAccessibleFieldDOMStructure) {
     // Remove the `slotProps` on `PickersTextField` as they are not supported.

--- a/test/regressions/index.test.ts
+++ b/test/regressions/index.test.ts
@@ -1,10 +1,7 @@
 import * as path from 'path';
 import * as childProcess from 'child_process';
 import { type Browser, chromium, Page } from '@playwright/test';
-import { major } from '@mui/material/version';
 import fs from 'node:fs/promises';
-
-const isMaterialUIv6 = major === 6;
 
 // Tests that need a longer timeout.
 const timeSensitiveSuites = [
@@ -407,12 +404,6 @@ async function main() {
 }
 
 function isConsoleWarningIgnored(msg?: string) {
-  const isMuiV6Error =
-    isMaterialUIv6 &&
-    msg?.startsWith(
-      'MUI: The Experimental_CssVarsProvider component has been ported into ThemeProvider.',
-    );
-
   const isReactRouterFlagsError = msg?.includes('React Router Future Flag Warning');
 
   const isNoDevRoute = msg?.includes('No routes matched location "/#no-dev"');
@@ -422,7 +413,7 @@ function isConsoleWarningIgnored(msg?: string) {
     'The browser build of Tailwind CSS should not be used in production.',
   );
 
-  if (isMuiV6Error || isReactRouterFlagsError || isNoDevRoute || isTailwindCdnWarning) {
+  if (isReactRouterFlagsError || isNoDevRoute || isTailwindCdnWarning) {
     return true;
   }
   return false;


### PR DESCRIPTION
**Remove `@mui/material` v6 version checks**

Since the minimum supported `@mui/material` version is now v7, all `materialMajor >= 6` runtime checks in `PickerFieldUI` were always true and have been removed. The `slotProps`-based code paths are now used unconditionally, and the `@mui/material/version` import was dropped.