### PR TITLE
[charts] Remove deprecated `MuiScatter` theme augmentation

### DIFF
--- a/packages/x-charts/src/themeAugmentation/components.ts
+++ b/packages/x-charts/src/themeAugmentation/components.ts
@@ -65,10 +65,6 @@ export interface ChartsComponents<Theme = unknown> {
     defaultProps?: ComponentsProps['MuiScatterChart'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiScatterChart'];
   };
-  /** @deprecated Use `MuiScatterChart` instead. */
-  MuiScatter?: {
-    styleOverrides?: ComponentsOverrides<Theme>['MuiScatterChart'];
-  };
   MuiRadarChart?: {
     styleOverrides?: ComponentsOverrides<Theme>['MuiRadarChart'];
   };


### PR DESCRIPTION
## Summary

- Removes the deprecated `MuiScatter` entry from the charts theme augmentation. `MuiScatterChart` is the replacement.