### PR TITLE
[charts-pro][ChartsToolbarRangeButtons] Add initialRangeKey support

### DIFF
--- a/docs/data/charts/toolbar/ChartsToolbarRangeButtons.js
+++ b/docs/data/charts/toolbar/ChartsToolbarRangeButtons.js
@@ -15,7 +15,6 @@ export default function ChartsToolbarRangeButtons() {
       ]}
       height={300}
       showToolbar
-      initialZoom={[{ axisId: 0, start: 80, end: 100 }]}
       initialRangeKey="5Y"
       slotProps={{
         toolbar: {

--- a/docs/data/charts/toolbar/ChartsToolbarRangeButtons.js
+++ b/docs/data/charts/toolbar/ChartsToolbarRangeButtons.js
@@ -15,6 +15,8 @@ export default function ChartsToolbarRangeButtons() {
       ]}
       height={300}
       showToolbar
+      initialZoom={[{ axisId: 0, start: 80, end: 100 }]}
+      initialRangeKey="5Y"
       slotProps={{
         toolbar: {
           rangeButtons: [

--- a/docs/data/charts/toolbar/ChartsToolbarRangeButtons.tsx
+++ b/docs/data/charts/toolbar/ChartsToolbarRangeButtons.tsx
@@ -17,6 +17,8 @@ export default function ChartsToolbarRangeButtons() {
       ]}
       height={300}
       showToolbar
+      initialZoom={[{ axisId: 0, start: 80, end: 100 }]}
+      initialRangeKey="5Y"
       slotProps={{
         toolbar: {
           rangeButtons: [

--- a/docs/data/charts/toolbar/ChartsToolbarRangeButtons.tsx
+++ b/docs/data/charts/toolbar/ChartsToolbarRangeButtons.tsx
@@ -17,7 +17,6 @@ export default function ChartsToolbarRangeButtons() {
       ]}
       height={300}
       showToolbar
-      initialZoom={[{ axisId: 0, start: 80, end: 100 }]}
       initialRangeKey="5Y"
       slotProps={{
         toolbar: {

--- a/docs/pages/x/api/charts/bar-chart-premium.json
+++ b/docs/pages/x/api/charts/bar-chart-premium.json
@@ -61,6 +61,7 @@
         "description": "Array&lt;{ dataIndex?: number, seriesId: string, type?: 'bar' }<br>&#124;&nbsp;{ dataIndex?: number, seriesId: string, type: 'bar' }&gt;"
       }
     },
+    "initialRangeKey": { "type": { "name": "string" } },
     "initialZoom": {
       "type": {
         "name": "arrayOf",

--- a/docs/pages/x/api/charts/bar-chart-premium.json
+++ b/docs/pages/x/api/charts/bar-chart-premium.json
@@ -136,6 +136,12 @@
         "describedArgs": ["zoomData"]
       }
     },
+    "rangeButtons": {
+      "type": {
+        "name": "arrayOf",
+        "description": "Array&lt;{ label: string, value?: Array&lt;Date&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;{ step?: number, unit: 'day'<br>&#124;&nbsp;'hour'<br>&#124;&nbsp;'microsecond'<br>&#124;&nbsp;'millisecond'<br>&#124;&nbsp;'minute'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'second'<br>&#124;&nbsp;'week'<br>&#124;&nbsp;'year' } }&gt;"
+      }
+    },
     "renderer": {
       "type": { "name": "enum", "description": "'svg-batch'<br>&#124;&nbsp;'svg-single'" },
       "default": "'svg-single'"

--- a/docs/pages/x/api/charts/bar-chart-pro.json
+++ b/docs/pages/x/api/charts/bar-chart-pro.json
@@ -61,6 +61,7 @@
         "description": "Array&lt;{ dataIndex?: number, seriesId: string, type?: 'bar' }<br>&#124;&nbsp;{ dataIndex?: number, seriesId: string, type: 'bar' }&gt;"
       }
     },
+    "initialRangeKey": { "type": { "name": "string" } },
     "initialZoom": {
       "type": {
         "name": "arrayOf",

--- a/docs/pages/x/api/charts/bar-chart-pro.json
+++ b/docs/pages/x/api/charts/bar-chart-pro.json
@@ -136,6 +136,12 @@
         "describedArgs": ["zoomData"]
       }
     },
+    "rangeButtons": {
+      "type": {
+        "name": "arrayOf",
+        "description": "Array&lt;{ label: string, value?: Array&lt;Date&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;{ step?: number, unit: 'day'<br>&#124;&nbsp;'hour'<br>&#124;&nbsp;'microsecond'<br>&#124;&nbsp;'millisecond'<br>&#124;&nbsp;'minute'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'second'<br>&#124;&nbsp;'week'<br>&#124;&nbsp;'year' } }&gt;"
+      }
+    },
     "renderer": {
       "type": { "name": "enum", "description": "'svg-batch'<br>&#124;&nbsp;'svg-single'" },
       "default": "'svg-single'"

--- a/docs/pages/x/api/charts/candlestick-chart.json
+++ b/docs/pages/x/api/charts/candlestick-chart.json
@@ -117,6 +117,12 @@
         "describedArgs": ["zoomData"]
       }
     },
+    "rangeButtons": {
+      "type": {
+        "name": "arrayOf",
+        "description": "Array&lt;{ label: string, value?: Array&lt;Date&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;{ step?: number, unit: 'day'<br>&#124;&nbsp;'hour'<br>&#124;&nbsp;'microsecond'<br>&#124;&nbsp;'millisecond'<br>&#124;&nbsp;'minute'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'second'<br>&#124;&nbsp;'week'<br>&#124;&nbsp;'year' } }&gt;"
+      }
+    },
     "showToolbar": { "type": { "name": "bool" }, "default": "false" },
     "skipAnimation": { "type": { "name": "bool" } },
     "slotProps": { "type": { "name": "object" }, "default": "{}" },

--- a/docs/pages/x/api/charts/candlestick-chart.json
+++ b/docs/pages/x/api/charts/candlestick-chart.json
@@ -53,6 +53,7 @@
         "description": "Array&lt;{ dataIndex?: number, seriesId: string, type?: 'ohlc' }<br>&#124;&nbsp;{ dataIndex?: number, seriesId: string, type: 'ohlc' }&gt;"
       }
     },
+    "initialRangeKey": { "type": { "name": "string" } },
     "initialZoom": {
       "type": {
         "name": "arrayOf",

--- a/docs/pages/x/api/charts/heatmap-premium.json
+++ b/docs/pages/x/api/charts/heatmap-premium.json
@@ -93,6 +93,12 @@
         "describedArgs": ["zoomData"]
       }
     },
+    "rangeButtons": {
+      "type": {
+        "name": "arrayOf",
+        "description": "Array&lt;{ label: string, value?: Array&lt;Date&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;{ step?: number, unit: 'day'<br>&#124;&nbsp;'hour'<br>&#124;&nbsp;'microsecond'<br>&#124;&nbsp;'millisecond'<br>&#124;&nbsp;'minute'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'second'<br>&#124;&nbsp;'week'<br>&#124;&nbsp;'year' } }&gt;"
+      }
+    },
     "renderer": {
       "type": { "name": "enum", "description": "'svg-single'<br>&#124;&nbsp;'webgl'" }
     },

--- a/docs/pages/x/api/charts/heatmap-premium.json
+++ b/docs/pages/x/api/charts/heatmap-premium.json
@@ -43,6 +43,7 @@
       }
     },
     "id": { "type": { "name": "string" } },
+    "initialRangeKey": { "type": { "name": "string" } },
     "initialZoom": {
       "type": {
         "name": "arrayOf",

--- a/docs/pages/x/api/charts/heatmap.json
+++ b/docs/pages/x/api/charts/heatmap.json
@@ -43,6 +43,7 @@
       }
     },
     "id": { "type": { "name": "string" } },
+    "initialRangeKey": { "type": { "name": "string" } },
     "initialZoom": {
       "type": {
         "name": "arrayOf",

--- a/docs/pages/x/api/charts/heatmap.json
+++ b/docs/pages/x/api/charts/heatmap.json
@@ -93,6 +93,12 @@
         "describedArgs": ["zoomData"]
       }
     },
+    "rangeButtons": {
+      "type": {
+        "name": "arrayOf",
+        "description": "Array&lt;{ label: string, value?: Array&lt;Date&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;{ step?: number, unit: 'day'<br>&#124;&nbsp;'hour'<br>&#124;&nbsp;'microsecond'<br>&#124;&nbsp;'millisecond'<br>&#124;&nbsp;'minute'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'second'<br>&#124;&nbsp;'week'<br>&#124;&nbsp;'year' } }&gt;"
+      }
+    },
     "showToolbar": { "type": { "name": "bool" }, "default": "false" },
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": {

--- a/docs/pages/x/api/charts/line-chart-pro.json
+++ b/docs/pages/x/api/charts/line-chart-pro.json
@@ -131,6 +131,12 @@
         "describedArgs": ["zoomData"]
       }
     },
+    "rangeButtons": {
+      "type": {
+        "name": "arrayOf",
+        "description": "Array&lt;{ label: string, value?: Array&lt;Date&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;{ step?: number, unit: 'day'<br>&#124;&nbsp;'hour'<br>&#124;&nbsp;'microsecond'<br>&#124;&nbsp;'millisecond'<br>&#124;&nbsp;'minute'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'second'<br>&#124;&nbsp;'week'<br>&#124;&nbsp;'year' } }&gt;"
+      }
+    },
     "showToolbar": { "type": { "name": "bool" }, "default": "false" },
     "skipAnimation": { "type": { "name": "bool" }, "default": "false" },
     "slotProps": { "type": { "name": "object" }, "default": "{}" },

--- a/docs/pages/x/api/charts/line-chart-pro.json
+++ b/docs/pages/x/api/charts/line-chart-pro.json
@@ -64,6 +64,7 @@
         "description": "Array&lt;{ dataIndex?: number, seriesId: string, type: 'line' }<br>&#124;&nbsp;{ dataIndex?: number, seriesId: string, type?: 'line' }&gt;"
       }
     },
