### PR TITLE
[pickers] Fix spurious `onBlur`/`onFocus` firing during field focus transitions

### DIFF
--- a/packages/x-date-pickers/src/DateField/tests/DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/DateField.test.tsx
@@ -1,10 +1,12 @@
+import { spy } from 'sinon';
 import InputAdornment, { InputAdornmentProps } from '@mui/material/InputAdornment';
 import { DateField } from '@mui/x-date-pickers/DateField';
 import { screen } from '@mui/internal-test-utils';
-import { createPickerRenderer } from 'test/utils/pickers';
+import { buildFieldInteractions, createPickerRenderer } from 'test/utils/pickers';
 
 describe('<DateField />', () => {
   const { render } = createPickerRenderer();
+  const { renderWithProps } = buildFieldInteractions({ render, Component: DateField });
 
   describe('slotProps behavior', () => {
     it('should respect the `slotProps.textField.slotProps.input`', () => {
@@ -37,6 +39,67 @@ describe('<DateField />', () => {
       );
 
       expect(screen.getByTestId('test-html-input')).not.to.equal(null);
+    });
+  });
+
+  describe('slotProps.textField focus/blur behavior', () => {
+    it('should not call `slotProps.textField.onBlur` when focus enters the field via tab', async () => {
+      const onBlur = spy();
+      const view = renderWithProps({ slotProps: { textField: { onBlur } } } as any);
+
+      // Tabbing into the field moves focus to the PickersSectionList root (tabIndex=0)
+      // first, then programmatically to section 0. The transient root blur must not
+      // dispatch the user's onBlur callback.
+      await view.user.tab();
+
+      expect(onBlur.callCount).to.equal(0);
+      view.unmount();
+    });
+
+    it('should call `slotProps.textField.onFocus` only once when focus enters the field via tab', async () => {
+      const onFocus = spy();
+      const view = renderWithProps({ slotProps: { textField: { onFocus } } } as any);
+
+      // Tabbing into the field fires a focus on the root and then on section 0.
+      // Only the first focus (from outside the field) should reach the user.
+      await view.user.tab();
+
+      expect(onFocus.callCount).to.equal(1);
+      view.unmount();
+    });
+
+    it('should call `slotProps.textField.onBlur` when focus leaves the field via tab', async () => {
+      const onBlur = spy();
+      const view = renderWithProps({ slotProps: { textField: { onBlur } } } as any);
+
+      await view.user.tab();
+      expect(onBlur.callCount).to.equal(0);
+
+      // Tab out of the field (to the document body or next focusable).
+      await view.user.tab();
+      expect(onBlur.callCount).to.equal(1);
+
+      view.unmount();
+    });
+
+    it('should not fire `slotProps.textField.onBlur` or `onFocus` when focus moves between sections', async () => {
+      const onBlur = spy();
+      const onFocus = spy();
+      const view = renderWithProps({
+        slotProps: { textField: { onBlur, onFocus } },
+      } as any);
+
+      await view.user.tab();
+      const blurCallCountAfterTabIn = onBlur.callCount;
+      const focusCallCountAfterTabIn = onFocus.callCount;
+
+      // Navigate across sections inside the field.
+      await view.user.keyboard('[ArrowRight][ArrowRight][ArrowLeft]');
+
+      expect(onBlur.callCount).to.equal(blurCallCountAfterTabIn);
+      expect(onFocus.callCount).to.equal(focusCallCountAfterTabIn);
+
+      view.unmount();
     });
   });
 

--- a/packages/x-date-pickers/src/DateField/tests/DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/DateField.test.tsx
@@ -2,11 +2,10 @@ import { spy } from 'sinon';
 import InputAdornment, { InputAdornmentProps } from '@mui/material/InputAdornment';
 import { DateField } from '@mui/x-date-pickers/DateField';
 import { screen } from '@mui/internal-test-utils';
-import { buildFieldInteractions, createPickerRenderer } from 'test/utils/pickers';
+import { createPickerRenderer } from 'test/utils/pickers';
 
 describe('<DateField />', () => {
   const { render } = createPickerRenderer();
-  const { renderWithProps } = buildFieldInteractions({ render, Component: DateField });
 
   describe('slotProps behavior', () => {
     it('should respect the `slotProps.textField.slotProps.input`', () => {
@@ -45,7 +44,7 @@ describe('<DateField />', () => {
   describe('slotProps.textField focus/blur behavior', () => {
     it('should not call `slotProps.textField.onBlur` when focus enters the field via tab', async () => {
       const onBlur = spy();
-      const view = renderWithProps({ slotProps: { textField: { onBlur } } } as any);
+      const view = render(<DateField slotProps={{ textField: { onBlur } }} />);
 
       // Tabbing into the field moves focus to the PickersSectionList root (tabIndex=0)
       // first, then programmatically to section 0. The transient root blur must not
@@ -53,24 +52,22 @@ describe('<DateField />', () => {
       await view.user.tab();
 
       expect(onBlur.callCount).to.equal(0);
-      view.unmount();
     });
 
     it('should call `slotProps.textField.onFocus` only once when focus enters the field via tab', async () => {
       const onFocus = spy();
-      const view = renderWithProps({ slotProps: { textField: { onFocus } } } as any);
+      const view = render(<DateField slotProps={{ textField: { onFocus } }} />);
 
       // Tabbing into the field fires a focus on the root and then on section 0.
       // Only the first focus (from outside the field) should reach the user.
       await view.user.tab();
 
       expect(onFocus.callCount).to.equal(1);
-      view.unmount();
     });
 
     it('should call `slotProps.textField.onBlur` when focus leaves the field via tab', async () => {
       const onBlur = spy();
-      const view = renderWithProps({ slotProps: { textField: { onBlur } } } as any);
+      const view = render(<DateField slotProps={{ textField: { onBlur } }} />);
 
       await view.user.tab();
       expect(onBlur.callCount).to.equal(0);
@@ -78,16 +75,12 @@ describe('<DateField />', () => {
       // Tab out of the field (to the document body or next focusable).
       await view.user.tab();
       expect(onBlur.callCount).to.equal(1);
-
-      view.unmount();
     });
 
     it('should not fire `slotProps.textField.onBlur` or `onFocus` when focus moves between sections', async () => {
       const onBlur = spy();
       const onFocus = spy();
-      const view = renderWithProps({
-        slotProps: { textField: { onBlur, onFocus } },
-      } as any);
+      const view = render(<DateField slotProps={{ textField: { onBlur, onFocus } }} />);
 
       await view.user.tab();
       const blurCallCountAfterTabIn = onBlur.callCount;
@@ -98,8 +91,6 @@ describe('<DateField />', () => {
 
       expect(onBlur.callCount).to.equal(blurCallCountAfterTabIn);
       expect(onFocus.callCount).to.equal(focusCallCountAfterTabIn);
-
-      view.unmount();
     });
   });
 

--- a/packages/x-date-pickers/src/DateField/tests/DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/DateField.test.tsx
@@ -65,6 +65,16 @@ describe('<DateField />', () => {
       expect(onFocus.callCount).to.equal(1);
     });
 
+    it('should call `slotProps.textField.onFocus` only once when focus is applied programmatically via autoFocus', () => {
+      const onFocus = spy();
+      // `autoFocus` triggers a programmatic `.focus()` on section 0 from a mount effect,
+      // which can produce a focus event with `relatedTarget === null`. The user callback
+      // must still fire exactly once.
+      render(<DateField autoFocus slotProps={{ textField: { onFocus } }} />);
+
+      expect(onFocus.callCount).to.equal(1);
+    });
+
     it('should call `slotProps.textField.onBlur` when focus leaves the field via tab', async () => {
       const onBlur = spy();
       const view = render(<DateField slotProps={{ textField: { onBlur } }} />);

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
@@ -163,13 +163,30 @@ export const useField = <
   });
 
   const handleRootBlur = useEventCallback((event: React.FocusEvent<HTMLDivElement>) => {
-    onBlur?.(event);
     rootProps.onBlur(event);
+    // Skip the user callback when focus is only moving to another element inside the field
+    // (e.g. the section that gains focus after the focusable root gives it up).
+    const next = event.relatedTarget;
+    if (domGetters.isReady() && next instanceof Node && domGetters.getRoot().contains(next)) {
+      return;
+    }
+    onBlur?.(event);
   });
 
   const handleRootFocus = useEventCallback((event: React.FocusEvent<HTMLDivElement>) => {
-    onFocus?.(event);
     rootProps.onFocus(event);
+    // Skip the user callback when focus is only arriving from another element inside the field
+    // (e.g. the focusable root receiving it before it is forwarded to a section, and the section
+    // focus event bubbling back up to the root).
+    const previous = event.relatedTarget;
+    if (
+      domGetters.isReady() &&
+      previous instanceof Node &&
+      domGetters.getRoot().contains(previous)
+    ) {
+      return;
+    }
+    onFocus?.(event);
   });
 
   const handleRootClick = useEventCallback((event: React.MouseEvent<HTMLDivElement>) => {


### PR DESCRIPTION
## Summary

Fixes #21973.

`slotProps.textField.onBlur` was firing whenever focus landed on a picker field, even though focus never actually left it. Symmetrically, `slotProps.textField.onFocus` fired twice on a single tab-in.

Root cause: the `PickersSectionList` root has `tabIndex=0`, so tabbing or clicking into a field lands focus on the root first. `useEnhancedEffect` then programmatically forwards focus to a section. The browser-generated blur on the root and focus on the section both bubble up to the field's DOM root, where the user-supplied handlers in `useField` invoked them unconditionally.

## Fix

Guard the user callbacks in `useField`'s `handleRootBlur` / `handleRootFocus` with an `event.relatedTarget` check:

- `onBlur` is skipped when `relatedTarget` is still inside the field root (focus is moving within the field).
- `onFocus` is skipped when `relatedTarget` is already inside the field root (focus is bubbling up from an internal section).

This reuses the same pattern already established on `SectionContent` in `PickersSectionList.handleContentBlur` (introduced in #19825 for section-to-section moves). Internal bookkeeping (`rootProps.onBlur` / `rootProps.onFocus`) still runs synchronously, so focused state and selected-sections tracking are unaffected.

Scope intentionally kept narrow:

- `muiFormControl.onBlur` / `onFocus` in `PickersInputBase` left as-is. The FormControl `focused` state flips false-then-true within a single event-loop tick and React batches the updates, so there is no visible flicker; touching it would expand blast radius into Material UI integration.
- Multi-input range fields are not affected: each inner single-input already uses `useField`, and the outer range wrapper uses `executeInTheNextEventLoopTick` + `contains(activeElement)`.

## Test plan

- [x] New tests in `DateField.test.tsx`:
  - Tab into the field: `onBlur` is not called, `onFocus` is called exactly once.
  - Tab out of the field: `onBlur` is called exactly once.
  - Moving between sections with arrow keys: neither callback fires.
- [x] `pnpm test:unit --project "x-date-pickers" --run`: 3245 passing, no regressions.
- [x] `pnpm test:unit --project "x-date-pickers-pro" --run`: 986 passing, no regressions.
- [x] `pnpm --filter "@mui/x-date-pickers" run typescript`: clean.
- [x] `pnpm eslint` on touched files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)