### PR TITLE
[pickers] Fix `onAccept` not being called after external value change

### DIFF
--- a/packages/x-date-pickers/src/MobileDatePicker/tests/MobileDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileDatePicker/tests/MobileDatePicker.test.tsx
@@ -148,6 +148,29 @@ describe('<MobileDatePicker />', () => {
       expect(onAccept.callCount).to.equal(1);
     });
 
+    // Ensures the case in https://github.com/mui/mui-x/issues/21962 works correctly
+    it('should call `onAccept` when clearing an externally-set controlled value', () => {
+      const onAccept = spy();
+
+      const view = renderWithProps({
+        value: null,
+        onAccept,
+        slotProps: {
+          actionBar: { actions: ['clear'] },
+        },
+      });
+
+      // Simulate external value update (e.g., from Redux)
+      view.setProps({ value: adapterToUse.date('2018-01-01') });
+
+      openPicker({ type: 'date' });
+
+      fireEvent.click(screen.getByText('Clear'));
+
+      expect(onAccept.callCount).to.equal(1);
+      expect(onAccept.lastCall.args[0]).to.equal(null);
+    });
+
     it('should update internal state when controlled value is updated', async () => {
       const view = renderWithProps({
         value: adapterToUse.date('2019-01-01'),

--- a/packages/x-date-pickers/src/internals/hooks/usePicker/hooks/useValueAndOpenStates.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePicker/hooks/useValueAndOpenStates.ts
@@ -147,6 +147,9 @@ export function useValueAndOpenStates<
       ...prevState,
       // We reset the shallow value whenever we fire onChange.
       clockShallowValue: shouldFireOnChange ? undefined : prevState.clockShallowValue,
+      // Track the value we're emitting so the external-change detector below doesn't
+      // re-fire when the controlled parent reflects our own onChange back.
+      lastExternalValue: shouldFireOnChange ? newValue : prevState.lastExternalValue,
       lastCommittedValue: shouldFireOnAccept ? newValue : prevState.lastCommittedValue,
       hasBeenModifiedSinceMount: true,
     }));
@@ -190,11 +193,14 @@ export function useValueAndOpenStates<
     }
   });
 
-  // If `prop.value` changes, we update the state to reflect the new value
+  // If `prop.value` changes externally (not as a result of our own onChange), sync both
+  // lastExternalValue and lastCommittedValue so that onAccept fires correctly when the user
+  // subsequently accepts/clears the externally-set value.
   if (value !== state.lastExternalValue) {
     setState((prevState) => ({
       ...prevState,
       lastExternalValue: value,
+      lastCommittedValue: value,
       clockShallowValue: undefined,
       hasBeenModifiedSinceMount: true,
     }));


### PR DESCRIPTION
This PR fixes a bug where the `onAccept` callback (and consequently the `Clear` action in the picker's action bar) would fail to fire if the picker's value had been updated externally (e.g., via a controlled `value` prop from Redux or parent state) since the last time the picker was opened or a value was committed.

Fixes #21962 