+    "initialRangeKey": { "type": { "name": "string" } },
     "initialZoom": {
       "type": {
         "name": "arrayOf",

--- a/docs/pages/x/api/charts/scatter-chart-pro.json
+++ b/docs/pages/x/api/charts/scatter-chart-pro.json
@@ -133,6 +133,12 @@
         "describedArgs": ["zoomData"]
       }
     },
+    "rangeButtons": {
+      "type": {
+        "name": "arrayOf",
+        "description": "Array&lt;{ label: string, value?: Array&lt;Date&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;{ step?: number, unit: 'day'<br>&#124;&nbsp;'hour'<br>&#124;&nbsp;'microsecond'<br>&#124;&nbsp;'millisecond'<br>&#124;&nbsp;'minute'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'second'<br>&#124;&nbsp;'week'<br>&#124;&nbsp;'year' } }&gt;"
+      }
+    },
     "renderer": {
       "type": { "name": "enum", "description": "'svg-batch'<br>&#124;&nbsp;'svg-single'" },
       "default": "'svg-single'"

--- a/docs/pages/x/api/charts/scatter-chart-pro.json
+++ b/docs/pages/x/api/charts/scatter-chart-pro.json
@@ -69,6 +69,7 @@
         "description": "Array&lt;{ dataIndex?: number, seriesId: string, type: 'scatter' }<br>&#124;&nbsp;{ dataIndex?: number, seriesId: string, type?: 'scatter' }&gt;"
       }
     },
