### PR TITLE
[docs] Add @mui/material upgrade requirement to v9 migration guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,7 @@ Refer to `package.json` for other available scripts.
 
 When updating demos in the `docs` folder, only update the `.tsx` files.
 To generate `.js` files, run `pnpm docs:typescript:formatted`.
+After updating the demo, run `pnpm markdownlint` and `pnpm valelint` to ensure the markdown files are valid. Fix the found issues.
 
 ## Codemods
 

--- a/docs/data/migration/migration-charts-v8/migration-charts-v8.md
+++ b/docs/data/migration/migration-charts-v8/migration-charts-v8.md
@@ -175,7 +175,7 @@ The minimum supported version of `@mui/material` and `@mui/system` has been upda
 The v5 and v6 versions are no longer supported.
 
 If you are using `@mui/material` v5 or v6, you need to upgrade to at least v7.
-Follow the [Material UI migration guide](/material-ui/migration/upgrade-to-v9/) to upgrade your implementation.
+Follow the [Material UI migration guide](/material-ui/migration/upgrade-to-v9/) to upgrade your implementation.
 
 ```diff
 -"@mui/material": "^5.x.x",

--- a/docs/data/migration/migration-charts-v8/migration-charts-v8.md
+++ b/docs/data/migration/migration-charts-v8/migration-charts-v8.md
@@ -169,6 +169,22 @@ Since `v9` is a major release, it contains changes that affect the public API.
 These changes were done for consistency, improved stability and to make room for new features.
 Described below are the steps needed to migrate from `v8` to `v9`.
 
+## Update `@mui/material` and `@mui/system` packages
+
+The minimum supported version of `@mui/material` and `@mui/system` has been updated to `^7.3.0` or `^9.0.0`.
+The v5 and v6 versions are no longer supported.
+
+If you are using `@mui/material` v5 or v6, you need to upgrade to at least v7.
+Follow the [Material UI migration guide](/material-ui/migration/upgrade-to-v9/) to upgrade your implementation.
+
+```diff
+-"@mui/material": "^5.x.x",
++"@mui/material": "^7.3.0",
+
+-"@mui/system": "^5.x.x",
++"@mui/system": "^7.3.0",
+```
+
 ## Run codemods
 
 The `preset-safe` codemod will automatically adjust the bulk of your code to account for breaking changes in v9. You can run `v9.0.0/charts/preset-safe` targeting only Charts or `v9.0.0/preset-safe` to target the other packages as well.

--- a/docs/data/migration/migration-charts-v8/migration-charts-v8.md
+++ b/docs/data/migration/migration-charts-v8/migration-charts-v8.md
@@ -172,9 +172,10 @@ Described below are the steps needed to migrate from `v8` to `v9`.
 ## Update `@mui/material` and `@mui/system` packages
 
 The minimum supported version of `@mui/material` and `@mui/system` has been updated to `^7.3.0` or `^9.0.0`.
+This change enables the opt-in [Native Color](/material-ui/customization/css-theme-variables/native-color/) feature, which replaces JavaScript color manipulation with native CSS.
 The v5 and v6 versions are no longer supported.
 
-If you are using `@mui/material` v5 or v6, you need to upgrade to at least v7.
+If you are using `@mui/material` v5 or v6, you need to upgrade to at least v7.3.0.
 Follow the [Material UI migration guide](/material-ui/migration/upgrade-to-v9/) to upgrade your implementation.
 
 ```diff

--- a/docs/data/migration/migration-data-grid-v8/migration-data-grid-v8.md
+++ b/docs/data/migration/migration-data-grid-v8/migration-data-grid-v8.md
@@ -33,9 +33,10 @@ In `package.json`, change the version of the Data Grid package to `^9.0.0`.
 ## Update `@mui/material` and `@mui/system` packages
 
 The minimum supported version of `@mui/material` and `@mui/system` has been updated to `^7.3.0` or `^9.0.0`.
+This change enables the opt-in [Native Color](/material-ui/customization/css-theme-variables/native-color/) feature, which replaces JavaScript color manipulation with native CSS.
 The v5 and v6 versions are no longer supported.
 
-If you are using `@mui/material` v5 or v6, you need to upgrade to at least v7.
+If you are using `@mui/material` v5 or v6, you need to upgrade to at least v7.3.0.
 Follow the [Material UI migration guide](/material-ui/migration/upgrade-to-v9/) to upgrade your implementation.
 
 ```diff

--- a/docs/data/migration/migration-data-grid-v8/migration-data-grid-v8.md
+++ b/docs/data/migration/migration-data-grid-v8/migration-data-grid-v8.md
@@ -30,6 +30,22 @@ In `package.json`, change the version of the Data Grid package to `^9.0.0`.
 +"@mui/x-data-grid-premium": "^9.0.0",
 ```
 
