### PR TITLE
[scheduler] Disabled border color for the repeat day picker in dark mode

### DIFF
--- a/packages/x-scheduler/src/internals/components/event-dialog/RecurrenceTab.tsx
+++ b/packages/x-scheduler/src/internals/components/event-dialog/RecurrenceTab.tsx
@@ -50,6 +50,9 @@ const RecurrenceSelectorContainer = styled('div', {
   borderRadius: theme.shape.borderRadius,
   width: 'fit-content',
   maxWidth: '100%',
+  '&[data-disabled]': {
+    borderColor: (theme.vars || theme).palette.action.disabled,
+  },
 }));
 
 const RadioButtonLabel = styled(FormControlLabel, {
@@ -493,6 +496,7 @@ export function RecurrenceTab(props: RecurrenceTabProps) {
                   className={classes.eventDialogRecurrenceSelectorContainer}
                   role="group"
                   aria-label={localeText.recurrenceWeeklyMonthlySpecificInputsLabel}
+                  data-disabled={customDisabled || undefined}
                 >
                   {weeklyDayItems.map(({ value: dayValue, ariaLabel, label }) => (
                     <WeekDaySelectorCheckbox
@@ -517,6 +521,7 @@ export function RecurrenceTab(props: RecurrenceTabProps) {
                 </RepeatSectionLabel>
                 <RecurrenceSelectorContainer
                   className={classes.eventDialogRecurrenceSelectorContainer}
+                  data-disabled={customDisabled || undefined}
                 >
                   <RecurrenceSelectorToggleGroup
                     className={classes.eventDialogRecurrenceSelectorToggleGroup}


### PR DESCRIPTION
Issue #21981 

Before:
<img width="494" height="655" alt="Screenshot 2026-04-03 at 16 54 01" src="https://github.com/user-attachments/assets/5cd2e494-5b82-4b1c-9095-7603465ad64d" />

After:
<img width="494" height="595" alt="Screenshot 2026-04-03 at 17 46 19" src="https://github.com/user-attachments/assets/32304da9-1d3c-42ed-9fba-85343c3238a3" />


<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