+    "initialRangeKey": { "type": { "name": "string" } },
     "initialZoom": {
       "type": {
         "name": "arrayOf",

--- a/docs/translations/api-docs/charts/bar-chart-premium/bar-chart-premium.json
+++ b/docs/translations/api-docs/charts/bar-chart-premium/bar-chart-premium.json
@@ -46,6 +46,9 @@
     "initialHiddenItems": {
       "description": "List of initially hidden series and/or items. Used for uncontrolled state.<br>Different chart types use different keys."
     },
+    "initialRangeKey": {
+      "description": "The label of the range button that corresponds to the initial zoom state. Used to pre-select that button on mount."
+    },
     "initialZoom": {
       "description": "The list of zoom data related to each axis. Used to initialize the zoom in a specific configuration without controlling it."
     },

--- a/docs/translations/api-docs/charts/bar-chart-premium/bar-chart-premium.json
+++ b/docs/translations/api-docs/charts/bar-chart-premium/bar-chart-premium.json
@@ -47,7 +47,7 @@
       "description": "List of initially hidden series and/or items. Used for uncontrolled state.<br>Different chart types use different keys."
     },
     "initialRangeKey": {
-      "description": "The label of the range button that corresponds to the initial zoom state. Used to pre-select that button on mount."
+      "description": "The label of the range button that corresponds to the initial zoom state. When set together with <code>rangeButtons</code>, automatically computes <code>initialZoom</code> from the matching button. Also pre-selects that button in the toolbar on mount."
     },
     "initialZoom": {
       "description": "The list of zoom data related to each axis. Used to initialize the zoom in a specific configuration without controlling it."
@@ -119,6 +119,9 @@
       "typeDescriptions": {
         "zoomData": { "name": "zoomData", "description": "Updated zoom data." }
       }
+    },
+    "rangeButtons": {
+      "description": "Configuration for range buttons. Used together with <code>initialRangeKey</code> to compute the initial zoom state automatically."
     },
     "renderer": {
       "description": "The type of renderer to use for the bar plot. - <code>svg-single</code>: Renders every bar in a <code>&lt;rect /&gt;</code> element. - <code>svg-batch</code>: Batch renders bars in <code>&lt;path /&gt;</code> elements for better performance with large datasets, at the cost of some limitations.                Read more: <a href=\"https://mui.com/x/react-charts/bars/#performance\">https://mui.com/x/react-charts/bars/#performance</a>"

--- a/docs/translations/api-docs/charts/bar-chart-pro/bar-chart-pro.json
+++ b/docs/translations/api-docs/charts/bar-chart-pro/bar-chart-pro.json
@@ -46,6 +46,9 @@
     "initialHiddenItems": {
       "description": "List of initially hidden series and/or items. Used for uncontrolled state.<br>Different chart types use different keys."
     },
+    "initialRangeKey": {
+      "description": "The label of the range button that corresponds to the initial zoom state. Used to pre-select that button on mount."
+    },
     "initialZoom": {
       "description": "The list of zoom data related to each axis. Used to initialize the zoom in a specific configuration without controlling it."
     },

--- a/docs/translations/api-docs/charts/bar-chart-pro/bar-chart-pro.json
+++ b/docs/translations/api-docs/charts/bar-chart-pro/bar-chart-pro.json
@@ -47,7 +47,7 @@
       "description": "List of initially hidden series and/or items. Used for uncontrolled state.<br>Different chart types use different keys."
     },
     "initialRangeKey": {
-      "description": "The label of the range button that corresponds to the initial zoom state. Used to pre-select that button on mount."
+      "description": "The label of the range button that corresponds to the initial zoom state. When set together with <code>rangeButtons</code>, automatically computes <code>initialZoom</code> from the matching button. Also pre-selects that button in the toolbar on mount."
     },
     "initialZoom": {
       "description": "The list of zoom data related to each axis. Used to initialize the zoom in a specific configuration without controlling it."
@@ -122,6 +122,9 @@
       "typeDescriptions": {
         "zoomData": { "name": "zoomData", "description": "Updated zoom data." }
       }
+    },
+    "rangeButtons": {
+      "description": "Configuration for range buttons. Used together with <code>initialRangeKey</code> to compute the initial zoom state automatically."
     },
     "renderer": {
       "description": "The type of renderer to use for the bar plot. - <code>svg-single</code>: Renders every bar in a <code>&lt;rect /&gt;</code> element. - <code>svg-batch</code>: Batch renders bars in <code>&lt;path /&gt;</code> elements for better performance with large datasets, at the cost of some limitations.                Read more: <a href=\"https://mui.com/x/react-charts/bars/#performance\">https://mui.com/x/react-charts/bars/#performance</a>"

--- a/docs/translations/api-docs/charts/candlestick-chart/candlestick-chart.json
+++ b/docs/translations/api-docs/charts/candlestick-chart/candlestick-chart.json
@@ -38,6 +38,9 @@
     "initialHiddenItems": {
       "description": "List of initially hidden series and/or items. Used for uncontrolled state.<br>Different chart types use different keys."
     },
+    "initialRangeKey": {
+      "description": "The label of the range button that corresponds to the initial zoom state. Used to pre-select that button on mount."
+    },
     "initialZoom": {
       "description": "The list of zoom data related to each axis. Used to initialize the zoom in a specific configuration without controlling it."
     },

--- a/docs/translations/api-docs/charts/candlestick-chart/candlestick-chart.json
+++ b/docs/translations/api-docs/charts/candlestick-chart/candlestick-chart.json
@@ -39,7 +39,7 @@
       "description": "List of initially hidden series and/or items. Used for uncontrolled state.<br>Different chart types use different keys."
     },
     "initialRangeKey": {
-      "description": "The label of the range button that corresponds to the initial zoom state. Used to pre-select that button on mount."
+      "description": "The label of the range button that corresponds to the initial zoom state. When set together with <code>rangeButtons</code>, automatically computes <code>initialZoom</code> from the matching button. Also pre-selects that button in the toolbar on mount."
     },
     "initialZoom": {
       "description": "The list of zoom data related to each axis. Used to initialize the zoom in a specific configuration without controlling it."
@@ -103,6 +103,9 @@
       "typeDescriptions": {
         "zoomData": { "name": "zoomData", "description": "Updated zoom data." }
       }
+    },
+    "rangeButtons": {
+      "description": "Configuration for range buttons. Used together with <code>initialRangeKey</code> to compute the initial zoom state automatically."
     },
     "series": {
       "description": "The series to display in the candlestick chart. An array of OHLCSeries objects.<br>Currently, only one OHLC series is supported. If would like to display more than one OHLC series, open an issue at <a href=\"https://github.com/mui/mui-x\">https://github.com/mui/mui-x</a> explaining your use case."

--- a/docs/translations/api-docs/charts/heatmap-premium/heatmap-premium.json
+++ b/docs/translations/api-docs/charts/heatmap-premium/heatmap-premium.json
@@ -29,6 +29,9 @@
     "id": {
       "description": "This prop is used to help implement the accessibility logic. If you don&#39;t provide this prop. It falls back to a randomly generated id."
     },
+    "initialRangeKey": {
+      "description": "The label of the range button that corresponds to the initial zoom state. Used to pre-select that button on mount."
+    },
     "initialZoom": {
       "description": "The list of zoom data related to each axis. Used to initialize the zoom in a specific configuration without controlling it."
     },

--- a/docs/translations/api-docs/charts/heatmap-premium/heatmap-premium.json
+++ b/docs/translations/api-docs/charts/heatmap-premium/heatmap-premium.json
@@ -30,7 +30,7 @@
       "description": "This prop is used to help implement the accessibility logic. If you don&#39;t provide this prop. It falls back to a randomly generated id."
     },
     "initialRangeKey": {
-      "description": "The label of the range button that corresponds to the initial zoom state. Used to pre-select that button on mount."
+      "description": "The label of the range button that corresponds to the initial zoom state. When set together with <code>rangeButtons</code>, automatically computes <code>initialZoom</code> from the matching button. Also pre-selects that button in the toolbar on mount."
     },
     "initialZoom": {
       "description": "The list of zoom data related to each axis. Used to initialize the zoom in a specific configuration without controlling it."
@@ -73,6 +73,9 @@
       "typeDescriptions": {
         "zoomData": { "name": "zoomData", "description": "Updated zoom data." }
       }
+    },
+    "rangeButtons": {
+      "description": "Configuration for range buttons. Used together with <code>initialRangeKey</code> to compute the initial zoom state automatically."
     },
     "renderer": {
       "description": "<p>The type of renderer to use for the heatmap plot.</p>\n<ul>\n<li><code>svg-single</code>: Renders every scatter item in a <code>&lt;rect /&gt;</code> element.</li>\n<li><code>webgl</code>: Renders heatmap cells using WebGL for better performance, at the cost of some limitations.\n         Read more: <a href=\"https://mui.com/x/react-charts/heatmap/#performance\">https://mui.com/x/react-charts/heatmap/#performance</a></li>\n</ul>\n"

--- a/docs/translations/api-docs/charts/heatmap/heatmap.json
+++ b/docs/translations/api-docs/charts/heatmap/heatmap.json
@@ -29,6 +29,9 @@
     "id": {
       "description": "This prop is used to help implement the accessibility logic. If you don&#39;t provide this prop. It falls back to a randomly generated id."
     },
+    "initialRangeKey": {
+      "description": "The label of the range button that corresponds to the initial zoom state. Used to pre-select that button on mount."
+    },
     "initialZoom": {
       "description": "The list of zoom data related to each axis. Used to initialize the zoom in a specific configuration without controlling it."
     },

--- a/docs/translations/api-docs/charts/heatmap/heatmap.json
+++ b/docs/translations/api-docs/charts/heatmap/heatmap.json
@@ -30,7 +30,7 @@
       "description": "This prop is used to help implement the accessibility logic. If you don&#39;t provide this prop. It falls back to a randomly generated id."
     },
     "initialRangeKey": {
-      "description": "The label of the range button that corresponds to the initial zoom state. Used to pre-select that button on mount."
+      "description": "The label of the range button that corresponds to the initial zoom state. When set together with <code>rangeButtons</code>, automatically computes <code>initialZoom</code> from the matching button. Also pre-selects that button in the toolbar on mount."
     },
     "initialZoom": {
       "description": "The list of zoom data related to each axis. Used to initialize the zoom in a specific configuration without controlling it."
@@ -73,6 +73,9 @@
       "typeDescriptions": {
         "zoomData": { "name": "zoomData", "description": "Updated zoom data." }
       }
+    },
+    "rangeButtons": {
+      "description": "Configuration for range buttons. Used together with <code>initialRangeKey</code> to compute the initial zoom state automatically."
     },
     "series": {
       "description": "The series to display in the bar chart. An array of <a href='/x/api/charts/heatmap-series/'>HeatmapSeries</a> objects."

--- a/docs/translations/api-docs/charts/line-chart-pro/line-chart-pro.json
+++ b/docs/translations/api-docs/charts/line-chart-pro/line-chart-pro.json
@@ -48,6 +48,9 @@
     "initialHiddenItems": {
       "description": "List of initially hidden series and/or items. Used for uncontrolled state.<br>Different chart types use different keys."
     },
+    "initialRangeKey": {
+      "description": "The label of the range button that corresponds to the initial zoom state. Used to pre-select that button on mount."
+    },
     "initialZoom": {
       "description": "The list of zoom data related to each axis. Used to initialize the zoom in a specific configuration without controlling it."
     },

--- a/docs/translations/api-docs/charts/line-chart-pro/line-chart-pro.json
+++ b/docs/translations/api-docs/charts/line-chart-pro/line-chart-pro.json
@@ -49,7 +49,7 @@
       "description": "List of initially hidden series and/or items. Used for uncontrolled state.<br>Different chart types use different keys."
     },
     "initialRangeKey": {
-      "description": "The label of the range button that corresponds to the initial zoom state. Used to pre-select that button on mount."
+      "description": "The label of the range button that corresponds to the initial zoom state. When set together with <code>rangeButtons</code>, automatically computes <code>initialZoom</code> from the matching button. Also pre-selects that button in the toolbar on mount."
     },
     "initialZoom": {
       "description": "The list of zoom data related to each axis. Used to initialize the zoom in a specific configuration without controlling it."
@@ -116,6 +116,9 @@
       "typeDescriptions": {
         "zoomData": { "name": "zoomData", "description": "Updated zoom data." }
       }
+    },
+    "rangeButtons": {
+      "description": "Configuration for range buttons. Used together with <code>initialRangeKey</code> to compute the initial zoom state automatically."
     },
     "series": {
       "description": "The series to display in the line chart. An array of <a href='/x/api/charts/line-series/'>LineSeries</a> objects."

--- a/docs/translations/api-docs/charts/scatter-chart-pro/scatter-chart-pro.json
+++ b/docs/translations/api-docs/charts/scatter-chart-pro/scatter-chart-pro.json
@@ -55,7 +55,7 @@
       "description": "List of initially hidden series and/or items. Used for uncontrolled state.<br>Different chart types use different keys."
     },
     "initialRangeKey": {
-      "description": "The label of the range button that corresponds to the initial zoom state. Used to pre-select that button on mount."
+      "description": "The label of the range button that corresponds to the initial zoom state. When set together with <code>rangeButtons</code>, automatically computes <code>initialZoom</code> from the matching button. Also pre-selects that button in the toolbar on mount."
     },
     "initialZoom": {
       "description": "The list of zoom data related to each axis. Used to initialize the zoom in a specific configuration without controlling it."
@@ -126,6 +126,9 @@
       "typeDescriptions": {
         "zoomData": { "name": "zoomData", "description": "Updated zoom data." }
       }
+    },
+    "rangeButtons": {
+      "description": "Configuration for range buttons. Used together with <code>initialRangeKey</code> to compute the initial zoom state automatically."
     },
     "renderer": {
       "description": "The type of renderer to use for the scatter plot. - <code>svg-single</code>: Renders every scatter item in a <code>&lt;circle /&gt;</code> element. - <code>svg-batch</code>: Batch renders scatter items in <code>&lt;path /&gt;</code> elements for better performance with large datasets, at the cost of some limitations.                Read more: <a href=\"https://mui.com/x/react-charts/scatter/#performance\">https://mui.com/x/react-charts/scatter/#performance</a>"

--- a/docs/translations/api-docs/charts/scatter-chart-pro/scatter-chart-pro.json
+++ b/docs/translations/api-docs/charts/scatter-chart-pro/scatter-chart-pro.json
@@ -54,6 +54,9 @@
     "initialHiddenItems": {
       "description": "List of initially hidden series and/or items. Used for uncontrolled state.<br>Different chart types use different keys."
     },
+    "initialRangeKey": {
+      "description": "The label of the range button that corresponds to the initial zoom state. Used to pre-select that button on mount."
+    },
     "initialZoom": {
       "description": "The list of zoom data related to each axis. Used to initialize the zoom in a specific configuration without controlling it."
     },

--- a/packages/x-charts-premium/src/BarChartPremium/BarChartPremium.tsx
+++ b/packages/x-charts-premium/src/BarChartPremium/BarChartPremium.tsx
@@ -332,7 +332,8 @@ BarChartPremium.propTypes = {
   ),
   /**
    * The label of the range button that corresponds to the initial zoom state.
-   * Used to pre-select that button on mount.
+   * When set together with `rangeButtons`, automatically computes `initialZoom` from the matching button.
+   * Also pre-selects that button in the toolbar on mount.
    */
   initialRangeKey: PropTypes.string,
   /**
@@ -427,6 +428,33 @@ BarChartPremium.propTypes = {
    * @param {ZoomData[]} zoomData Updated zoom data.
    */
   onZoomChange: PropTypes.func,
+  /**
+   * Configuration for range buttons.
+   * Used together with `initialRangeKey` to compute the initial zoom state automatically.
+   */
+  rangeButtons: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      value: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.instanceOf(Date).isRequired),
+        PropTypes.func,
+        PropTypes.shape({
+          step: PropTypes.number,
+          unit: PropTypes.oneOf([
+            'day',
+            'hour',
+            'microsecond',
+            'millisecond',
+            'minute',
+            'month',
+            'second',
+            'week',
+            'year',
+          ]).isRequired,
+        }),
+      ]),
+    }),
+  ),
   /**
    * The type of renderer to use for the bar plot.
    * - `svg-single`: Renders every bar in a `<rect />` element.

--- a/packages/x-charts-premium/src/BarChartPremium/BarChartPremium.tsx
+++ b/packages/x-charts-premium/src/BarChartPremium/BarChartPremium.tsx
@@ -331,6 +331,11 @@ BarChartPremium.propTypes = {
     ]).isRequired,
   ),
   /**
+   * The label of the range button that corresponds to the initial zoom state.
+   * Used to pre-select that button on mount.
+   */
+  initialRangeKey: PropTypes.string,
+  /**
    * The list of zoom data related to each axis.
    * Used to initialize the zoom in a specific configuration without controlling it.
    */