+## Update `@mui/material` and `@mui/system` packages
+
+The minimum supported version of `@mui/material` and `@mui/system` has been updated to `^7.3.0` or `^9.0.0`.
+The v5 and v6 versions are no longer supported.
+
+If you are using `@mui/material` v5 or v6, you need to upgrade to at least v7.
+Follow the [Material UI migration guide](/material-ui/migration/upgrade-to-v9/) to upgrade your implementation.
+
+```diff
+-"@mui/material": "^5.x.x",
++"@mui/material": "^7.3.0",
+
+-"@mui/system": "^5.x.x",
++"@mui/system": "^7.3.0",
+```
+
 ## Breaking changes
 
 ### Stabilized `experimentalFeatures`

--- a/docs/data/migration/migration-data-grid-v8/migration-data-grid-v8.md
+++ b/docs/data/migration/migration-data-grid-v8/migration-data-grid-v8.md
@@ -36,7 +36,7 @@ The minimum supported version of `@mui/material` and `@mui/system` has been upda
 The v5 and v6 versions are no longer supported.
 
 If you are using `@mui/material` v5 or v6, you need to upgrade to at least v7.
-Follow the [Material UI migration guide](/material-ui/migration/upgrade-to-v9/) to upgrade your implementation.
+Follow the [Material UI migration guide](/material-ui/migration/upgrade-to-v9/) to upgrade your implementation.
 
 ```diff
 -"@mui/material": "^5.x.x",

--- a/docs/data/migration/migration-pickers-v8/migration-pickers-v8.md
+++ b/docs/data/migration/migration-pickers-v8/migration-pickers-v8.md
@@ -30,9 +30,10 @@ Described below are the steps needed to migrate from `v8` to `v9`.
 ## Update `@mui/material` and `@mui/system` packages
 
 The minimum supported version of `@mui/material` and `@mui/system` has been updated to `^7.3.0` or `^9.0.0`.
+This change enables the opt-in [Native Color](/material-ui/customization/css-theme-variables/native-color/) feature, which replaces JavaScript color manipulation with native CSS.
 The v5 and v6 versions are no longer supported.
 
-If you are using `@mui/material` v5 or v6, you need to upgrade to at least v7.
+If you are using `@mui/material` v5 or v6, you need to upgrade to at least v7.3.0.
 Follow the [Material UI migration guide](/material-ui/migration/upgrade-to-v9/) to upgrade your implementation.
 
 ```diff

--- a/docs/data/migration/migration-pickers-v8/migration-pickers-v8.md
+++ b/docs/data/migration/migration-pickers-v8/migration-pickers-v8.md
@@ -29,7 +29,7 @@ The minimum supported version of `@mui/material` and `@mui/system` has been upda
 The v5 and v6 versions are no longer supported.
 
 If you are using `@mui/material` v5 or v6, you need to upgrade to at least v7.
-Follow the [Material UI migration guide](/material-ui/migration/upgrade-to-v9/) to upgrade your implementation.
+Follow the [Material UI migration guide](/material-ui/migration/upgrade-to-v9/) to upgrade your implementation.
 
 ```diff
 -"@mui/material": "^5.x.x",

--- a/docs/data/migration/migration-pickers-v8/migration-pickers-v8.md
+++ b/docs/data/migration/migration-pickers-v8/migration-pickers-v8.md
@@ -23,6 +23,10 @@ In `package.json`, change the version of the date pickers package to `^9.0.0`.
 +"@mui/x-date-pickers-pro": "^9.0.0",
 ```
 
+Since `v9` is a major release, it contains changes that affect the public API.
+These changes were done for consistency, improved stability and to make room for new features.
+Described below are the steps needed to migrate from `v8` to `v9`.
+
 ## Update `@mui/material` and `@mui/system` packages
 
 The minimum supported version of `@mui/material` and `@mui/system` has been updated to `^7.3.0` or `^9.0.0`.
@@ -38,10 +42,6 @@ Follow the [Material UI migration guide](/material-ui/migration/upgrade-to-v9/)
 -"@mui/system": "^5.x.x",
 +"@mui/system": "^7.3.0",
 ```
-
-Since `v9` is a major release, it contains changes that affect the public API.
-These changes were done for consistency, improved stability and to make room for new features.
-Described below are the steps needed to migrate from `v8` to `v9`.
 
 :::success
 The amount of breaking changes is relatively large, but most of them might impact only a small portion of users, who are using advanced customization.

--- a/docs/data/migration/migration-pickers-v8/migration-pickers-v8.md
+++ b/docs/data/migration/migration-pickers-v8/migration-pickers-v8.md
@@ -23,6 +23,22 @@ In `package.json`, change the version of the date pickers package to `^9.0.0`.
 +"@mui/x-date-pickers-pro": "^9.0.0",
 ```
 
