### PR TITLE
[charts] Remove duplicate `useThemeProps` call

### DIFF
--- a/packages/x-charts/src/ChartsDataProvider/useChartsDataProviderProps.ts
+++ b/packages/x-charts/src/ChartsDataProvider/useChartsDataProviderProps.ts
@@ -19,9 +19,7 @@ export const useChartsDataProviderProps = <
   inProps: ChartsDataProviderProps<SeriesType, TSignatures> & ChartsLocalizationProviderProps,
 ) => {
   // eslint-disable-next-line mui/material-ui-name-matches-component-name
-  const themedProps = useThemeProps({ props: inProps, name: 'MuiChartsDataProvider' });
-  // eslint-disable-next-line mui/material-ui-name-matches-component-name
-  const props = useThemeProps({ props: themedProps, name: 'MuiChartsDataProvider' });
+  const props = useThemeProps({ props: inProps, name: 'MuiChartsDataProvider' });
 
   const {
     children,


### PR DESCRIPTION
## Summary
- Remove a duplicate `useThemeProps` call in `useChartsDataProviderProps` that was applying theme props twice on the same input

## Test plan
- Existing tests should pass — this is a no-op fix (the second call was redundant)


🤖 Generated with [Claude Code](https://claude.com/claude-code)