--- a/packages/x-charts-premium/src/CandlestickChart/CandlestickChart.tsx
+++ b/packages/x-charts-premium/src/CandlestickChart/CandlestickChart.tsx
@@ -347,6 +347,11 @@ CandlestickChart.propTypes = {
     ]).isRequired,
   ),
   /**
+   * The label of the range button that corresponds to the initial zoom state.
+   * Used to pre-select that button on mount.
+   */
+  initialRangeKey: PropTypes.string,
+  /**
    * The list of zoom data related to each axis.
    * Used to initialize the zoom in a specific configuration without controlling it.
    */

--- a/packages/x-charts-premium/src/CandlestickChart/CandlestickChart.tsx
+++ b/packages/x-charts-premium/src/CandlestickChart/CandlestickChart.tsx
@@ -348,7 +348,8 @@ CandlestickChart.propTypes = {
   ),
   /**
    * The label of the range button that corresponds to the initial zoom state.
-   * Used to pre-select that button on mount.
+   * When set together with `rangeButtons`, automatically computes `initialZoom` from the matching button.
+   * Also pre-selects that button in the toolbar on mount.
    */
   initialRangeKey: PropTypes.string,
   /**
@@ -432,6 +433,33 @@ CandlestickChart.propTypes = {
    * @param {ZoomData[]} zoomData Updated zoom data.
    */
   onZoomChange: PropTypes.func,
