### PR TITLE
[pickers] Support `K` and `k` hour format tokens

### DIFF
--- a/docs/data/date-pickers/adapters-locale/adapters-locale.md
+++ b/docs/data/date-pickers/adapters-locale/adapters-locale.md
@@ -164,7 +164,7 @@ Here is the list of the currently supported formats:
 - The hours
   - ✅ 0-based 12-hours values (for example, `03`)
   - ✅ 0-based 24-hours values (for example, `15`)
-  - ❌ 1-based values (for example, `24` instead of `00`)
+  - ⚠️ 1-based values are only supported with date-fns (for example, `24` instead of `00`)
 
 - The minutes
 

--- a/docs/data/date-pickers/adapters-locale/adapters-locale.md
+++ b/docs/data/date-pickers/adapters-locale/adapters-locale.md
@@ -164,7 +164,7 @@ Here is the list of the currently supported formats:
 - The hours
   - ✅ 0-based 12-hours values (for example, `03`)
   - ✅ 0-based 24-hours values (for example, `15`)
-  - ⚠️ 1-based values are only supported with date-fns (for example, `24` instead of `00`)
+  - ⚠️ 1-based values are currently only supported with the date-fns and Moment.js adapters (for example, `24` instead of `00`)
 
 - The minutes
 

--- a/packages/x-date-pickers/src/AdapterDateFnsBase/AdapterDateFnsBase.ts
+++ b/packages/x-date-pickers/src/AdapterDateFnsBase/AdapterDateFnsBase.ts
@@ -72,6 +72,8 @@ const formatTokenMap: FieldFormatTokenMap = {
   HH: 'hours',
   h: { sectionType: 'hours', contentType: 'digit', maxLength: 2 },
   hh: 'hours',
+  K: { sectionType: 'hours', contentType: 'digit', maxLength: 2 },
+  KK: 'hours',
 
   // Minutes
   m: { sectionType: 'minutes', contentType: 'digit', maxLength: 2 },

--- a/packages/x-date-pickers/src/AdapterDateFnsBase/AdapterDateFnsBase.ts
+++ b/packages/x-date-pickers/src/AdapterDateFnsBase/AdapterDateFnsBase.ts
@@ -72,8 +72,12 @@ const formatTokenMap: FieldFormatTokenMap = {
   HH: 'hours',
   h: { sectionType: 'hours', contentType: 'digit', maxLength: 2 },
   hh: 'hours',
+  // Hour [0-11] (12h cycle, 0-based) — date-fns only
   K: { sectionType: 'hours', contentType: 'digit', maxLength: 2 },
   KK: 'hours',
+  // Hour [1-24] (24h cycle, 1-based) — date-fns only
+  k: { sectionType: 'hours', contentType: 'digit', maxLength: 2 },
+  kk: 'hours',
 
   // Minutes
   m: { sectionType: 'minutes', contentType: 'digit', maxLength: 2 },

--- a/packages/x-date-pickers/src/AdapterMoment/AdapterMoment.ts
+++ b/packages/x-date-pickers/src/AdapterMoment/AdapterMoment.ts
@@ -44,6 +44,8 @@ const formatTokenMap: FieldFormatTokenMap = {
   HH: 'hours',
   h: { sectionType: 'hours', contentType: 'digit', maxLength: 2 },
   hh: 'hours',
+  k: { sectionType: 'hours', contentType: 'digit', maxLength: 2 },
+  kk: 'hours',
 
   // Minutes
   m: { sectionType: 'minutes', contentType: 'digit', maxLength: 2 },

--- a/packages/x-date-pickers/src/TimeField/tests/editing.TimeField.test.tsx
+++ b/packages/x-date-pickers/src/TimeField/tests/editing.TimeField.test.tsx
@@ -733,7 +733,6 @@ describe('<TimeField /> - Editing', () => {
         defaultValue: adapter.date('2022-06-15T14:12:00'),
       });
       expectFieldValue(view.getSectionsContainer(), '02:12 PM');
-      view.unmount();
     });
 
     it('should render the correct hour value with KK format', () => {
@@ -742,7 +741,6 @@ describe('<TimeField /> - Editing', () => {
         defaultValue: adapter.date('2022-06-15T14:12:00'),
       });
       expectFieldValue(view.getSectionsContainer(), '02:12 PM');
-      view.unmount();
     });
 
     it('should wrap from 11 to 0 when pressing ArrowUp at the maximum', () => {
@@ -752,6 +750,22 @@ describe('<TimeField /> - Editing', () => {
         key: 'ArrowUp',
         expectedValue: '00:12 PM',
       });
+    });
+
+    it('should produce noon (12:xx) when wrapping K from 11 to 0 with PM meridiem', async () => {
+      const onChange = spy();
+
+      const view = renderWithProps({
+        format: 'K:mm aa',
+        defaultValue: adapter.date('2022-06-15T23:12:00'),
+        onChange,
+      });
+
+      await view.selectSectionAsync('hours');
+      fireEvent.keyDown(view.getActiveSection(0), { key: 'ArrowUp' });
+
+      // K=0 + PM = noon (12:xx), not midnight (00:xx)
+      expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2022, 5, 15, 12, 12, 0));
     });
 
     it('should wrap from 0 to 11 when pressing ArrowDown at the minimum', () => {
@@ -790,7 +804,6 @@ describe('<TimeField /> - Editing', () => {
           defaultValue: adapter.date('2022-06-15T00:12:00'),
         });
         expectFieldValue(view.getSectionsContainer(), '24:12');
-        view.unmount();
       });
 
       it('should render the correct hour value with kk format', () => {
@@ -799,7 +812,6 @@ describe('<TimeField /> - Editing', () => {
           defaultValue: adapter.date('2022-06-15T14:12:00'),
         });
         expectFieldValue(view.getSectionsContainer(), '14:12');
-        view.unmount();
       });
 
       it('should wrap from 24 to 1 when pressing ArrowUp at the maximum', () => {

--- a/packages/x-date-pickers/src/TimeField/tests/editing.TimeField.test.tsx
+++ b/packages/x-date-pickers/src/TimeField/tests/editing.TimeField.test.tsx
@@ -1,7 +1,13 @@
 import { spy } from 'sinon';
 import { TimeField } from '@mui/x-date-pickers/TimeField';
 import { fireEvent } from '@mui/internal-test-utils';
-import { expectFieldValue, getCleanedSelectedContent, describeAdapters } from 'test/utils/pickers';
+import {
+  expectFieldValue,
+  getCleanedSelectedContent,
+  describeAdapters,
+  createPickerRenderer,
+  buildFieldInteractions,
+} from 'test/utils/pickers';
 
 describe('<TimeField /> - Editing', () => {
   describeAdapters('key: ArrowDown', TimeField, ({ adapter, testFieldKeyPress }) => {
@@ -709,6 +715,119 @@ describe('<TimeField /> - Editing', () => {
         key: 'ArrowUp',
         minutesStep: 5,
         expectedValue: '05',
+      });
+    });
+  });
+
+  describe('K / KK format tokens (hour 0-11, date-fns only)', () => {
+    const { render, adapter } = createPickerRenderer({ adapterName: 'date-fns' });
+    const { renderWithProps, testFieldKeyPress, testFieldChange } = buildFieldInteractions({
+      render,
+      Component: TimeField,
+    });
+
+    it('should render the correct hour value with K format', () => {
+      // 14:xx = 2 PM → K=2, displayed with leading zero as "02"
+      const view = renderWithProps({
+        format: 'K:mm aa',
+        defaultValue: adapter.date('2022-06-15T14:12:00'),
+      });
+      expectFieldValue(view.getSectionsContainer(), '02:12 PM');
+      view.unmount();
+    });
+
+    it('should render the correct hour value with KK format', () => {
+      const view = renderWithProps({
+        format: 'KK:mm aa',
+        defaultValue: adapter.date('2022-06-15T14:12:00'),
+      });
+      expectFieldValue(view.getSectionsContainer(), '02:12 PM');
+      view.unmount();
+    });
+
+    it('should wrap from 11 to 0 when pressing ArrowUp at the maximum', () => {
+      testFieldKeyPress({
+        format: 'K:mm aa',
+        defaultValue: adapter.date('2022-06-15T23:12:00'),
+        key: 'ArrowUp',
+        expectedValue: '00:12 PM',
+      });
+    });
+
+    it('should wrap from 0 to 11 when pressing ArrowDown at the minimum', () => {
+      testFieldKeyPress({
+        format: 'K:mm aa',
+        defaultValue: adapter.date('2022-06-15T12:12:00'),
+        key: 'ArrowDown',
+        expectedValue: '11:12 PM',
+      });
+    });
+
+    it('should accept typed digit input for K format', () => {
+      testFieldChange({
+        format: 'K:mm aa',
+        keyStrokes: [
+          // "1" stays in the section because "10" and "11" are still valid
+          { value: '1', expected: '01:mm aa' },
+          // "1" again → K=11 (maximum), commits and advances to minutes
+          { value: '1', expected: '11:mm aa' },
+        ],
+      });
+    });
+  });
+
+  (['date-fns', 'moment'] as const).forEach((adapterName) => {
+    describe(`k / kk format tokens (hour 1-24, ${adapterName})`, () => {
+      const { render, adapter } = createPickerRenderer({ adapterName });
+      const { renderWithProps, testFieldKeyPress, testFieldChange } = buildFieldInteractions({
+        render,
+        Component: TimeField,
+      });
+
+      it('should render 24 for midnight with k format', () => {
+        const view = renderWithProps({
+          format: 'k:mm',
+          defaultValue: adapter.date('2022-06-15T00:12:00'),
+        });
+        expectFieldValue(view.getSectionsContainer(), '24:12');
+        view.unmount();
+      });
+
+      it('should render the correct hour value with kk format', () => {
+        const view = renderWithProps({
+          format: 'kk:mm',
+          defaultValue: adapter.date('2022-06-15T14:12:00'),
+        });
+        expectFieldValue(view.getSectionsContainer(), '14:12');
+        view.unmount();
+      });
+
+      it('should wrap from 24 to 1 when pressing ArrowUp at the maximum', () => {
+        testFieldKeyPress({
+          format: 'k:mm',
+          defaultValue: adapter.date('2022-06-15T00:12:00'),
+          key: 'ArrowUp',
+          expectedValue: '01:12',
+        });
+      });
+
+      it('should wrap from 1 to 24 when pressing ArrowDown at the minimum', () => {
+        testFieldKeyPress({
+          format: 'k:mm',
+          defaultValue: adapter.date('2022-06-15T01:12:00'),
+          key: 'ArrowDown',
+          expectedValue: '24:12',
+        });
+      });
+
+      it('should accept two-digit input for kk format', () => {
+        testFieldChange({
+          format: 'kk:mm',
+          keyStrokes: [
+            { value: '1', expected: '01:mm' },
+            { value: '4', expected: '14:mm' },
+          ],
+        });
       });
     });
   });

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.test.tsx
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.test.tsx
@@ -79,6 +79,12 @@ describe('useField utility functions', () => {
       expect(result.maximum).to.equal(12);
     });
 
+    it('should return correct boundaries for "hh" format (hour 1-12, padded)', () => {
+      const result = boundaries.hours({ currentDate: null, format: 'hh', contentType: 'digit' });
+      expect(result.minimum).to.equal(1);
+      expect(result.maximum).to.equal(12);
+    });
+
     it('should return correct boundaries for "K" format (hour 0-11)', () => {
       const result = boundaries.hours({ currentDate: null, format: 'K', contentType: 'digit' });
       expect(result.minimum).to.equal(0);
@@ -93,6 +99,12 @@ describe('useField utility functions', () => {
 
     it('should return correct boundaries for "H" format (hour 0-23)', () => {
       const result = boundaries.hours({ currentDate: null, format: 'H', contentType: 'digit' });
+      expect(result.minimum).to.equal(0);
+      expect(result.maximum).to.equal(23);
+    });
+
+    it('should return correct boundaries for "HH" format (hour 0-23, padded)', () => {
+      const result = boundaries.hours({ currentDate: null, format: 'HH', contentType: 'digit' });
       expect(result.minimum).to.equal(0);
       expect(result.maximum).to.equal(23);
     });

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.test.tsx
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.test.tsx
@@ -1,8 +1,8 @@
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import {
   getSectionVisibleValue,
-  parseSelectedSections,
   getSectionsBoundaries,
+  parseSelectedSections,
 } from './useField.utils';
 
 const COMMON_PROPERTIES = {
@@ -66,41 +66,37 @@ describe('useField utility functions', () => {
       expect(parseSelectedSections('year', [])).to.equal(null);
     });
   });
+
   describe('getSectionsBoundaries', () => {
     const adapter = new AdapterDateFns();
     const timezone = 'default';
 
-    it('should return correct boundaries for hours with "h" format', () => {
+    it('should return correct boundaries for "h" format (hour 1-12)', () => {
       const boundaries = getSectionsBoundaries(adapter, DEFAULT_LOCALIZED_DIGITS, timezone);
-      const hoursBoundaries = boundaries.hours({
-        currentDate: null,
-        format: 'h',
-        contentType: 'digit',
-      });
-      expect(hoursBoundaries.minimum).to.equal(1);
-      expect(hoursBoundaries.maximum).to.equal(12);
+      const result = boundaries.hours({ currentDate: null, format: 'h', contentType: 'digit' });
+      expect(result.minimum).to.equal(1);
+      expect(result.maximum).to.equal(12);
     });
 
-    it('should return correct boundaries for hours with "K" format', () => {
+    it('should return correct boundaries for "K" format (hour 0-11)', () => {
       const boundaries = getSectionsBoundaries(adapter, DEFAULT_LOCALIZED_DIGITS, timezone);
-      const hoursBoundaries = boundaries.hours({
-        currentDate: null,
-        format: 'K',
-        contentType: 'digit',
-      });
-      expect(hoursBoundaries.minimum).to.equal(0);
-      expect(hoursBoundaries.maximum).to.equal(11);
+      const result = boundaries.hours({ currentDate: null, format: 'K', contentType: 'digit' });
+      expect(result.minimum).to.equal(0);
+      expect(result.maximum).to.equal(11);
     });
 
-    it('should return correct boundaries for hours with "HH" format', () => {
+    it('should return correct boundaries for "H" format (hour 0-23)', () => {
       const boundaries = getSectionsBoundaries(adapter, DEFAULT_LOCALIZED_DIGITS, timezone);
-      const hoursBoundaries = boundaries.hours({
-        currentDate: null,
-        format: 'HH',
-        contentType: 'digit',
-      });
-      expect(hoursBoundaries.minimum).to.equal(0);
-      expect(hoursBoundaries.maximum).to.equal(23);
+      const result = boundaries.hours({ currentDate: null, format: 'H', contentType: 'digit' });
+      expect(result.minimum).to.equal(0);
+      expect(result.maximum).to.equal(23);
+    });
+
+    it('should return correct boundaries for "k" format (hour 1-24)', () => {
+      const boundaries = getSectionsBoundaries(adapter, DEFAULT_LOCALIZED_DIGITS, timezone);
+      const result = boundaries.hours({ currentDate: null, format: 'k', contentType: 'digit' });
+      expect(result.minimum).to.equal(1);
+      expect(result.maximum).to.equal(24);
     });
   });
 });

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.test.tsx
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.test.tsx
@@ -69,31 +69,27 @@ describe('useField utility functions', () => {
 
   describe('getSectionsBoundaries', () => {
     const adapter = new AdapterDateFns();
-    const timezone = 'default';
+    const boundaries = getSectionsBoundaries(adapter, DEFAULT_LOCALIZED_DIGITS, 'default');
 
     it('should return correct boundaries for "h" format (hour 1-12)', () => {
-      const boundaries = getSectionsBoundaries(adapter, DEFAULT_LOCALIZED_DIGITS, timezone);
       const result = boundaries.hours({ currentDate: null, format: 'h', contentType: 'digit' });
       expect(result.minimum).to.equal(1);
       expect(result.maximum).to.equal(12);
     });
 
     it('should return correct boundaries for "K" format (hour 0-11)', () => {
-      const boundaries = getSectionsBoundaries(adapter, DEFAULT_LOCALIZED_DIGITS, timezone);
       const result = boundaries.hours({ currentDate: null, format: 'K', contentType: 'digit' });
       expect(result.minimum).to.equal(0);
       expect(result.maximum).to.equal(11);
     });
 
     it('should return correct boundaries for "H" format (hour 0-23)', () => {
-      const boundaries = getSectionsBoundaries(adapter, DEFAULT_LOCALIZED_DIGITS, timezone);
       const result = boundaries.hours({ currentDate: null, format: 'H', contentType: 'digit' });
       expect(result.minimum).to.equal(0);
       expect(result.maximum).to.equal(23);
     });
 
     it('should return correct boundaries for "k" format (hour 1-24)', () => {
-      const boundaries = getSectionsBoundaries(adapter, DEFAULT_LOCALIZED_DIGITS, timezone);
       const result = boundaries.hours({ currentDate: null, format: 'k', contentType: 'digit' });
       expect(result.minimum).to.equal(1);
       expect(result.maximum).to.equal(24);

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.test.tsx
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.test.tsx
@@ -1,9 +1,11 @@
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { DEFAULT_LOCALE } from '@mui/x-date-pickers/locales';
 import {
   getSectionVisibleValue,
   getSectionsBoundaries,
   parseSelectedSections,
 } from './useField.utils';
+import { buildSectionsFromFormat } from './buildSectionsFromFormat';
 
 const COMMON_PROPERTIES = {
   startSeparator: '',
@@ -83,6 +85,12 @@ describe('useField utility functions', () => {
       expect(result.maximum).to.equal(11);
     });
 
+    it('should return correct boundaries for "KK" format (hour 0-11, padded)', () => {
+      const result = boundaries.hours({ currentDate: null, format: 'KK', contentType: 'digit' });
+      expect(result.minimum).to.equal(0);
+      expect(result.maximum).to.equal(11);
+    });
+
     it('should return correct boundaries for "H" format (hour 0-23)', () => {
       const result = boundaries.hours({ currentDate: null, format: 'H', contentType: 'digit' });
       expect(result.minimum).to.equal(0);
@@ -93,6 +101,37 @@ describe('useField utility functions', () => {
       const result = boundaries.hours({ currentDate: null, format: 'k', contentType: 'digit' });
       expect(result.minimum).to.equal(1);
       expect(result.maximum).to.equal(24);
+    });
+
+    it('should return correct boundaries for "kk" format (hour 1-24, padded)', () => {
+      const result = boundaries.hours({ currentDate: null, format: 'kk', contentType: 'digit' });
+      expect(result.minimum).to.equal(1);
+      expect(result.maximum).to.equal(24);
+    });
+  });
+
+  describe('buildSectionsFromFormat – formatTokenMap section parsing', () => {
+    const adapter = new AdapterDateFns();
+    const BASE_PARAMS = {
+      adapter,
+      formatDensity: 'dense' as const,
+      isRtl: false,
+      shouldRespectLeadingZeros: false,
+      localeText: DEFAULT_LOCALE,
+      localizedDigits: DEFAULT_LOCALIZED_DIGITS,
+      date: null,
+    };
+
+    it('should parse "KK:mm aa" into [hours, minutes, meridiem] sections', () => {
+      const sections = buildSectionsFromFormat({ ...BASE_PARAMS, format: 'KK:mm aa' });
+      expect(sections.map((s) => s.type)).to.deep.equal(['hours', 'minutes', 'meridiem']);
+      expect(sections[0].format).to.equal('KK');
+    });
+
+    it('should parse "kk:mm" into [hours, minutes] sections', () => {
+      const sections = buildSectionsFromFormat({ ...BASE_PARAMS, format: 'kk:mm' });
+      expect(sections.map((s) => s.type)).to.deep.equal(['hours', 'minutes']);
+      expect(sections[0].format).to.equal('kk');
     });
   });
 });

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.test.tsx
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.test.tsx
@@ -72,21 +72,33 @@ describe('useField utility functions', () => {
 
     it('should return correct boundaries for hours with "h" format', () => {
       const boundaries = getSectionsBoundaries(adapter, DEFAULT_LOCALIZED_DIGITS, timezone);
-      const hoursBoundaries = boundaries.hours({ currentDate: null, format: 'h', contentType: 'digit' });
+      const hoursBoundaries = boundaries.hours({
+        currentDate: null,
+        format: 'h',
+        contentType: 'digit',
+      });
       expect(hoursBoundaries.minimum).to.equal(1);
       expect(hoursBoundaries.maximum).to.equal(12);
     });
 
     it('should return correct boundaries for hours with "K" format', () => {
       const boundaries = getSectionsBoundaries(adapter, DEFAULT_LOCALIZED_DIGITS, timezone);
-      const hoursBoundaries = boundaries.hours({ currentDate: null, format: 'K', contentType: 'digit' });
+      const hoursBoundaries = boundaries.hours({
+        currentDate: null,
+        format: 'K',
+        contentType: 'digit',
+      });
       expect(hoursBoundaries.minimum).to.equal(0);
       expect(hoursBoundaries.maximum).to.equal(11);
     });
 
     it('should return correct boundaries for hours with "HH" format', () => {
       const boundaries = getSectionsBoundaries(adapter, DEFAULT_LOCALIZED_DIGITS, timezone);
-      const hoursBoundaries = boundaries.hours({ currentDate: null, format: 'HH', contentType: 'digit' });
+      const hoursBoundaries = boundaries.hours({
+        currentDate: null,
+        format: 'HH',
+        contentType: 'digit',
+      });
       expect(hoursBoundaries.minimum).to.equal(0);
       expect(hoursBoundaries.maximum).to.equal(23);
     });

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.test.tsx
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.test.tsx
@@ -1,4 +1,9 @@
-import { getSectionVisibleValue, parseSelectedSections } from './useField.utils';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import {
+  getSectionVisibleValue,
+  parseSelectedSections,
+  getSectionsBoundaries,
+} from './useField.utils';
 
 const COMMON_PROPERTIES = {
   startSeparator: '',
@@ -59,6 +64,31 @@ describe('useField utility functions', () => {
   describe('parseSelectedSections', () => {
     it('should return null when selectedSections is not available in sections', () => {
       expect(parseSelectedSections('year', [])).to.equal(null);
+    });
+  });
+  describe('getSectionsBoundaries', () => {
+    const adapter = new AdapterDateFns();
+    const timezone = 'default';
+
+    it('should return correct boundaries for hours with "h" format', () => {
+      const boundaries = getSectionsBoundaries(adapter, DEFAULT_LOCALIZED_DIGITS, timezone);
+      const hoursBoundaries = boundaries.hours({ currentDate: null, format: 'h', contentType: 'digit' });
+      expect(hoursBoundaries.minimum).to.equal(1);
+      expect(hoursBoundaries.maximum).to.equal(12);
+    });
+
+    it('should return correct boundaries for hours with "K" format', () => {
+      const boundaries = getSectionsBoundaries(adapter, DEFAULT_LOCALIZED_DIGITS, timezone);
+      const hoursBoundaries = boundaries.hours({ currentDate: null, format: 'K', contentType: 'digit' });
+      expect(hoursBoundaries.minimum).to.equal(0);
+      expect(hoursBoundaries.maximum).to.equal(11);
+    });
+
+    it('should return correct boundaries for hours with "HH" format', () => {
+      const boundaries = getSectionsBoundaries(adapter, DEFAULT_LOCALIZED_DIGITS, timezone);
+      const hoursBoundaries = boundaries.hours({ currentDate: null, format: 'HH', contentType: 'digit' });
+      expect(hoursBoundaries.minimum).to.equal(0);
+      expect(hoursBoundaries.maximum).to.equal(23);
     });
   });
 });

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.utils.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.utils.ts
@@ -417,14 +417,16 @@ export const getSectionsBoundaries = (
         ) !== lastHourInDay.toString();
 
       if (hasMeridiem) {
-        return {
-          minimum: 1,
-          maximum: Number(
-            removeLocalizedDigits(
-              adapter.formatByString(adapter.startOfDay(today), format),
-              localizedDigits,
-            ),
+        const startValue = Number(
+          removeLocalizedDigits(
+            adapter.formatByString(adapter.startOfDay(today), format),
+            localizedDigits,
           ),
+        );
+
+        return {
+          minimum: startValue === 0 ? 0 : 1,
+          maximum: startValue === 0 ? 11 : startValue,
         };
       }
 

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.utils.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.utils.ts
@@ -410,6 +410,14 @@ export const getSectionsBoundaries = (
     },
     hours: ({ format }) => {
       const lastHourInDay = adapter.getHours(endOfDay);
+
+      const formattedMidnight = Number(
+        removeLocalizedDigits(
+          adapter.formatByString(adapter.startOfDay(today), format),
+          localizedDigits,
+        ),
+      );
+
       const hasMeridiem =
         removeLocalizedDigits(
           adapter.formatByString(adapter.endOfDay(today), format),
@@ -417,23 +425,21 @@ export const getSectionsBoundaries = (
         ) !== lastHourInDay.toString();
 
       if (hasMeridiem) {
-        const startValue = Number(
-          removeLocalizedDigits(
-            adapter.formatByString(adapter.startOfDay(today), format),
-            localizedDigits,
-          ),
-        );
-
-        return {
-          minimum: startValue === 0 ? 0 : 1,
-          maximum: startValue === 0 ? 11 : startValue,
-        };
+        // K/KK format (hour 0-11): midnight formats as 0
+        if (formattedMidnight === 0) {
+          return { minimum: 0, maximum: 11 };
+        }
+        // h/hh format (hour 1-12): midnight formats as 12
+        return { minimum: 1, maximum: formattedMidnight };
       }
 
-      return {
-        minimum: 0,
-        maximum: lastHourInDay,
-      };
+      // k/kk format (hour 1-24): midnight formats as 24 (> lastHourInDay)
+      if (formattedMidnight > lastHourInDay) {
+        return { minimum: 1, maximum: formattedMidnight };
+      }
+
+      // H/HH format (hour 0-23)
+      return { minimum: 0, maximum: lastHourInDay };
     },
     minutes: () => ({
       minimum: 0,

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.utils.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.utils.ts
@@ -418,16 +418,19 @@ export const getSectionsBoundaries = (
         ),
       );
 
-      const hasMeridiem =
+      const formattedEndOfDay = Number(
         removeLocalizedDigits(
           adapter.formatByString(adapter.endOfDay(today), format),
           localizedDigits,
-        ) !== lastHourInDay.toString();
+        ),
+      );
+
+      const hasMeridiem = formattedEndOfDay !== lastHourInDay;
 
       if (hasMeridiem) {
         // K/KK format (hour 0-11): midnight formats as 0
         if (formattedMidnight === 0) {
-          return { minimum: 0, maximum: 11 };
+          return { minimum: 0, maximum: formattedEndOfDay };
         }
         // h/hh format (hour 1-12): midnight formats as 12
         return { minimum: 1, maximum: formattedMidnight };


### PR DESCRIPTION
Adds support for the `'K'/'KK'` (Hour [0-11]) format tokens from date-fns in the field components.

Previously, using KK in a format string (e.g. KK:mm:ss aa) would cause the field to display the literal characters "KK" instead of the hour value, because the token was not registered in AdapterDateFnsBase's formatTokenMap.

Changes:
  - Register K and KK as hours section tokens in AdapterDateFnsBase (covers both `AdapterDateFns` and `AdapterDateFnsV2`)
  - Fix getSectionsBoundaries to return the correct range for K/KK — [0, 11] instead of the `'h'/'hh'` range [1, 12], detected by checking whether midnight formats as 0 vs 12
  - Add unit tests for the boundary logic

The other adapters (Dayjs, Moment, Luxon) do not support `'K'/'KK'` natively (they output the literal characters), so no changes are needed there.

Fixes #21278