### PR TITLE
[charts] Deprecate `Scatter` component

### DIFF
--- a/docs/pages/x/api/charts/scatter.json
+++ b/docs/pages/x/api/charts/scatter.json
@@ -48,5 +48,6 @@
   "filename": "/packages/x-charts/src/ScatterChart/Scatter.tsx",
   "inheritance": null,
   "demos": "<ul><li><a href=\"/x/react-charts/scatter-demo/\">Charts - Scatter demos</a></li></ul>",
-  "cssComponent": false
+  "cssComponent": false,
+  "deprecated": true
 }

--- a/docs/translations/api-docs/charts/scatter/scatter.json
+++ b/docs/translations/api-docs/charts/scatter/scatter.json
@@ -1,5 +1,6 @@
 {
   "componentDescription": "",
+  "deprecationInfo": "The <code>Scatter</code> component is an internal implementation detail of <code>ScatterPlot</code> and will be removed from the public API in v10. Use <code>ScatterPlot</code> instead.<br>Demos:<br>- <a href=\"https://mui.com/x/react-charts/scatter/\">Scatter</a> - <a href=\"https://mui.com/x/react-charts/scatter-demo/\">Scatter demonstration</a><br>API:<br>- <a href=\"https://mui.com/x/api/charts/scatter/\">Scatter API</a>",
   "propDescriptions": {
     "colorGetter": {
       "description": "Function to get the color of a scatter item given its data index. The data index argument is optional. If not provided, the color for the entire series is returned. If provided, the color for the specific scatter item is returned."

--- a/packages/x-charts/src/ScatterChart/Scatter.tsx
+++ b/packages/x-charts/src/ScatterChart/Scatter.tsx
@@ -26,6 +26,9 @@ import { type UseChartTooltipSignature } from '../internals/plugins/featurePlugi
 import { type UseChartInteractionSignature } from '../internals/plugins/featurePlugins/useChartInteraction';
 import { type UseChartHighlightSignature } from '../internals/plugins/featurePlugins/useChartHighlight';
 
+/**
+ * @deprecated The `Scatter` component is an internal implementation detail of `ScatterPlot` and will be removed from the public API in v10. Use `ScatterPlot` instead.
+ */
 export interface ScatterProps {
   series: DefaultizedScatterSeriesType;
   xScale: D3Scale;
@@ -51,11 +54,19 @@ export interface ScatterProps {
   slotProps?: ScatterSlotProps;
 }
 
+/**
+ * @deprecated The `Scatter` component is an internal implementation detail of `ScatterPlot` and will be removed from the public API in v10. Use `ScatterPlot` instead.
+ */
 export interface ScatterSlots extends ScatterMarkerSlots {}
 
+/**
+ * @deprecated The `Scatter` component is an internal implementation detail of `ScatterPlot` and will be removed from the public API in v10. Use `ScatterPlot` instead.
+ */
 export interface ScatterSlotProps extends ScatterMarkerSlotProps {}
 
 /**
+ * @deprecated The `Scatter` component is an internal implementation detail of `ScatterPlot` and will be removed from the public API in v10. Use `ScatterPlot` instead.
+ *
  * Demos:
  *
  * - [Scatter](https://mui.com/x/react-charts/scatter/)


### PR DESCRIPTION
## Summary

- Follow-up to #22059.
- Deprecates the `Scatter` component (and its `ScatterProps`/`ScatterSlots`/`ScatterSlotProps` types) from `@mui/x-charts`. It's only used internally by `ScatterPlot` as the default non-batch renderer, and its required props (`series: DefaultizedScatterSeriesType`, `xScale`, `yScale`, `colorGetter`) are internal types users cannot reasonably construct.
- Scheduled for removal from the public API in v10.