+  /**
+   * Configuration for range buttons.
+   * Used together with `initialRangeKey` to compute the initial zoom state automatically.
+   */
+  rangeButtons: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      value: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.instanceOf(Date).isRequired),
+        PropTypes.func,
+        PropTypes.shape({
+          step: PropTypes.number,
+          unit: PropTypes.oneOf([
+            'day',
+            'hour',
+            'microsecond',
+            'millisecond',
+            'minute',
+            'month',
+            'second',
+            'week',
+            'year',
+          ]).isRequired,
+        }),
+      ]),
+    }),
+  ),
   /**
    * The series to display in the candlestick chart.
    * An array of [[OHLCSeries]] objects.

--- a/packages/x-charts-premium/src/HeatmapPremium/HeatmapPremium.tsx
+++ b/packages/x-charts-premium/src/HeatmapPremium/HeatmapPremium.tsx
@@ -176,6 +176,11 @@ HeatmapPremium.propTypes = {
    */
   id: PropTypes.string,
   /**
+   * The label of the range button that corresponds to the initial zoom state.
+   * Used to pre-select that button on mount.
+   */
+  initialRangeKey: PropTypes.string,
+  /**
    * The list of zoom data related to each axis.
    * Used to initialize the zoom in a specific configuration without controlling it.
    */

--- a/packages/x-charts-premium/src/HeatmapPremium/HeatmapPremium.tsx
+++ b/packages/x-charts-premium/src/HeatmapPremium/HeatmapPremium.tsx
@@ -177,7 +177,8 @@ HeatmapPremium.propTypes = {
   id: PropTypes.string,
   /**
    * The label of the range button that corresponds to the initial zoom state.
-   * Used to pre-select that button on mount.
+   * When set together with `rangeButtons`, automatically computes `initialZoom` from the matching button.
+   * Also pre-selects that button in the toolbar on mount.
    */
   initialRangeKey: PropTypes.string,
   /**
@@ -248,6 +249,33 @@ HeatmapPremium.propTypes = {
    * @param {ZoomData[]} zoomData Updated zoom data.
    */
   onZoomChange: PropTypes.func,
+  /**
+   * Configuration for range buttons.
+   * Used together with `initialRangeKey` to compute the initial zoom state automatically.
+   */
+  rangeButtons: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      value: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.instanceOf(Date).isRequired),
+        PropTypes.func,
+        PropTypes.shape({
+          step: PropTypes.number,
+          unit: PropTypes.oneOf([
+            'day',
+            'hour',
+            'microsecond',
+            'millisecond',
+            'minute',
+            'month',
+            'second',
+            'week',
+            'year',
+          ]).isRequired,
+        }),
+      ]),
+    }),
+  ),
   /**
    * The type of renderer to use for the heatmap plot.
    * - `svg-single`: Renders every scatter item in a `<rect />` element.

--- a/packages/x-charts-pro/src/BarChartPro/BarChartPro.tsx
+++ b/packages/x-charts-pro/src/BarChartPro/BarChartPro.tsx
@@ -317,7 +317,8 @@ BarChartPro.propTypes = {
   ),
   /**
    * The label of the range button that corresponds to the initial zoom state.
-   * Used to pre-select that button on mount.
+   * When set together with `rangeButtons`, automatically computes `initialZoom` from the matching button.
+   * Also pre-selects that button in the toolbar on mount.
    */
   initialRangeKey: PropTypes.string,
   /**
@@ -412,6 +413,33 @@ BarChartPro.propTypes = {
    * @param {ZoomData[]} zoomData Updated zoom data.
    */
   onZoomChange: PropTypes.func,
