### PR TITLE
[scheduler] Prefix element IDs with a unique Scheduler instance ID

### DIFF
--- a/packages/x-scheduler-headless/src/calendar-grid/day-cell/CalendarGridDayCell.tsx
+++ b/packages/x-scheduler-headless/src/calendar-grid/day-cell/CalendarGridDayCell.tsx
@@ -48,6 +48,8 @@ export const CalendarGridDayCell = React.forwardRef(function CalendarGridDayCell
     [index],
   );
 
+  // Associate this cell with its column header, matching the pattern used by DayEvent and TimeEvent.
+  // Any additional aria-labelledby passed by the styled layer (e.g., an "All day" row header) is appended.
   const ariaLabelledBy = [columnHeaderId, elementProps['aria-labelledby']]
     .filter(Boolean)
     .join(' ');

--- a/packages/x-scheduler-headless/src/calendar-grid/day-cell/CalendarGridDayCell.tsx
+++ b/packages/x-scheduler-headless/src/calendar-grid/day-cell/CalendarGridDayCell.tsx
@@ -32,7 +32,13 @@ export const CalendarGridDayCell = React.forwardRef(function CalendarGridDayCell
   } = componentProps;
 
   const adapter = useAdapterContext();
-  const { id: rootId, focusedCell, setFocusedCell, rowTypes, rowsPerType } = useCalendarGridRootContext();
+  const {
+    id: rootId,
+    focusedCell,
+    setFocusedCell,
+    rowTypes,
+    rowsPerType,
+  } = useCalendarGridRootContext();
   const { rowIndex } = useCalendarGridDayRowContext();
   const { ref: listItemRef, index } = useCompositeListItem();
   const { elementsRef } = useCompositeListContext();

--- a/packages/x-scheduler-headless/src/calendar-grid/day-cell/CalendarGridDayCell.tsx
+++ b/packages/x-scheduler-headless/src/calendar-grid/day-cell/CalendarGridDayCell.tsx
@@ -5,6 +5,8 @@ import { BaseUIComponentProps } from '../../base-ui-copy/utils/types';
 import { useCompositeListItem } from '../../base-ui-copy/composite/list/useCompositeListItem';
 import { useAdapterContext } from '../../use-adapter-context';
 import { useEventCreation } from '../../internals/utils/useEventCreation';
+import { getCalendarGridHeaderCellId } from '../../internals/utils/accessibility-utils';
+import { useCalendarGridRootContext } from '../root/CalendarGridRootContext';
 import { useDayCellDropTarget } from './useDayCellDropTarget';
 import { CalendarGridDayCellContext } from './CalendarGridDayCellContext';
 
@@ -26,8 +28,10 @@ export const CalendarGridDayCell = React.forwardRef(function CalendarGridDayCell
   } = componentProps;
 
   const adapter = useAdapterContext();
+  const { id: rootId } = useCalendarGridRootContext();
   const { ref: listItemRef, index } = useCompositeListItem();
   const dropTargetRef = useDayCellDropTarget({ value, addPropertiesToDroppedEvent });
