### PR TITLE
[data grid] Add validation warnings to scrollToIndexes when rowIndex or colIndex is out of range

### DIFF
--- a/packages/x-data-grid/src/hooks/features/scroll/useGridScroll.ts
+++ b/packages/x-data-grid/src/hooks/features/scroll/useGridScroll.ts
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import type { RefObject } from '@mui/x-internals/types';
+import { warnOnce } from '@mui/x-internals/warning';
 import { useRtl } from '@mui/system/RtlProvider';
 import type { GridCellIndexCoordinates } from '../../../models/gridCell';
 import type { GridPrivateApiCommunity } from '../../../models/api/gridApiCommunity';
 import { useGridLogger } from '../../utils/useGridLogger';
+import { warnOnce } from '@mui/x-internals/warning';
 import {
   gridColumnPositionsSelector,
   gridVisibleColumnDefinitionsSelector,
@@ -66,7 +68,53 @@ export const useGridScroll = (
       const totalRowCount = gridRowCountSelector(apiRef);
       const visibleColumns = gridVisibleColumnDefinitionsSelector(apiRef);
       const scrollToHeader = params.rowIndex == null;
+
+      if (params.rowIndex !== undefined && (params.rowIndex < 0 || params.rowIndex >= totalRowCount)) {
+        warnOnce(
+          `MUI X: \`scrollToIndexes\` was called with a \`rowIndex\` (${params.rowIndex}) that is out of range [0, ${totalRowCount - 1}].`,
+          'warn',
+        );
+        return false;
+      }
+
+      if (
+        params.colIndex !== undefined &&
+        (params.colIndex < 0 || params.colIndex >= visibleColumns.length)
+      ) {
+        warnOnce(
+          `MUI X: \`scrollToIndexes\` was called with a \`colIndex\` (${
+            params.colIndex
+          }) that is out of range [0, ${visibleColumns.length - 1}].`,
+          'warn',
+        );
+        return false;
+      }
+
       if ((!scrollToHeader && totalRowCount === 0) || visibleColumns.length === 0) {
+        return false;
+      }
+
+      if (params.colIndex !== undefined && (params.colIndex < 0 || params.colIndex > visibleColumns.length - 1)) {
+        warnOnce(
+          [
+            `MUI X Data Grid: The \`colIndex\` provided to \`scrollToIndexes\` is out of range.`,
+            `Index ${params.colIndex} is not within the visible columns range (0 to ${visibleColumns.length - 1}).`,
+            'Make sure the provided index is within the grid visible columns.',
+          ],
+          'warning',
+        );
+        return false;
+      }
+
+      if (params.rowIndex !== undefined && (params.rowIndex < 0 || params.rowIndex > totalRowCount - 1)) {
+        warnOnce(
+          [
+            `MUI X Data Grid: The \`rowIndex\` provided to \`scrollToIndexes\` is out of range.`,
+            `Index ${params.rowIndex} is not within the row count range (0 to ${totalRowCount - 1}).`,
+            'Make sure the provided index is within the grid rows.',
+          ],
+          'warning',
+        );
         return false;
       }
 

--- a/packages/x-data-grid/src/tests/layout.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/layout.DataGrid.test.tsx
@@ -961,6 +961,40 @@ describe('<DataGrid /> - Layout & warnings', () => {
         'The Data Grid component requires all rows to have a unique `id` property',
       );
     });
+
+    it('should warn when scrollToIndexes is called with out of range rowIndex', () => {
+      const apiRef = { current: null as any };
+      function Test() {
+        apiRef.current = useGridApiRef();
+        return (
+          <div style={{ width: 300, height: 300 }}>
+            <DataGrid {...baselineProps} apiRef={apiRef.current} />
+          </div>
+        );
+      }
+      render(<Test />);
+
+      expect(() => {
+        apiRef.current.scrollToIndexes({ rowIndex: 100 });
+      }).toErrorDev('MUI X: `scrollToIndexes` was called with a `rowIndex` (100) that is out of range [0, 2].');
+    });
+
+    it('should warn when scrollToIndexes is called with out of range colIndex', () => {
+      const apiRef = { current: null as any };
+      function Test() {
+        apiRef.current = useGridApiRef();
+        return (
+          <div style={{ width: 300, height: 300 }}>
+            <DataGrid {...baselineProps} apiRef={apiRef.current} />
+          </div>
+        );
+      }
+      render(<Test />);
+
+      expect(() => {
+        apiRef.current.scrollToIndexes({ colIndex: 10 });
+      }).toErrorDev('MUI X: `scrollToIndexes` was called with a `colIndex` (10) that is out of range [0, 0].');
+    });
   });
 
   describe('localeText', () => {
@@ -989,6 +1023,50 @@ describe('<DataGrid /> - Layout & warnings', () => {
       expect(screen.getByPlaceholderText('Recherche')).not.to.equal(null);
       setProps({ localeText: { toolbarQuickFilterPlaceholder: 'Buscar' } });
       expect(screen.getByPlaceholderText('Buscar')).not.to.equal(null);
+    });
+
+    describe('scrollToIndexes', () => {
+      it('should warn and return false when colIndex is out of range', () => {
+        let apiRef!: RefObject<GridApi | null>;
+        function TestCase() {
+          apiRef = useGridApiRef();
+          return (
+            <div style={{ width: 300, height: 300 }}>
+              <DataGrid {...baselineProps} apiRef={apiRef} />
+            </div>
+          );
+        }
+        render(<TestCase />);
+
+        let result: boolean | undefined;
+        expect(() => {
+          result = apiRef.current!.scrollToIndexes({ colIndex: 999 });
+        }).toErrorDev(
+          'MUI X Data Grid: The `colIndex` provided to `scrollToIndexes` is out of range.',
+        );
+        expect(result).to.equal(false);
+      });
+
+      it('should warn and return false when rowIndex is out of range', () => {
+        let apiRef!: RefObject<GridApi | null>;
+        function TestCase() {
+          apiRef = useGridApiRef();
+          return (
+            <div style={{ width: 300, height: 300 }}>
+              <DataGrid {...baselineProps} apiRef={apiRef} />
+            </div>
+          );
+        }
+        render(<TestCase />);
+
+        let result: boolean | undefined;
+        expect(() => {
+          result = apiRef.current!.scrollToIndexes({ rowIndex: 999 });
+        }).toErrorDev(
+          'MUI X Data Grid: The `rowIndex` provided to `scrollToIndexes` is out of range.',
+        );
+        expect(result).to.equal(false);
+      });
     });
   });
 


### PR DESCRIPTION
Fixes #13578

Added validation warnings to the `scrollToIndexes` method in `useGridScroll`. If `rowIndex` or `colIndex` is provided but out of the valid range (based on the current total row count and visible column count), a warning is logged to the console using `warnOnce` and the method returns `false`.

**Changes:**
- Updated `packages/x-data-grid/src/hooks/features/scroll/useGridScroll.ts` to include index validation.
- Added regression tests in `packages/x-data-grid/src/tests/layout.DataGrid.test.tsx` verifying the warnings are logged for both `rowIndex` and `colIndex` out-of-range scenarios.