### PR TITLE
[charts] Make line series type support radial and cartesian

### DIFF
--- a/packages/x-charts/src/ChartsTooltip/ChartsTooltipContainer.tsx
+++ b/packages/x-charts/src/ChartsTooltip/ChartsTooltipContainer.tsx
@@ -37,7 +37,7 @@ const selectorReturnNull = () => null;
 
 function getIsOpenSelector(
   trigger: TriggerOptions,
-  axisSystem: 'none' | 'polar' | 'cartesian',
+  axisSystem: 'none' | 'radial' | 'cartesian',
   shouldPreventBecauseOfBrush?: boolean,
 ) {
   if (shouldPreventBecauseOfBrush) {
@@ -46,7 +46,7 @@ function getIsOpenSelector(
   if (trigger === 'item') {
     return selectorChartsTooltipItemIsDefined;
   }
-  if (axisSystem === 'polar') {
+  if (axisSystem === 'radial') {
     return selectorChartsInteractionPolarAxisTooltip;
   }
   if (axisSystem === 'cartesian') {

--- a/packages/x-charts/src/ChartsTooltip/useAxesTooltip.tsx
+++ b/packages/x-charts/src/ChartsTooltip/useAxesTooltip.tsx
@@ -3,6 +3,7 @@ import { useSeries } from '../hooks/useSeries';
 import { useColorProcessor } from '../internals/plugins/corePlugins/useChartSeries/useColorProcessor';
 import { type SeriesId } from '../models/seriesType/common';
 import {
+  type ChartSeriesDefaultized,
   type CartesianChartSeriesType,
   type ChartsSeriesConfig,
   type PolarChartSeriesType,
@@ -33,6 +34,7 @@ import {
   type ComposableCartesianChartSeriesType,
   composableCartesianSeriesTypes,
 } from '../models/seriesType/composition';
+import type { ProcessedSeries } from '../internals/plugins/corePlugins/useChartSeries/useChartSeries.types';
 
 export interface UseAxesTooltipReturnValue<
   SeriesType extends CartesianChartSeriesType | PolarChartSeriesType =
@@ -156,82 +158,92 @@ export function useAxesTooltip<
     });
   }
 
-  Object.keys(series)
-    .filter((seriesType): seriesType is ComposableCartesianChartSeriesType =>
-      composableCartesianSeriesTypes.has(seriesType as ComposableCartesianChartSeriesType),
-    )
-    .forEach(<Type extends ComposableCartesianChartSeriesType>(seriesType: Type) => {
-      const seriesOfType = series[seriesType];
-      if (!seriesOfType) {
-        return [];
-      }
-      return seriesOfType.seriesOrder.forEach((seriesId) => {
-        const seriesToAdd = seriesOfType.series[seriesId]!;
+  const isCartesianContext = xAxis !== undefined || yAxis !== undefined;
 
-        // Skip hidden series (only if visibility manager is available)
-        if (isItemVisible && !isItemVisible({ type: seriesType, seriesId })) {
-          return;
+  if (isCartesianContext) {
+    Object.keys(series)
+      .filter((seriesType): seriesType is ComposableCartesianChartSeriesType =>
+        composableCartesianSeriesTypes.has(seriesType as ComposableCartesianChartSeriesType),
+      )
+      .forEach(<Type extends ComposableCartesianChartSeriesType>(seriesType: Type) => {
+        const seriesOfType = series[seriesType] as ProcessedSeries<Type, 'cartesian'>[Type];
+        if (!seriesOfType) {
+          return [];
         }
+        return seriesOfType.seriesOrder.forEach((seriesId) => {
+          const seriesToAdd = seriesOfType.series[seriesId] as ChartSeriesDefaultized<
+            Type,
+            'cartesian'
+          >;
 
-        const providedXAxisId = seriesToAdd.xAxisId ?? defaultXAxis.id;
-        const providedYAxisId = seriesToAdd.yAxisId ?? defaultYAxis.id;
-
-        const tooltipItemIndex = tooltipAxes.findIndex(
-          ({ axisDirection, axisId }) =>
-            (axisDirection === 'x' && axisId === providedXAxisId) ||
-            (axisDirection === 'y' && axisId === providedYAxisId),
-        );
-        // Test if the series uses the default axis
-        if (tooltipItemIndex >= 0) {
-          const zAxisId = 'zAxisId' in seriesToAdd ? seriesToAdd.zAxisId : zAxisIds[0];
-          const { dataIndex } = tooltipAxes[tooltipItemIndex];
-          const color =
-            colorProcessors[seriesType]?.(
-              seriesToAdd,
-              xAxis[providedXAxisId],
-              yAxis[providedYAxisId],
-              zAxisId ? zAxis[zAxisId] : undefined,
-            )(dataIndex) ?? '';
-
-          const rawValue = seriesToAdd.data[dataIndex] ?? null;
-          const formattedLabel = getLabel(seriesToAdd.label, 'tooltip') ?? null;
-
-          let value: any;
-          let formattedValue: any;
-
-          if (seriesType === 'ohlc' && Array.isArray(rawValue)) {
-            const [open, high, low, close] = rawValue as [number, number, number, number];
-            const formatter = seriesToAdd.valueFormatter as any;
-            value = { open, high, low, close };
-            formattedValue = {
-              open: formatter(open, { dataIndex, field: 'open' }),
-              high: formatter(high, { dataIndex, field: 'high' }),
-              low: formatter(low, { dataIndex, field: 'low' }),
-              close: formatter(close, { dataIndex, field: 'close' }),
-            };
-          } else {
-            value = rawValue;
-            formattedValue = (seriesToAdd.valueFormatter as any)(rawValue, {
-              dataIndex,
-            });
+          // Skip hidden series (only if visibility manager is available)
+          if (isItemVisible && !isItemVisible({ type: seriesType, seriesId })) {
+            return;
           }
 
-          tooltipAxes[tooltipItemIndex].seriesItems.push({
-            seriesId,
-            color,
-            value,
-            formattedValue,
-            formattedLabel,
-            markType: seriesToAdd.labelMarkType,
-            markShape:
-              'showMark' in seriesToAdd && seriesToAdd.showMark
-                ? (seriesToAdd.shape ?? 'circle')
-                : undefined,
-          });
-        }
-      });
-    });
+          const providedXAxisId = seriesToAdd.xAxisId ?? defaultXAxis.id;
+          const providedYAxisId = seriesToAdd.yAxisId ?? defaultYAxis.id;
 
+          const tooltipItemIndex = tooltipAxes.findIndex(
+            ({ axisDirection, axisId }) =>
+              (axisDirection === 'x' && axisId === providedXAxisId) ||
+              (axisDirection === 'y' && axisId === providedYAxisId),
+          );
+          // Test if the series uses the default axis
+          if (tooltipItemIndex >= 0) {
+            const zAxisId = 'zAxisId' in seriesToAdd ? seriesToAdd.zAxisId : zAxisIds[0];
+            const { dataIndex } = tooltipAxes[tooltipItemIndex];
+            const color =
+              colorProcessors[seriesType]?.(
+                seriesToAdd,
+                xAxis[providedXAxisId],
+                yAxis[providedYAxisId],
+                zAxisId ? zAxis[zAxisId] : undefined,
+              )(dataIndex) ?? '';
+
+            const rawValue = seriesToAdd.data[dataIndex] ?? null;
+            const formattedLabel = getLabel(seriesToAdd.label, 'tooltip') ?? null;
+
+            let value: any;
+            let formattedValue: any;
+
+            if (seriesType === 'ohlc' && Array.isArray(rawValue)) {
+              const [open, high, low, close] = rawValue as [number, number, number, number];
+              const formatter = seriesToAdd.valueFormatter as any;
+              value = { open, high, low, close };
+              formattedValue = {
+                open: formatter(open, { dataIndex, field: 'open' }),
+                high: formatter(high, { dataIndex, field: 'high' }),
+                low: formatter(low, { dataIndex, field: 'low' }),
+                close: formatter(close, { dataIndex, field: 'close' }),
+              };
+            } else {
+              value = rawValue;
+              formattedValue = (seriesToAdd.valueFormatter as any)(rawValue, {
+                dataIndex,
+              });
+            }
+
+            tooltipAxes[tooltipItemIndex].seriesItems.push({
+              seriesId,
+              color,
+              value,
+              formattedValue,
+              formattedLabel,
+              markType: seriesToAdd.labelMarkType,
+              markShape:
+                'showMark' in seriesToAdd && seriesToAdd.showMark
+                  ? (seriesToAdd.shape ?? 'circle')
+                  : undefined,
+            });
+          }
+        });
+      });
+
+    return tooltipAxes as UseAxesTooltipReturnValue<SeriesType>[];
+  }
+
+  // For polar charts
   Object.keys(series)
     .filter(isPolarSeriesType)
     .forEach(<Type extends PolarChartSeriesType>(seriesType: Type) => {
@@ -278,6 +290,5 @@ export function useAxesTooltip<
         }
       });
     });
-
   return tooltipAxes as UseAxesTooltipReturnValue<SeriesType>[];
 }

--- a/packages/x-charts/src/LineChart/seriesConfig/getItemAtPosition.ts
+++ b/packages/x-charts/src/LineChart/seriesConfig/getItemAtPosition.ts
@@ -154,7 +154,10 @@ export default function getItemAtPosition(
 
   const { axis: xAxes, axisIds: xAxisIds } = selectorChartXAxis(state);
   const { axis: yAxes, axisIds: yAxisIds } = selectorChartYAxis(state);
-  const series = selectorAllSeriesOfType(state, 'line') as ProcessedSeries<'line', 'cartesian'>['line'];
+  const series = selectorAllSeriesOfType(state, 'line') as ProcessedSeries<
+    'line',
+    'cartesian'
+  >['line'];
 
   if (!series || series.seriesOrder.length === 0) {
     return undefined;

--- a/packages/x-charts/src/LineChart/seriesConfig/getItemAtPosition.ts
+++ b/packages/x-charts/src/LineChart/seriesConfig/getItemAtPosition.ts
@@ -154,7 +154,7 @@ export default function getItemAtPosition(
 
   const { axis: xAxes, axisIds: xAxisIds } = selectorChartXAxis(state);
   const { axis: yAxes, axisIds: yAxisIds } = selectorChartYAxis(state);
-  const series = selectorAllSeriesOfType(state, 'line') as ProcessedSeries['line'];
+  const series = selectorAllSeriesOfType(state, 'line') as ProcessedSeries<'line', 'cartesian'>['line'];
 
   if (!series || series.seriesOrder.length === 0) {
     return undefined;

--- a/packages/x-charts/src/LineChart/seriesConfig/index.ts
+++ b/packages/x-charts/src/LineChart/seriesConfig/index.ts
@@ -16,7 +16,7 @@ import {
 } from '../../internals/plugins/featurePlugins/useChartHighlight';
 import descriptionGetter from './descriptionGetter';
 
-export const lineSeriesConfig: ChartSeriesTypeConfig<'line'> = {
+export const lineSeriesConfig: ChartSeriesTypeConfig<'line', 'cartesian'> = {
   colorProcessor: getColor,
   seriesProcessor,
   legendGetter,

--- a/packages/x-charts/src/LineChart/seriesConfig/tooltip.ts
+++ b/packages/x-charts/src/LineChart/seriesConfig/tooltip.ts
@@ -4,7 +4,7 @@ import type {
   TooltipGetter,
 } from '../../internals/plugins/corePlugins/useChartSeriesConfig';
 
-const tooltipGetter: TooltipGetter<'line'> = (params) => {
+const tooltipGetter: TooltipGetter<'line', 'cartesian'> = (params) => {
   const { series, getColor, identifier } = params;
 
   if (!identifier || identifier.dataIndex === undefined) {

--- a/packages/x-charts/src/hooks/useAxisSystem.tsx
+++ b/packages/x-charts/src/hooks/useAxisSystem.tsx
@@ -13,13 +13,13 @@ import { useStore } from '../internals/store/useStore';
  * The hook assumes polar and cartesian are never implemented at the same time.
  * @returns The coordinate system
  */
-export function useAxisSystem(): 'none' | 'polar' | 'cartesian' {
+export function useAxisSystem(): 'none' | 'radial' | 'cartesian' {
   const store = useStore<[UseChartPolarAxisSignature]>();
   const rawRotationAxis = store.use(selectorChartRawRotationAxis);
   const rawXAxis = store.use(selectorChartRawXAxis);
 
   if (rawRotationAxis !== undefined) {
-    return 'polar';
+    return 'radial';
   }
   if (rawXAxis !== undefined) {
     return 'cartesian';

--- a/packages/x-charts/src/hooks/useLineSeries.ts
+++ b/packages/x-charts/src/hooks/useLineSeries.ts
@@ -4,8 +4,10 @@ import { type SeriesId } from '../models/seriesType/common';
 import { type ChartSeriesDefaultized } from '../models/seriesType/config';
 import { useSeriesOfType, useAllSeriesOfType } from '../internals/seriesSelectorOfType';
 
-export type UseLineSeriesReturnValue<AxisType extends 'cartesian' | 'polar'> = ChartSeriesDefaultized<'line', AxisType>;
-export type UseLineSeriesContextReturnValue<AxisType extends 'cartesian' | 'polar'> = ProcessedSeries<'line', AxisType>['line'];
+export type UseLineSeriesReturnValue<AxisType extends 'cartesian' | 'polar'> =
+  ChartSeriesDefaultized<'line', AxisType>;
+export type UseLineSeriesContextReturnValue<AxisType extends 'cartesian' | 'polar'> =
+  ProcessedSeries<'line', AxisType>['line'];
 
 /**
  * Get access to the internal state of line series.
@@ -13,7 +15,9 @@ export type UseLineSeriesContextReturnValue<AxisType extends 'cartesian' | 'pola
  * @param {SeriesId} seriesId The id of the series to get.
  * @returns {UseLineSeriesReturnValue} the line series
  */
-export function useLineSeries<AxisType extends 'cartesian' | 'polar' = 'cartesian'>(seriesId: SeriesId): UseLineSeriesReturnValue<AxisType> | undefined;
+export function useLineSeries<AxisType extends 'cartesian' | 'polar' = 'cartesian'>(
+  seriesId: SeriesId,
+): UseLineSeriesReturnValue<AxisType> | undefined;
 /**
  * Get access to the internal state of line series.
  *
@@ -21,14 +25,18 @@ export function useLineSeries<AxisType extends 'cartesian' | 'polar' = 'cartesia
  *
  * @returns {UseLineSeriesReturnValue[]} the line series
  */
-export function useLineSeries<AxisType extends 'cartesian' | 'polar' = 'cartesian'>(): UseLineSeriesReturnValue<AxisType>[];
+export function useLineSeries<
+  AxisType extends 'cartesian' | 'polar' = 'cartesian',
+>(): UseLineSeriesReturnValue<AxisType>[];
 /**
  * Get access to the internal state of line series.
  *
  * @param {SeriesId[]} seriesIds The ids of the series to get. Order is preserved.
  * @returns {UseLineSeriesReturnValue[]} the line series
  */
-export function useLineSeries<AxisType extends 'cartesian' | 'polar' = 'cartesian'>(seriesIds: SeriesId[]): UseLineSeriesReturnValue<AxisType>[];
+export function useLineSeries<AxisType extends 'cartesian' | 'polar' = 'cartesian'>(
+  seriesIds: SeriesId[],
+): UseLineSeriesReturnValue<AxisType>[];
 export function useLineSeries(seriesIds?: SeriesId | SeriesId[]) {
   return useSeriesOfType('line', seriesIds);
 }
@@ -41,6 +49,8 @@ export function useLineSeries(seriesIds?: SeriesId | SeriesId[]) {
  * - stackingGroups: the array of stacking groups. Each group contains the series ids stacked and the strategy to use.
  * @returns the line series
  */
-export function useLineSeriesContext<AxisType extends 'cartesian' | 'polar' = 'cartesian'>(): UseLineSeriesContextReturnValue<AxisType> {
+export function useLineSeriesContext<
+  AxisType extends 'cartesian' | 'polar' = 'cartesian',
+>(): UseLineSeriesContextReturnValue<AxisType> {
   return useAllSeriesOfType('line');
 }

--- a/packages/x-charts/src/hooks/useLineSeries.ts
+++ b/packages/x-charts/src/hooks/useLineSeries.ts
@@ -4,9 +4,9 @@ import { type SeriesId } from '../models/seriesType/common';
 import { type ChartSeriesDefaultized } from '../models/seriesType/config';
 import { useSeriesOfType, useAllSeriesOfType } from '../internals/seriesSelectorOfType';
 
-export type UseLineSeriesReturnValue<AxisType extends 'cartesian' | 'polar'> =
+export type UseLineSeriesReturnValue<AxisType extends 'cartesian' | 'radial'> =
   ChartSeriesDefaultized<'line', AxisType>;
-export type UseLineSeriesContextReturnValue<AxisType extends 'cartesian' | 'polar'> =
+export type UseLineSeriesContextReturnValue<AxisType extends 'cartesian' | 'radial'> =
   ProcessedSeries<'line', AxisType>['line'];
 
 /**
@@ -15,7 +15,7 @@ export type UseLineSeriesContextReturnValue<AxisType extends 'cartesian' | 'pola
  * @param {SeriesId} seriesId The id of the series to get.
  * @returns {UseLineSeriesReturnValue} the line series
  */
-export function useLineSeries<AxisType extends 'cartesian' | 'polar' = 'cartesian'>(
+export function useLineSeries<AxisType extends 'cartesian' | 'radial' = 'cartesian'>(
   seriesId: SeriesId,
 ): UseLineSeriesReturnValue<AxisType> | undefined;
 /**
@@ -26,7 +26,7 @@ export function useLineSeries<AxisType extends 'cartesian' | 'polar' = 'cartesia
  * @returns {UseLineSeriesReturnValue[]} the line series
  */
 export function useLineSeries<
-  AxisType extends 'cartesian' | 'polar' = 'cartesian',
+  AxisType extends 'cartesian' | 'radial' = 'cartesian',
 >(): UseLineSeriesReturnValue<AxisType>[];
 /**
  * Get access to the internal state of line series.
@@ -34,7 +34,7 @@ export function useLineSeries<
  * @param {SeriesId[]} seriesIds The ids of the series to get. Order is preserved.
  * @returns {UseLineSeriesReturnValue[]} the line series
  */
-export function useLineSeries<AxisType extends 'cartesian' | 'polar' = 'cartesian'>(
+export function useLineSeries<AxisType extends 'cartesian' | 'radial' = 'cartesian'>(
   seriesIds: SeriesId[],
 ): UseLineSeriesReturnValue<AxisType>[];
 export function useLineSeries(seriesIds?: SeriesId | SeriesId[]) {
@@ -50,7 +50,7 @@ export function useLineSeries(seriesIds?: SeriesId | SeriesId[]) {
  * @returns the line series
  */
 export function useLineSeriesContext<
-  AxisType extends 'cartesian' | 'polar' = 'cartesian',
+  AxisType extends 'cartesian' | 'radial' = 'cartesian',
 >(): UseLineSeriesContextReturnValue<AxisType> {
   return useAllSeriesOfType('line');
 }

--- a/packages/x-charts/src/hooks/useLineSeries.ts
+++ b/packages/x-charts/src/hooks/useLineSeries.ts
@@ -4,8 +4,8 @@ import { type SeriesId } from '../models/seriesType/common';
 import { type ChartSeriesDefaultized } from '../models/seriesType/config';
 import { useSeriesOfType, useAllSeriesOfType } from '../internals/seriesSelectorOfType';
 
-export type UseLineSeriesReturnValue = ChartSeriesDefaultized<'line'>;
-export type UseLineSeriesContextReturnValue = ProcessedSeries['line'];
+export type UseLineSeriesReturnValue<AxisType extends 'cartesian' | 'polar'> = ChartSeriesDefaultized<'line', AxisType>;
+export type UseLineSeriesContextReturnValue<AxisType extends 'cartesian' | 'polar'> = ProcessedSeries<'line', AxisType>['line'];
 
 /**
  * Get access to the internal state of line series.
@@ -13,7 +13,7 @@ export type UseLineSeriesContextReturnValue = ProcessedSeries['line'];
  * @param {SeriesId} seriesId The id of the series to get.
  * @returns {UseLineSeriesReturnValue} the line series
  */
-export function useLineSeries(seriesId: SeriesId): UseLineSeriesReturnValue | undefined;
+export function useLineSeries<AxisType extends 'cartesian' | 'polar' = 'cartesian'>(seriesId: SeriesId): UseLineSeriesReturnValue<AxisType> | undefined;
 /**
  * Get access to the internal state of line series.
  *
@@ -21,14 +21,14 @@ export function useLineSeries(seriesId: SeriesId): UseLineSeriesReturnValue | un
  *
  * @returns {UseLineSeriesReturnValue[]} the line series
  */
-export function useLineSeries(): UseLineSeriesReturnValue[];
+export function useLineSeries<AxisType extends 'cartesian' | 'polar' = 'cartesian'>(): UseLineSeriesReturnValue<AxisType>[];
 /**
  * Get access to the internal state of line series.
  *
  * @param {SeriesId[]} seriesIds The ids of the series to get. Order is preserved.
  * @returns {UseLineSeriesReturnValue[]} the line series
  */
-export function useLineSeries(seriesIds: SeriesId[]): UseLineSeriesReturnValue[];
+export function useLineSeries<AxisType extends 'cartesian' | 'polar' = 'cartesian'>(seriesIds: SeriesId[]): UseLineSeriesReturnValue<AxisType>[];
 export function useLineSeries(seriesIds?: SeriesId | SeriesId[]) {
   return useSeriesOfType('line', seriesIds);
 }
@@ -41,6 +41,6 @@ export function useLineSeries(seriesIds?: SeriesId | SeriesId[]) {
  * - stackingGroups: the array of stacking groups. Each group contains the series ids stacked and the strategy to use.
  * @returns the line series
  */
-export function useLineSeriesContext(): UseLineSeriesContextReturnValue {
+export function useLineSeriesContext<AxisType extends 'cartesian' | 'polar' = 'cartesian'>(): UseLineSeriesContextReturnValue<AxisType> {
   return useAllSeriesOfType('line');
 }

--- a/packages/x-charts/src/internals/configInit.ts
+++ b/packages/x-charts/src/internals/configInit.ts
@@ -13,8 +13,8 @@ class CartesianSeriesTypes {
     if (cartesianInstance) {
       throw new Error(
         'MUI X Charts: Only one CartesianSeriesTypes instance can be created. ' +
-        'This is a singleton class used internally for series type registration. ' +
-        'Use the existing instance instead of creating a new one.',
+          'This is a singleton class used internally for series type registration. ' +
+          'Use the existing instance instead of creating a new one.',
       );
     }
     cartesianInstance = this.types;
@@ -36,8 +36,8 @@ class PolarSeriesTypes {
     if (polarInstance) {
       throw new Error(
         'MUI X Charts: Only one PolarSeriesTypes instance can be created. ' +
-        'This is a singleton class used internally for series type registration. ' +
-        'Use the existing instance instead of creating a new one.',
+          'This is a singleton class used internally for series type registration. ' +
+          'Use the existing instance instead of creating a new one.',
       );
     }
     polarInstance = this.types;

--- a/packages/x-charts/src/internals/configInit.ts
+++ b/packages/x-charts/src/internals/configInit.ts
@@ -61,3 +61,5 @@ cartesianSeriesTypes.addType('scatter');
 export const polarSeriesTypes = new PolarSeriesTypes();
 
 polarSeriesTypes.addType('radar');
+polarSeriesTypes.addType('line');
+polarSeriesTypes.addType('bar');

--- a/packages/x-charts/src/internals/configInit.ts
+++ b/packages/x-charts/src/internals/configInit.ts
@@ -13,8 +13,8 @@ class CartesianSeriesTypes {
     if (cartesianInstance) {
       throw new Error(
         'MUI X Charts: Only one CartesianSeriesTypes instance can be created. ' +
-          'This is a singleton class used internally for series type registration. ' +
-          'Use the existing instance instead of creating a new one.',
+        'This is a singleton class used internally for series type registration. ' +
+        'Use the existing instance instead of creating a new one.',
       );
     }
     cartesianInstance = this.types;
@@ -36,8 +36,8 @@ class PolarSeriesTypes {
     if (polarInstance) {
       throw new Error(
         'MUI X Charts: Only one PolarSeriesTypes instance can be created. ' +
-          'This is a singleton class used internally for series type registration. ' +
-          'Use the existing instance instead of creating a new one.',
+        'This is a singleton class used internally for series type registration. ' +
+        'Use the existing instance instead of creating a new one.',
       );
     }
     polarInstance = this.types;
@@ -62,4 +62,3 @@ export const polarSeriesTypes = new PolarSeriesTypes();
 
 polarSeriesTypes.addType('radar');
 polarSeriesTypes.addType('line');
-polarSeriesTypes.addType('bar');

--- a/packages/x-charts/src/internals/isCartesian.ts
+++ b/packages/x-charts/src/internals/isCartesian.ts
@@ -11,6 +11,6 @@ export function isCartesianSeriesType(seriesType: string): seriesType is Cartesi
 
 export function isCartesianSeries(
   series: ChartSeriesDefaultized<ChartSeriesType>,
-): series is ChartSeriesDefaultized<CartesianChartSeriesType> {
+): series is ChartSeriesDefaultized<CartesianChartSeriesType, 'cartesian'> {
   return isCartesianSeriesType(series.type);
 }

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartSeries/useChartSeries.types.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartSeries/useChartSeries.types.ts
@@ -56,7 +56,10 @@ export type UseChartSeriesDefaultizedParameters<
   theme: 'light' | 'dark';
 };
 
-export type ProcessedSeries<SeriesType extends ChartSeriesType = ChartSeriesType, AxisType extends 'cartesian' | 'polar' = any> = {
+export type ProcessedSeries<
+  SeriesType extends ChartSeriesType = ChartSeriesType,
+  AxisType extends 'cartesian' | 'polar' = any,
+> = {
   [type in SeriesType]?: SeriesProcessorResult<type, AxisType>;
 };
 

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartSeries/useChartSeries.types.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartSeries/useChartSeries.types.ts
@@ -58,7 +58,7 @@ export type UseChartSeriesDefaultizedParameters<
 
 export type ProcessedSeries<
   SeriesType extends ChartSeriesType = ChartSeriesType,
-  AxisType extends 'cartesian' | 'polar' = any,
+  AxisType extends 'cartesian' | 'radial' = any,
 > = {
   [type in SeriesType]?: SeriesProcessorResult<type, AxisType>;
 };

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartSeries/useChartSeries.types.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartSeries/useChartSeries.types.ts
@@ -56,8 +56,8 @@ export type UseChartSeriesDefaultizedParameters<
   theme: 'light' | 'dark';
 };
 
-export type ProcessedSeries<SeriesType extends ChartSeriesType = ChartSeriesType> = {
-  [type in SeriesType]?: SeriesProcessorResult<type>;
+export type ProcessedSeries<SeriesType extends ChartSeriesType = ChartSeriesType, AxisType extends 'cartesian' | 'polar' = any> = {
+  [type in SeriesType]?: SeriesProcessorResult<type, AxisType>;
 };
 
 export type SeriesLayout<SeriesType extends ChartSeriesType = ChartSeriesType> = {

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/cartesianExtremumGetter.types.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/cartesianExtremumGetter.types.ts
@@ -6,7 +6,7 @@ import type { AxisConfig, AxisId } from '../../../../../models/axis';
 import type { SeriesId } from '../../../../../models/seriesType/common';
 
 type CartesianExtremumGetterParams<SeriesType extends CartesianChartSeriesType> = {
-  series: Record<SeriesId, ChartSeriesDefaultized<SeriesType>>;
+  series: Record<SeriesId, ChartSeriesDefaultized<SeriesType, 'cartesian'>>;
   axis: AxisConfig;
   axisIndex: number;
   isDefaultAxis: boolean;

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/getItemAtPosition.types.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/getItemAtPosition.types.ts
@@ -3,7 +3,10 @@ import type { ChartState } from '../../../models/chart';
 import type { ChartSeriesType } from '../../../../../models/seriesType/config';
 import type { ChartSeriesTypeRequiredPlugins } from './seriesConfig.types';
 
-export type GetItemAtPosition<SeriesType extends ChartSeriesType, AxisType extends 'cartesian' | 'polar'> = (
+export type GetItemAtPosition<
+  SeriesType extends ChartSeriesType,
+  AxisType extends 'cartesian' | 'polar',
+> = (
   state: ChartState<ChartSeriesTypeRequiredPlugins<SeriesType, AxisType>>,
   point: { x: number; y: number },
 ) => SeriesItemIdentifierWithType<SeriesType> | undefined;

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/getItemAtPosition.types.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/getItemAtPosition.types.ts
@@ -5,7 +5,7 @@ import type { ChartSeriesTypeRequiredPlugins } from './seriesConfig.types';
 
 export type GetItemAtPosition<
   SeriesType extends ChartSeriesType,
-  AxisType extends 'cartesian' | 'polar',
+  AxisType extends 'cartesian' | 'radial',
 > = (
   state: ChartState<ChartSeriesTypeRequiredPlugins<SeriesType, AxisType>>,
   point: { x: number; y: number },

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/getItemAtPosition.types.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/getItemAtPosition.types.ts
@@ -3,7 +3,7 @@ import type { ChartState } from '../../../models/chart';
 import type { ChartSeriesType } from '../../../../../models/seriesType/config';
 import type { ChartSeriesTypeRequiredPlugins } from './seriesConfig.types';
 
-export type GetItemAtPosition<SeriesType extends ChartSeriesType> = (
-  state: ChartState<ChartSeriesTypeRequiredPlugins<SeriesType>>,
+export type GetItemAtPosition<SeriesType extends ChartSeriesType, AxisType extends 'cartesian' | 'polar'> = (
+  state: ChartState<ChartSeriesTypeRequiredPlugins<SeriesType, AxisType>>,
   point: { x: number; y: number },
 ) => SeriesItemIdentifierWithType<SeriesType> | undefined;

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/seriesConfig.types.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/seriesConfig.types.ts
@@ -24,27 +24,43 @@ import { type UseChartPolarAxisSignature } from '../../../featurePlugins/useChar
 import { type HighlightCreator } from '../../../featurePlugins/useChartHighlight/highlightCreator.types';
 import { type AxisTooltipContentProps, type ItemTooltipContentProps } from './TooltipContent.types';
 
-
-export type ChartSeriesTypeRequiredPlugins<SeriesType extends ChartSeriesType, AxisType extends 'cartesian' | 'polar' = any> =
+export type ChartSeriesTypeRequiredPlugins<
+  SeriesType extends ChartSeriesType,
+  AxisType extends 'cartesian' | 'polar' = any,
+> =
   Extract<ChartsSeriesConfig[SeriesType], { axisType: AxisType }> extends { axisType: infer A }
-  ? 'cartesian' extends A
-  ? 'polar' extends A
-  ? [] // Dual-mode series (both cartesian and polar): should be [polar] | [cartesian], but this look too complex to maintain compared to its benefits.
-  : [UseChartCartesianAxisSignature]
-  : 'polar' extends A
-  ? [UseChartPolarAxisSignature]
-  : []
-  : [];
+    ? 'cartesian' extends A
+      ? 'polar' extends A
+        ? [] // Dual-mode series (both cartesian and polar): should be [polar] | [cartesian], but this look too complex to maintain compared to its benefits.
+        : [UseChartCartesianAxisSignature]
+      : 'polar' extends A
+        ? [UseChartPolarAxisSignature]
+        : []
+    : [];
 
 /**
  * Helper type to compute the axis directions available for a given series type.
  * Dual-mode series (both cartesian and polar) get all four directions.
  */
-type ChartSeriesTypeAxisDirections<SeriesType extends ChartSeriesType, AxisType extends 'cartesian' | 'polar' = any> =
-  | (SeriesType extends CartesianChartSeriesType ? AxisType extends 'cartesian' ? 'x' | 'y' : never : never)
-  | (SeriesType extends PolarChartSeriesType ? AxisType extends 'polar' ? 'rotation' | 'radius' : never : never);
+type ChartSeriesTypeAxisDirections<
+  SeriesType extends ChartSeriesType,
+  AxisType extends 'cartesian' | 'polar' = any,
+> =
+  | (SeriesType extends CartesianChartSeriesType
+      ? AxisType extends 'cartesian'
+        ? 'x' | 'y'
+        : never
+      : never)
+  | (SeriesType extends PolarChartSeriesType
+      ? AxisType extends 'polar'
+        ? 'rotation' | 'radius'
+        : never
+      : never);
 
-export type ChartSeriesTypeConfig<SeriesType extends ChartSeriesType, AxisType extends 'cartesian' | 'polar' = any> = {
+export type ChartSeriesTypeConfig<
+  SeriesType extends ChartSeriesType,
+  AxisType extends 'cartesian' | 'polar' = any,
+> = {
   seriesProcessor: SeriesProcessor<SeriesType>;
   /**
    * A processor to add series layout when the layout does not depend from other series.
@@ -74,28 +90,35 @@ export type ChartSeriesTypeConfig<SeriesType extends ChartSeriesType, AxisType e
   descriptionGetter: DescriptionGetter<SeriesType>;
   isHighlightedCreator: HighlightCreator<SeriesType>;
   isFadedCreator: HighlightCreator<SeriesType>;
-} & (SeriesType extends CartesianChartSeriesType ? AxisType extends 'cartesian'
-  ? {
-    xExtremumGetter: CartesianExtremumGetter<SeriesType>;
-    yExtremumGetter: CartesianExtremumGetter<SeriesType>;
-  }
-  : {} : {}) &
-  (SeriesType extends PolarChartSeriesType ? AxisType extends 'polar'
+} & (SeriesType extends CartesianChartSeriesType
+  ? AxisType extends 'cartesian'
     ? {
-      rotationExtremumGetter: PolarExtremumGetter<SeriesType>;
-      radiusExtremumGetter: PolarExtremumGetter<SeriesType>;
-    }
-    : {} : {}) &
+        xExtremumGetter: CartesianExtremumGetter<SeriesType>;
+        yExtremumGetter: CartesianExtremumGetter<SeriesType>;
+      }
+    : {}
+  : {}) &
+  (SeriesType extends PolarChartSeriesType
+    ? AxisType extends 'polar'
+      ? {
+          rotationExtremumGetter: PolarExtremumGetter<SeriesType>;
+          radiusExtremumGetter: PolarExtremumGetter<SeriesType>;
+        }
+      : {}
+    : {}) &
   (SeriesType extends CartesianChartSeriesType | PolarChartSeriesType
     ? {
-      AxisTooltipContent?: React.ComponentType<AxisTooltipContentProps<SeriesType>>;
-      axisTooltipGetter?: AxisTooltipGetter<
-        SeriesType,
-        ChartSeriesTypeAxisDirections<SeriesType, AxisType>
-      >;
-    }
+        AxisTooltipContent?: React.ComponentType<AxisTooltipContentProps<SeriesType>>;
+        axisTooltipGetter?: AxisTooltipGetter<
+          SeriesType,
+          ChartSeriesTypeAxisDirections<SeriesType, AxisType>
+        >;
+      }
     : {});
 
-export type ChartSeriesConfig<SeriesType extends ChartSeriesType, AxisType extends 'cartesian' | 'polar' = any> = {
+export type ChartSeriesConfig<
+  SeriesType extends ChartSeriesType,
+  AxisType extends 'cartesian' | 'polar' = any,
+> = {
   [Key in SeriesType]: ChartSeriesTypeConfig<Key, AxisType>;
 };

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/seriesConfig.types.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/seriesConfig.types.ts
@@ -25,11 +25,23 @@ import { type HighlightCreator } from '../../../featurePlugins/useChartHighlight
 import { type AxisTooltipContentProps, type ItemTooltipContentProps } from './TooltipContent.types';
 
 export type ChartSeriesTypeRequiredPlugins<SeriesType extends ChartSeriesType> =
-  ChartsSeriesConfig[SeriesType] extends { axisType: 'cartesian' }
-    ? [UseChartCartesianAxisSignature]
-    : ChartsSeriesConfig[SeriesType] extends { axisType: 'polar' }
-      ? [UseChartPolarAxisSignature]
-      : [];
+  ChartsSeriesConfig[SeriesType] extends { axisType: infer A }
+    ? 'cartesian' extends A
+      ? 'polar' extends A
+        ? [] // Dual-mode series (both cartesian and polar): should be [polar] | [cartesian], but this look too complex to maintain compared to its benefits.
+        : [UseChartCartesianAxisSignature]
+      : 'polar' extends A
+        ? [UseChartPolarAxisSignature]
+        : []
+    : [];
+
+/**
+ * Helper type to compute the axis directions available for a given series type.
+ * Dual-mode series (both cartesian and polar) get all four directions.
+ */
+type ChartSeriesTypeAxisDirections<SeriesType extends ChartSeriesType> =
+  | (SeriesType extends CartesianChartSeriesType ? 'x' | 'y' : never)
+  | (SeriesType extends PolarChartSeriesType ? 'rotation' | 'radius' : never);
 
 export type ChartSeriesTypeConfig<SeriesType extends ChartSeriesType> = {
   seriesProcessor: SeriesProcessor<SeriesType>;
@@ -65,16 +77,21 @@ export type ChartSeriesTypeConfig<SeriesType extends ChartSeriesType> = {
   ? {
       xExtremumGetter: CartesianExtremumGetter<SeriesType>;
       yExtremumGetter: CartesianExtremumGetter<SeriesType>;
-      axisTooltipGetter?: AxisTooltipGetter<SeriesType, 'x' | 'y'>;
-      AxisTooltipContent?: React.ComponentType<AxisTooltipContentProps<SeriesType>>;
     }
   : {}) &
   (SeriesType extends PolarChartSeriesType
     ? {
         rotationExtremumGetter: PolarExtremumGetter<SeriesType>;
         radiusExtremumGetter: PolarExtremumGetter<SeriesType>;
-        axisTooltipGetter?: AxisTooltipGetter<SeriesType, 'rotation' | 'radius'>;
+      }
+    : {}) &
+  (SeriesType extends CartesianChartSeriesType | PolarChartSeriesType
+    ? {
         AxisTooltipContent?: React.ComponentType<AxisTooltipContentProps<SeriesType>>;
+        axisTooltipGetter?: AxisTooltipGetter<
+          SeriesType,
+          ChartSeriesTypeAxisDirections<SeriesType>
+        >;
       }
     : {});
 

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/seriesConfig.types.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/seriesConfig.types.ts
@@ -26,14 +26,14 @@ import { type AxisTooltipContentProps, type ItemTooltipContentProps } from './To
 
 export type ChartSeriesTypeRequiredPlugins<
   SeriesType extends ChartSeriesType,
-  AxisType extends 'cartesian' | 'polar' = any,
+  AxisType extends 'cartesian' | 'radial' = any,
 > =
   Extract<ChartsSeriesConfig[SeriesType], { axisType: AxisType }> extends { axisType: infer A }
     ? 'cartesian' extends A
-      ? 'polar' extends A
+      ? 'radial' extends A
         ? [] // Dual-mode series (both cartesian and polar): should be [polar] | [cartesian], but this look too complex to maintain compared to its benefits.
         : [UseChartCartesianAxisSignature]
-      : 'polar' extends A
+      : 'radial' extends A
         ? [UseChartPolarAxisSignature]
         : []
     : [];
@@ -44,7 +44,7 @@ export type ChartSeriesTypeRequiredPlugins<
  */
 type ChartSeriesTypeAxisDirections<
   SeriesType extends ChartSeriesType,
-  AxisType extends 'cartesian' | 'polar' = any,
+  AxisType extends 'cartesian' | 'radial' = any,
 > =
   | (SeriesType extends CartesianChartSeriesType
       ? AxisType extends 'cartesian'
@@ -52,14 +52,14 @@ type ChartSeriesTypeAxisDirections<
         : never
       : never)
   | (SeriesType extends PolarChartSeriesType
-      ? AxisType extends 'polar'
+      ? AxisType extends 'radial'
         ? 'rotation' | 'radius'
         : never
       : never);
 
 export type ChartSeriesTypeConfig<
   SeriesType extends ChartSeriesType,
-  AxisType extends 'cartesian' | 'polar' = any,
+  AxisType extends 'cartesian' | 'radial' = any,
 > = {
   seriesProcessor: SeriesProcessor<SeriesType>;
   /**
@@ -99,7 +99,7 @@ export type ChartSeriesTypeConfig<
     : {}
   : {}) &
   (SeriesType extends PolarChartSeriesType
-    ? AxisType extends 'polar'
+    ? AxisType extends 'radial'
       ? {
           rotationExtremumGetter: PolarExtremumGetter<SeriesType>;
           radiusExtremumGetter: PolarExtremumGetter<SeriesType>;
@@ -118,7 +118,7 @@ export type ChartSeriesTypeConfig<
 
 export type ChartSeriesConfig<
   SeriesType extends ChartSeriesType,
-  AxisType extends 'cartesian' | 'polar' = any,
+  AxisType extends 'cartesian' | 'radial' = any,
 > = {
   [Key in SeriesType]: ChartSeriesTypeConfig<Key, AxisType>;
 };

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/seriesConfig.types.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/seriesConfig.types.ts
@@ -24,26 +24,27 @@ import { type UseChartPolarAxisSignature } from '../../../featurePlugins/useChar
 import { type HighlightCreator } from '../../../featurePlugins/useChartHighlight/highlightCreator.types';
 import { type AxisTooltipContentProps, type ItemTooltipContentProps } from './TooltipContent.types';
 
-export type ChartSeriesTypeRequiredPlugins<SeriesType extends ChartSeriesType> =
-  ChartsSeriesConfig[SeriesType] extends { axisType: infer A }
-    ? 'cartesian' extends A
-      ? 'polar' extends A
-        ? [] // Dual-mode series (both cartesian and polar): should be [polar] | [cartesian], but this look too complex to maintain compared to its benefits.
-        : [UseChartCartesianAxisSignature]
-      : 'polar' extends A
-        ? [UseChartPolarAxisSignature]
-        : []
-    : [];
+
+export type ChartSeriesTypeRequiredPlugins<SeriesType extends ChartSeriesType, AxisType extends 'cartesian' | 'polar' = any> =
+  Extract<ChartsSeriesConfig[SeriesType], { axisType: AxisType }> extends { axisType: infer A }
+  ? 'cartesian' extends A
+  ? 'polar' extends A
+  ? [] // Dual-mode series (both cartesian and polar): should be [polar] | [cartesian], but this look too complex to maintain compared to its benefits.
+  : [UseChartCartesianAxisSignature]
+  : 'polar' extends A
+  ? [UseChartPolarAxisSignature]
+  : []
+  : [];
 
 /**
  * Helper type to compute the axis directions available for a given series type.
  * Dual-mode series (both cartesian and polar) get all four directions.
  */
-type ChartSeriesTypeAxisDirections<SeriesType extends ChartSeriesType> =
-  | (SeriesType extends CartesianChartSeriesType ? 'x' | 'y' : never)
-  | (SeriesType extends PolarChartSeriesType ? 'rotation' | 'radius' : never);
+type ChartSeriesTypeAxisDirections<SeriesType extends ChartSeriesType, AxisType extends 'cartesian' | 'polar' = any> =
+  | (SeriesType extends CartesianChartSeriesType ? AxisType extends 'cartesian' ? 'x' | 'y' : never : never)
+  | (SeriesType extends PolarChartSeriesType ? AxisType extends 'polar' ? 'rotation' | 'radius' : never : never);
 
-export type ChartSeriesTypeConfig<SeriesType extends ChartSeriesType> = {
+export type ChartSeriesTypeConfig<SeriesType extends ChartSeriesType, AxisType extends 'cartesian' | 'polar' = any> = {
   seriesProcessor: SeriesProcessor<SeriesType>;
   /**
    * A processor to add series layout when the layout does not depend from other series.
@@ -69,32 +70,32 @@ export type ChartSeriesTypeConfig<SeriesType extends ChartSeriesType> = {
    * @returns {SeriesItemIdentifierWithType<SeriesType>} A cleaned identifier with only the relevant properties.
    */
   identifierCleaner: IdentifierCleaner<SeriesType>;
-  getItemAtPosition?: GetItemAtPosition<SeriesType>;
+  getItemAtPosition?: GetItemAtPosition<SeriesType, AxisType>;
   descriptionGetter: DescriptionGetter<SeriesType>;
   isHighlightedCreator: HighlightCreator<SeriesType>;
   isFadedCreator: HighlightCreator<SeriesType>;
-} & (SeriesType extends CartesianChartSeriesType
+} & (SeriesType extends CartesianChartSeriesType ? AxisType extends 'cartesian'
   ? {
-      xExtremumGetter: CartesianExtremumGetter<SeriesType>;
-      yExtremumGetter: CartesianExtremumGetter<SeriesType>;
-    }
-  : {}) &
-  (SeriesType extends PolarChartSeriesType
+    xExtremumGetter: CartesianExtremumGetter<SeriesType>;
+    yExtremumGetter: CartesianExtremumGetter<SeriesType>;
+  }
+  : {} : {}) &
+  (SeriesType extends PolarChartSeriesType ? AxisType extends 'polar'
     ? {
-        rotationExtremumGetter: PolarExtremumGetter<SeriesType>;
-        radiusExtremumGetter: PolarExtremumGetter<SeriesType>;
-      }
-    : {}) &
+      rotationExtremumGetter: PolarExtremumGetter<SeriesType>;
+      radiusExtremumGetter: PolarExtremumGetter<SeriesType>;
+    }
+    : {} : {}) &
   (SeriesType extends CartesianChartSeriesType | PolarChartSeriesType
     ? {
-        AxisTooltipContent?: React.ComponentType<AxisTooltipContentProps<SeriesType>>;
-        axisTooltipGetter?: AxisTooltipGetter<
-          SeriesType,
-          ChartSeriesTypeAxisDirections<SeriesType>
-        >;
-      }
+      AxisTooltipContent?: React.ComponentType<AxisTooltipContentProps<SeriesType>>;
+      axisTooltipGetter?: AxisTooltipGetter<
+        SeriesType,
+        ChartSeriesTypeAxisDirections<SeriesType, AxisType>
+      >;
+    }
     : {});
 
-export type ChartSeriesConfig<SeriesType extends ChartSeriesType> = {
-  [Key in SeriesType]: ChartSeriesTypeConfig<Key>;
+export type ChartSeriesConfig<SeriesType extends ChartSeriesType, AxisType extends 'cartesian' | 'polar' = any> = {
+  [Key in SeriesType]: ChartSeriesTypeConfig<Key, AxisType>;
 };

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/seriesProcessor.types.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/seriesProcessor.types.ts
@@ -13,7 +13,10 @@ export type SeriesProcessorParams<SeriesType extends ChartSeriesType> = {
   seriesOrder: SeriesId[];
 };
 
-export type SeriesProcessorResult<SeriesType extends ChartSeriesType, AxisType extends 'cartesian' | 'polar' = any> = {
+export type SeriesProcessorResult<
+  SeriesType extends ChartSeriesType,
+  AxisType extends 'cartesian' | 'polar' = any,
+> = {
   series: Record<SeriesId, ChartSeriesDefaultized<SeriesType, AxisType>>;
   seriesOrder: SeriesId[];
 } & (ChartsSeriesConfig[SeriesType] extends {
@@ -22,7 +25,10 @@ export type SeriesProcessorResult<SeriesType extends ChartSeriesType, AxisType e
   ? { stackingGroups: StackingGroupsType }
   : {});
 
-export type SeriesProcessor<SeriesType extends ChartSeriesType, AxisType extends 'cartesian' | 'polar' = any> = (
+export type SeriesProcessor<
+  SeriesType extends ChartSeriesType,
+  AxisType extends 'cartesian' | 'polar' = any,
+> = (
   params: SeriesProcessorParams<SeriesType>,
   dataset?: Readonly<DatasetType>,
   isItemVisible?: IsItemVisibleFunction,

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/seriesProcessor.types.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/seriesProcessor.types.ts
@@ -13,8 +13,8 @@ export type SeriesProcessorParams<SeriesType extends ChartSeriesType> = {
   seriesOrder: SeriesId[];
 };
 
-export type SeriesProcessorResult<SeriesType extends ChartSeriesType> = {
-  series: Record<SeriesId, ChartSeriesDefaultized<SeriesType>>;
+export type SeriesProcessorResult<SeriesType extends ChartSeriesType, AxisType extends 'cartesian' | 'polar' = any> = {
+  series: Record<SeriesId, ChartSeriesDefaultized<SeriesType, AxisType>>;
   seriesOrder: SeriesId[];
 } & (ChartsSeriesConfig[SeriesType] extends {
   canBeStacked: true;
@@ -22,8 +22,8 @@ export type SeriesProcessorResult<SeriesType extends ChartSeriesType> = {
   ? { stackingGroups: StackingGroupsType }
   : {});
 
-export type SeriesProcessor<SeriesType extends ChartSeriesType> = (
+export type SeriesProcessor<SeriesType extends ChartSeriesType, AxisType extends 'cartesian' | 'polar' = any> = (
   params: SeriesProcessorParams<SeriesType>,
   dataset?: Readonly<DatasetType>,
   isItemVisible?: IsItemVisibleFunction,
-) => SeriesProcessorResult<SeriesType>;
+) => SeriesProcessorResult<SeriesType, AxisType>;

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/seriesProcessor.types.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/seriesProcessor.types.ts
@@ -15,7 +15,7 @@ export type SeriesProcessorParams<SeriesType extends ChartSeriesType> = {
 
 export type SeriesProcessorResult<
   SeriesType extends ChartSeriesType,
-  AxisType extends 'cartesian' | 'polar' = any,
+  AxisType extends 'cartesian' | 'radial' = any,
 > = {
   series: Record<SeriesId, ChartSeriesDefaultized<SeriesType, AxisType>>;
   seriesOrder: SeriesId[];
@@ -27,7 +27,7 @@ export type SeriesProcessorResult<
 
 export type SeriesProcessor<
   SeriesType extends ChartSeriesType,
-  AxisType extends 'cartesian' | 'polar' = any,
+  AxisType extends 'cartesian' | 'radial' = any,
 > = (
   params: SeriesProcessorParams<SeriesType>,
   dataset?: Readonly<DatasetType>,

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/tooltipGetter.types.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/tooltipGetter.types.ts
@@ -74,7 +74,7 @@ export interface TooltipGetterAxesConfig {
 
 export type TooltipGetter<
   SeriesType extends ChartSeriesType,
-  AxisType extends 'cartesian' | 'polar' = any,
+  AxisType extends 'cartesian' | 'radial' = any,
 > = (params: {
   series: ChartSeriesDefaultized<SeriesType, AxisType>;
   axesConfig: TooltipGetterAxesConfig;
@@ -98,6 +98,6 @@ export type AxisTooltipGetter<
 > = (
   series: Record<
     SeriesId,
-    ChartSeriesDefaultized<SeriesType, Directions extends 'x' | 'y' ? 'cartesian' : 'polar'>
+    ChartSeriesDefaultized<SeriesType, Directions extends 'x' | 'y' ? 'cartesian' : 'radial'>
   >,
 ) => { direction: Directions; axisId: AxisId | undefined }[];

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/tooltipGetter.types.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/tooltipGetter.types.ts
@@ -72,8 +72,8 @@ export interface TooltipGetterAxesConfig {
   radius?: PolarAxisDefaultized<any, any, ChartsRadiusAxisProps>;
 }
 
-export type TooltipGetter<SeriesType extends ChartSeriesType> = (params: {
-  series: ChartSeriesDefaultized<SeriesType>;
+export type TooltipGetter<SeriesType extends ChartSeriesType, AxisType extends 'cartesian' | 'polar' = any> = (params: {
+  series: ChartSeriesDefaultized<SeriesType, AxisType>;
   axesConfig: TooltipGetterAxesConfig;
   getColor: ColorGetter<SeriesType>;
   identifier: SeriesItemIdentifierWithType<SeriesType> | null;
@@ -93,5 +93,5 @@ export type AxisTooltipGetter<
   SeriesType extends ChartSeriesType,
   Directions extends 'x' | 'y' | 'rotation' | 'radius' = 'x' | 'y',
 > = (
-  series: Record<SeriesId, ChartSeriesDefaultized<SeriesType>>,
+  series: Record<SeriesId, ChartSeriesDefaultized<SeriesType, Directions extends 'x' | 'y' ? 'cartesian' : 'polar'>>,
 ) => { direction: Directions; axisId: AxisId | undefined }[];

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/tooltipGetter.types.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/tooltipGetter.types.ts
@@ -72,7 +72,10 @@ export interface TooltipGetterAxesConfig {
   radius?: PolarAxisDefaultized<any, any, ChartsRadiusAxisProps>;
 }
 
-export type TooltipGetter<SeriesType extends ChartSeriesType, AxisType extends 'cartesian' | 'polar' = any> = (params: {
+export type TooltipGetter<
+  SeriesType extends ChartSeriesType,
+  AxisType extends 'cartesian' | 'polar' = any,
+> = (params: {
   series: ChartSeriesDefaultized<SeriesType, AxisType>;
   axesConfig: TooltipGetterAxesConfig;
   getColor: ColorGetter<SeriesType>;
@@ -93,5 +96,8 @@ export type AxisTooltipGetter<
   SeriesType extends ChartSeriesType,
   Directions extends 'x' | 'y' | 'rotation' | 'radius' = 'x' | 'y',
 > = (
-  series: Record<SeriesId, ChartSeriesDefaultized<SeriesType, Directions extends 'x' | 'y' ? 'cartesian' : 'polar'>>,
+  series: Record<
+    SeriesId,
+    ChartSeriesDefaultized<SeriesType, Directions extends 'x' | 'y' ? 'cartesian' : 'polar'>
+  >,
 ) => { direction: Directions; axisId: AxisId | undefined }[];

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/getAxisDomainLimit.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/getAxisDomainLimit.ts
@@ -7,7 +7,7 @@ export const getAxisDomainLimit = <T extends CartesianChartSeriesType>(
   axis: Pick<AxisConfig, 'id' | 'domainLimit'>,
   axisDirection: 'x' | 'y',
   axisIndex: number,
-  formattedSeries: ProcessedSeries<T | 'line'>,
+  formattedSeries: ProcessedSeries<T | 'line', 'cartesian'>,
 ):
   | 'nice'
   | 'strict'

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/getAxisExtrema.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/getAxisExtrema.ts
@@ -13,7 +13,7 @@ const axisExtremumCallback = <SeriesType extends CartesianChartSeriesType>(
   chartType: SeriesType,
   axis: AxisConfig,
   axisDirection: 'x' | 'y',
-  seriesConfig: ChartSeriesConfig<SeriesType>,
+  seriesConfig: ChartSeriesConfig<SeriesType, 'cartesian'>,
   axisIndex: number,
   formattedSeries: ProcessedSeries<SeriesType>,
   getFilters?: GetZoomAxisFilters,

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxis.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxis.ts
@@ -18,6 +18,8 @@ import { selectorChartsInteractionIsInitialized } from '../useChartInteraction';
 import { selectorChartAxisInteraction } from './useChartCartesianInteraction.selectors';
 import { checkHasInteractionPlugin } from '../useChartInteraction/checkHasInteractionPlugin';
 import { type ChartsAxisData, type SeriesId } from '../../../../models';
+import { type ProcessedSeries } from '../../corePlugins/useChartSeries';
+import { type ChartSeriesType } from '../../../../models/seriesType/config';
 
 const AXIS_CLICK_SERIES_TYPES = new Set(['bar', 'rangeBar', 'line'] as const);
 type AxisClickSeriesType = typeof AXIS_CLICK_SERIES_TYPES extends Set<infer U> ? U : never;
@@ -47,7 +49,7 @@ export const useChartCartesianAxis: ChartPlugin<UseChartCartesianAxisSignature<a
   }
 
   const drawingArea = store.use(selectorChartDrawingArea);
-  const processedSeries = store.use(selectorChartSeriesProcessed);
+  const processedSeries: ProcessedSeries<ChartSeriesType, 'cartesian'> = store.use(selectorChartSeriesProcessed);
 
   const isInteractionEnabled = store.use(selectorChartsInteractionIsInitialized);
   const { axis: xAxisWithScale, axisIds: xAxisIds } = store.use(selectorChartXAxis);
@@ -134,7 +136,7 @@ export const useChartCartesianAxis: ChartPlugin<UseChartCartesianAxisSignature<a
   React.useEffect(() => {
     const element = chartsLayerContainerRef.current;
     if (!isInteractionEnabled || !hasInteractionPlugin || !element || params.disableAxisListener) {
-      return () => {};
+      return () => { };
     }
 
     // Clean the interaction when the mouse leaves the chart.
@@ -205,7 +207,7 @@ export const useChartCartesianAxis: ChartPlugin<UseChartCartesianAxisSignature<a
     const element = chartsLayerContainerRef.current;
     const onAxisClick = params.onAxisClick;
     if (element === null || !onAxisClick) {
-      return () => {};
+      return () => { };
     }
 
     const axisClickHandler = instance.addInteractionListener('tap', (event) => {
@@ -309,6 +311,6 @@ useChartCartesianAxis.getInitialState = (params) => ({
   ...(params.highlightedAxis === undefined
     ? {}
     : {
-        controlledCartesianAxisHighlight: params.highlightedAxis,
-      }),
+      controlledCartesianAxisHighlight: params.highlightedAxis,
+    }),
 });

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxis.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxis.ts
@@ -49,7 +49,9 @@ export const useChartCartesianAxis: ChartPlugin<UseChartCartesianAxisSignature<a
   }
 
   const drawingArea = store.use(selectorChartDrawingArea);
-  const processedSeries: ProcessedSeries<ChartSeriesType, 'cartesian'> = store.use(selectorChartSeriesProcessed);
+  const processedSeries: ProcessedSeries<ChartSeriesType, 'cartesian'> = store.use(
+    selectorChartSeriesProcessed,
+  );
 
   const isInteractionEnabled = store.use(selectorChartsInteractionIsInitialized);
   const { axis: xAxisWithScale, axisIds: xAxisIds } = store.use(selectorChartXAxis);
@@ -136,7 +138,7 @@ export const useChartCartesianAxis: ChartPlugin<UseChartCartesianAxisSignature<a
   React.useEffect(() => {
     const element = chartsLayerContainerRef.current;
     if (!isInteractionEnabled || !hasInteractionPlugin || !element || params.disableAxisListener) {
-      return () => { };
+      return () => {};
     }
 
     // Clean the interaction when the mouse leaves the chart.
@@ -207,7 +209,7 @@ export const useChartCartesianAxis: ChartPlugin<UseChartCartesianAxisSignature<a
     const element = chartsLayerContainerRef.current;
     const onAxisClick = params.onAxisClick;
     if (element === null || !onAxisClick) {
-      return () => { };
+      return () => {};
     }
 
     const axisClickHandler = instance.addInteractionListener('tap', (event) => {
@@ -311,6 +313,6 @@ useChartCartesianAxis.getInitialState = (params) => ({
   ...(params.highlightedAxis === undefined
     ? {}
     : {
-      controlledCartesianAxisHighlight: params.highlightedAxis,
-    }),
+        controlledCartesianAxisHighlight: params.highlightedAxis,
+      }),
 });

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartPolarAxis/getAxisExtremum.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartPolarAxis/getAxisExtremum.ts
@@ -13,7 +13,7 @@ const axisExtremumCallback = <SeriesType extends PolarChartSeriesType>(
   chartType: SeriesType,
   axis: AxisConfig,
   axisDirection: 'rotation' | 'radius',
-  seriesConfig: ChartSeriesConfig<SeriesType, 'polar'>,
+  seriesConfig: ChartSeriesConfig<SeriesType, 'radial'>,
   axisIndex: number,
   formattedSeries: ProcessedSeries<SeriesType>,
 ): PolarExtremumGetterResult => {

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartPolarAxis/getAxisExtremum.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartPolarAxis/getAxisExtremum.ts
@@ -1,8 +1,9 @@
 import { type AxisConfig } from '../../../../models/axis';
 import { type PolarChartSeriesType } from '../../../../models/seriesType/config';
-import {
-  type ChartSeriesConfig,
-  type PolarExtremumGetterResult,
+import type {
+  PolarExtremumGetter,
+  ChartSeriesConfig,
+  PolarExtremumGetterResult,
 } from '../../corePlugins/useChartSeriesConfig';
 import { type ProcessedSeries } from '../../corePlugins/useChartSeries/useChartSeries.types';
 import { isPolarSeriesType } from '../../../isPolar';
@@ -12,7 +13,7 @@ const axisExtremumCallback = <SeriesType extends PolarChartSeriesType>(
   chartType: SeriesType,
   axis: AxisConfig,
   axisDirection: 'rotation' | 'radius',
-  seriesConfig: ChartSeriesConfig<SeriesType>,
+  seriesConfig: ChartSeriesConfig<SeriesType, 'polar'>,
   axisIndex: number,
   formattedSeries: ProcessedSeries<SeriesType>,
 ): PolarExtremumGetterResult => {
@@ -22,7 +23,7 @@ const axisExtremumCallback = <SeriesType extends PolarChartSeriesType>(
       : seriesConfig[chartType].radiusExtremumGetter;
   const series = formattedSeries[chartType]?.series ?? {};
 
-  const [minChartTypeData, maxChartTypeData] = getter?.({
+  const [minChartTypeData, maxChartTypeData] = (getter as PolarExtremumGetter<SeriesType>)?.({
     series,
     axis,
     axisIndex,

--- a/packages/x-charts/src/internals/seriesSelectorOfType.ts
+++ b/packages/x-charts/src/internals/seriesSelectorOfType.ts
@@ -1,7 +1,7 @@
 import { warnOnce } from '@mui/x-internals/warning';
 import { createSelector, createSelectorMemoized } from '@mui/x-internals/store';
-import { type ChartSeriesDefaultized, type ChartsSeriesConfig } from '../models/seriesType/config';
-import { type SeriesId } from '../models/seriesType/common';
+import type { ChartSeriesType, ChartSeriesDefaultized, ChartsSeriesConfig } from '../models/seriesType/config';
+import type { SeriesId } from '../models/seriesType/common';
 import { selectorChartSeriesProcessed } from './plugins/corePlugins/useChartSeries/useChartSeries.selectors';
 import type { ProcessedSeries } from './plugins/corePlugins/useChartSeries';
 import { useStore } from './store/useStore';
@@ -53,18 +53,18 @@ export const selectorSeriesOfType = createSelectorMemoized(
   },
 );
 
-export const useAllSeriesOfType = <T extends keyof ChartsSeriesConfig>(seriesType: T) => {
+export const useAllSeriesOfType = <T extends ChartSeriesType, AxisType extends 'cartesian' | 'polar' = any>(seriesType: T) => {
   const store = useStore();
-  return store.use(selectorAllSeriesOfType, seriesType) as ProcessedSeries[T];
+  return store.use(selectorAllSeriesOfType, seriesType) as ProcessedSeries<T, AxisType>[T];
 };
 
-export const useSeriesOfType = <T extends keyof ChartsSeriesConfig>(
+export const useSeriesOfType = <T extends ChartSeriesType, AxisType extends 'cartesian' | 'polar' = any>(
   seriesType: T,
   seriesId?: SeriesId | SeriesId[],
 ) => {
   const store = useStore();
   return store.use(selectorSeriesOfType, seriesType, seriesId) as
-    | ChartSeriesDefaultized<T>
-    | ChartSeriesDefaultized<T>[]
+    | ChartSeriesDefaultized<T, AxisType>
+    | ChartSeriesDefaultized<T, AxisType>[]
     | undefined;
 };

--- a/packages/x-charts/src/internals/seriesSelectorOfType.ts
+++ b/packages/x-charts/src/internals/seriesSelectorOfType.ts
@@ -59,7 +59,7 @@ export const selectorSeriesOfType = createSelectorMemoized(
 
 export const useAllSeriesOfType = <
   T extends ChartSeriesType,
-  AxisType extends 'cartesian' | 'polar' = any,
+  AxisType extends 'cartesian' | 'radial' = any,
 >(
   seriesType: T,
 ) => {
@@ -69,7 +69,7 @@ export const useAllSeriesOfType = <
 
 export const useSeriesOfType = <
   T extends ChartSeriesType,
-  AxisType extends 'cartesian' | 'polar' = any,
+  AxisType extends 'cartesian' | 'radial' = any,
 >(
   seriesType: T,
   seriesId?: SeriesId | SeriesId[],

--- a/packages/x-charts/src/internals/seriesSelectorOfType.ts
+++ b/packages/x-charts/src/internals/seriesSelectorOfType.ts
@@ -1,6 +1,10 @@
 import { warnOnce } from '@mui/x-internals/warning';
 import { createSelector, createSelectorMemoized } from '@mui/x-internals/store';
-import type { ChartSeriesType, ChartSeriesDefaultized, ChartsSeriesConfig } from '../models/seriesType/config';
+import type {
+  ChartSeriesType,
+  ChartSeriesDefaultized,
+  ChartsSeriesConfig,
+} from '../models/seriesType/config';
 import type { SeriesId } from '../models/seriesType/common';
 import { selectorChartSeriesProcessed } from './plugins/corePlugins/useChartSeries/useChartSeries.selectors';
 import type { ProcessedSeries } from './plugins/corePlugins/useChartSeries';
@@ -53,12 +57,20 @@ export const selectorSeriesOfType = createSelectorMemoized(
   },
 );
 
-export const useAllSeriesOfType = <T extends ChartSeriesType, AxisType extends 'cartesian' | 'polar' = any>(seriesType: T) => {
+export const useAllSeriesOfType = <
+  T extends ChartSeriesType,
+  AxisType extends 'cartesian' | 'polar' = any,
+>(
+  seriesType: T,
+) => {
   const store = useStore();
   return store.use(selectorAllSeriesOfType, seriesType) as ProcessedSeries<T, AxisType>[T];
 };
 
-export const useSeriesOfType = <T extends ChartSeriesType, AxisType extends 'cartesian' | 'polar' = any>(
+export const useSeriesOfType = <
+  T extends ChartSeriesType,
+  AxisType extends 'cartesian' | 'polar' = any,
+>(
   seriesType: T,
   seriesId?: SeriesId | SeriesId[],
 ) => {

--- a/packages/x-charts/src/models/seriesType/common.ts
+++ b/packages/x-charts/src/models/seriesType/common.ts
@@ -79,6 +79,17 @@ export type CartesianSeriesType = {
   yAxisId?: AxisId;
 };
 
+export type RadialSeriesType = {
+  /**
+   * The id of the rotation axis used to render the series.
+   */
+  rotationAxisId?: AxisId;
+  /**
+   * The id of the radius axis used to render the series.
+   */
+  radiusAxisId?: AxisId;
+};
+
 export type StackableSeriesType = {
   /**
    * The key that identifies the stacking group.

--- a/packages/x-charts/src/models/seriesType/config.ts
+++ b/packages/x-charts/src/models/seriesType/config.ts
@@ -5,7 +5,13 @@ import type {
   ScatterItemIdentifier,
   ScatterValueType,
 } from './scatter';
-import type { LineSeriesType, DefaultizedLineSeriesType, LineItemIdentifier, RadialLineSeriesType, DefaultizedRadialLineSeriesType } from './line';
+import type {
+  LineSeriesType,
+  DefaultizedLineSeriesType,
+  LineItemIdentifier,
+  RadialLineSeriesType,
+  DefaultizedRadialLineSeriesType,
+} from './line';
 import type { BarItemIdentifier, BarSeriesType, DefaultizedBarSeriesType } from './bar';
 import type {
   PieSeriesType,
@@ -32,7 +38,7 @@ export interface ChartsSeriesConfig {
      * Series type when passed to the formatter (some ids are given default values to simplify the DX)
      */
     seriesInput: DefaultizedProps<BarSeriesType, 'id'> &
-    MakeRequired<SeriesColor<number | null>, 'color'>;
+      MakeRequired<SeriesColor<number | null>, 'color'>;
     /**
      * Series type when stored in the context (with all the preprocessing added))
      */
@@ -70,56 +76,58 @@ export interface ChartsSeriesConfig {
       dataIndex?: number | undefined;
     };
   };
-  line: {
-    seriesInput: DefaultizedProps<LineSeriesType, 'id'> &
-    MakeRequired<SeriesColor<number | null>, 'color'>;
-    series: DefaultizedLineSeriesType;
-    seriesLayout: {};
-    seriesProp: LineSeriesType;
-    itemIdentifier: LineItemIdentifier;
-    itemIdentifierWithData: LineItemIdentifier;
-    valueType: number | null;
-    canBeStacked: true;
-    axisType: 'cartesian';
-    highlightScope: CommonHighlightScope;
-    descriptionGetterParams: {
-      identifier: LineItemIdentifier;
-      xAxis: ComputedXAxis;
-      yAxis: ComputedYAxis;
-      series: DefaultizedLineSeriesType;
-    };
-    highlightIdentifier: {
-      type: 'line';
-      seriesId: SeriesId;
-      dataIndex?: number;
-    };
-  } | {
-    seriesInput: DefaultizedProps<RadialLineSeriesType, 'id'> &
-    MakeRequired<SeriesColor<number | null>, 'color'>;
-    series: DefaultizedRadialLineSeriesType;
-    seriesLayout: {};
-    seriesProp: RadialLineSeriesType;
-    itemIdentifier: LineItemIdentifier;
-    itemIdentifierWithData: LineItemIdentifier;
-    valueType: number | null;
-    canBeStacked: true;
-    axisType: 'polar';
-    highlightScope: CommonHighlightScope;
-    descriptionGetterParams: {
-      identifier: LineItemIdentifier;
-      xAxis: ComputedXAxis;
-      yAxis: ComputedYAxis;
-      series: DefaultizedRadialLineSeriesType;
-    };
-    highlightIdentifier: {
-      type: 'line';
-      seriesId: SeriesId;
-      dataIndex?: number;
-    };
-  };
+  line:
+    | {
+        seriesInput: DefaultizedProps<LineSeriesType, 'id'> &
+          MakeRequired<SeriesColor<number | null>, 'color'>;
+        series: DefaultizedLineSeriesType;
+        seriesLayout: {};
+        seriesProp: LineSeriesType;
+        itemIdentifier: LineItemIdentifier;
+        itemIdentifierWithData: LineItemIdentifier;
+        valueType: number | null;
+        canBeStacked: true;
+        axisType: 'cartesian';
+        highlightScope: CommonHighlightScope;
+        descriptionGetterParams: {
+          identifier: LineItemIdentifier;
+          xAxis: ComputedXAxis;
+          yAxis: ComputedYAxis;
+          series: DefaultizedLineSeriesType;
+        };
+        highlightIdentifier: {
+          type: 'line';
+          seriesId: SeriesId;
+          dataIndex?: number;
+        };
+      }
+    | {
+        seriesInput: DefaultizedProps<RadialLineSeriesType, 'id'> &
+          MakeRequired<SeriesColor<number | null>, 'color'>;
+        series: DefaultizedRadialLineSeriesType;
+        seriesLayout: {};
+        seriesProp: RadialLineSeriesType;
+        itemIdentifier: LineItemIdentifier;
+        itemIdentifierWithData: LineItemIdentifier;
+        valueType: number | null;
+        canBeStacked: true;
+        axisType: 'polar';
+        highlightScope: CommonHighlightScope;
+        descriptionGetterParams: {
+          identifier: LineItemIdentifier;
+          xAxis: ComputedXAxis;
+          yAxis: ComputedYAxis;
+          series: DefaultizedRadialLineSeriesType;
+        };
+        highlightIdentifier: {
+          type: 'line';
+          seriesId: SeriesId;
+          dataIndex?: number;
+        };
+      };
   scatter: {
     seriesInput: DefaultizedProps<ScatterSeriesType, 'id'> &
-    MakeRequired<SeriesColor<ScatterValueType | null>, 'color'>;
+      MakeRequired<SeriesColor<ScatterValueType | null>, 'color'>;
     series: DefaultizedScatterSeriesType;
     seriesLayout: {};
     seriesProp: ScatterSeriesType;
@@ -165,7 +173,7 @@ export interface ChartsSeriesConfig {
   };
   radar: {
     seriesInput: DefaultizedProps<RadarSeriesType, 'id'> &
-    MakeRequired<SeriesColor<number>, 'color'>;
+      MakeRequired<SeriesColor<number>, 'color'>;
     series: DefaultizedRadarSeriesType;
     seriesLayout: {};
     seriesProp: RadarSeriesType;
@@ -197,10 +205,10 @@ export type CartesianChartSeriesType = keyof Pick<
   ChartsSeriesConfig,
   {
     [Key in ChartSeriesType]: ChartsSeriesConfig[Key] extends { axisType: infer A }
-    ? 'cartesian' extends A
-    ? Key
-    : never
-    : never;
+      ? 'cartesian' extends A
+        ? Key
+        : never
+      : never;
   }[ChartSeriesType]
 >;
 
@@ -211,18 +219,18 @@ export type CartesianChartSeriesType = keyof Pick<
  */
 export type SeriesTypeWithDataIndex = {
   [K in ChartSeriesType]: 'dataIndex' extends keyof ChartsSeriesConfig[K]['itemIdentifier']
-  ? K
-  : never;
+    ? K
+    : never;
 }[ChartSeriesType];
 
 export type PolarChartSeriesType = keyof Pick<
   ChartsSeriesConfig,
   {
     [Key in ChartSeriesType]: ChartsSeriesConfig[Key] extends { axisType: infer A }
-    ? 'polar' extends A
-    ? Key
-    : never
-    : never;
+      ? 'polar' extends A
+        ? Key
+        : never
+      : never;
   }[ChartSeriesType]
 >;
 
@@ -233,25 +241,33 @@ export type StackableChartSeriesType = keyof Pick<
   }[ChartSeriesType]
 >;
 
-export type ChartSeries<SeriesType extends ChartSeriesType, AxisType extends 'cartesian' | 'polar' = any> =
-  (AxisType extends 'cartesian' | 'polar' ? Extract<ChartsSeriesConfig[SeriesType], { axisType: AxisType }>['seriesInput'] : ChartsSeriesConfig[SeriesType]['seriesInput']);
+export type ChartSeries<
+  SeriesType extends ChartSeriesType,
+  AxisType extends 'cartesian' | 'polar' = any,
+> = AxisType extends 'cartesian' | 'polar'
+  ? Extract<ChartsSeriesConfig[SeriesType], { axisType: AxisType }>['seriesInput']
+  : ChartsSeriesConfig[SeriesType]['seriesInput'];
 
-export type ChartSeriesDefaultized<SeriesType extends ChartSeriesType, AxisType extends 'cartesian' | 'polar' = any> =
-  (AxisType extends 'cartesian' | 'polar' ? Extract<ChartsSeriesConfig[SeriesType], { axisType: AxisType }>['series'] : ChartsSeriesConfig[SeriesType]['series']) &
+export type ChartSeriesDefaultized<
+  SeriesType extends ChartSeriesType,
+  AxisType extends 'cartesian' | 'polar' = any,
+> = (AxisType extends 'cartesian' | 'polar'
+  ? Extract<ChartsSeriesConfig[SeriesType], { axisType: AxisType }>['series']
+  : ChartsSeriesConfig[SeriesType]['series']) &
   (ChartsSeriesConfig[SeriesType] extends {
     canBeStacked: true;
   }
     ? {
-      visibleStackedData: [number, number][];
+        visibleStackedData: [number, number][];
 
-      stackedData: [number, number][];
-    }
+        stackedData: [number, number][];
+      }
     : {});
 
 export type ChartSeriesLayout<SeriesType extends ChartSeriesType> =
   ChartsSeriesConfig[SeriesType] extends any
-  ? ChartsSeriesConfig[SeriesType]['seriesLayout']
-  : never;
+    ? ChartsSeriesConfig[SeriesType]['seriesLayout']
+    : never;
 
 export type DatasetElementType<T> = {
   [key: string]: T;
@@ -260,5 +276,5 @@ export type DatasetType<T = unknown> = DatasetElementType<T>[];
 
 export type HighlightScope<SeriesType extends ChartSeriesType> =
   ChartsSeriesConfig[SeriesType] extends any
-  ? ChartsSeriesConfig[SeriesType]['highlightScope']
-  : never;
+    ? ChartsSeriesConfig[SeriesType]['highlightScope']
+    : never;

--- a/packages/x-charts/src/models/seriesType/config.ts
+++ b/packages/x-charts/src/models/seriesType/config.ts
@@ -5,7 +5,7 @@ import type {
   ScatterItemIdentifier,
   ScatterValueType,
 } from './scatter';
-import type { LineSeriesType, DefaultizedLineSeriesType, LineItemIdentifier } from './line';
+import type { LineSeriesType, DefaultizedLineSeriesType, LineItemIdentifier, RadialLineSeriesType, DefaultizedRadialLineSeriesType } from './line';
 import type { BarItemIdentifier, BarSeriesType, DefaultizedBarSeriesType } from './bar';
 import type {
   PieSeriesType,
@@ -32,7 +32,7 @@ export interface ChartsSeriesConfig {
      * Series type when passed to the formatter (some ids are given default values to simplify the DX)
      */
     seriesInput: DefaultizedProps<BarSeriesType, 'id'> &
-      MakeRequired<SeriesColor<number | null>, 'color'>;
+    MakeRequired<SeriesColor<number | null>, 'color'>;
     /**
      * Series type when stored in the context (with all the preprocessing added))
      */
@@ -56,7 +56,7 @@ export interface ChartsSeriesConfig {
     itemIdentifierWithData: BarItemIdentifier;
     valueType: number | null;
     canBeStacked: true;
-    axisType: 'cartesian' | 'polar';
+    axisType: 'cartesian';
     highlightScope: CommonHighlightScope;
     descriptionGetterParams: {
       identifier: BarItemIdentifier;
@@ -72,7 +72,7 @@ export interface ChartsSeriesConfig {
   };
   line: {
     seriesInput: DefaultizedProps<LineSeriesType, 'id'> &
-      MakeRequired<SeriesColor<number | null>, 'color'>;
+    MakeRequired<SeriesColor<number | null>, 'color'>;
     series: DefaultizedLineSeriesType;
     seriesLayout: {};
     seriesProp: LineSeriesType;
@@ -80,7 +80,7 @@ export interface ChartsSeriesConfig {
     itemIdentifierWithData: LineItemIdentifier;
     valueType: number | null;
     canBeStacked: true;
-    axisType: 'cartesian' | 'polar';
+    axisType: 'cartesian';
     highlightScope: CommonHighlightScope;
     descriptionGetterParams: {
       identifier: LineItemIdentifier;
@@ -93,10 +93,33 @@ export interface ChartsSeriesConfig {
       seriesId: SeriesId;
       dataIndex?: number;
     };
+  } | {
+    seriesInput: DefaultizedProps<RadialLineSeriesType, 'id'> &
+    MakeRequired<SeriesColor<number | null>, 'color'>;
+    series: DefaultizedRadialLineSeriesType;
+    seriesLayout: {};
+    seriesProp: RadialLineSeriesType;
+    itemIdentifier: LineItemIdentifier;
+    itemIdentifierWithData: LineItemIdentifier;
+    valueType: number | null;
+    canBeStacked: true;
+    axisType: 'polar';
+    highlightScope: CommonHighlightScope;
+    descriptionGetterParams: {
+      identifier: LineItemIdentifier;
+      xAxis: ComputedXAxis;
+      yAxis: ComputedYAxis;
+      series: DefaultizedRadialLineSeriesType;
+    };
+    highlightIdentifier: {
+      type: 'line';
+      seriesId: SeriesId;
+      dataIndex?: number;
+    };
   };
   scatter: {
     seriesInput: DefaultizedProps<ScatterSeriesType, 'id'> &
-      MakeRequired<SeriesColor<ScatterValueType | null>, 'color'>;
+    MakeRequired<SeriesColor<ScatterValueType | null>, 'color'>;
     series: DefaultizedScatterSeriesType;
     seriesLayout: {};
     seriesProp: ScatterSeriesType;
@@ -142,7 +165,7 @@ export interface ChartsSeriesConfig {
   };
   radar: {
     seriesInput: DefaultizedProps<RadarSeriesType, 'id'> &
-      MakeRequired<SeriesColor<number>, 'color'>;
+    MakeRequired<SeriesColor<number>, 'color'>;
     series: DefaultizedRadarSeriesType;
     seriesLayout: {};
     seriesProp: RadarSeriesType;
@@ -174,10 +197,10 @@ export type CartesianChartSeriesType = keyof Pick<
   ChartsSeriesConfig,
   {
     [Key in ChartSeriesType]: ChartsSeriesConfig[Key] extends { axisType: infer A }
-      ? 'cartesian' extends A
-        ? Key
-        : never
-      : never;
+    ? 'cartesian' extends A
+    ? Key
+    : never
+    : never;
   }[ChartSeriesType]
 >;
 
@@ -188,18 +211,18 @@ export type CartesianChartSeriesType = keyof Pick<
  */
 export type SeriesTypeWithDataIndex = {
   [K in ChartSeriesType]: 'dataIndex' extends keyof ChartsSeriesConfig[K]['itemIdentifier']
-    ? K
-    : never;
+  ? K
+  : never;
 }[ChartSeriesType];
 
 export type PolarChartSeriesType = keyof Pick<
   ChartsSeriesConfig,
   {
     [Key in ChartSeriesType]: ChartsSeriesConfig[Key] extends { axisType: infer A }
-      ? 'polar' extends A
-        ? Key
-        : never
-      : never;
+    ? 'polar' extends A
+    ? Key
+    : never
+    : never;
   }[ChartSeriesType]
 >;
 
@@ -210,23 +233,25 @@ export type StackableChartSeriesType = keyof Pick<
   }[ChartSeriesType]
 >;
 
-export type ChartSeries<SeriesType extends ChartSeriesType> =
-  ChartsSeriesConfig[SeriesType]['seriesInput'];
+export type ChartSeries<SeriesType extends ChartSeriesType, AxisType extends 'cartesian' | 'polar' = any> =
+  (AxisType extends 'cartesian' | 'polar' ? Extract<ChartsSeriesConfig[SeriesType], { axisType: AxisType }>['seriesInput'] : ChartsSeriesConfig[SeriesType]['seriesInput']);
 
-export type ChartSeriesDefaultized<SeriesType extends ChartSeriesType> =
-  ChartsSeriesConfig[SeriesType] extends {
+export type ChartSeriesDefaultized<SeriesType extends ChartSeriesType, AxisType extends 'cartesian' | 'polar' = any> =
+  (AxisType extends 'cartesian' | 'polar' ? Extract<ChartsSeriesConfig[SeriesType], { axisType: AxisType }>['series'] : ChartsSeriesConfig[SeriesType]['series']) &
+  (ChartsSeriesConfig[SeriesType] extends {
     canBeStacked: true;
   }
-    ? ChartsSeriesConfig[SeriesType]['series'] & {
-        visibleStackedData: [number, number][];
-        stackedData: [number, number][];
-      }
-    : ChartsSeriesConfig[SeriesType]['series'];
+    ? {
+      visibleStackedData: [number, number][];
+
+      stackedData: [number, number][];
+    }
+    : {});
 
 export type ChartSeriesLayout<SeriesType extends ChartSeriesType> =
   ChartsSeriesConfig[SeriesType] extends any
-    ? ChartsSeriesConfig[SeriesType]['seriesLayout']
-    : never;
+  ? ChartsSeriesConfig[SeriesType]['seriesLayout']
+  : never;
 
 export type DatasetElementType<T> = {
   [key: string]: T;
@@ -235,5 +260,5 @@ export type DatasetType<T = unknown> = DatasetElementType<T>[];
 
 export type HighlightScope<SeriesType extends ChartSeriesType> =
   ChartsSeriesConfig[SeriesType] extends any
-    ? ChartsSeriesConfig[SeriesType]['highlightScope']
-    : never;
+  ? ChartsSeriesConfig[SeriesType]['highlightScope']
+  : never;

--- a/packages/x-charts/src/models/seriesType/config.ts
+++ b/packages/x-charts/src/models/seriesType/config.ts
@@ -111,7 +111,7 @@ export interface ChartsSeriesConfig {
         itemIdentifierWithData: LineItemIdentifier;
         valueType: number | null;
         canBeStacked: true;
-        axisType: 'polar';
+        axisType: 'radial';
         highlightScope: CommonHighlightScope;
         descriptionGetterParams: {
           identifier: LineItemIdentifier;
@@ -180,7 +180,7 @@ export interface ChartsSeriesConfig {
     itemIdentifier: RadarItemIdentifier;
     itemIdentifierWithData: RadarItemIdentifier;
     valueType: number;
-    axisType: 'polar';
+    axisType: 'radial';
     highlightScope: CommonHighlightScope;
     descriptionGetterParams: {
       identifier: RadarItemIdentifier;
@@ -227,7 +227,7 @@ export type PolarChartSeriesType = keyof Pick<
   ChartsSeriesConfig,
   {
     [Key in ChartSeriesType]: ChartsSeriesConfig[Key] extends { axisType: infer A }
-      ? 'polar' extends A
+      ? 'radial' extends A
         ? Key
         : never
       : never;
@@ -243,15 +243,15 @@ export type StackableChartSeriesType = keyof Pick<
 
 export type ChartSeries<
   SeriesType extends ChartSeriesType,
-  AxisType extends 'cartesian' | 'polar' = any,
-> = AxisType extends 'cartesian' | 'polar'
+  AxisType extends 'cartesian' | 'radial' = any,
+> = AxisType extends 'cartesian' | 'radial'
   ? Extract<ChartsSeriesConfig[SeriesType], { axisType: AxisType }>['seriesInput']
   : ChartsSeriesConfig[SeriesType]['seriesInput'];
 
 export type ChartSeriesDefaultized<
   SeriesType extends ChartSeriesType,
-  AxisType extends 'cartesian' | 'polar' = any,
-> = (AxisType extends 'cartesian' | 'polar'
+  AxisType extends 'cartesian' | 'radial' = any,
+> = (AxisType extends 'cartesian' | 'radial'
   ? Extract<ChartsSeriesConfig[SeriesType], { axisType: AxisType }>['series']
   : ChartsSeriesConfig[SeriesType]['series']) &
   (ChartsSeriesConfig[SeriesType] extends {

--- a/packages/x-charts/src/models/seriesType/config.ts
+++ b/packages/x-charts/src/models/seriesType/config.ts
@@ -56,7 +56,7 @@ export interface ChartsSeriesConfig {
     itemIdentifierWithData: BarItemIdentifier;
     valueType: number | null;
     canBeStacked: true;
-    axisType: 'cartesian';
+    axisType: 'cartesian' | 'polar';
     highlightScope: CommonHighlightScope;
     descriptionGetterParams: {
       identifier: BarItemIdentifier;
@@ -80,7 +80,7 @@ export interface ChartsSeriesConfig {
     itemIdentifierWithData: LineItemIdentifier;
     valueType: number | null;
     canBeStacked: true;
-    axisType: 'cartesian';
+    axisType: 'cartesian' | 'polar';
     highlightScope: CommonHighlightScope;
     descriptionGetterParams: {
       identifier: LineItemIdentifier;
@@ -173,8 +173,10 @@ export type ChartSeriesType = keyof ChartsSeriesConfig;
 export type CartesianChartSeriesType = keyof Pick<
   ChartsSeriesConfig,
   {
-    [Key in ChartSeriesType]: ChartsSeriesConfig[Key] extends { axisType: 'cartesian' }
-      ? Key
+    [Key in ChartSeriesType]: ChartsSeriesConfig[Key] extends { axisType: infer A }
+      ? 'cartesian' extends A
+        ? Key
+        : never
       : never;
   }[ChartSeriesType]
 >;
@@ -193,7 +195,11 @@ export type SeriesTypeWithDataIndex = {
 export type PolarChartSeriesType = keyof Pick<
   ChartsSeriesConfig,
   {
-    [Key in ChartSeriesType]: ChartsSeriesConfig[Key] extends { axisType: 'polar' } ? Key : never;
+    [Key in ChartSeriesType]: ChartsSeriesConfig[Key] extends { axisType: infer A }
+      ? 'polar' extends A
+        ? Key
+        : never
+      : never;
   }[ChartSeriesType]
 >;
 

--- a/packages/x-charts/src/models/seriesType/line.ts
+++ b/packages/x-charts/src/models/seriesType/line.ts
@@ -137,3 +137,10 @@ export interface DefaultizedLineSeriesType extends DefaultizedProps<
 > {
   hidden: boolean;
 }
+
+export interface DefaultizedRadialLineSeriesType extends DefaultizedProps<
+  RadialLineSeriesType,
+  CommonDefaultizedProps | 'color'
+> {
+  hidden: boolean;
+}

--- a/packages/x-charts/src/models/seriesType/line.ts
+++ b/packages/x-charts/src/models/seriesType/line.ts
@@ -1,11 +1,12 @@
 import { type DefaultizedProps } from '@mui/x-internals/types';
 import type { StackOffsetType } from '../stacking';
-import {
-  type CartesianSeriesType,
-  type CommonDefaultizedProps,
-  type CommonSeriesType,
-  type SeriesId,
-  type StackableSeriesType,
+import type {
+  RadialSeriesType,
+  CartesianSeriesType,
+  CommonDefaultizedProps,
+  CommonSeriesType,
+  SeriesId,
+  StackableSeriesType,
 } from './common';
 import { type DatasetElementType } from './config';
 import { type CurveType } from '../curve';
@@ -35,8 +36,8 @@ export interface ShowMarkParams<AxisValue = number | Date> {
 
 export type MarkShape = 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye';
 
-export interface LineSeriesType
-  extends CommonSeriesType<number | null, 'line'>, CartesianSeriesType, StackableSeriesType {
+interface CommonLineSeriesType
+  extends CommonSeriesType<number | null, 'line'>, StackableSeriesType {
   type: 'line';
   /**
    * Data associated to the line.
@@ -112,6 +113,10 @@ export interface LineSeriesType
    */
   baseline?: number | 'min' | 'max';
 }
+
+export interface LineSeriesType extends CommonLineSeriesType, CartesianSeriesType {}
+
+export interface RadialLineSeriesType extends CommonLineSeriesType, RadialSeriesType {}
 
 /**
  * An object that allows to identify a single line.

--- a/scripts/x-charts-premium.exports.json
+++ b/scripts/x-charts-premium.exports.json
@@ -497,6 +497,7 @@
   { "name": "RadarSeriesPlot", "kind": "Function" },
   { "name": "RadarSeriesPlotProps", "kind": "Interface" },
   { "name": "RadarSeriesType", "kind": "Interface" },
+  { "name": "RadialLineSeriesType", "kind": "Interface" },
   { "name": "RadiusAxis", "kind": "TypeAlias" },
   { "name": "rainbowSurgePalette", "kind": "Variable" },
   { "name": "rainbowSurgePaletteDark", "kind": "Variable" },

--- a/scripts/x-charts-premium.exports.json
+++ b/scripts/x-charts-premium.exports.json
@@ -246,6 +246,7 @@
   { "name": "DefaultizedPieSeriesType", "kind": "Interface" },
   { "name": "DefaultizedPieValueType", "kind": "TypeAlias" },
   { "name": "DefaultizedRadarSeriesType", "kind": "Interface" },
+  { "name": "DefaultizedRadialLineSeriesType", "kind": "Interface" },
   { "name": "DefaultizedRangeBarSeriesType", "kind": "Interface" },
   { "name": "DefaultizedScatterSeriesType", "kind": "Interface" },
   { "name": "DefaultizedSeriesType", "kind": "TypeAlias" },

--- a/scripts/x-charts-pro.exports.json
+++ b/scripts/x-charts-pro.exports.json
@@ -240,6 +240,7 @@
   { "name": "DefaultizedPieSeriesType", "kind": "Interface" },
   { "name": "DefaultizedPieValueType", "kind": "TypeAlias" },
   { "name": "DefaultizedRadarSeriesType", "kind": "Interface" },
+  { "name": "DefaultizedRadialLineSeriesType", "kind": "Interface" },
   { "name": "DefaultizedSankeySeriesType", "kind": "Interface" },
   { "name": "DefaultizedScatterSeriesType", "kind": "Interface" },
   { "name": "DefaultizedSeriesType", "kind": "TypeAlias" },

--- a/scripts/x-charts-pro.exports.json
+++ b/scripts/x-charts-pro.exports.json
@@ -477,6 +477,7 @@
   { "name": "RadarSeriesPlot", "kind": "Function" },
   { "name": "RadarSeriesPlotProps", "kind": "Interface" },
   { "name": "RadarSeriesType", "kind": "Interface" },
+  { "name": "RadialLineSeriesType", "kind": "Interface" },
   { "name": "RadiusAxis", "kind": "TypeAlias" },
   { "name": "rainbowSurgePalette", "kind": "Variable" },
   { "name": "rainbowSurgePaletteDark", "kind": "Variable" },

--- a/scripts/x-charts.exports.json
+++ b/scripts/x-charts.exports.json
@@ -204,6 +204,7 @@
   { "name": "DefaultizedPieSeriesType", "kind": "Interface" },
   { "name": "DefaultizedPieValueType", "kind": "TypeAlias" },
   { "name": "DefaultizedRadarSeriesType", "kind": "Interface" },
+  { "name": "DefaultizedRadialLineSeriesType", "kind": "Interface" },
   { "name": "DefaultizedScatterSeriesType", "kind": "Interface" },
   { "name": "DefaultizedSeriesType", "kind": "TypeAlias" },
   { "name": "Direction", "kind": "TypeAlias" },

--- a/scripts/x-charts.exports.json
+++ b/scripts/x-charts.exports.json
@@ -360,6 +360,7 @@
   { "name": "RadarSeriesPlot", "kind": "Function" },
   { "name": "RadarSeriesPlotProps", "kind": "Interface" },
   { "name": "RadarSeriesType", "kind": "Interface" },
+  { "name": "RadialLineSeriesType", "kind": "Interface" },
   { "name": "RadiusAxis", "kind": "TypeAlias" },
   { "name": "rainbowSurgePalette", "kind": "Variable" },
   { "name": "rainbowSurgePaletteDark", "kind": "Variable" },


### PR DESCRIPTION
Extracted from #21968

In this PR the series config can now be `axisType: 'cartesian' | 'polar';` to indicate the series support both


Having different series type for cartesian and polar series makes it tricky because they have the same seriesType (`'line'`) but one has some xAxis, whereas the other has a rotationAxis.


In this PR I propose to add an extra `AxisType` generic argument to distinguish when necessary the cartesian / radial

## Other options

- Add a `coordinateSystem?: 'cartesian' | 'radial'` to the series type with the default set to cartesian.
	- pros: cartesian specific code can easily skip those with `coordinateSystem === 'radial'` and then get the correct type.
	- cons: Users will need to specify this when using composition. Or we might be able to set the correct default value based on the available plugins.

- Keep only one series type. For the axes id, we could use `xAxisId`, `yAxisId` for the rotation/radius axes. Or assume radial lines have only one axis, so radial plot just ignore those.
	- pros: little or no modification
	- cons: properties that are specific to a given coordinate type might leak in the other one

- Introduce a new series type `radialLine` that copies most of the line series.
	- pros: straightforward with clear distinction
	- cons: does not communicate the fact that it's exactly the same concept as the line chart but in a radial coordinate system