+## Update `@mui/material` and `@mui/system` packages
+
+The minimum supported version of `@mui/material` and `@mui/system` has been updated to `^7.3.0` or `^9.0.0`.
+The v5 and v6 versions are no longer supported.
+
+If you are using `@mui/material` v5 or v6, you need to upgrade to at least v7.
+Follow the [Material UI migration guide](/material-ui/migration/upgrade-to-v9/) to upgrade your implementation.
+
+```diff
+-"@mui/material": "^5.x.x",
++"@mui/material": "^7.3.0",
+
+-"@mui/system": "^5.x.x",
++"@mui/system": "^7.3.0",
+```
+
 Since `v9` is a major release, it contains changes that affect the public API.
 These changes were done for consistency, improved stability and to make room for new features.
 Described below are the steps needed to migrate from `v8` to `v9`.

--- a/docs/data/migration/migration-tree-view-v8/migration-tree-view-v8.md
+++ b/docs/data/migration/migration-tree-view-v8/migration-tree-view-v8.md
@@ -30,9 +30,10 @@ Described below are the steps needed to migrate from `v8` to `v9`.
 ## Update `@mui/material` and `@mui/system` packages
 
 The minimum supported version of `@mui/material` and `@mui/system` has been updated to `^7.3.0` or `^9.0.0`.
+This change enables the opt-in [Native Color](/material-ui/customization/css-theme-variables/native-color/) feature, which replaces JavaScript color manipulation with native CSS.
 The v5 and v6 versions are no longer supported.
 
-If you are using `@mui/material` v5 or v6, you need to upgrade to at least v7.
+If you are using `@mui/material` v5 or v6, you need to upgrade to at least v7.3.0.
 Follow the [Material UI migration guide](/material-ui/migration/upgrade-to-v9/) to upgrade your implementation.
 
 ```diff

--- a/docs/data/migration/migration-tree-view-v8/migration-tree-view-v8.md
+++ b/docs/data/migration/migration-tree-view-v8/migration-tree-view-v8.md
@@ -23,6 +23,10 @@ In `package.json`, change the version of the Tree View package to `^9.0.0`.
 +"@mui/x-tree-view-pro": "^9.0.0",
 ```
 
+The `v9` major release contains changes that affect the public API.
+These changes were done for consistency, improved stability and to make room for new features.
+Described below are the steps needed to migrate from `v8` to `v9`.
+
 ## Update `@mui/material` and `@mui/system` packages
 
 The minimum supported version of `@mui/material` and `@mui/system` has been updated to `^7.3.0` or `^9.0.0`.
@@ -38,10 +42,6 @@ Follow the [Material UI migration guide](/material-ui/migration/upgrade-to-v9/)
 -"@mui/system": "^5.x.x",
 +"@mui/system": "^7.3.0",
 ```
-
-The `v9` major release contains changes that affect the public API.
-These changes were done for consistency, improved stability and to make room for new features.
-Described below are the steps needed to migrate from `v8` to `v9`.
 
 ## Breaking changes
 

--- a/docs/data/migration/migration-tree-view-v8/migration-tree-view-v8.md
+++ b/docs/data/migration/migration-tree-view-v8/migration-tree-view-v8.md
@@ -23,6 +23,22 @@ In `package.json`, change the version of the Tree View package to `^9.0.0`.
 +"@mui/x-tree-view-pro": "^9.0.0",
 ```
 
+## Update `@mui/material` and `@mui/system` packages
+
+The minimum supported version of `@mui/material` and `@mui/system` has been updated to `^7.3.0` or `^9.0.0`.
+The v5 and v6 versions are no longer supported.
+
+If you are using `@mui/material` v5 or v6, you need to upgrade to at least v7.
+Follow the [Material UI migration guide](/material-ui/migration/upgrade-to-v9/) to upgrade your implementation.
+
+```diff
+-"@mui/material": "^5.x.x",
++"@mui/material": "^7.3.0",
+
+-"@mui/system": "^5.x.x",
++"@mui/system": "^7.3.0",
+```
+
 The `v9` major release contains changes that affect the public API.
 These changes were done for consistency, improved stability and to make room for new features.
 Described below are the steps needed to migrate from `v8` to `v9`.

--- a/docs/data/migration/migration-tree-view-v8/migration-tree-view-v8.md
+++ b/docs/data/migration/migration-tree-view-v8/migration-tree-view-v8.md
@@ -29,7 +29,7 @@ The minimum supported version of `@mui/material` and `@mui/system` has been upda
 The v5 and v6 versions are no longer supported.
 
 If you are using `@mui/material` v5 or v6, you need to upgrade to at least v7.
-Follow the [Material UI migration guide](/material-ui/migration/upgrade-to-v9/) to upgrade your implementation.
+Follow the [Material UI migration guide](/material-ui/migration/upgrade-to-v9/) to upgrade your implementation.
 
 ```diff
 -"@mui/material": "^5.x.x",


### PR DESCRIPTION
## Summary

- Adds an "Update @mui/material and @mui/system packages" section to all four v9 migration guides (Data Grid, Date Pickers, Tree View, Charts)
- Documents that `@mui/material` and `@mui/system` v5/v6 are no longer supported and must be upgraded to `^7.3.0` or `^9.0.0`
- Links to the Material UI migration guide for upgrade instructions

Closes #22065

🤖 Generated with [Claude Code](https://claude.com/claude-code)