### PR TITLE
[charts] Fix radius grid lines when axis uses point scale

### DIFF
--- a/packages/x-charts/src/ChartsRadialGrid/ChartsRadialGrid.test.tsx
+++ b/packages/x-charts/src/ChartsRadialGrid/ChartsRadialGrid.test.tsx
@@ -52,6 +52,31 @@ describe('<ChartsRadialGrid />', () => {
 
     expect(getRadiusLinesCount()).to.equal(10);
   });
+
+  it('should render full circles with rotation scaleType set to point', () => {
+    const { getRadiusLinesCount } = testRadialGrid(render, {
+      radialGrid: { radius: true },
+      rotationAxis: { scaleType: 'point', data: ['A', 'B', 'C', 'D', 'E'] },
+    });
+
+    expect(getRadiusLinesCount('circle')).to.equal(2);
+    expect(getRadiusLinesCount('path')).to.equal(0);
+  });
+
+  it('should render paths when rotation scaleType is set to point, but have different start/end angles', () => {
+    const { getRadiusLinesCount } = testRadialGrid(render, {
+      radialGrid: { radius: true },
+      rotationAxis: {
+        scaleType: 'point',
+        data: ['A', 'B', 'C', 'D', 'E'],
+        startAngle: 0,
+        endAngle: Math.PI,
+      },
+    });
+
+    expect(getRadiusLinesCount('circle')).to.equal(0);
+    expect(getRadiusLinesCount('path')).to.equal(2);
+  });
 });
 
 /**
@@ -78,8 +103,8 @@ function testRadialGrid(
     </Unstable_ChartsRadialDataProvider>,
   );
 
-  const getRadiusLinesCount = () =>
-    container.querySelectorAll(`.${chartsRadialGridClasses.radiusLine}`).length;
+  const getRadiusLinesCount = (elementType?: 'path' | 'circle') =>
+    container.querySelectorAll(`${elementType ?? ''}.${chartsRadialGridClasses.radiusLine}`).length;
   const getRotationLinesCount = () =>
     container.querySelectorAll(`.${chartsRadialGridClasses.rotationLine}`).length;
 

--- a/packages/x-charts/src/ChartsRadialGrid/ChartsRadialGrid.tsx
+++ b/packages/x-charts/src/ChartsRadialGrid/ChartsRadialGrid.tsx
@@ -11,6 +11,7 @@ import { GridRoot } from './styledComponents';
 import { ChartsRotationGrid } from './ChartsRotationGrid';
 import { ChartsRadiusGrid } from './ChartsRadiusGrid';
 import { useRotationAxes, useRadiusAxes } from '../hooks/useAxis';
+import { EPSILON } from '../utils/epsilon';
 
 const useUtilityClasses = ({ classes }: ChartsRadialGridProps) => {
   const slots = {
@@ -66,7 +67,20 @@ function ChartsRadialGrid(inProps: ChartsRadialGridProps) {
   const outerRadius = radiusAxisConfig?.scale.range()[1] ?? 0;
 
   const startAngle = rotationAxisConfig?.scale.range()[0] ?? 0;
-  const endAngle = rotationAxisConfig?.scale.range()[1] ?? 0;
+  let endAngle = rotationAxisConfig?.scale.range()[1] ?? 0;
+
+  if (rotationAxisConfig.scaleType === 'point') {
+    // The rotation gap we add between the first and last point.
+    const dataRotationGap = (2 * Math.PI) / rotationAxisConfig.data!.length;
+
+    // The missing angle between the last and first point.
+    const angleGap = 2 * Math.PI - Math.abs(endAngle - startAngle);
+    if (Math.abs(angleGap - dataRotationGap) < EPSILON) {
+      // If they are close enough we close the circle.
+      // Otherwise it means user deliberately modified the angles and so keep it as it is.
+      endAngle = startAngle + 2 * Math.PI;
+    }
+  }
 
   return (
     <GridRoot {...other} className={clsx(classes.root, className)}>


### PR DESCRIPTION
The rotation axis with point scale as an edge case to consider when rendering the grid.

Its range (the red arrow) is by default 2*PI * ( N - 1) / N.  The ratio N-1/N is here to avoid getting the last tick overlapping with the first one.

But we still would like to display a full circle for the grid. Before this PR the orange arcs would be missing.

<img width="478" height="452" alt="image" src="https://github.com/user-attachments/assets/ddd6879d-9586-4a4c-8ba0-cbc5283db139" />



So I'm adding a condition in the grid component.

- If we are close to this N-1/N ratio we modify the `endAngle` to display full circles
- If we are not we keep it as it is. Allowing users to display charts on half circles.

