### PR TITLE
[scheduler] Add missing ARIA attributes to side panel toggle and resources legend

### DIFF
--- a/packages/x-scheduler/src/event-calendar/EventCalendarRoot.tsx
+++ b/packages/x-scheduler/src/event-calendar/EventCalendarRoot.tsx
@@ -144,7 +144,11 @@ export const EventCalendarRoot = React.forwardRef<HTMLDivElement, EventCalendarR
             orientation="horizontal"
             className={classes.sidePanelCollapse}
           >
-            <EventCalendarSidePanel className={classes.sidePanel}>
+            <EventCalendarSidePanel
+              id="event-calendar-side-panel"
+              className={classes.sidePanel}
+              aria-hidden={!isSidePanelOpen}
+            >
               <MiniCalendar />
               <Divider className={classes.sidePanelDivider} />
               <ResourcesLegend />

--- a/packages/x-scheduler/src/event-calendar/header-toolbar/HeaderToolbar.tsx
+++ b/packages/x-scheduler/src/event-calendar/header-toolbar/HeaderToolbar.tsx
@@ -98,6 +98,8 @@ export const HeaderToolbar = React.forwardRef(function HeaderToolbar(
         <IconButton
           className={classes.headerToolbarSidePanelToggle}
           aria-label={isSidePanelOpen ? localeText.closeSidePanel : localeText.openSidePanel}
+          aria-expanded={isSidePanelOpen}
+          aria-controls="event-calendar-side-panel"
           onClick={(event) =>
             store.setPreferences({ isSidePanelOpen: !isSidePanelOpen }, event.nativeEvent)
           }

--- a/packages/x-scheduler/src/event-calendar/resources-legend/ResourcesLegend.tsx
+++ b/packages/x-scheduler/src/event-calendar/resources-legend/ResourcesLegend.tsx
@@ -138,11 +138,14 @@ export const ResourcesLegend = React.forwardRef(function ResourcesLegend(
   return (
     <ResourcesLegendRoot
       ref={forwardedRef}
-      aria-label={localeText.resourcesLegendSectionLabel}
+      aria-labelledby="event-calendar-resources-legend-label"
       {...props}
       className={clsx(props.className, classes.resourcesLegend)}
     >
-      <ResourcesLegendLabel className={classes.resourcesLegendLabel}>
+      <ResourcesLegendLabel
+        id="event-calendar-resources-legend-label"
+        className={classes.resourcesLegendLabel}
+      >
         {localeText.resourcesLabel}
       </ResourcesLegendLabel>
       {resources.map((resource) => (


### PR DESCRIPTION
Closes #21982
Closes #21983
Closes #21984

## Summary

Three accessibility improvements to the EventCalendar scheduler:

**Side panel toggle button (HeaderToolbar)** — issue #21982:
- Added `aria-expanded={isSidePanelOpen}` so screen readers can report whether the panel is open or closed
- Added `aria-controls="event-calendar-side-panel"` linking the button to the panel it controls, matching the pattern already used by `PreferencesMenu`

**Side panel when collapsed** — issue #21983:
- Added `id="event-calendar-side-panel"` to `EventCalendarSidePanel` (the `aria-controls` target)
- Added `aria-hidden={!isSidePanelOpen}` so collapsed panel content is hidden from the accessibility tree

**Resources legend section** — issue #21984:
- Replaced `aria-label` (which differed from the visible label) with `aria-labelledby` pointing to the visible "Resources" label
- Added `id` to `ResourcesLegendLabel` so both sighted and screen reader users get the same label text

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).