### PR TITLE
[internal] Remove 'conf' from codebase

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -36,11 +36,6 @@
       "groupName": "fingerprintjs",
       "matchPackageNames": ["@fingerprintjs/fingerprintjs"],
       "allowedVersions": "< 4.0.0"
-    },
-    {
-      "groupName": "conf",
-      "matchPackageNames": ["conf"],
-      "allowedVersions": "< 12.0.0"
     }
   ]
 }


### PR DESCRIPTION
We worked on removing `conf` in #21470, but this still returns hits in the codebase: https://github.com/search?q=org%3Amui+conf%22&type=code.

---

Side note, I didn't realize, removing conf has another huge benefit, cleaning up the dependency bloat.

v8: https://npm.anvaka.com/#/view/2d/%40mui%2Fx-data-grid-pro/8.28.2

<img width="617" height="766" alt="SCR-20260405-mbjv" src="https://github.com/user-attachments/assets/da9c4a53-2cbf-43a2-9890-eb99f8e54443" />

v9: https://npm.anvaka.com/#/view/2d/%40mui%2Fx-data-grid-pro/9.0.0

removed the red area