### PR TITLE
[internal] Fix ChartsRadialDataProvider API page imports

### DIFF
--- a/docs/pages/x/api/charts/charts-radial-data-provider.js
+++ b/docs/pages/x/api/charts/charts-radial-data-provider.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import ApiPage from 'docs/src/modules/components/ApiPage';
-import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
+import { ApiPage } from '@mui/internal-core-docs/ApiPage';
+import { mapApiPageTranslations } from '@mui/internal-core-docs/mapApiPageTranslations';
 import jsonPageContent from './charts-radial-data-provider.json';
 
 export default function Page(props) {

--- a/docs/pages/x/react-charts/radial-lines.js
+++ b/docs/pages/x/react-charts/radial-lines.js
@@ -1,4 +1,4 @@
-import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import { MarkdownDocs } from '@mui/internal-core-docs/MarkdownDocs';
 import * as pageProps from 'docsx/data/charts/radial-lines/radial-lines.md?muiMarkdown';
 
 export default function Page() {


### PR DESCRIPTION
Fix the `ChartsRadialDataProvider` API page to import from the new package: https://github.com/mui/mui-x/pull/22047#issuecomment-4238338530.