### PR TITLE
[docs] Remove obsolete v7 deprecation warning for `dayOfWeekFormatter`

### DIFF
--- a/docs/data/date-pickers/adapters-locale/adapters-locale.md
+++ b/docs/data/date-pickers/adapters-locale/adapters-locale.md
@@ -242,10 +242,6 @@ Use `dayOfWeekFormatter` to customize day names in the calendar header.
 This prop takes two parameters, `day` (a string with the name of the day) and `date` (the day in the format of your date library), and returns the formatted string to display.
 The default formatter only keeps the first letter of the name and capitalizes it.
 
-:::warning
-The first parameter `day` will be removed in v7 in favor of the second parameter `date` for more flexibility.
-:::
-
 :::info
 This prop is available on all components that render a day calendar, including the Date Calendar as well as all Date Pickers, Date Time Pickers, and Date Range Pickers.
 :::


### PR DESCRIPTION
Backporting this to v7 and v8 as it was removed in v7.

## Summary

- Removes a stale `:::warning` admonition in the [Custom day of week format](https://mui.com/x/react-date-pickers/adapters-locale/#custom-day-of-week-format) section that announced the removal of the `day` parameter "in v7".
- The library is now on v9 and the parameter still exists, so the warning is misleading and redundant.

## Test plan

- [x] Verify the warning no longer renders on the docs page.