### PR TITLE
[data grid] Fix `:first-child` SSR warning when using `ThemeProvider` overrides

### DIFF
--- a/packages/x-data-grid/src/components/containers/GridRootStyles.ts
+++ b/packages/x-data-grid/src/components/containers/GridRootStyles.ts
@@ -22,11 +22,6 @@ const separatorIconDragStyles = {
   x: 10.5,
 };
 
-// Emotion thinks it knows better than us which selector we should use.
-// https://github.com/emotion-js/emotion/issues/1105#issuecomment-1722524968
-const ignoreSsrWarning =
-  '/* emotion-disable-server-rendering-unsafe-selector-warning-please-do-not-use-this-the-warning-exists-for-a-reason */';
-
 const shouldShowBorderTopRightRadiusSelector = (apiRef: RefObject<GridApiCommunity>) =>
   !apiRef.current.state.dimensions.isReady
     ? apiRef.current.state.dimensions.scrollbarSize === 0
@@ -187,7 +182,7 @@ export const GridRootStyles = styled('div', {
     overflowAnchor: 'none', // Keep the same scrolling position
     transform: 'translate(0, 0)', // Create a stacking context to keep scrollbars from showing on top
 
-    [`.${c.main} > *:first-child${ignoreSsrWarning}`]: {
+    [`.${c.main} > *:first-of-type`]: {
       borderTopLeftRadius: 'var(--unstable_DataGrid-radius)',
       borderTopRightRadius: 'var(--unstable_DataGrid-radius)',
     },


### PR DESCRIPTION
- Replaces :first-child with :first-of-type in GridRootStyles.ts to eliminate Emotion's SSR pseudo-class warning at the source
- Removes the now-unnecessary ignoreSsrWarning suppression comment constant

The suppression comment approach was fragile: in v9, when a user provides a `ThemeProvider` with MuiDataGrid style overrides, the theme processing re-serializes the styles and drops the comment, causing Emotion to log the warning even in client-side rendering. Since all children of `.MuiDataGrid-main` are `div` elements, `:first-of-type` is semantically equivalent to `:first-child` here.

Fixes #22071