+  /**
+   * Configuration for range buttons.
+   * Used together with `initialRangeKey` to compute the initial zoom state automatically.
+   */
+  rangeButtons: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      value: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.instanceOf(Date).isRequired),
+        PropTypes.func,
+        PropTypes.shape({
+          step: PropTypes.number,
+          unit: PropTypes.oneOf([
+            'day',
+            'hour',
+            'microsecond',
+            'millisecond',
+            'minute',
+            'month',
+            'second',
+            'week',
+            'year',
+          ]).isRequired,
+        }),
+      ]),
+    }),
+  ),
   /**
    * The type of renderer to use for the bar plot.
    * - `svg-single`: Renders every bar in a `<rect />` element.

--- a/packages/x-charts-pro/src/BarChartPro/BarChartPro.tsx
+++ b/packages/x-charts-pro/src/BarChartPro/BarChartPro.tsx
@@ -74,7 +74,8 @@ const BarChartPro = React.forwardRef(function BarChartPro(
   ref: React.Ref<HTMLDivElement>,
 ) {
   const props = useThemeProps({ props: inProps, name: 'MuiBarChartPro' });
-  const { initialZoom, zoomData, onZoomChange, apiRef, showToolbar, ...other } = props;
+  const { initialZoom, initialRangeKey, zoomData, onZoomChange, apiRef, showToolbar, ...other } =
+    props;
   const {
     chartsWrapperProps,
     chartsContainerProps,
@@ -95,6 +96,7 @@ const BarChartPro = React.forwardRef(function BarChartPro(
   >({
     ...chartsContainerProps,
     initialZoom,
+    initialRangeKey,
     zoomData,
     onZoomChange,
     apiRef,
@@ -312,6 +314,11 @@ BarChartPro.propTypes = {
       }),
     ]).isRequired,
   ),
+  /**
+   * The label of the range button that corresponds to the initial zoom state.
+   * Used to pre-select that button on mount.
+   */
+  initialRangeKey: PropTypes.string,
   /**
    * The list of zoom data related to each axis.
    * Used to initialize the zoom in a specific configuration without controlling it.

--- a/packages/x-charts-pro/src/BarChartPro/BarChartPro.tsx
+++ b/packages/x-charts-pro/src/BarChartPro/BarChartPro.tsx
@@ -100,6 +100,7 @@ const BarChartPro = React.forwardRef(function BarChartPro(
     zoomData,
     onZoomChange,
     apiRef,
+    rangeButtons: props.slotProps?.toolbar?.rangeButtons,
     plugins: BAR_CHART_PRO_PLUGINS,
   });
 

--- a/packages/x-charts-pro/src/ChartsContainerPro/useChartsContainerProProps.ts
+++ b/packages/x-charts-pro/src/ChartsContainerPro/useChartsContainerProProps.ts
@@ -31,6 +31,7 @@ export const useChartsContainerProProps = <
     zoomData,
     onZoomChange,
     zoomInteractionConfig,
+    rangeButtons,
     plugins,
     apiRef,
     ...baseProps
@@ -46,6 +47,7 @@ export const useChartsContainerProProps = <
     zoomData,
     onZoomChange,
     zoomInteractionConfig,
+    rangeButtons,
     apiRef,
     plugins: plugins ?? DEFAULT_PLUGINS,
   } as unknown as ChartsDataProviderProProps<SeriesType, TSignatures>;

--- a/packages/x-charts-pro/src/ChartsContainerPro/useChartsContainerProProps.ts
+++ b/packages/x-charts-pro/src/ChartsContainerPro/useChartsContainerProProps.ts
@@ -27,6 +27,7 @@ export const useChartsContainerProProps = <
 ): UseChartsContainerProPropsReturnValue<SeriesType, TSignatures> => {
   const {
     initialZoom,
+    initialRangeKey,
     zoomData,
     onZoomChange,
     zoomInteractionConfig,
@@ -41,6 +42,7 @@ export const useChartsContainerProProps = <
   const chartsDataProviderProProps = {
     ...chartsDataProviderProps,
     initialZoom,
+    initialRangeKey,
     zoomData,
     onZoomChange,
     zoomInteractionConfig,

--- a/packages/x-charts-pro/src/ChartsToolbarPro/ChartsToolbarPro.tsx
+++ b/packages/x-charts-pro/src/ChartsToolbarPro/ChartsToolbarPro.tsx
@@ -19,8 +19,8 @@ import { selectorChartZoomIsEnabled } from '../internals/plugins/useChartProZoom
 import { ChartsToolbarZoomInTrigger } from './ChartsToolbarZoomInTrigger';
 import { ChartsToolbarZoomOutTrigger } from './ChartsToolbarZoomOutTrigger';
 import { ChartsToolbarRangeButtonTrigger } from './ChartsToolbarRangeButtonTrigger';
-import { type RangeButtonValue } from './rangeButtonValueToZoom';
 import { type ChartsSlotsPro } from '../internals/material';
+import { type RangeButtonConfig } from './rangeButtonValueToZoom';
 import {
   type ChartsToolbarPrintExportOptions,
   ChartsToolbarPrintExportTrigger,
@@ -31,22 +31,7 @@ import {
 } from './ChartsToolbarImageExportTrigger';
 
 export type { RangeButtonFunctionParams } from './rangeButtonValueToZoom';
-
-export interface RangeButtonConfig {
-  /**
-   * The label displayed on the button (e.g., "1M", "3M", "1Y").
-   */
-  label: string;
-  /**
-   * The range value.
-   *
-   * - `{ unit, step }` — A calendar interval from the end of the data (e.g., `{ unit: 'month', step: 3 }` for 3 months).
-   * - `[start, end]` — An absolute date range.
-   * - `(params) => { start, end }` — A function that receives axis context (`scaleType`, `data`, `domain`) and returns zoom percentages (0-100).
-   * - `null` — Resets zoom to show all data.
-   */
-  value: RangeButtonValue;
-}
+export type { RangeButtonConfig } from './rangeButtonValueToZoom';
 
 export interface ChartsToolbarProProps extends ChartsToolbarProps {
   printOptions?: ChartsToolbarPrintExportOptions;

--- a/packages/x-charts-pro/src/ChartsToolbarPro/rangeButtonValueToZoom.ts
+++ b/packages/x-charts-pro/src/ChartsToolbarPro/rangeButtonValueToZoom.ts
@@ -243,3 +243,23 @@ function computeIntervalStart(
       return 0;
   }
 }
+
+/**
+ * Configuration for a range button shown in the toolbar.
+ */
+export interface RangeButtonConfig {
+  /**
+   * The label displayed on the button (e.g., "1M", "3M", "1Y").
+   * Also used to match `initialRangeKey` for computing the initial zoom.
+   */
+  label: string;
+  /**
+   * The range value.
+   *
+   * - `{ unit, step }` — A calendar interval from the end of the data (e.g., `{ unit: 'month', step: 3 }` for 3 months).
+   * - `[start, end]` — An absolute date range.
+   * - `(params) => { start, end }` — A function that receives axis context (`scaleType`, `data`, `domain`) and returns zoom percentages (0-100).
+   * - `null` — Resets zoom to show all data.
+   */
+  value: RangeButtonValue;
+}

--- a/packages/x-charts-pro/src/Heatmap/Heatmap.tsx
+++ b/packages/x-charts-pro/src/Heatmap/Heatmap.tsx
@@ -271,6 +271,11 @@ Heatmap.propTypes = {
    */
   id: PropTypes.string,
   /**
+   * The label of the range button that corresponds to the initial zoom state.
+   * Used to pre-select that button on mount.
+   */
+  initialRangeKey: PropTypes.string,
+  /**
    * The list of zoom data related to each axis.
    * Used to initialize the zoom in a specific configuration without controlling it.
    */

--- a/packages/x-charts-pro/src/Heatmap/Heatmap.tsx
+++ b/packages/x-charts-pro/src/Heatmap/Heatmap.tsx
@@ -272,7 +272,8 @@ Heatmap.propTypes = {
   id: PropTypes.string,
   /**
    * The label of the range button that corresponds to the initial zoom state.
-   * Used to pre-select that button on mount.
+   * When set together with `rangeButtons`, automatically computes `initialZoom` from the matching button.
+   * Also pre-selects that button in the toolbar on mount.
    */
   initialRangeKey: PropTypes.string,
   /**
@@ -343,6 +344,33 @@ Heatmap.propTypes = {
    * @param {ZoomData[]} zoomData Updated zoom data.
    */
   onZoomChange: PropTypes.func,
+  /**
+   * Configuration for range buttons.
+   * Used together with `initialRangeKey` to compute the initial zoom state automatically.
+   */
+  rangeButtons: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      value: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.instanceOf(Date).isRequired),
+        PropTypes.func,
+        PropTypes.shape({
+          step: PropTypes.number,
+          unit: PropTypes.oneOf([
+            'day',
+            'hour',
+            'microsecond',
+            'millisecond',
+            'minute',
+            'month',
+            'second',
+            'week',
+            'year',
+          ]).isRequired,
+        }),
+      ]),
+    }),
+  ),
   /**
    * The series to display in the bar chart.
    * An array of [[HeatmapSeries]] objects.

--- a/packages/x-charts-pro/src/LineChartPro/LineChartPro.tsx
+++ b/packages/x-charts-pro/src/LineChartPro/LineChartPro.tsx
@@ -76,7 +76,8 @@ const LineChartPro = React.forwardRef(function LineChartPro(
   ref: React.Ref<HTMLDivElement>,
 ) {
   const props = useThemeProps({ props: inProps, name: 'MuiLineChartPro' });
-  const { initialZoom, zoomData, onZoomChange, apiRef, showToolbar, ...other } = props;
+  const { initialZoom, initialRangeKey, zoomData, onZoomChange, apiRef, showToolbar, ...other } =
+    props;
   const {
     chartsWrapperProps,
     chartsContainerProps,
@@ -99,6 +100,7 @@ const LineChartPro = React.forwardRef(function LineChartPro(
   >({
     ...chartsContainerProps,
     initialZoom,
+    initialRangeKey,
     zoomData,
     onZoomChange,
     apiRef,
@@ -323,6 +325,11 @@ LineChartPro.propTypes = {
       }),
     ]).isRequired,
   ),
+  /**
+   * The label of the range button that corresponds to the initial zoom state.
+   * Used to pre-select that button on mount.
+   */
+  initialRangeKey: PropTypes.string,
   /**
    * The list of zoom data related to each axis.
    * Used to initialize the zoom in a specific configuration without controlling it.

--- a/packages/x-charts-pro/src/LineChartPro/LineChartPro.tsx
+++ b/packages/x-charts-pro/src/LineChartPro/LineChartPro.tsx
@@ -328,7 +328,8 @@ LineChartPro.propTypes = {
   ),
   /**
    * The label of the range button that corresponds to the initial zoom state.
-   * Used to pre-select that button on mount.
+   * When set together with `rangeButtons`, automatically computes `initialZoom` from the matching button.
+   * Also pre-selects that button in the toolbar on mount.
    */
   initialRangeKey: PropTypes.string,
   /**
@@ -424,6 +425,33 @@ LineChartPro.propTypes = {
    * @param {ZoomData[]} zoomData Updated zoom data.
    */
   onZoomChange: PropTypes.func,
