### PR TITLE
[test] Remove redundant explicit `unmount()` calls from Pickers tests

### DIFF
--- a/packages/x-date-pickers-pro/src/SingleInputDateRangeField/tests/editing.SingleInputDateRangeField.test.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputDateRangeField/tests/editing.SingleInputDateRangeField.test.tsx
@@ -12,8 +12,6 @@ describe('<SingleInputDateRangeField /> - Editing', () => {
         const view = renderWithProps({});
 
         expectFieldValue(view.getSectionsContainer(), 'MM/DD/YYYY – MM/DD/YYYY');
-
-        view.unmount();
       });
 
       it('should use the default value when defined', () => {
@@ -22,8 +20,6 @@ describe('<SingleInputDateRangeField /> - Editing', () => {
         });
 
         expectFieldValue(view.getSectionsContainer(), '06/04/2022 – 06/05/2022');
-
-        view.unmount();
       });
 
       it('should use the controlled value instead of the default value when both are defined', () => {
@@ -33,8 +29,6 @@ describe('<SingleInputDateRangeField /> - Editing', () => {
         });
 
         expectFieldValue(view.getSectionsContainer(), '06/04/2022 – 06/05/2022');
-
-        view.unmount();
       });
 
       it('should use the controlled value instead of the default value when both are defined and the controlled value has null dates', () => {
@@ -44,8 +38,6 @@ describe('<SingleInputDateRangeField /> - Editing', () => {
         });
 
         expectFieldValue(view.getSectionsContainer(), '06/04/2022 – MM/DD/YYYY');
-
-        view.unmount();
       });
 
       it('should react to controlled value update (from a non null date to another non null date)', () => {
@@ -59,8 +51,6 @@ describe('<SingleInputDateRangeField /> - Editing', () => {
           value: [adapter.date('2023-06-04'), adapter.date('2023-06-05')],
         });
         expectFieldValue(view.getSectionsContainer(), '06/04/2023 – 06/05/2023');
-
-        view.unmount();
       });
 
       it('should react to controlled value update (from a non null date to a null date)', () => {
@@ -74,8 +64,6 @@ describe('<SingleInputDateRangeField /> - Editing', () => {
           value: [null, adapter.date('2022-06-05')],
         });
         expectFieldValue(view.getSectionsContainer(), 'MM/DD/YYYY – 06/05/2022');
-
-        view.unmount();
       });
 
       it('should react to controlled value update (from a null date to a non null date)', () => {
@@ -89,8 +77,6 @@ describe('<SingleInputDateRangeField /> - Editing', () => {
           value: [adapter.date('2022-06-04'), adapter.date('2022-06-05')],
         });
         expectFieldValue(view.getSectionsContainer(), '06/04/2022 – 06/05/2022');
-
-        view.unmount();
       });
 
       it('should call the onChange callback when the value is updated but should not change the displayed value if the value is controlled', async () => {
@@ -108,8 +94,6 @@ describe('<SingleInputDateRangeField /> - Editing', () => {
         expect(onChange.callCount).to.equal(1);
         expect(onChange.lastCall.firstArg[0]).toEqualDateTime(new Date(2023, 5, 4));
         expect(onChange.lastCall.firstArg[1]).toEqualDateTime(new Date(2022, 5, 5));
-
-        view.unmount();
       });
 
       it('should call the onChange callback when the value is updated and should change the displayed value if the value is not controlled', async () => {
@@ -127,8 +111,6 @@ describe('<SingleInputDateRangeField /> - Editing', () => {
         expect(onChange.callCount).to.equal(1);
         expect(onChange.lastCall.firstArg[0]).toEqualDateTime(new Date(2023, 5, 4));
         expect(onChange.lastCall.firstArg[1]).toEqualDateTime(new Date(2022, 5, 5));
-
-        view.unmount();
       });
 
       it('should not call the onChange callback before filling the last section of the active date when starting from a null value', async () => {
@@ -153,8 +135,6 @@ describe('<SingleInputDateRangeField /> - Editing', () => {
         await waitFor(() => {
           expectFieldValue(view.getSectionsContainer(), 'DD MMMM – DD MMMM');
         });
-
-        view.unmount();
       });
     },
   );
@@ -177,8 +157,6 @@ describe('<SingleInputDateRangeField /> - Editing', () => {
 
       fireEvent.keyDown(view.getSectionsContainer(), { key: 'Delete' });
       expectFieldValue(view.getSectionsContainer(), 'MMMM YYYY – MMMM YYYY');
-
-      view.unmount();
     });
 
     it('should clear all the sections when all sections are selected and not all sections are completed', async () => {
@@ -201,8 +179,6 @@ describe('<SingleInputDateRangeField /> - Editing', () => {
 
       fireEvent.keyDown(view.getSectionsContainer(), { key: 'Delete' });
       expectFieldValue(view.getSectionsContainer(), 'MMMM YYYY – MMMM YYYY');
-
-      view.unmount();
     });
 
     it('should not call `onChange` when clearing all sections and both dates are already empty', async () => {
@@ -224,8 +200,6 @@ describe('<SingleInputDateRangeField /> - Editing', () => {
 
       fireEvent.keyDown(view.getSectionsContainer(), { key: 'Delete' });
       expect(onChange.callCount).to.equal(0);
-
-      view.unmount();
     });
 
     it('should call `onChange` when clearing the first section of each date', async () => {
@@ -266,8 +240,6 @@ describe('<SingleInputDateRangeField /> - Editing', () => {
       fireEvent.keyDown(view.getActiveSection(4), { key: 'ArrowRight' });
       fireEvent.keyDown(view.getActiveSection(5), { key: 'Delete' });
       expect(onChange.callCount).to.equal(2);
-
-      view.unmount();
     });
 
     it('should not call `onChange` if the section is already empty', async () => {
@@ -286,8 +258,6 @@ describe('<SingleInputDateRangeField /> - Editing', () => {
 
       fireEvent.keyDown(view.getActiveSection(0), { key: 'Delete' });
       expect(onChange.callCount).to.equal(1);
-
-      view.unmount();
     });
   });
 
@@ -312,8 +282,6 @@ describe('<SingleInputDateRangeField /> - Editing', () => {
 
         view.pressKey(null, '');
         expectFieldValue(view.getSectionsContainer(), 'MMMM YYYY – MMMM YYYY');
-
-        view.unmount();
       });
 
       it('should clear all the sections when all sections are selected and not all sections are completed (Backspace)', async () => {
@@ -336,8 +304,6 @@ describe('<SingleInputDateRangeField /> - Editing', () => {
 
         view.pressKey(null, '');
         expectFieldValue(view.getSectionsContainer(), 'MMMM YYYY – MMMM YYYY');
-
-        view.unmount();
       });
 
       it('should not call `onChange` when clearing all sections and both dates are already empty (Backspace)', async () => {
@@ -359,8 +325,6 @@ describe('<SingleInputDateRangeField /> - Editing', () => {
 
         view.pressKey(null, '');
         expect(onChange.callCount).to.equal(0);
-
-        view.unmount();
       });
 
       it('should call `onChange` when clearing the first section of each date (Backspace)', async () => {
@@ -401,8 +365,6 @@ describe('<SingleInputDateRangeField /> - Editing', () => {
         fireEvent.keyDown(view.getActiveSection(4), { key: 'ArrowRight' });
         view.pressKey(5, '');
         expect(onChange.callCount).to.equal(2);
-
-        view.unmount();
       });
 
       it('should not call `onChange` if the section is already empty (Backspace)', async () => {
@@ -421,8 +383,6 @@ describe('<SingleInputDateRangeField /> - Editing', () => {
 
         await view.user.keyboard('{Backspace}');
         expect(onChange.callCount).to.equal(1);
-
-        view.unmount();
       });
     },
   );

--- a/packages/x-date-pickers-pro/src/SingleInputDateRangeField/tests/selection.SingleInputDateRangeField.test.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputDateRangeField/tests/selection.SingleInputDateRangeField.test.tsx
@@ -22,8 +22,6 @@ describe('<SingleInputDateRangeField /> - Selection', () => {
       });
       expectFieldValue(view.getSectionsContainer(), 'MM/DD/YYYY – MM/DD/YYYY');
       expect(getCleanedSelectedContent()).to.equal('MM');
-
-      view.unmount();
     });
   });
 
@@ -46,8 +44,6 @@ describe('<SingleInputDateRangeField /> - Selection', () => {
 
       await view.selectSectionAsync('day', 'last');
       expect(getCleanedSelectedContent()).to.equal('24');
-
-      view.unmount();
     });
 
     it('should not change the selection when clicking on the only already selected section', async () => {
@@ -68,8 +64,6 @@ describe('<SingleInputDateRangeField /> - Selection', () => {
 
       await view.selectSectionAsync('day', 'last');
       expect(getCleanedSelectedContent()).to.equal('24');
-
-      view.unmount();
     });
   });
 
@@ -94,8 +88,6 @@ describe('<SingleInputDateRangeField /> - Selection', () => {
 
       fireEvent.keyDown(view.getActiveSection(4), { key: 'ArrowRight' });
       expect(getCleanedSelectedContent()).to.equal('YYYY');
-
-      view.unmount();
     });
 
     it('should stay on the current section when the last section is selected', async () => {
@@ -105,8 +97,6 @@ describe('<SingleInputDateRangeField /> - Selection', () => {
       expect(getCleanedSelectedContent()).to.equal('YYYY');
       fireEvent.keyDown(view.getActiveSection(5), { key: 'ArrowRight' });
       expect(getCleanedSelectedContent()).to.equal('YYYY');
-
-      view.unmount();
     });
   });
 
@@ -130,8 +120,6 @@ describe('<SingleInputDateRangeField /> - Selection', () => {
 
       fireEvent.keyDown(view.getActiveSection(1), { key: 'ArrowLeft' });
       expect(getCleanedSelectedContent()).to.equal('MM');
-
-      view.unmount();
     });
 
     it('should stay on the current section when the first section is selected', async () => {
@@ -141,8 +129,6 @@ describe('<SingleInputDateRangeField /> - Selection', () => {
       expect(getCleanedSelectedContent()).to.equal('MM');
       fireEvent.keyDown(view.getActiveSection(0), { key: 'ArrowLeft' });
       expect(getCleanedSelectedContent()).to.equal('MM');
-
-      view.unmount();
     });
   });
 });

--- a/packages/x-date-pickers/src/DateField/tests/editing.DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/editing.DateField.test.tsx
@@ -23,8 +23,6 @@ describe('<DateField /> - Editing', () => {
 
         expect(onChange.callCount).to.equal(1);
         expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2023, 5, 4));
-
-        view.unmount();
       });
 
       it('should call the onChange callback when the value is updated and should change the displayed value if the value is not controlled', async () => {
@@ -41,8 +39,6 @@ describe('<DateField /> - Editing', () => {
 
         expect(onChange.callCount).to.equal(1);
         expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2023, 5, 4));
-
-        view.unmount();
       });
 
       it('should not call the onChange callback before filling the last section when starting from a null value', async () => {
@@ -66,8 +62,6 @@ describe('<DateField /> - Editing', () => {
         await waitFor(() => {
           expectFieldValue(view.getSectionsContainer(), 'DD MMMM');
         });
-
-        view.unmount();
       });
     },
   );
@@ -103,8 +97,6 @@ describe('<DateField /> - Editing', () => {
       // digit key press
       fireUserEvent.keyPress(view.getActiveSection(0), { key: '2' });
       expectFieldValue(view.getSectionsContainer(), 'MM/DD/YYYY');
-
-      view.unmount();
     });
   });
 
@@ -292,8 +284,6 @@ describe('<DateField /> - Editing', () => {
 
       await view.user.keyboard('8');
       expectFieldValue(view.getSectionsContainer(), '02/29/1988');
-
-      view.unmount();
     });
 
     it('should not edit when props.readOnly = true and no value is provided', () => {
@@ -327,8 +317,6 @@ describe('<DateField /> - Editing', () => {
 
       view.pressKey(null, '1');
       expect(getCleanedSelectedContent()).to.equal('01');
-
-      view.unmount();
     });
 
     it('should be editable after reenabling field', async () => {
@@ -346,8 +334,6 @@ describe('<DateField /> - Editing', () => {
 
       view.pressKey(undefined, '2');
       expectFieldValue(view.getSectionsContainer(), 'MM/DD/0002');
-
-      view.unmount();
     });
   });
 
@@ -450,8 +436,6 @@ describe('<DateField /> - Editing', () => {
 
         view.pressKey(null, 'j');
         expect(getCleanedSelectedContent()).to.equal(adapter.lib === 'luxon' ? '1' : '01');
-
-        view.unmount();
       });
     },
   );
@@ -471,8 +455,6 @@ describe('<DateField /> - Editing', () => {
 
         await view.user.keyboard('[Backspace]');
         expectFieldValue(view.getSectionsContainer(), 'MMMM YYYY');
-
-        view.unmount();
       });
 
       it('should clear the selected section when all sections are completed (Backspace)', async () => {
@@ -485,8 +467,6 @@ describe('<DateField /> - Editing', () => {
 
         await view.user.keyboard('[Backspace]');
         expectFieldValue(view.getSectionsContainer(), 'MMMM 2022');
-
-        view.unmount();
       });
 
       it('should clear all the sections when all sections are selected and all sections are completed (Backspace)', async () => {
@@ -506,8 +486,6 @@ describe('<DateField /> - Editing', () => {
 
         view.pressKey(null, '');
         expectFieldValue(view.getSectionsContainer(), 'MMMM YYYY');
-
-        view.unmount();
       });
 
       it('should clear all the sections when all sections are selected and not all sections are completed (Backspace)', async () => {
@@ -528,8 +506,6 @@ describe('<DateField /> - Editing', () => {
 
         await view.user.keyboard('[Backspace]');
         expectFieldValue(view.getSectionsContainer(), 'MMMM YYYY');
-
-        view.unmount();
       });
 
       it('should not keep query after typing again on a cleared section (Backspace)', () => {
@@ -581,8 +557,6 @@ describe('<DateField /> - Editing', () => {
         await view.selectSectionAsync('year');
         view.pressKey(1, '');
         expect(onChange.callCount).to.equal(1);
-
-        view.unmount();
       });
 
       it('should not call `onChange` if the section is already empty (Backspace)', () => {
@@ -646,8 +620,6 @@ describe('<DateField /> - Editing', () => {
 
       expect(onChange.callCount).to.equal(1);
       expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2022, 8, 16));
-
-      view.unmount();
     });
 
     it('should set the date when all sections are selected, the pasted value is valid and no value is provided', async () => {
@@ -668,7 +640,6 @@ describe('<DateField /> - Editing', () => {
 
       expect(onChange.callCount).to.equal(1);
       expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2022, 8, 16));
-      view.unmount();
     });
 
     it('should not set the date when all sections are selected and the pasted value is not valid', async () => {
@@ -687,7 +658,6 @@ describe('<DateField /> - Editing', () => {
 
       await firePasteEvent(view.getSectionsContainer(), 'Some invalid content');
       expectFieldValue(view.getSectionsContainer(), 'MM/DD/YYYY');
-      view.unmount();
     });
 
     it('should set the date when all sections are selected and the format contains escaped characters', async () => {
@@ -711,7 +681,6 @@ describe('<DateField /> - Editing', () => {
       await firePasteEvent(view.getSectionsContainer(), `Escaped 2014`);
       expect(onChange.callCount).to.equal(1);
       expect(adapter.getYear(onChange.lastCall.firstArg)).to.equal(2014);
-      view.unmount();
     });
 
     it('should not set the date when all sections are selected and props.readOnly = true', async () => {
@@ -733,8 +702,6 @@ describe('<DateField /> - Editing', () => {
 
       await firePasteEvent(view.getSectionsContainer(), '09/16/2022');
       expect(onChange.callCount).to.equal(0);
-
-      view.unmount();
     });
 
     it('should set the section when one section is selected, the pasted value has the correct type and no value is provided', async () => {
@@ -751,8 +718,6 @@ describe('<DateField /> - Editing', () => {
 
       expect(onChange.callCount).to.equal(0);
       expectFieldValue(view.getSectionsContainer(), '12/DD/YYYY');
-
-      view.unmount();
     });
 
     it('should set the section when one section is selected, the pasted value has the correct type and value is provided', async () => {
@@ -770,8 +735,6 @@ describe('<DateField /> - Editing', () => {
       expectFieldValue(view.getSectionsContainer(), '12/13/2018');
       expect(onChange.callCount).to.equal(1);
       expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2018, 11, 13));
-
-      view.unmount();
     });
 
     it('should not update the section when one section is selected and the pasted value has incorrect type', async () => {
@@ -788,8 +751,6 @@ describe('<DateField /> - Editing', () => {
       await firePasteEvent(view.getActiveSection(0), 'Jun');
       expectFieldValue(view.getSectionsContainer(), '01/13/2018');
       expect(onChange.callCount).to.equal(0);
-
-      view.unmount();
     });
 
     it('should reset sections internal state when pasting', async () => {
@@ -812,8 +773,6 @@ describe('<DateField /> - Editing', () => {
 
       view.pressKey(1, '2'); // Press 2
       expectFieldValue(view.getSectionsContainer(), '09/02/2022'); // If internal state is not reset it would be 22 instead of 02
-
-      view.unmount();
     });
 
     it('should allow pasting a section', async () => {
@@ -853,8 +812,6 @@ describe('<DateField /> - Editing', () => {
       await firePasteEvent(view.getSectionsContainer(), '09/16/2022');
       expect(onChange.callCount).to.equal(0);
       expectFieldValue(view.getSectionsContainer(), 'MM/DD/YYYY');
-
-      view.unmount();
     });
   });
 
@@ -871,8 +828,6 @@ describe('<DateField /> - Editing', () => {
         await view.selectSectionAsync('year');
         await view.user.keyboard('{ArrowDown}');
         expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2009, 3, 3, 3, 3, 3));
-
-        view.unmount();
       });
 
       it('should not loose time information when cleaning the date then filling it again', async () => {
@@ -905,8 +860,6 @@ describe('<DateField /> - Editing', () => {
         await view.user.keyboard('2009');
         expectFieldValue(view.getSectionsContainer(), '11/25/2009');
         expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2009, 10, 25, 3, 3, 3));
-
-        view.unmount();
       });
 
       it('should not loose date information when using the year format and value is provided', async () => {
@@ -922,8 +875,6 @@ describe('<DateField /> - Editing', () => {
         await view.user.keyboard('{ArrowDown}');
 
         expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2009, 3, 3, 3, 3, 3));
-
-        view.unmount();
       });
 
       it('should not loose date information when using the month format and value is provided', async () => {
@@ -938,8 +889,6 @@ describe('<DateField /> - Editing', () => {
         await view.selectSectionAsync('month');
         await view.user.keyboard('{ArrowDown}');
         expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2010, 2, 3, 3, 3, 3));
-
-        view.unmount();
       });
     },
   );
@@ -957,8 +906,6 @@ describe('<DateField /> - Editing', () => {
 
         expect(onChange.callCount).to.equal(1);
         expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2022, 8, 16));
-
-        view.unmount();
       });
 
       it('should set the date when the change value is valid and a value is provided', () => {
@@ -973,8 +920,6 @@ describe('<DateField /> - Editing', () => {
 
         expect(onChange.callCount).to.equal(1);
         expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2022, 8, 16, 3, 3, 3));
-
-        view.unmount();
       });
     },
   );
@@ -990,8 +935,6 @@ describe('<DateField /> - Editing', () => {
 
       await view.selectSectionAsync('month');
       expectFieldValue(view.getSectionsContainer(), 'MM/DD/YYYY');
-
-      view.unmount();
     });
 
     it.skipIf(adapter.lib !== 'dayjs')(
@@ -1027,8 +970,6 @@ describe('<DateField /> - Editing', () => {
 
         await view.user.keyboard('1');
         expectFieldValue(view.getSectionsContainer(), '11/01/YYYY');
-
-        view.unmount();
       },
     );
   });
@@ -1049,8 +990,6 @@ describe('<DateField /> - Editing', () => {
       view.pressKey(null, '9');
 
       expectFieldValue(view.getSectionsContainer(), '09/DD/YYYY');
-
-      view.unmount();
     });
   });
 });

--- a/packages/x-date-pickers/src/DateField/tests/editingKeyboard.DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/editingKeyboard.DateField.test.tsx
@@ -219,8 +219,6 @@ describe('<DateField /> - Editing Keyboard', () => {
 
       fireUserEvent.keyPress(view.getActiveSection(0), { key: 'Delete' });
       expectFieldValue(view.getSectionsContainer(), 'MMMM YYYY');
-
-      view.unmount();
     });
 
     it('should clear the selected section when all sections are completed', () => {
@@ -249,8 +247,6 @@ describe('<DateField /> - Editing Keyboard', () => {
 
       fireUserEvent.keyPress(view.getSectionsContainer(), { key: 'Delete' });
       expectFieldValue(view.getSectionsContainer(), 'MMMM YYYY');
-
-      view.unmount();
     });
 
     it('should clear all the sections when all sections are selected and not all sections are completed', async () => {
@@ -273,8 +269,6 @@ describe('<DateField /> - Editing Keyboard', () => {
 
       fireUserEvent.keyPress(view.getSectionsContainer(), { key: 'Delete' });
       expectFieldValue(view.getSectionsContainer(), 'MMMM YYYY');
-
-      view.unmount();
     });
 
     it('should not keep query after typing again on a cleared section', async () => {
@@ -292,8 +286,6 @@ describe('<DateField /> - Editing Keyboard', () => {
 
       view.pressKey(0, '2');
       expectFieldValue(view.getSectionsContainer(), '0002');
-
-      view.unmount();
     });
 
     it('should not clear the sections when props.readOnly = true', () => {
@@ -325,8 +317,6 @@ describe('<DateField /> - Editing Keyboard', () => {
 
       fireUserEvent.keyPress(view.getSectionsContainer(), { key: 'Delete' });
       expect(onChange.callCount).to.equal(0);
-
-      view.unmount();
     });
 
     it('should call `onChange` when clearing the first section', async () => {
@@ -347,8 +337,6 @@ describe('<DateField /> - Editing Keyboard', () => {
       await view.user.keyboard('[ArrowRight][Delete]');
 
       expect(onChange.callCount).to.equal(1);
-
-      view.unmount();
     });
 
     it('should not call `onChange` if the section is already empty', async () => {
@@ -367,8 +355,6 @@ describe('<DateField /> - Editing Keyboard', () => {
 
       await view.user.keyboard('[Delete]');
       expect(onChange.callCount).to.equal(1);
-
-      view.unmount();
     });
   });
 

--- a/packages/x-date-pickers/src/DateField/tests/format.DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/format.DateField.test.tsx
@@ -13,8 +13,6 @@ describeAdapters('<DateField /> - Format', DateField, ({ adapter, renderWithProp
 
     view.setProps({ value: adapter.date('2019-01-01') });
     expectFieldValue(view.getSectionsContainer(), 'Escaped 2019');
-
-    view.unmount();
   });
 
   it('should support escaped characters between sections separator', () => {
@@ -28,8 +26,6 @@ describeAdapters('<DateField /> - Format', DateField, ({ adapter, renderWithProp
 
     view.setProps({ value: adapter.date('2019-01-01') });
     expectFieldValue(view.getSectionsContainer(), 'January Escaped 2019');
-
-    view.unmount();
   });
 
   // If your start character and end character are equal
@@ -45,8 +41,6 @@ describeAdapters('<DateField /> - Format', DateField, ({ adapter, renderWithProp
 
     view.setProps({ value: adapter.date('2019-01-01') });
     expectFieldValue(view.getSectionsContainer(), 'January Escaped [ 2019');
-
-    view.unmount();
   });
 
   it('should support several escaped parts', () => {
@@ -60,8 +54,6 @@ describeAdapters('<DateField /> - Format', DateField, ({ adapter, renderWithProp
 
     view.setProps({ value: adapter.date('2019-01-01') });
     expectFieldValue(view.getSectionsContainer(), 'Escaped January Escaped 2019');
-
-    view.unmount();
   });
 
   it('should support format with only escaped parts', () => {
@@ -72,8 +64,6 @@ describeAdapters('<DateField /> - Format', DateField, ({ adapter, renderWithProp
     });
 
     expectFieldValue(view.getSectionsContainer(), 'Escaped Escaped');
-
-    view.unmount();
   });
 
   it('should support format without separators', () => {
@@ -94,8 +84,6 @@ describeAdapters('<DateField /> - Format', DateField, ({ adapter, renderWithProp
 
     view.setProps({ value: adapter.date('2019-01-01') });
     expectFieldValue(view.getSectionsContainer(), '01 / 01 / 2019');
-
-    view.unmount();
   });
 
   it('should add spaces around `.` when `formatDensity = "spacious"`', () => {
@@ -109,8 +97,6 @@ describeAdapters('<DateField /> - Format', DateField, ({ adapter, renderWithProp
 
     view.setProps({ value: adapter.date('2019-01-01') });
     expectFieldValue(view.getSectionsContainer(), '01 . 01 . 2019');
-
-    view.unmount();
   });
 
   it('should add spaces around `-` when `formatDensity = "spacious"`', () => {
@@ -124,7 +110,5 @@ describeAdapters('<DateField /> - Format', DateField, ({ adapter, renderWithProp
 
     view.setProps({ value: adapter.date('2019-01-01') });
     expectFieldValue(view.getSectionsContainer(), '01 - 01 - 2019');
-
-    view.unmount();
   });
 });

--- a/packages/x-date-pickers/src/DateField/tests/invalidStateKeyboard.DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/invalidStateKeyboard.DateField.test.tsx
@@ -42,8 +42,6 @@ describeAdapters(
 
       // Should still be invalid despite cycling 3 times, must not flash to valid between spins
       expect(inputRoot).to.have.attribute('aria-invalid', 'true');
-
-      view.unmount();
     });
   },
 );

--- a/packages/x-date-pickers/src/DateField/tests/selection.DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/selection.DateField.test.tsx
@@ -20,7 +20,6 @@ describe('<DateField /> - Selection', () => {
       });
       expectFieldValue(view.getSectionsContainer(), 'MM/DD/YYYY');
       expect(getCleanedSelectedContent()).to.equal('MM');
-      view.unmount();
     });
 
     it('should select 1st section (`autoFocus = true`) with start separator', () => {
@@ -30,7 +29,6 @@ describe('<DateField /> - Selection', () => {
       });
       expectFieldValue(view.getSectionsContainer(), '- YYYY');
       expect(getCleanedSelectedContent()).to.equal('YYYY');
-      view.unmount();
     });
 
     it('should not select 1st section on mount (`autoFocus = true` and `disabled = true`)', () => {
@@ -40,7 +38,6 @@ describe('<DateField /> - Selection', () => {
       });
       expectFieldValue(view.getSectionsContainer(), 'MM/DD/YYYY');
       expect(getCleanedSelectedContent()).to.equal('');
-      view.unmount();
     });
   });
 
@@ -53,8 +50,6 @@ describe('<DateField /> - Selection', () => {
 
       await view.selectSectionAsync('month');
       expect(getCleanedSelectedContent()).to.equal('MM');
-
-      view.unmount();
     });
 
     it('should not change the selection when clicking on the only already selected section', async () => {
@@ -65,8 +60,6 @@ describe('<DateField /> - Selection', () => {
 
       await view.selectSectionAsync('day');
       expect(getCleanedSelectedContent()).to.equal('DD');
-
-      view.unmount();
     });
 
     it('should not select section on click (`disabled = true`)', async () => {
@@ -76,8 +69,6 @@ describe('<DateField /> - Selection', () => {
 
       await view.selectSectionAsync('day');
       expect(getCleanedSelectedContent()).to.equal('');
-
-      view.unmount();
     });
   });
 
@@ -91,8 +82,6 @@ describe('<DateField /> - Selection', () => {
         ctrlKey: true,
       });
       expect(getCleanedSelectedContent()).to.equal('MM/DD/YYYY');
-
-      view.unmount();
     });
 
     it('should select all sections with start separator', async () => {
@@ -106,8 +95,6 @@ describe('<DateField /> - Selection', () => {
         ctrlKey: true,
       });
       expect(getCleanedSelectedContent()).to.equal('- YYYY');
-
-      view.unmount();
     });
   });
 
@@ -118,7 +105,6 @@ describe('<DateField /> - Selection', () => {
       expect(getCleanedSelectedContent()).to.equal('DD');
       fireEvent.keyDown(view.getActiveSection(1), { key: 'ArrowRight' });
       expect(getCleanedSelectedContent()).to.equal('YYYY');
-      view.unmount();
     });
 
     it('should stay on the current section when the last section is selected', async () => {
@@ -127,7 +113,6 @@ describe('<DateField /> - Selection', () => {
       expect(getCleanedSelectedContent()).to.equal('YYYY');
       fireEvent.keyDown(view.getActiveSection(2), { key: 'ArrowRight' });
       expect(getCleanedSelectedContent()).to.equal('YYYY');
-      view.unmount();
     });
 
     it('should select the last section when all the sections are selected', async () => {
@@ -144,8 +129,6 @@ describe('<DateField /> - Selection', () => {
 
       fireEvent.keyDown(view.getSectionsContainer(), { key: 'ArrowRight' });
       expect(getCleanedSelectedContent()).to.equal('YYYY');
-
-      view.unmount();
     });
 
     it('should select the next section when editing after all the sections were selected', async () => {
@@ -165,8 +148,6 @@ describe('<DateField /> - Selection', () => {
 
       fireEvent.keyDown(view.getActiveSection(0), { key: 'ArrowRight' });
       expect(getCleanedSelectedContent()).to.equal('DD');
-
-      view.unmount();
     });
   });
 
@@ -177,7 +158,6 @@ describe('<DateField /> - Selection', () => {
       expect(getCleanedSelectedContent()).to.equal('DD');
       fireEvent.keyDown(view.getActiveSection(1), { key: 'ArrowLeft' });
       expect(getCleanedSelectedContent()).to.equal('MM');
-      view.unmount();
     });
 
     it('should stay on the current section when the first section is selected', async () => {
@@ -186,7 +166,6 @@ describe('<DateField /> - Selection', () => {
       expect(getCleanedSelectedContent()).to.equal('MM');
       fireEvent.keyDown(view.getActiveSection(0), { key: 'ArrowLeft' });
       expect(getCleanedSelectedContent()).to.equal('MM');
-      view.unmount();
     });
 
     it('should select the first section when all the sections are selected', async () => {
@@ -203,8 +182,6 @@ describe('<DateField /> - Selection', () => {
 
       fireEvent.keyDown(view.getSectionsContainer(), { key: 'ArrowLeft' });
       expect(getCleanedSelectedContent()).to.equal('MM');
-
-      view.unmount();
     });
 
     it('should select the first section when `inputRef.current` is focused', () => {

--- a/packages/x-date-pickers/src/TimeField/tests/editing.TimeField.test.tsx
+++ b/packages/x-date-pickers/src/TimeField/tests/editing.TimeField.test.tsx
@@ -498,8 +498,6 @@ describe('<TimeField /> - Editing', () => {
       view.pressKey(0, '2');
       expectFieldValue(view.getSectionsContainer(), '02:mm aa');
       expect(getCleanedSelectedContent()).to.equal('mm');
-
-      view.unmount();
     });
 
     it('should go to the next section when pressing `1` then `3` in a 12-hours format', async () => {
@@ -517,8 +515,6 @@ describe('<TimeField /> - Editing', () => {
       view.pressKey(0, '3');
       expectFieldValue(view.getSectionsContainer(), '03:mm aa');
       expect(getCleanedSelectedContent()).to.equal('mm');
-
-      view.unmount();
     });
   });
 
@@ -602,8 +598,6 @@ describe('<TimeField /> - Editing', () => {
         fireEvent.keyDown(view.getActiveSection(0), { key: 'ArrowDown' });
 
         expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2010, 3, 3, 2, 3, 3));
-
-        view.unmount();
       });
 
       it('should not loose date information when cleaning the date then filling it again', async () => {
@@ -630,8 +624,6 @@ describe('<TimeField /> - Editing', () => {
         view.pressKey(1, '4');
         expectFieldValue(view.getSectionsContainer(), '03:04');
         expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2010, 3, 3, 3, 4, 3));
-
-        view.unmount();
       });
 
       it('should not loose time information when using the hour format and value is provided', async () => {
@@ -647,8 +639,6 @@ describe('<TimeField /> - Editing', () => {
         fireEvent.keyDown(view.getActiveSection(0), { key: 'ArrowDown' });
 
         expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2010, 3, 3, 2, 3, 3));
-
-        view.unmount();
       });
     },
   );

--- a/packages/x-date-pickers/src/tests/fieldKeyboardInteraction.test.tsx
+++ b/packages/x-date-pickers/src/tests/fieldKeyboardInteraction.test.tsx
@@ -80,8 +80,6 @@ describe(`RTL - test arrows navigation`, () => {
       expect(getCleanedSelectedContent()).to.equal(expectedValue);
       fireEvent.keyDown(view.getActiveSection(undefined), { key: 'ArrowRight' });
     });
-
-    view.unmount();
   });
 
   it('should move selected section to the previous section respecting RTL order in empty field', () => {
@@ -95,8 +93,6 @@ describe(`RTL - test arrows navigation`, () => {
       expect(getCleanedSelectedContent()).to.equal(expectedValue);
       fireEvent.keyDown(view.getActiveSection(undefined), { key: 'ArrowLeft' });
     });
-
-    view.unmount();
   });
 
   it('should move selected section to the next section respecting RTL order in non-empty field', () => {
@@ -116,8 +112,6 @@ describe(`RTL - test arrows navigation`, () => {
       expect(getCleanedSelectedContent()).to.equal(expectedValue);
       fireEvent.keyDown(view.getActiveSection(undefined), { key: 'ArrowRight' });
     });
-
-    view.unmount();
   });
 
   it('should move selected section to the previous section respecting RTL order in non-empty field', () => {
@@ -137,8 +131,6 @@ describe(`RTL - test arrows navigation`, () => {
       expect(getCleanedSelectedContent()).to.equal(expectedValue);
       fireEvent.keyDown(view.getActiveSection(undefined), { key: 'ArrowLeft' });
     });
-
-    view.unmount();
   });
 });
 

--- a/test/utils/pickers/fields.tsx
+++ b/test/utils/pickers/fields.tsx
@@ -258,7 +258,6 @@ export const buildFieldInteractions = <P extends {}>({
     response.selectSection(selectedSection);
     response.pressKey(undefined, key);
     expectFieldValue(response.getSectionsContainer(), expectedValue);
-    response.unmount();
   };
 
   const testFieldChange: BuildFieldInteractionsResponse<P>['testFieldChange'] = ({
@@ -278,7 +277,6 @@ export const buildFieldInteractions = <P extends {}>({
         (props as any).shouldRespectLeadingZeros ? 'singleDigit' : undefined,
       );
     });
-    response.unmount();
   };
 
   return { testFieldKeyPress, testFieldChange, renderWithProps };


### PR DESCRIPTION
## Summary

- Remove 101 redundant `unmount()` calls across 10 test files + the `fields.tsx` helper in the Pickers test suite.
- These were leftovers from the v6/v7 field DOM structure era (each test used to render twice, unmount between renders, and unmount at the end); removed in #21966 but the trailing call was never cleaned up.
- Vitest's auto-cleanup (`afterEach(() => cleanup())` registered in `@mui/internal-test-utils/setupVitest`) already handles unmounting between tests, so the explicit calls are redundant.
- The three `testFormat` helpers in the Desktop picker field tests are intentionally left alone: they render 6–9 instances within a single `it()` block and the intermediate `unmount()` is load-bearing (`document.querySelector` would otherwise return a stale container from the first render).

## Test plan

- [x] `pnpm --filter \"@mui/x-date-pickers*\" run typescript`
- [x] `pnpm test:unit --project \"x-date-pickers\" --run` (3252 passed, 816 skipped)
- [x] `pnpm test:unit --project \"x-date-pickers-pro\" --run` (986 passed, 299 skipped, 2 todo)
- [x] `pnpm prettier`

🤖 Generated with [Claude Code](https://claude.com/claude-code)