### PR TITLE
[fields] Allow `openPickerButtonPosition` on single-input range fields

### DIFF
--- a/docs/pages/x/api/date-pickers/single-input-date-range-field.json
+++ b/docs/pages/x/api/date-pickers/single-input-date-range-field.json
@@ -86,6 +86,10 @@
         "describedArgs": ["newValue"]
       }
     },
+    "openPickerButtonPosition": {
+      "type": { "name": "enum", "description": "'end'<br>&#124;&nbsp;'start'" },
+      "default": "'end'"
+    },
     "readOnly": { "type": { "name": "bool" }, "default": "false" },
     "referenceDate": {
       "type": { "name": "union", "description": "Array&lt;object&gt;<br>&#124;&nbsp;object" },

--- a/docs/pages/x/api/date-pickers/single-input-date-time-range-field.json
+++ b/docs/pages/x/api/date-pickers/single-input-date-time-range-field.json
@@ -93,6 +93,10 @@
         "describedArgs": ["newValue"]
       }
     },
+    "openPickerButtonPosition": {
+      "type": { "name": "enum", "description": "'end'<br>&#124;&nbsp;'start'" },
+      "default": "'end'"
+    },
     "readOnly": { "type": { "name": "bool" }, "default": "false" },
     "referenceDate": {
       "type": { "name": "union", "description": "Array&lt;object&gt;<br>&#124;&nbsp;object" },

--- a/docs/pages/x/api/date-pickers/single-input-time-range-field.json
+++ b/docs/pages/x/api/date-pickers/single-input-time-range-field.json
@@ -89,6 +89,10 @@
         "describedArgs": ["newValue"]
       }
     },
+    "openPickerButtonPosition": {
+      "type": { "name": "enum", "description": "'end'<br>&#124;&nbsp;'start'" },
+      "default": "'end'"
+    },
     "readOnly": { "type": { "name": "bool" }, "default": "false" },
     "referenceDate": {
       "type": { "name": "union", "description": "Array&lt;object&gt;<br>&#124;&nbsp;object" },

--- a/docs/translations/api-docs/date-pickers/single-input-date-range-field/single-input-date-range-field.json
+++ b/docs/translations/api-docs/date-pickers/single-input-date-range-field/single-input-date-range-field.json
@@ -108,6 +108,9 @@
         "newValue": { "name": "newValue", "description": "The new selected sections." }
       }
     },
+    "openPickerButtonPosition": {
+      "description": "The position at which the opening button is placed. If there is no Picker to open, the button is not rendered"
+    },
     "readOnly": {
       "description": "If <code>true</code>, the component is read-only. When read-only, the value cannot be changed but the user can interact with the interface."
     },

--- a/docs/translations/api-docs/date-pickers/single-input-date-time-range-field/single-input-date-time-range-field.json
+++ b/docs/translations/api-docs/date-pickers/single-input-date-time-range-field/single-input-date-time-range-field.json
@@ -125,6 +125,9 @@
         "newValue": { "name": "newValue", "description": "The new selected sections." }
       }
     },
+    "openPickerButtonPosition": {
+      "description": "The position at which the opening button is placed. If there is no Picker to open, the button is not rendered"
+    },
     "readOnly": {
       "description": "If <code>true</code>, the component is read-only. When read-only, the value cannot be changed but the user can interact with the interface."
     },

--- a/docs/translations/api-docs/date-pickers/single-input-time-range-field/single-input-time-range-field.json
+++ b/docs/translations/api-docs/date-pickers/single-input-time-range-field/single-input-time-range-field.json
@@ -117,6 +117,9 @@
         "newValue": { "name": "newValue", "description": "The new selected sections." }
       }
     },
+    "openPickerButtonPosition": {
+      "description": "The position at which the opening button is placed. If there is no Picker to open, the button is not rendered"
+    },
     "readOnly": {
       "description": "If <code>true</code>, the component is read-only. When read-only, the value cannot be changed but the user can interact with the interface."
     },