+  /**
+   * Configuration for range buttons.
+   * Used together with `initialRangeKey` to compute the initial zoom state automatically.
+   */
+  rangeButtons: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      value: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.instanceOf(Date).isRequired),
+        PropTypes.func,
+        PropTypes.shape({
+          step: PropTypes.number,
+          unit: PropTypes.oneOf([
+            'day',
+            'hour',
+            'microsecond',
+            'millisecond',
+            'minute',
+            'month',
+            'second',
+            'week',
+            'year',
+          ]).isRequired,
+        }),
+      ]),
+    }),
+  ),
   /**
    * The series to display in the line chart.
    * An array of [[LineSeries]] objects.

--- a/packages/x-charts-pro/src/LineChartPro/LineChartPro.tsx
+++ b/packages/x-charts-pro/src/LineChartPro/LineChartPro.tsx
@@ -104,6 +104,7 @@ const LineChartPro = React.forwardRef(function LineChartPro(
     zoomData,
     onZoomChange,
     apiRef,
+    rangeButtons: props.slotProps?.toolbar?.rangeButtons,
     plugins: LINE_CHART_PRO_PLUGINS,
   });
 

--- a/packages/x-charts-pro/src/ScatterChartPro/ScatterChartPro.tsx
+++ b/packages/x-charts-pro/src/ScatterChartPro/ScatterChartPro.tsx
@@ -336,7 +336,8 @@ ScatterChartPro.propTypes = {
   ),
   /**
    * The label of the range button that corresponds to the initial zoom state.
-   * Used to pre-select that button on mount.
+   * When set together with `rangeButtons`, automatically computes `initialZoom` from the matching button.
+   * Also pre-selects that button in the toolbar on mount.
    */
   initialRangeKey: PropTypes.string,
   /**
@@ -418,6 +419,33 @@ ScatterChartPro.propTypes = {
    * @param {ZoomData[]} zoomData Updated zoom data.
    */
   onZoomChange: PropTypes.func,
