### PR TITLE
[pickers] Fix `onBlur` firing on field focus

### DIFF
--- a/packages/x-date-pickers/src/DateField/tests/DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/DateField.test.tsx
@@ -1,10 +1,13 @@
+import * as React from 'react';
+import { spy } from 'sinon';
 import InputAdornment, { InputAdornmentProps } from '@mui/material/InputAdornment';
 import { DateField } from '@mui/x-date-pickers/DateField';
 import { screen } from '@mui/internal-test-utils';
-import { createPickerRenderer } from 'test/utils/pickers';
+import { buildFieldInteractions, createPickerRenderer } from 'test/utils/pickers';
 
 describe('<DateField />', () => {
   const { render } = createPickerRenderer();
+  const { renderWithProps } = buildFieldInteractions({ render, Component: DateField });
 
   describe('slotProps behavior', () => {
     it('should respect the `slotProps.textField.slotProps.input`', () => {
@@ -37,6 +40,19 @@ describe('<DateField />', () => {
       );
 
       expect(screen.getByTestId('test-html-input')).not.to.equal(null);
+    });
+
+    it('should not call `slotProps.textField.onBlur` when the field gains focus', async () => {
+      const onBlur = spy();
+      const view = renderWithProps({ slotProps: { textField: { onBlur } } } as any);
+
+      // Tab into the field: the PickersSectionList root (tabIndex=0) receives focus first,
+      // then focus moves programmatically to section 0. That transient root blur must NOT
+      // dispatch the user's onBlur callback.
+      await view.user.tab();
+
+      expect(onBlur.callCount).to.equal(0);
+      view.unmount();
     });
   });
 

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
@@ -163,8 +163,19 @@ export const useField = <
   });
 
   const handleRootBlur = useEventCallback((event: React.FocusEvent<HTMLDivElement>) => {
-    onBlur?.(event);
     rootProps.onBlur(event);
+    // Defer the user's onBlur callback to match the internal field behavior:
+    // only fire when focus truly leaves the field, not on transient blurs
+    // caused by focus moving between sections or programmatic focus changes.
+    setTimeout(() => {
+      if (!domGetters.isReady()) {
+        return;
+      }
+      const activeElement = getActiveElement(domGetters.getRoot());
+      if (!domGetters.getRoot().contains(activeElement)) {
+        onBlur?.(event);
+      }
+    });
   });
 
   const handleRootFocus = useEventCallback((event: React.FocusEvent<HTMLDivElement>) => {


### PR DESCRIPTION
`slotProps.textField.onBlur` was called immediately whenever any blur event bubbled up to the field root — including transient blurs caused by programmatic focus changes within the field. The most common trigger: Tab-navigating into the field. The `PickersSectionList` root has `tabIndex=0` and initially receives focus, then `handleFocus` programmatically moves focus to section 0. The resulting root blur unconditionally dispatched `onBlur` to the user before focus had settled.

Fixes #21973