### PR TITLE
[docs] Use mui.com for broken links checker known targets

### DIFF
--- a/docs/scripts/reportBrokenLinks.mts
+++ b/docs/scripts/reportBrokenLinks.mts
@@ -11,10 +11,7 @@ async function main() {
       // TODO: Seed crawler with stored links from e.g. mui.com/x/link-structure.json
       // /^\/(base-ui|joy-ui|store|toolpad)(\/|$)/,
     ],
-    knownTargetsDownloadUrl: [
-      // TODO: replace with https://mui.com/material-ui/link-structure.json when available
-      'https://material-ui.netlify.app/material-ui/link-structure.json',
-    ],
+    knownTargetsDownloadUrl: ['https://mui.com/material-ui/link-structure.json'],
   });
 
   process.exit(issues.length);


### PR DESCRIPTION
## Summary

Replaces the netlify staging URL with the production `mui.com/material-ui/link-structure.json` in `docs/scripts/reportBrokenLinks.mts`, resolving the corresponding TODO. The mui.com URL is now live (verified 200).

The other TODO (seeding the crawler from `mui.com/x/link-structure.json`) remains — that endpoint still 404s.