+  /**
+   * Configuration for range buttons.
+   * Used together with `initialRangeKey` to compute the initial zoom state automatically.
+   */
+  rangeButtons: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      value: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.instanceOf(Date).isRequired),
+        PropTypes.func,
+        PropTypes.shape({
+          step: PropTypes.number,
+          unit: PropTypes.oneOf([
+            'day',
+            'hour',
+            'microsecond',
+            'millisecond',
+            'minute',
+            'month',
+            'second',
+            'week',
+            'year',
+          ]).isRequired,
+        }),
+      ]),
+    }),
+  ),
   /**
    * The type of renderer to use for the scatter plot.
    * - `svg-single`: Renders every scatter item in a `<circle />` element.

--- a/packages/x-charts-pro/src/ScatterChartPro/ScatterChartPro.tsx
+++ b/packages/x-charts-pro/src/ScatterChartPro/ScatterChartPro.tsx
@@ -86,7 +86,8 @@ const ScatterChartPro = React.forwardRef(function ScatterChartPro(
   ref: React.Ref<HTMLDivElement>,
 ) {
   const props = useThemeProps({ props: inProps, name: 'MuiScatterChartPro' });
-  const { initialZoom, zoomData, onZoomChange, apiRef, showToolbar, ...other } = props;
+  const { initialZoom, initialRangeKey, zoomData, onZoomChange, apiRef, showToolbar, ...other } =
+    props;
   const {
     chartsWrapperProps,
     chartsContainerProps,
@@ -104,6 +105,7 @@ const ScatterChartPro = React.forwardRef(function ScatterChartPro(
   >({
     ...chartsContainerProps,
     initialZoom,
+    initialRangeKey,
     zoomData,
     onZoomChange,
     apiRef,
@@ -331,6 +333,11 @@ ScatterChartPro.propTypes = {
       }),
     ]).isRequired,
   ),
+  /**
+   * The label of the range button that corresponds to the initial zoom state.
+   * Used to pre-select that button on mount.
+   */
+  initialRangeKey: PropTypes.string,
   /**
    * The list of zoom data related to each axis.
    * Used to initialize the zoom in a specific configuration without controlling it.

--- a/packages/x-charts-pro/src/ScatterChartPro/ScatterChartPro.tsx
+++ b/packages/x-charts-pro/src/ScatterChartPro/ScatterChartPro.tsx
@@ -109,6 +109,7 @@ const ScatterChartPro = React.forwardRef(function ScatterChartPro(
     zoomData,
     onZoomChange,
     apiRef,
+    rangeButtons: props.slotProps?.toolbar?.rangeButtons,
     plugins: SCATTER_CHART_PRO_PLUGINS,
   });
 

--- a/packages/x-charts-pro/src/internals/plugins/useChartProZoom/useChartProZoom.ts
+++ b/packages/x-charts-pro/src/internals/plugins/useChartProZoom/useChartProZoom.ts
@@ -24,6 +24,7 @@ import { useZoomOnBrush } from './gestureHooks/useZoomOnBrush';
 import { useZoomOnDoubleTapReset } from './gestureHooks/useZoomOnDoubleTapReset';
 import { initializeZoomInteractionConfig } from './initializeZoomInteractionConfig';
 import { initializeZoomData } from './initializeZoomData';
+import { rangeButtonValueToZoom } from '../../../ChartsToolbarPro/rangeButtonValueToZoom';
 
 export const useChartProZoom: ChartPlugin<UseChartProZoomSignature> = (pluginData) => {
   const { store, params } = pluginData;
@@ -233,18 +234,90 @@ useChartProZoom.params = {
   onZoomChange: true,
   zoomData: true,
   zoomInteractionConfig: true,
+  rangeButtons: true,
 };
 
 useChartProZoom.getInitialState = (params) => {
-  const { initialZoom, initialRangeKey, zoomData, defaultizedXAxis, defaultizedYAxis } = params;
+  const {
+    initialZoom,
+    initialRangeKey,
+    zoomData,
+    defaultizedXAxis,
+    defaultizedYAxis,
+    rangeButtons,
+  } = params;
 
   const optionsLookup = {
     ...createZoomLookup('x')(defaultizedXAxis),
     ...createZoomLookup('y')(defaultizedYAxis),
   };
-  const userZoomData =
-    // eslint-disable-next-line no-nested-ternary
-    zoomData !== undefined ? zoomData : initialZoom !== undefined ? initialZoom : undefined;
+
+  let userZoomData: readonly ZoomData[] | undefined;
+
+  // Priority order:
+  // 1. Controlled zoom (zoomData prop)
+  if (zoomData !== undefined) {
+    userZoomData = zoomData;
+  }
+  // 2. Explicit initial zoom
+  else if (initialZoom !== undefined) {
+    userZoomData = initialZoom;
+  }
+  // 3. Initial range key — compute zoom from the matching range button
+  else if (initialRangeKey !== undefined && rangeButtons && rangeButtons.length > 0) {
+    const rangeButton = rangeButtons.find((button) => button.label === initialRangeKey);
+    // Find the first x-axis that has zoom enabled
+    const zoomableXAxis = defaultizedXAxis.find((axis) => optionsLookup[axis.id]);
+
+    if (rangeButton && zoomableXAxis) {
+      const { data: axisData, scaleType } = zoomableXAxis;
+      const isOrdinal = scaleType === 'band' || scaleType === 'point';
+
+      let domain: { min: number; max: number } | undefined;
+
+      if (isOrdinal) {
+        domain = { min: 0, max: (axisData?.length ?? 1) - 1 };
+      } else if (axisData && axisData.length >= 2) {
+        let min = Infinity;
+        let max = -Infinity;
+        for (const val of axisData) {
+          const n = Number(val);
+          // eslint-disable-next-line no-restricted-globals
+          if (!isNaN(n)) {
+            if (n < min) {
+              min = n;
+            }
+            if (n > max) {
+              max = n;
+            }
+          }
+        }
+        if (Number.isFinite(min) && Number.isFinite(max)) {
+          domain = { min, max };
+        }
+      }
+
+      if (domain) {
+        try {
+          const zoom = rangeButtonValueToZoom(rangeButton.value, {
+            scaleType: scaleType ?? 'linear',
+            data: axisData,
+            domain,
+          });
+          userZoomData = [
+            {
+              axisId: zoomableXAxis.id,
+              start: zoom.start,
+              end: zoom.end,
+            },
+          ];
+        } catch {
+          // Fall through to default if computation fails
+        }
+      }
+    }
+  }
+  // 4. Default (full data range)
 
   return {
     zoom: {

--- a/packages/x-charts-pro/src/internals/plugins/useChartProZoom/useChartProZoom.ts
+++ b/packages/x-charts-pro/src/internals/plugins/useChartProZoom/useChartProZoom.ts
@@ -33,7 +33,7 @@ export const useChartProZoom: ChartPlugin<UseChartProZoomSignature> = (pluginDat
     zoomInteractionConfig,
   } = params;
 
-  const onZoomChange = useEventCallback(onZoomChangeProp ?? (() => { }));
+  const onZoomChange = useEventCallback(onZoomChangeProp ?? (() => {}));
   const optionsLookup = store.use(selectorChartZoomOptionsLookup);
 
   useEffectAfterFirstRender(() => {

--- a/packages/x-charts-pro/src/internals/plugins/useChartProZoom/useChartProZoom.ts
+++ b/packages/x-charts-pro/src/internals/plugins/useChartProZoom/useChartProZoom.ts
@@ -33,7 +33,7 @@ export const useChartProZoom: ChartPlugin<UseChartProZoomSignature> = (pluginDat
     zoomInteractionConfig,
   } = params;
 
-  const onZoomChange = useEventCallback(onZoomChangeProp ?? (() => {}));
+  const onZoomChange = useEventCallback(onZoomChangeProp ?? (() => { }));
   const optionsLookup = store.use(selectorChartZoomOptionsLookup);
 
   useEffectAfterFirstRender(() => {
@@ -229,13 +229,14 @@ export const useChartProZoom: ChartPlugin<UseChartProZoomSignature> = (pluginDat
 
 useChartProZoom.params = {
   initialZoom: true,
+  initialRangeKey: true,
   onZoomChange: true,
   zoomData: true,
   zoomInteractionConfig: true,
 };
 
 useChartProZoom.getInitialState = (params) => {
-  const { initialZoom, zoomData, defaultizedXAxis, defaultizedYAxis } = params;
+  const { initialZoom, initialRangeKey, zoomData, defaultizedXAxis, defaultizedYAxis } = params;
 
   const optionsLookup = {
     ...createZoomLookup('x')(defaultizedXAxis),
@@ -254,7 +255,7 @@ useChartProZoom.getInitialState = (params) => {
         params.zoomInteractionConfig,
         optionsLookup,
       ),
-      activeRangeButtonKey: null,
+      activeRangeButtonKey: initialRangeKey ?? null,
     },
   };
 };

--- a/packages/x-charts-pro/src/internals/plugins/useChartProZoom/useChartProZoom.types.ts
+++ b/packages/x-charts-pro/src/internals/plugins/useChartProZoom/useChartProZoom.types.ts
@@ -32,6 +32,11 @@ export interface UseChartProZoomParameters {
    * Configuration for zoom interactions.
    */
   zoomInteractionConfig?: ZoomInteractionConfig;
+  /**
+   * The label of the range button that corresponds to the initial zoom state.
+   * Used to pre-select that button on mount.
+   */
+  initialRangeKey?: string;
 }
 
 export type UseChartProZoomDefaultizedParameters = UseChartProZoomParameters &

--- a/packages/x-charts-pro/src/internals/plugins/useChartProZoom/useChartProZoom.types.ts
+++ b/packages/x-charts-pro/src/internals/plugins/useChartProZoom/useChartProZoom.types.ts
@@ -11,6 +11,7 @@ import {
   type ZoomInteractionConfig,
   type DefaultizedZoomInteractionConfig,
 } from './ZoomInteractionConfig.types';
+import type { RangeButtonConfig } from '../../../ChartsToolbarPro/rangeButtonValueToZoom';
 
 export interface UseChartProZoomParameters {
   /**
@@ -34,9 +35,15 @@ export interface UseChartProZoomParameters {
   zoomInteractionConfig?: ZoomInteractionConfig;
   /**
    * The label of the range button that corresponds to the initial zoom state.
-   * Used to pre-select that button on mount.
+   * When set together with `rangeButtons`, automatically computes `initialZoom` from the matching button.
+   * Also pre-selects that button in the toolbar on mount.
    */
   initialRangeKey?: string;
+  /**
+   * Configuration for range buttons.
+   * Used together with `initialRangeKey` to compute the initial zoom state automatically.
+   */
+  rangeButtons?: readonly RangeButtonConfig[];
 }
 
 export type UseChartProZoomDefaultizedParameters = UseChartProZoomParameters &


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

## Changelog
- [charts-pro] Add `initialRangeKey` prop to range buttons to reflect the initial zoom selection in the toolbar.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