--- a/packages/x-date-pickers-pro/src/SingleInputDateRangeField/SingleInputDateRangeField.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputDateRangeField/SingleInputDateRangeField.tsx
@@ -248,6 +248,12 @@ SingleInputDateRangeField.propTypes = {
    */
   onSelectedSectionsChange: PropTypes.func,
   /**
+   * The position at which the opening button is placed.
+   * If there is no Picker to open, the button is not rendered
+   * @default 'end'
+   */
+  openPickerButtonPosition: PropTypes.oneOf(['end', 'start']),
+  /**
    * If `true`, the component is read-only.
    * When read-only, the value cannot be changed but the user can interact with the interface.
    * @default false

--- a/packages/x-date-pickers-pro/src/SingleInputDateRangeField/SingleInputDateRangeField.types.ts
+++ b/packages/x-date-pickers-pro/src/SingleInputDateRangeField/SingleInputDateRangeField.types.ts
@@ -7,10 +7,7 @@ import { BuiltInFieldTextFieldProps } from '@mui/x-date-pickers/models';
 import { DateRangeManagerFieldInternalProps } from '../managers/useDateRangeManager';
 
 export interface UseSingleInputDateRangeFieldProps
-  extends
-    DateRangeManagerFieldInternalProps,
-    // TODO v8: Remove once the range fields open with a button.
-    Omit<ExportedPickerFieldUIProps, 'openPickerButtonPosition'> {}
+  extends DateRangeManagerFieldInternalProps, ExportedPickerFieldUIProps {}
 
 export type SingleInputDateRangeFieldProps = Omit<
   BuiltInFieldTextFieldProps,

--- a/packages/x-date-pickers-pro/src/SingleInputDateTimeRangeField/SingleInputDateTimeRangeField.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputDateTimeRangeField/SingleInputDateTimeRangeField.tsx
@@ -281,6 +281,12 @@ SingleInputDateTimeRangeField.propTypes = {
    */
   onSelectedSectionsChange: PropTypes.func,
   /**
+   * The position at which the opening button is placed.
+   * If there is no Picker to open, the button is not rendered
+   * @default 'end'
+   */
+  openPickerButtonPosition: PropTypes.oneOf(['end', 'start']),
+  /**
    * If `true`, the component is read-only.
    * When read-only, the value cannot be changed but the user can interact with the interface.
    * @default false

--- a/packages/x-date-pickers-pro/src/SingleInputDateTimeRangeField/SingleInputDateTimeRangeField.types.ts
+++ b/packages/x-date-pickers-pro/src/SingleInputDateTimeRangeField/SingleInputDateTimeRangeField.types.ts
@@ -7,10 +7,7 @@ import { BuiltInFieldTextFieldProps } from '@mui/x-date-pickers/models';
 import { DateTimeRangeManagerFieldInternalProps } from '../managers/useDateTimeRangeManager';
 
 export interface UseSingleInputDateTimeRangeFieldProps
-  extends
-    DateTimeRangeManagerFieldInternalProps,
-    // TODO v8: Remove once the range fields open with a button.
-    Omit<ExportedPickerFieldUIProps, 'openPickerButtonPosition'> {}
+  extends DateTimeRangeManagerFieldInternalProps, ExportedPickerFieldUIProps {}
 
 export type SingleInputDateTimeRangeFieldProps = Omit<
   BuiltInFieldTextFieldProps,

--- a/packages/x-date-pickers-pro/src/SingleInputTimeRangeField/SingleInputTimeRangeField.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputTimeRangeField/SingleInputTimeRangeField.tsx
@@ -263,6 +263,12 @@ SingleInputTimeRangeField.propTypes = {
    */
   onSelectedSectionsChange: PropTypes.func,
   /**
+   * The position at which the opening button is placed.
+   * If there is no Picker to open, the button is not rendered
+   * @default 'end'
+   */
+  openPickerButtonPosition: PropTypes.oneOf(['end', 'start']),
+  /**
    * If `true`, the component is read-only.
    * When read-only, the value cannot be changed but the user can interact with the interface.
    * @default false

--- a/packages/x-date-pickers-pro/src/SingleInputTimeRangeField/SingleInputTimeRangeField.types.ts
+++ b/packages/x-date-pickers-pro/src/SingleInputTimeRangeField/SingleInputTimeRangeField.types.ts
@@ -7,10 +7,7 @@ import { BuiltInFieldTextFieldProps } from '@mui/x-date-pickers/models';
 import { TimeRangeManagerFieldInternalProps } from '../managers/useTimeRangeManager';
 
 export interface UseSingleInputTimeRangeFieldProps
-  extends
-    TimeRangeManagerFieldInternalProps,
-    // TODO v8: Remove once the range fields open with a button.
-    Omit<ExportedPickerFieldUIProps, 'openPickerButtonPosition'> {}
+  extends TimeRangeManagerFieldInternalProps, ExportedPickerFieldUIProps {}
 
 export type SingleInputTimeRangeFieldProps = Omit<
   BuiltInFieldTextFieldProps,


### PR DESCRIPTION
## Summary

The three `SingleInput*RangeField` type definitions were wrapping `ExportedPickerFieldUIProps` in `Omit<..., 'openPickerButtonPosition'>` with a `TODO v8: Remove once the range fields open with a button.` comment. That omit is purely a type-level guard — `PickerFieldUI` already renders the open button for these fields whenever `triggerStatus !== 'hidden'`, and the existing `openPickerAsync(type: 'date-range', fieldType: 'single-input')` test helper already clicks through a `getByLabelText(/choose range/i)` button on them today.

Dropping the omit exposes the prop in the public type surface so users can position the open button on the start side or disable it via slot props, without requiring any runtime changes. The autogenerated proptype arrays, API JSON, and translation JSON are the usual `pnpm proptypes && pnpm docs:api` output for the new public prop.

Strictly additive — no breaking changes.

## Test plan

- [x] `pnpm --filter "@mui/x-date-pickers" --filter "@mui/x-date-pickers-pro" run typescript` — clean
- [x] `pnpm test:unit --project "x-date-pickers-pro" --run SingleInput` — 317/317 pass across all three `SingleInput*RangeField` components
- [x] `pnpm proptypes && pnpm docs:api` — regenerates exactly the 9 autogenerated files in this commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)