+  const columnHeaderId = getCalendarGridHeaderCellId(rootId, index);
 
   const eventCreationProps = useEventCreation(() => ({
     surfaceType: 'day-grid',
@@ -44,9 +48,17 @@ export const CalendarGridDayCell = React.forwardRef(function CalendarGridDayCell
     [index],
   );
 
+  const ariaLabelledBy = [columnHeaderId, elementProps['aria-labelledby']]
+    .filter(Boolean)
+    .join(' ');
+
   const element = useRenderElement('div', componentProps, {
     ref: [forwardedRef, dropTargetRef, listItemRef],
-    props: [elementProps, { role: 'gridcell' }, eventCreationProps],
+    props: [
+      elementProps,
+      { role: 'gridcell', 'aria-labelledby': ariaLabelledBy || undefined },
+      eventCreationProps,
+    ],
   });
 
   return (

--- a/packages/x-scheduler-headless/src/internals/index.ts
+++ b/packages/x-scheduler-headless/src/internals/index.ts
@@ -2,4 +2,3 @@ export type { EventDropDataLookup, EventDropData } from '../build-is-valid-drop-
 export { buildIsValidDropTarget } from '../build-is-valid-drop-target';
 export * from './utils';
 export * from './models';
-export { useCalendarGridRootContext } from '../calendar-grid/root/CalendarGridRootContext';

--- a/packages/x-scheduler-headless/src/internals/index.ts
+++ b/packages/x-scheduler-headless/src/internals/index.ts
@@ -2,3 +2,4 @@ export type { EventDropDataLookup, EventDropData } from '../build-is-valid-drop-
 export { buildIsValidDropTarget } from '../build-is-valid-drop-target';
 export * from './utils';
 export * from './models';
+export { useCalendarGridRootContext } from '../calendar-grid/root/CalendarGridRootContext';

--- a/packages/x-scheduler-headless/src/internals/utils/index.ts
+++ b/packages/x-scheduler-headless/src/internals/utils/index.ts
@@ -10,3 +10,4 @@ export * from './TimeoutManager';
 export * from './date-utils';
 export * from './useInitializeApiRef';
 export * from './useEventCreation';
+export * from './accessibility-utils';

--- a/packages/x-scheduler-headless/src/internals/utils/index.ts
+++ b/packages/x-scheduler-headless/src/internals/utils/index.ts
@@ -10,4 +10,3 @@ export * from './TimeoutManager';
 export * from './date-utils';
 export * from './useInitializeApiRef';
 export * from './useEventCreation';
-export * from './accessibility-utils';

--- a/packages/x-scheduler-premium/src/event-calendar-premium/EventCalendarPremium.tsx
+++ b/packages/x-scheduler-premium/src/event-calendar-premium/EventCalendarPremium.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { useThemeProps } from '@mui/material/styles';
 import { useLicenseVerifier, Watermark } from '@mui/x-license/internals';
+import { useId } from '@base-ui/utils/useId';
 import { useExtractEventCalendarParameters } from '@mui/x-scheduler-headless/use-event-calendar';
 import { SchedulerStoreContext } from '@mui/x-scheduler-headless/use-scheduler-store-context';
 import { useInitializeApiRef } from '@mui/x-scheduler-headless/internals';
@@ -54,19 +55,21 @@ const EventCalendarPremium = React.forwardRef(function EventCalendarPremium<
   const { localeText, apiRef, ...other } = forwardedProps;
   useInitializeApiRef(store, apiRef);
 
+  const schedulerId = useId();
+
   const mergedLocaleText = React.useMemo(
     () => ({ ...EVENT_CALENDAR_DEFAULT_LOCALE_TEXT, ...localeText }),
     [localeText],
   );
 
   const calendarStyledContextValue = React.useMemo(
-    () => ({ classes, localeText: mergedLocaleText }),
-    [classes, mergedLocaleText],
+    () => ({ schedulerId, classes, localeText: mergedLocaleText }),
+    [schedulerId, classes, mergedLocaleText],
   );
 
   const dialogStyledContextValue = React.useMemo(
-    () => ({ classes, localeText: mergedLocaleText }),
-    [classes, mergedLocaleText],
+    () => ({ schedulerId, classes, localeText: mergedLocaleText }),
+    [schedulerId, classes, mergedLocaleText],
   );
 
   return (

--- a/packages/x-scheduler-premium/src/event-timeline-premium/EventTimelinePremium.test.tsx
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/EventTimelinePremium.test.tsx
@@ -74,7 +74,7 @@ describe('<EventTimelinePremium />', () => {
       });
       // Check that we have one title cell per resource by counting the cells with IDs
       const resourceTitleCells = baseResources.map((resource) =>
-        document.getElementById(`EventTimelinePremiumTitleCell-${resource.id}`),
+        document.querySelector(`[id$="-EventTimelinePremiumTitleCell-${resource.id}"]`),
       );
       expect(resourceTitleCells.filter(Boolean).length).to.equal(baseResources.length);
     });

--- a/packages/x-scheduler-premium/src/event-timeline-premium/EventTimelinePremium.tsx
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/EventTimelinePremium.tsx
@@ -11,6 +11,7 @@ import {
 } from '@mui/x-scheduler-headless-premium/use-event-timeline-premium';
 import { SchedulerStoreContext } from '@mui/x-scheduler-headless/use-scheduler-store-context';
 import { useInitializeApiRef } from '@mui/x-scheduler-headless/internals';
+import { useId } from '@base-ui/utils/useId';
 import {
   eventDialogSlots,
   EventDialogStyledContext,
@@ -129,19 +130,21 @@ const EventTimelinePremium = React.forwardRef(function EventTimelinePremium<
   const { localeText, resourceColumnLabel, apiRef, ...other } = forwardedProps;
   useInitializeApiRef(store, apiRef);
 
+  const schedulerId = useId();
+
   const mergedLocaleText = React.useMemo(
     () => ({ ...EVENT_TIMELINE_DEFAULT_LOCALE_TEXT, ...localeText }),
     [localeText],
   );
 
   const timelineStyledContextValue = React.useMemo(
-    () => ({ classes, localeText: mergedLocaleText, resourceColumnLabel }),
-    [classes, mergedLocaleText, resourceColumnLabel],
+    () => ({ schedulerId, classes, localeText: mergedLocaleText, resourceColumnLabel }),
+    [schedulerId, classes, mergedLocaleText, resourceColumnLabel],
   );
 
   const dialogStyledContextValue = React.useMemo(
-    () => ({ classes, localeText: mergedLocaleText }),
-    [classes, mergedLocaleText],
+    () => ({ schedulerId, classes, localeText: mergedLocaleText }),
+    [schedulerId, classes, mergedLocaleText],
   );
 
   return (

--- a/packages/x-scheduler-premium/src/event-timeline-premium/EventTimelinePremiumStyledContext.ts
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/EventTimelinePremiumStyledContext.ts
@@ -4,6 +4,7 @@ import type { EventTimelineLocaleText } from '@mui/x-scheduler/models';
 import type { EventTimelinePremiumClasses } from './eventTimelinePremiumClasses';
 
 export interface EventTimelinePremiumStyledContextValue {
+  schedulerId: string | undefined;
   classes: EventTimelinePremiumClasses;
   localeText: EventTimelineLocaleText;
   resourceColumnLabel?: string;

--- a/packages/x-scheduler-premium/src/event-timeline-premium/content/EventTimelinePremiumContent.tsx
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/content/EventTimelinePremiumContent.tsx
@@ -218,6 +218,7 @@ function EventRowContent({
   placeholder: useEventOccurrencesWithTimelinePosition.EventOccurrencePlaceholderWithPosition | null;
 }) {
   const store = useEventTimelinePremiumStoreContext();
+  const { schedulerId } = useEventTimelinePremiumStyledContext();
   const { onOpen: startEditing } = useEventDialogContext();
   const placeholderRef = React.useRef<HTMLDivElement | null>(null);
 
@@ -240,7 +241,7 @@ function EventRowContent({
         <EventDialogTrigger key={occurrence.key} occurrence={occurrence}>
           <EventTimelinePremiumEvent
             occurrence={occurrence}
-            ariaLabelledBy={`TimelineTitleCell-${occurrence.resource}`}
+            ariaLabelledBy={`${schedulerId}-EventTimelinePremiumTitleCell-${occurrence.resource}`}
             variant="regular"
           />
         </EventDialogTrigger>
@@ -249,7 +250,7 @@ function EventRowContent({
         <EventTimelinePremiumEvent
           ref={placeholderRef}
           occurrence={placeholder}
-          ariaLabelledBy={`EventTimelinePremiumTitleCell-${placeholder.resource}`}
+          ariaLabelledBy={`${schedulerId}-EventTimelinePremiumTitleCell-${placeholder.resource}`}
           variant="placeholder"
         />
       )}

--- a/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-title-cell/EventTimelinePremiumTitleCell.tsx
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-title-cell/EventTimelinePremiumTitleCell.tsx
@@ -47,7 +47,7 @@ export default function EventTimelinePremiumTitleCell(props: { resourceId: Sched
 
   // Context hooks
   const store = useEventTimelinePremiumStoreContext();
-  const { classes } = useEventTimelinePremiumStyledContext();
+  const { schedulerId, classes } = useEventTimelinePremiumStyledContext();
 
   // Selector hooks
   const eventColor = useStore(store, schedulerResourceSelectors.defaultEventColor, resourceId);
@@ -60,7 +60,7 @@ export default function EventTimelinePremiumTitleCell(props: { resourceId: Sched
       style={{ '--resource-depth': depth } as React.CSSProperties}
     >
       <EventTimelinePremiumTitleCellRoot
-        id={`EventTimelinePremiumTitleCell-${resourceId}`}
+        id={`${schedulerId}-EventTimelinePremiumTitleCell-${resourceId}`}
         className={classes.titleCell}
         data-palette={eventColor}
       >

--- a/packages/x-scheduler/src/agenda-view/AgendaView.tsx
+++ b/packages/x-scheduler/src/agenda-view/AgendaView.tsx
@@ -149,7 +149,7 @@ export const AgendaView = React.memo(
   ) {
     // Context hooks
     const adapter = useAdapterContext();
-    const { classes } = useEventCalendarStyledContext();
+    const { schedulerId, classes } = useEventCalendarStyledContext();
     const store = useEventCalendarStoreContext();
 
     // Ref hooks
@@ -185,12 +185,12 @@ export const AgendaView = React.memo(
           <AgendaViewRow
             className={classes.agendaViewRow}
             key={date.key}
-            id={`AgendaViewRow-${date.key}`}
-            aria-labelledby={`DayHeaderCell-${date.key}`}
+            id={`${schedulerId}-AgendaViewRow-${date.key}`}
+            aria-labelledby={`${schedulerId}-DayHeaderCell-${date.key}`}
           >
             <DayHeaderCell
               className={classes.agendaViewDayHeaderCell}
-              id={`DayHeaderCell-${date.key}`}
+              id={`${schedulerId}-DayHeaderCell-${date.key}`}
               aria-label={`${adapter.format(date.value, 'weekday')} ${adapter.format(date.value, 'dayOfMonth')}`}
               data-current={adapter.isSameDay(date.value, now) ? '' : undefined}
             >

--- a/packages/x-scheduler/src/event-calendar/EventCalendar.tsx
+++ b/packages/x-scheduler/src/event-calendar/EventCalendar.tsx
@@ -8,6 +8,7 @@ import {
 } from '@mui/x-scheduler-headless/use-event-calendar';
 import { SchedulerStoreContext } from '@mui/x-scheduler-headless/use-scheduler-store-context';
 import { useInitializeApiRef } from '@mui/x-scheduler-headless/internals';
+import { useId } from '@base-ui/utils/useId';
 import { EventCalendarProps } from './EventCalendar.types';
 import { EventDialogProvider } from '../internals/components/event-dialog';
 import { useEventCalendarUtilityClasses } from './eventCalendarClasses';
@@ -35,19 +36,21 @@ const EventCalendar = React.forwardRef(function EventCalendar<
   const { localeText, apiRef, ...other } = forwardedProps;
   useInitializeApiRef(store, apiRef);
 
+  const schedulerId = useId();
+
   const mergedLocaleText = React.useMemo(
     () => ({ ...EVENT_CALENDAR_DEFAULT_LOCALE_TEXT, ...localeText }),
     [localeText],
   );
 
   const calendarStyledContextValue = React.useMemo(
-    () => ({ classes, localeText: mergedLocaleText }),
-    [classes, mergedLocaleText],
+    () => ({ schedulerId, classes, localeText: mergedLocaleText }),
+    [schedulerId, classes, mergedLocaleText],
   );
 
   const dialogStyledContextValue = React.useMemo(
-    () => ({ classes, localeText: mergedLocaleText }),
-    [classes, mergedLocaleText],
+    () => ({ schedulerId, classes, localeText: mergedLocaleText }),
+    [schedulerId, classes, mergedLocaleText],
   );
 
   return (

--- a/packages/x-scheduler/src/event-calendar/EventCalendarStyledContext.ts
+++ b/packages/x-scheduler/src/event-calendar/EventCalendarStyledContext.ts
@@ -4,6 +4,7 @@ import type { EventCalendarClasses } from './eventCalendarClasses';
 import type { EventCalendarLocaleText } from '../models/translations';
 
 export interface EventCalendarStyledContextValue {
+  schedulerId: string | undefined;
   classes: EventCalendarClasses;
   localeText: EventCalendarLocaleText;
 }

--- a/packages/x-scheduler/src/event-calendar/header-toolbar/preferences-menu/PreferencesMenu.tsx
+++ b/packages/x-scheduler/src/event-calendar/header-toolbar/preferences-menu/PreferencesMenu.tsx
@@ -55,7 +55,7 @@ export const PreferencesMenu = React.forwardRef(function PreferencesMenu(
   forwardedRef: React.ForwardedRef<HTMLDivElement>,
 ) {
   // Context hooks
-  const { classes, localeText } = useEventCalendarStyledContext();
+  const { schedulerId, classes, localeText } = useEventCalendarStyledContext();
   const store = useEventCalendarStoreContext();
 
   // Ref hooks
@@ -150,7 +150,7 @@ export const PreferencesMenu = React.forwardRef(function PreferencesMenu(
         className={classes.preferencesMenuButton}
         aria-label={localeText.preferencesMenu}
         onClick={handleClick}
-        aria-controls={open ? 'preferences-menu' : undefined}
+        aria-controls={open ? `${schedulerId}-preferences-menu` : undefined}
         aria-haspopup="true"
         aria-expanded={open ? 'true' : undefined}
       >
@@ -158,7 +158,7 @@ export const PreferencesMenu = React.forwardRef(function PreferencesMenu(
       </IconButton>
       <Menu
         className={classes.preferencesMenuList}
-        id="preferences-menu"
+        id={`${schedulerId}-preferences-menu`}
         anchorEl={anchorEl}
         open={open}
         onClose={handleClose}

--- a/packages/x-scheduler/src/event-calendar/header-toolbar/view-switcher/ViewSwitcher.tsx
+++ b/packages/x-scheduler/src/event-calendar/header-toolbar/view-switcher/ViewSwitcher.tsx
@@ -37,7 +37,7 @@ export const ViewSwitcher = React.forwardRef(function ViewSwitcher(
 
   const containerRef = React.useRef<HTMLElement | null>(null);
   const handleRef = useMergedRefs(forwardedRef, containerRef);
-  const { classes, localeText } = useEventCalendarStyledContext();
+  const { schedulerId, classes, localeText } = useEventCalendarStyledContext();
 
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
@@ -60,8 +60,8 @@ export const ViewSwitcher = React.forwardRef(function ViewSwitcher(
       <Button
         className={classes.viewSwitcherButton}
         size="medium"
-        id="view-switcher-button"
-        aria-controls={open ? 'view-switcher-menu' : undefined}
+        id={`${schedulerId}-view-switcher-button`}
+        aria-controls={open ? `${schedulerId}-view-switcher-menu` : undefined}
         aria-haspopup="true"
         aria-expanded={open ? 'true' : undefined}
         aria-label="Switch View"
@@ -72,13 +72,13 @@ export const ViewSwitcher = React.forwardRef(function ViewSwitcher(
       </Button>
       <Menu
         className={classes.viewSwitcherMenu}
-        id="view-switcher-menu"
+        id={`${schedulerId}-view-switcher-menu`}
         anchorEl={anchorEl}
         open={open}
         onClose={handleMenuClose}
         slotProps={{
           list: {
-            'aria-labelledby': 'view-switcher-button',
+            'aria-labelledby': `${schedulerId}-view-switcher-button`,
             role: 'listbox',
           },
         }}

--- a/packages/x-scheduler/src/internals/components/EventCalendarProvider.tsx
+++ b/packages/x-scheduler/src/internals/components/EventCalendarProvider.tsx
@@ -1,6 +1,7 @@
 'use client';
 import * as React from 'react';
 import { styled } from '@mui/material/styles';
+import { useId } from '@base-ui/utils/useId';
 import { EventCalendarProvider as HeadlessEventCalendarProvider } from '@mui/x-scheduler-headless/event-calendar-provider';
 import { eventCalendarClasses } from '../../event-calendar/eventCalendarClasses';
 import { EventCalendarStyledContext } from '../../event-calendar/EventCalendarStyledContext';
@@ -23,19 +24,28 @@ const StandaloneViewRoot = styled('div', {
   },
 }));
 
-const calendarStyledValue = {
-  classes: eventCalendarClasses,
-  localeText: EVENT_CALENDAR_DEFAULT_LOCALE_TEXT,
-};
-const dialogStyledValue = {
-  classes: eventCalendarClasses,
-  localeText: EVENT_CALENDAR_DEFAULT_LOCALE_TEXT,
-};
-
 export function EventCalendarProvider<TEvent extends object, TResource extends object>(
   props: HeadlessEventCalendarProvider.Props<TEvent, TResource>,
 ) {
   const { children, ...other } = props;
+  const schedulerId = useId();
+
+  const calendarStyledValue = React.useMemo(
+    () => ({
+      schedulerId,
+      classes: eventCalendarClasses,
+      localeText: EVENT_CALENDAR_DEFAULT_LOCALE_TEXT,
+    }),
+    [schedulerId],
+  );
+  const dialogStyledValue = React.useMemo(
+    () => ({
+      schedulerId,
+      classes: eventCalendarClasses,
+      localeText: EVENT_CALENDAR_DEFAULT_LOCALE_TEXT,
+    }),
+    [schedulerId],
+  );
 
   return (
     <HeadlessEventCalendarProvider {...other}>

--- a/packages/x-scheduler/src/internals/components/day-time-grid/DayGridCell.tsx
+++ b/packages/x-scheduler/src/internals/components/day-time-grid/DayGridCell.tsx
@@ -91,7 +91,7 @@ export function DayGridCell(props: DayGridCellProps) {
           '--row-count': rowCount,
         } as React.CSSProperties
       }
-      aria-labelledby={`DayTimeGridHeaderCell-${adapter.getDate(day.value)} ${schedulerId}-DayTimeGridAllDayEventsHeaderCell`}
+      aria-labelledby={`${schedulerId}-DayTimeGridAllDayEventsHeaderCell`}
       role="gridcell"
       data-weekend={isWeekend(adapter, day.value) || undefined}
     >

--- a/packages/x-scheduler/src/internals/components/day-time-grid/DayGridCell.tsx
+++ b/packages/x-scheduler/src/internals/components/day-time-grid/DayGridCell.tsx
@@ -9,10 +9,6 @@ import { useEventOccurrencesWithDayGridPosition } from '@mui/x-scheduler-headles
 import { useEventCalendarStoreContext } from '@mui/x-scheduler-headless/use-event-calendar-store-context';
 import { eventCalendarOccurrencePlaceholderSelectors } from '@mui/x-scheduler-headless/event-calendar-selectors';
 import { schedulerOtherSelectors } from '@mui/x-scheduler-headless/scheduler-selectors';
-import {
-  getCalendarGridHeaderCellId,
-  useCalendarGridRootContext,
-} from '@mui/x-scheduler-headless/internals';
 import { DayGridEvent } from '../event';
 import { EventDialogTrigger } from '../event-dialog';
 import { useEventDialogContext } from '../event-dialog/EventDialog';
@@ -55,14 +51,13 @@ const DayTimeGridAllDayEventContainer = styled('div', {
 });
 
 export function DayGridCell(props: DayGridCellProps) {
-  const { day, row, columnIndex } = props;
+  const { day, row } = props;
 
   // Context hooks
   const adapter = useAdapterContext();
   const store = useEventCalendarStoreContext();
   const { onOpen: startEditing } = useEventDialogContext();
   const { schedulerId, classes } = useEventCalendarStyledContext();
-  const { id: rootId } = useCalendarGridRootContext();
 
   // Ref hooks
   const cellRef = React.useRef<HTMLDivElement | null>(null);
@@ -96,7 +91,7 @@ export function DayGridCell(props: DayGridCellProps) {
           '--row-count': rowCount,
         } as React.CSSProperties
       }
-      aria-labelledby={`${getCalendarGridHeaderCellId(rootId, columnIndex)} ${schedulerId}-DayTimeGridAllDayEventsHeaderCell`}
+      aria-labelledby={`${schedulerId}-DayTimeGridAllDayEventsHeaderCell`}
       role="gridcell"
       data-weekend={isWeekend(adapter, day.value) || undefined}
     >
@@ -128,7 +123,6 @@ export function DayGridCell(props: DayGridCellProps) {
 interface DayGridCellProps {
   day: useEventOccurrencesWithDayGridPosition.DayData;
   row: useEventOccurrencesWithDayGridPosition.ReturnValue;
-  columnIndex: number;
 }
 
 /**

--- a/packages/x-scheduler/src/internals/components/day-time-grid/DayGridCell.tsx
+++ b/packages/x-scheduler/src/internals/components/day-time-grid/DayGridCell.tsx
@@ -9,6 +9,10 @@ import { useEventOccurrencesWithDayGridPosition } from '@mui/x-scheduler-headles
 import { useEventCalendarStoreContext } from '@mui/x-scheduler-headless/use-event-calendar-store-context';
 import { eventCalendarOccurrencePlaceholderSelectors } from '@mui/x-scheduler-headless/event-calendar-selectors';
 import { schedulerOtherSelectors } from '@mui/x-scheduler-headless/scheduler-selectors';
+import {
+  getCalendarGridHeaderCellId,
+  useCalendarGridRootContext,
+} from '@mui/x-scheduler-headless/internals';
 import { DayGridEvent } from '../event';
 import { EventDialogTrigger } from '../event-dialog';
 import { useEventDialogContext } from '../event-dialog/EventDialog';
@@ -51,13 +55,14 @@ const DayTimeGridAllDayEventContainer = styled('div', {
 });
 
 export function DayGridCell(props: DayGridCellProps) {
-  const { day, row } = props;
+  const { day, row, columnIndex } = props;
 
   // Context hooks
   const adapter = useAdapterContext();
   const store = useEventCalendarStoreContext();
   const { onOpen: startEditing } = useEventDialogContext();
   const { schedulerId, classes } = useEventCalendarStyledContext();
+  const { id: rootId } = useCalendarGridRootContext();
 
   // Ref hooks
   const cellRef = React.useRef<HTMLDivElement | null>(null);
@@ -91,7 +96,7 @@ export function DayGridCell(props: DayGridCellProps) {
           '--row-count': rowCount,
         } as React.CSSProperties
       }
-      aria-labelledby={`${schedulerId}-DayTimeGridAllDayEventsHeaderCell`}
+      aria-labelledby={`${getCalendarGridHeaderCellId(rootId, columnIndex)} ${schedulerId}-DayTimeGridAllDayEventsHeaderCell`}
       role="gridcell"
       data-weekend={isWeekend(adapter, day.value) || undefined}
     >
@@ -123,6 +128,7 @@ export function DayGridCell(props: DayGridCellProps) {
 interface DayGridCellProps {
   day: useEventOccurrencesWithDayGridPosition.DayData;
   row: useEventOccurrencesWithDayGridPosition.ReturnValue;
+  columnIndex: number;
 }
 
 /**

--- a/packages/x-scheduler/src/internals/components/day-time-grid/DayGridCell.tsx
+++ b/packages/x-scheduler/src/internals/components/day-time-grid/DayGridCell.tsx
@@ -57,7 +57,7 @@ export function DayGridCell(props: DayGridCellProps) {
   const adapter = useAdapterContext();
   const store = useEventCalendarStoreContext();
   const { onOpen: startEditing } = useEventDialogContext();
-  const { classes } = useEventCalendarStyledContext();
+  const { schedulerId, classes } = useEventCalendarStyledContext();
 
   // Ref hooks
   const cellRef = React.useRef<HTMLDivElement | null>(null);
@@ -91,7 +91,7 @@ export function DayGridCell(props: DayGridCellProps) {
           '--row-count': rowCount,
         } as React.CSSProperties
       }
-      aria-labelledby={`DayTimeGridHeaderCell-${adapter.getDate(day.value)} DayTimeGridAllDayEventsHeaderCell`}
+      aria-labelledby={`DayTimeGridHeaderCell-${adapter.getDate(day.value)} ${schedulerId}-DayTimeGridAllDayEventsHeaderCell`}
       role="gridcell"
       data-weekend={isWeekend(adapter, day.value) || undefined}
     >

--- a/packages/x-scheduler/src/internals/components/day-time-grid/DayTimeGrid.tsx
+++ b/packages/x-scheduler/src/internals/components/day-time-grid/DayTimeGrid.tsx
@@ -321,7 +321,7 @@ export const DayTimeGrid = React.forwardRef(function DayTimeGrid(
 
   // Context hooks
   const adapter = useAdapterContext();
-  const { classes, localeText } = useEventCalendarStyledContext();
+  const { schedulerId, classes, localeText } = useEventCalendarStyledContext();
   const store = useEventCalendarStoreContext();
 
   // Ref hooks
@@ -440,7 +440,7 @@ export const DayTimeGrid = React.forwardRef(function DayTimeGrid(
       >
         <DayTimeGridAllDayEventsHeaderCell
           className={classes.dayTimeGridAllDayEventsHeaderCell}
-          id="DayTimeGridAllDayEventsHeaderCell"
+          id={`${schedulerId}-DayTimeGridAllDayEventsHeaderCell`}
           role="columnheader"
         >
           {localeText.allDay}

--- a/packages/x-scheduler/src/internals/components/day-time-grid/DayTimeGrid.tsx
+++ b/packages/x-scheduler/src/internals/components/day-time-grid/DayTimeGrid.tsx
@@ -452,8 +452,8 @@ export const DayTimeGrid = React.forwardRef(function DayTimeGrid(
           role="row"
           className={classes.dayTimeGridAllDayEventsRow}
         >
-          {occurrences.days.map((day) => (
-            <DayGridCell key={day.key} day={day} row={occurrences} />
+          {occurrences.days.map((day, index) => (
+            <DayGridCell key={day.key} day={day} row={occurrences} columnIndex={index} />
           ))}
         </DayTimeGridAllDayEventsRow>
         <div className={classes.dayTimeGridScrollablePlaceholder} />

--- a/packages/x-scheduler/src/internals/components/day-time-grid/DayTimeGrid.tsx
+++ b/packages/x-scheduler/src/internals/components/day-time-grid/DayTimeGrid.tsx
@@ -452,8 +452,8 @@ export const DayTimeGrid = React.forwardRef(function DayTimeGrid(
           role="row"
           className={classes.dayTimeGridAllDayEventsRow}
         >
-          {occurrences.days.map((day, index) => (
-            <DayGridCell key={day.key} day={day} row={occurrences} columnIndex={index} />
+          {occurrences.days.map((day) => (
+            <DayGridCell key={day.key} day={day} row={occurrences} />
           ))}
         </DayTimeGridAllDayEventsRow>
         <div className={classes.dayTimeGridScrollablePlaceholder} />

--- a/packages/x-scheduler/src/internals/components/event-dialog/EventDialog.tsx
+++ b/packages/x-scheduler/src/internals/components/event-dialog/EventDialog.tsx
@@ -125,7 +125,7 @@ export const EventDialogContent = React.forwardRef(function EventDialogContent(
   const { style, anchorRef, occurrence, onClose, open, ...other } = props;
   // Context hooks
   const store = useSchedulerStoreContext();
-  const { classes } = useEventDialogStyledContext();
+  const { schedulerId, classes } = useEventDialogStyledContext();
 
   // Selector hooks
   const isEventReadOnly = useStore(store, schedulerEventSelectors.isReadOnly, occurrence.id);
@@ -139,7 +139,7 @@ export const EventDialogContent = React.forwardRef(function EventDialogContent(
       open={open}
       onClose={onClose}
       PaperComponent={PaperComponent}
-      aria-labelledby="event-dialog-title"
+      aria-labelledby={`${schedulerId}-event-dialog-title`}
       aria-modal="false"
       className={classes.eventDialog}
       slotProps={{

--- a/packages/x-scheduler/src/internals/components/event-dialog/EventDialogStyledContext.ts
+++ b/packages/x-scheduler/src/internals/components/event-dialog/EventDialogStyledContext.ts
@@ -4,6 +4,7 @@ import type { EventDialogClasses } from './eventDialogClasses';
 import type { EventDialogLocaleText } from '../../../models/translations';
 
 export interface EventDialogStyledContextValue {
+  schedulerId: string | undefined;
   classes: EventDialogClasses;
   localeText: EventDialogLocaleText;
 }

--- a/packages/x-scheduler/src/internals/components/event-dialog/FormContent.tsx
+++ b/packages/x-scheduler/src/internals/components/event-dialog/FormContent.tsx
@@ -100,7 +100,7 @@ export function FormContent(props: FormContentProps) {
 
   // Context hooks
   const adapter = useAdapterContext();
-  const { classes, localeText } = useEventDialogStyledContext();
+  const { schedulerId, classes, localeText } = useEventDialogStyledContext();
   const store = useSchedulerStoreContext();
 
   // Selector hooks
@@ -239,7 +239,7 @@ export function FormContent(props: FormContentProps) {
       <EventDialogForm onSubmit={handleSubmit} className={classes.eventDialogForm}>
         <EventDialogHeader onClose={onClose} dragHandlerRef={dragHandlerRef}>
           <span
-            id="event-dialog-title"
+            id={`${schedulerId}-event-dialog-title`}
             style={{ position: 'absolute', width: 0, height: 0, overflow: 'hidden' }}
           >
             {occurrence.title}
@@ -265,13 +265,13 @@ export function FormContent(props: FormContentProps) {
           <EventDialogTabsContainer className={classes.eventDialogTabsContainer}>
             <EventDialogTabs value={tabValue} onChange={handleTabChange}>
               <Tab
-                id="general-tab"
+                id={`${schedulerId}-general-tab`}
                 className={classes.eventDialogTab}
                 label={localeText.generalTabLabel}
                 value="general"
               />
               <Tab
-                id="recurrence-tab"
+                id={`${schedulerId}-recurrence-tab`}
                 className={classes.eventDialogTab}
                 label={localeText.recurrenceTabLabel}
                 value="recurrence"

--- a/packages/x-scheduler/src/internals/components/event-dialog/GeneralTab.tsx
+++ b/packages/x-scheduler/src/internals/components/event-dialog/GeneralTab.tsx
@@ -80,7 +80,7 @@ export function GeneralTab(props: GeneralTabProps) {
 
   // Context hooks
   const adapter = useAdapterContext();
-  const { classes, localeText } = useEventDialogStyledContext();
+  const { schedulerId, classes, localeText } = useEventDialogStyledContext();
   const store = useSchedulerStoreContext();
 
   // Selector hooks
@@ -146,8 +146,8 @@ export function GeneralTab(props: GeneralTabProps) {
   return (
     <EventDialogTabPanel
       role="tabpanel"
-      id="general-tabpanel"
-      aria-labelledby="general-tab"
+      id={`${schedulerId}-general-tabpanel`}
+      aria-labelledby={`${schedulerId}-general-tab`}
       className={classes.eventDialogTabPanel}
       hidden={value !== 'general'}
     >
@@ -221,7 +221,7 @@ export function GeneralTab(props: GeneralTabProps) {
           <AllDayFormControlLabel
             control={
               <Switch
-                id="enable-all-day-switch"
+                id={`${schedulerId}-enable-all-day-switch`}
                 checked={controlled.allDay}
                 onChange={(event) => handleToggleAllDay(event.target.checked)}
                 disabled={isPropertyReadOnly('allDay')}

--- a/packages/x-scheduler/src/internals/components/event-dialog/ReadonlyContent.tsx
+++ b/packages/x-scheduler/src/internals/components/event-dialog/ReadonlyContent.tsx
@@ -125,7 +125,7 @@ export default function ReadonlyContent(props: ReadonlyContentProps) {
 
   // Context hooks
   const adapter = useAdapterContext();
-  const { classes, localeText } = useEventDialogStyledContext();
+  const { schedulerId, classes, localeText } = useEventDialogStyledContext();
   const store = useSchedulerStoreContext();
 
   // Selector hooks
@@ -157,7 +157,7 @@ export default function ReadonlyContent(props: ReadonlyContentProps) {
       <EventDialogHeader onClose={onClose}>
         <EventDialogTitle
           variant="h6"
-          id="draggable-dialog-title"
+          id={`${schedulerId}-draggable-dialog-title`}
           className={classes.eventDialogTitle}
         >
           {occurrence.title}

--- a/packages/x-scheduler/src/internals/components/event-dialog/RecurrenceTab.tsx
+++ b/packages/x-scheduler/src/internals/components/event-dialog/RecurrenceTab.tsx
@@ -176,7 +176,7 @@ export function RecurrenceTab(props: RecurrenceTabProps) {
 
   // Context hooks
   const adapter = useAdapterContext();
-  const { classes, localeText } = useEventDialogStyledContext();
+  const { schedulerId, classes, localeText } = useEventDialogStyledContext();
   const store = useSchedulerStoreContext();
 
   // Selector hooks
@@ -416,18 +416,18 @@ export function RecurrenceTab(props: RecurrenceTabProps) {
   return (
     <EventDialogTabPanel
       role="tabpanel"
-      id="recurrence-tabpanel"
-      aria-labelledby="recurrence-tab"
+      id={`${schedulerId}-recurrence-tabpanel`}
+      aria-labelledby={`${schedulerId}-recurrence-tab`}
       className={classes.eventDialogTabPanel}
       hidden={tabValue !== 'recurrence'}
     >
       <EventDialogTabContent className={classes.eventDialogTabContent}>
         <FormControl fullWidth size="small">
-          <InputLabel id="recurrence-preset-label">
+          <InputLabel id={`${schedulerId}-recurrence-preset-label`}>
             {localeText.recurrenceMainSelectCustomLabel}
           </InputLabel>
           <Select
-            labelId="recurrence-preset-label"
+            labelId={`${schedulerId}-recurrence-preset-label`}
             name="recurrencePreset"
             label={localeText.recurrenceMainSelectCustomLabel}
             value={controlled.recurrenceSelection ?? 'no-repeat'}

--- a/packages/x-scheduler/src/internals/components/event-dialog/ResourceAndColorSection.tsx
+++ b/packages/x-scheduler/src/internals/components/event-dialog/ResourceAndColorSection.tsx
@@ -129,7 +129,7 @@ export default function ResourceAndColorSection(props: ResourceSelectProps) {
   const { readOnly, resourceId, onResourceChange, onColorChange, color } = props;
 
   // Context hooks
-  const { classes, localeText } = useEventDialogStyledContext();
+  const { schedulerId, classes, localeText } = useEventDialogStyledContext();
   const store = useSchedulerStoreContext();
 
   // Selector hooks
@@ -189,9 +189,11 @@ export default function ResourceAndColorSection(props: ResourceSelectProps) {
   return (
     <React.Fragment>
       <FormControl size="small" fullWidth>
-        <InputLabel id="resource-select-label">{localeText.resourceLabel}</InputLabel>
+        <InputLabel id={`${schedulerId}-resource-select-label`}>
+          {localeText.resourceLabel}
+        </InputLabel>
         <Select
-          labelId="resource-select-label"
+          labelId={`${schedulerId}-resource-select-label`}
           label={localeText.resourceLabel}
           value={resourceId ?? NO_RESOURCE_VALUE}
           displayEmpty

--- a/packages/x-scheduler/src/internals/components/more-events-popover/MoreEventsPopover.tsx
+++ b/packages/x-scheduler/src/internals/components/more-events-popover/MoreEventsPopover.tsx
@@ -66,7 +66,7 @@ export default function MoreEventsPopoverContent(props: MoreEventsPopoverProps) 
 
   // Context hooks
   const adapter = useAdapterContext();
-  const { classes } = useEventCalendarStyledContext();
+  const { schedulerId, classes } = useEventCalendarStyledContext();
   const { subscribeCloseHandler } = useEventDialogContext();
 
   React.useEffect(() => {
@@ -79,7 +79,7 @@ export default function MoreEventsPopoverContent(props: MoreEventsPopoverProps) 
     <Popover className={classes.moreEventsPopover} open={open} anchorEl={anchor} onClose={onClose}>
       <MoreEventsPopoverHeader
         className={classes.moreEventsPopoverHeader}
-        id={`PopoverHeader-${day.key}`}
+        id={`${schedulerId}-PopoverHeader-${day.key}`}
         aria-label={`${formatWeekDayMonthAndDayOfMonth(day.value, adapter)}`}
       >
         <MoreEventsPopoverTitle className={classes.moreEventsPopoverTitle}>

--- a/packages/x-scheduler/src/internals/components/scope-dialog/ScopeDialog.tsx
+++ b/packages/x-scheduler/src/internals/components/scope-dialog/ScopeDialog.tsx
@@ -19,7 +19,7 @@ import { useEventDialogStyledContext } from '../event-dialog/EventDialogStyledCo
 export const RecurringScopeDialog = React.forwardRef<HTMLDivElement, ScopePopoverProps>(
   function ScopeDialog(props, ref) {
     // Context hooks
-    const { localeText } = useEventDialogStyledContext();
+    const { schedulerId, localeText } = useEventDialogStyledContext();
     const store = useSchedulerStoreContext();
 
     // Selector hooks
@@ -47,11 +47,11 @@ export const RecurringScopeDialog = React.forwardRef<HTMLDivElement, ScopePopove
         open={open}
         ref={ref}
         onClose={() => handleOpenChange(false)}
-        aria-labelledby="scope-dialog-title"
+        aria-labelledby={`${schedulerId}-scope-dialog-title`}
         {...props}
       >
         <form onSubmit={handleSubmit}>
-          <DialogTitle id="scope-dialog-title">{localeText.title}</DialogTitle>
+          <DialogTitle id={`${schedulerId}-scope-dialog-title`}>{localeText.title}</DialogTitle>
           <DialogContent>
             <FormControl>
               <RadioGroup

--- a/packages/x-scheduler/src/week-view/tests/WeekView.test.tsx
+++ b/packages/x-scheduler/src/week-view/tests/WeekView.test.tsx
@@ -42,16 +42,16 @@ describe('<WeekView />', () => {
       );
 
       const getEventsFromDate = (date: number) => {
-        return screen
-          .getAllByRole('gridcell')
-          .find((cell) => {
-            const labelledBy = cell.getAttribute('aria-labelledby');
-            return (
-              labelledBy?.includes(`DayTimeGridHeaderCell-${date}`) &&
-              labelledBy?.includes('DayTimeGridAllDayEventsHeaderCell')
-            );
-          })!
-          .querySelectorAll(`.${eventCalendarClasses.dayGridEvent}`);
+        const cells = document.querySelectorAll<HTMLElement>(
+          '[role="gridcell"][aria-labelledby*="DayTimeGridAllDayEventsHeaderCell"]',
+        );
+        const headers = Array.from(
+          document.querySelectorAll<HTMLElement>('[role="columnheader"][aria-label]'),
+        );
+        const columnIndex = headers.findIndex((h) =>
+          h.getAttribute('aria-label')?.endsWith(` ${date}`),
+        );
+        return cells[columnIndex].querySelectorAll(`.${eventCalendarClasses.dayGridEvent}`);
       };
 
       // Main event should render in the start date cell

--- a/packages/x-scheduler/src/week-view/tests/WeekView.test.tsx
+++ b/packages/x-scheduler/src/week-view/tests/WeekView.test.tsx
@@ -46,8 +46,9 @@ describe('<WeekView />', () => {
           .getAllByRole('gridcell')
           .find((cell) => {
             const labelledBy = cell.getAttribute('aria-labelledby');
-            return labelledBy?.includes(
-              `DayTimeGridHeaderCell-${date} DayTimeGridAllDayEventsHeaderCell`,
+            return (
+              labelledBy?.includes(`DayTimeGridHeaderCell-${date}`) &&
+              labelledBy?.includes('DayTimeGridAllDayEventsHeaderCell')
             );
           })!
           .querySelectorAll(`.${eventCalendarClasses.dayGridEvent}`);

--- a/packages/x-scheduler/src/week-view/tests/WeekView.test.tsx
+++ b/packages/x-scheduler/src/week-view/tests/WeekView.test.tsx
@@ -42,16 +42,16 @@ describe('<WeekView />', () => {
       );
 
       const getEventsFromDate = (date: number) => {
-        const cells = document.querySelectorAll<HTMLElement>(
-          '[role="gridcell"][aria-labelledby*="DayTimeGridAllDayEventsHeaderCell"]',
-        );
-        const headers = Array.from(
+        const header = Array.from(
           document.querySelectorAll<HTMLElement>('[role="columnheader"][aria-label]'),
-        );
-        const columnIndex = headers.findIndex((h) =>
-          h.getAttribute('aria-label')?.endsWith(` ${date}`),
-        );
-        return cells[columnIndex].querySelectorAll(`.${eventCalendarClasses.dayGridEvent}`);
+        ).find((h) => h.getAttribute('aria-label')?.endsWith(` ${date}`));
+
+        return screen
+          .getAllByRole('gridcell')
+          .find((cell) =>
+            cell.getAttribute('aria-labelledby')?.includes(header!.id),
+          )!
+          .querySelectorAll(`.${eventCalendarClasses.dayGridEvent}`);
       };
 
       // Main event should render in the start date cell

--- a/packages/x-scheduler/src/week-view/tests/WeekView.test.tsx
+++ b/packages/x-scheduler/src/week-view/tests/WeekView.test.tsx
@@ -48,9 +48,7 @@ describe('<WeekView />', () => {
 
         return screen
           .getAllByRole('gridcell')
-          .find((cell) =>
-            cell.getAttribute('aria-labelledby')?.includes(header!.id),
-          )!
+          .find((cell) => cell.getAttribute('aria-labelledby')?.includes(header!.id))!
           .querySelectorAll(`.${eventCalendarClasses.dayGridEvent}`);
       };
 

--- a/packages/x-scheduler/src/week-view/tests/dragAndDrop.WeekView.test.tsx
+++ b/packages/x-scheduler/src/week-view/tests/dragAndDrop.WeekView.test.tsx
@@ -27,9 +27,16 @@ function getTimeGridColumns(): HTMLElement[] {
  * E.g., `getDayGridCell(3)` returns the cell for the 3rd of the month.
  */
 function getDayGridCell(dayOfMonth: number): HTMLElement {
-  const cell = document.querySelector<HTMLElement>(
-    `[role="gridcell"][aria-labelledby*="DayTimeGridHeaderCell-${dayOfMonth}"][aria-labelledby*="DayTimeGridAllDayEventsHeaderCell"]`,
+  const cells = document.querySelectorAll<HTMLElement>(
+    '[role="gridcell"][aria-labelledby*="DayTimeGridAllDayEventsHeaderCell"]',
   );
+  const headers = Array.from(
+    document.querySelectorAll<HTMLElement>('[role="columnheader"][aria-label]'),
+  );
+  const columnIndex = headers.findIndex((h) =>
+    h.getAttribute('aria-label')?.endsWith(` ${dayOfMonth}`),
+  );
+  const cell = cells[columnIndex];
   if (!cell) {
     throw new Error(`Could not find day grid cell for day ${dayOfMonth}`);
   }

--- a/packages/x-scheduler/src/week-view/tests/dragAndDrop.WeekView.test.tsx
+++ b/packages/x-scheduler/src/week-view/tests/dragAndDrop.WeekView.test.tsx
@@ -27,16 +27,13 @@ function getTimeGridColumns(): HTMLElement[] {
  * E.g., `getDayGridCell(3)` returns the cell for the 3rd of the month.
  */
 function getDayGridCell(dayOfMonth: number): HTMLElement {
-  const cells = document.querySelectorAll<HTMLElement>(
-    '[role="gridcell"][aria-labelledby*="DayTimeGridAllDayEventsHeaderCell"]',
-  );
-  const headers = Array.from(
+  const header = Array.from(
     document.querySelectorAll<HTMLElement>('[role="columnheader"][aria-label]'),
-  );
-  const columnIndex = headers.findIndex((h) =>
-    h.getAttribute('aria-label')?.endsWith(` ${dayOfMonth}`),
-  );
-  const cell = cells[columnIndex];
+  ).find((h) => h.getAttribute('aria-label')?.endsWith(` ${dayOfMonth}`));
+
+  const cell = screen
+    .getAllByRole('gridcell')
+    .find((c) => c.getAttribute('aria-labelledby')?.includes(header!.id));
   if (!cell) {
     throw new Error(`Could not find day grid cell for day ${dayOfMonth}`);
   }

--- a/packages/x-scheduler/src/week-view/tests/dragAndDrop.WeekView.test.tsx
+++ b/packages/x-scheduler/src/week-view/tests/dragAndDrop.WeekView.test.tsx
@@ -28,7 +28,7 @@ function getTimeGridColumns(): HTMLElement[] {
  */
 function getDayGridCell(dayOfMonth: number): HTMLElement {
   const cell = document.querySelector<HTMLElement>(
-    `[role="gridcell"][aria-labelledby="DayTimeGridHeaderCell-${dayOfMonth} DayTimeGridAllDayEventsHeaderCell"]`,
+    `[role="gridcell"][aria-labelledby*="DayTimeGridHeaderCell-${dayOfMonth}"][aria-labelledby*="DayTimeGridAllDayEventsHeaderCell"]`,
   );
   if (!cell) {
     throw new Error(`Could not find day grid cell for day ${dayOfMonth}`);


### PR DESCRIPTION
Adds a schedulerId (via `useId()`) to each styled context (`EventCalendarStyledContext`, `EventDialogStyledContext`, `EventTimelinePremiumStyledContext`) and prefixes all hardcoded element IDs with it.

This ensures unique IDs when multiple Scheduler instances are rendered on the same page, fixing broken aria-controls/aria-labelledby associations.

Related PR: #22054

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
