### PR TITLE
[infra] Update .gitignore to exclude `.claude/worktrees`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .vscode
 .cursor
 .claude/settings.local.json
+.claude/worktrees
 .junie
 
 __diff_output__


### PR DESCRIPTION
This polutes `git status` by a fair bit.