### PR TITLE
[pickers] Forward data-* and aria-* attributes through static pickers

### DIFF
--- a/docs/pages/x/api/date-pickers/date-picker.json
+++ b/docs/pages/x/api/date-pickers/date-picker.json
@@ -372,7 +372,7 @@
     }
   ],
   "classes": [],
-  "spread": false,
+  "spread": true,
   "themeDefaultProps": false,
   "muiName": "MuiDatePicker",
   "forwardsRefTo": "HTMLDivElement",

--- a/docs/pages/x/api/date-pickers/date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/date-range-picker.json
@@ -322,7 +322,7 @@
     }
   ],
   "classes": [],
-  "spread": false,
+  "spread": true,
   "themeDefaultProps": false,
   "muiName": "MuiDateRangePicker",
   "forwardsRefTo": "HTMLDivElement",

--- a/docs/pages/x/api/date-pickers/date-time-picker.json
+++ b/docs/pages/x/api/date-pickers/date-time-picker.json
@@ -415,7 +415,7 @@
     }
   ],
   "classes": [],
-  "spread": false,
+  "spread": true,
   "themeDefaultProps": false,
   "muiName": "MuiDateTimePicker",
   "forwardsRefTo": "HTMLDivElement",

--- a/docs/pages/x/api/date-pickers/date-time-range-picker.json
+++ b/docs/pages/x/api/date-pickers/date-time-range-picker.json
@@ -388,7 +388,7 @@
     }
   ],
   "classes": [],
-  "spread": false,
+  "spread": true,
   "themeDefaultProps": false,
   "muiName": "MuiDateTimeRangePicker",
   "forwardsRefTo": "HTMLDivElement",

--- a/docs/pages/x/api/date-pickers/desktop-date-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-date-picker.json
@@ -347,7 +347,7 @@
     }
   ],
   "classes": [],
-  "spread": false,
+  "spread": true,
   "themeDefaultProps": false,
   "muiName": "MuiDesktopDatePicker",
   "forwardsRefTo": "HTMLDivElement",

--- a/docs/pages/x/api/date-pickers/desktop-date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-date-range-picker.json
@@ -297,7 +297,7 @@
     }
   ],
   "classes": [],
-  "spread": false,
+  "spread": true,
   "themeDefaultProps": false,
   "muiName": "MuiDesktopDateRangePicker",
   "forwardsRefTo": "HTMLDivElement",

--- a/docs/pages/x/api/date-pickers/desktop-date-time-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-date-time-picker.json
@@ -393,7 +393,7 @@
     }
   ],
   "classes": [],
-  "spread": false,
+  "spread": true,
   "themeDefaultProps": false,
   "muiName": "MuiDesktopDateTimePicker",
   "forwardsRefTo": "HTMLDivElement",

--- a/docs/pages/x/api/date-pickers/desktop-date-time-range-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-date-time-range-picker.json
@@ -366,7 +366,7 @@
     }
   ],
   "classes": [],
-  "spread": false,
+  "spread": true,
   "themeDefaultProps": false,
   "muiName": "MuiDesktopDateTimeRangePicker",
   "forwardsRefTo": "HTMLDivElement",

--- a/docs/pages/x/api/date-pickers/desktop-time-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-time-picker.json
@@ -277,7 +277,7 @@
     }
   ],
   "classes": [],
-  "spread": false,
+  "spread": true,
   "themeDefaultProps": false,
   "muiName": "MuiDesktopTimePicker",
   "forwardsRefTo": "HTMLDivElement",

--- a/docs/pages/x/api/date-pickers/desktop-time-range-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-time-range-picker.json
@@ -292,7 +292,7 @@
     }
   ],
   "classes": [],
-  "spread": false,
+  "spread": true,
   "themeDefaultProps": false,
   "muiName": "MuiDesktopTimeRangePicker",
   "forwardsRefTo": "HTMLDivElement",

--- a/docs/pages/x/api/date-pickers/mobile-date-picker.json
+++ b/docs/pages/x/api/date-pickers/mobile-date-picker.json
@@ -341,7 +341,7 @@
     }
   ],
   "classes": [],
-  "spread": false,
+  "spread": true,
   "themeDefaultProps": false,
   "muiName": "MuiMobileDatePicker",
   "forwardsRefTo": "HTMLDivElement",

--- a/docs/pages/x/api/date-pickers/mobile-date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/mobile-date-range-picker.json
@@ -287,7 +287,7 @@
     }
   ],
   "classes": [],
-  "spread": false,
+  "spread": true,
   "themeDefaultProps": false,
   "muiName": "MuiMobileDateRangePicker",
   "forwardsRefTo": "HTMLDivElement",

--- a/docs/pages/x/api/date-pickers/mobile-date-time-picker.json
+++ b/docs/pages/x/api/date-pickers/mobile-date-time-picker.json
@@ -387,7 +387,7 @@
     }
   ],
   "classes": [],
-  "spread": false,
+  "spread": true,
   "themeDefaultProps": false,
   "muiName": "MuiMobileDateTimePicker",
   "forwardsRefTo": "HTMLDivElement",

--- a/docs/pages/x/api/date-pickers/mobile-date-time-range-picker.json
+++ b/docs/pages/x/api/date-pickers/mobile-date-time-range-picker.json
@@ -356,7 +356,7 @@
     }
   ],
   "classes": [],
-  "spread": false,
+  "spread": true,
   "themeDefaultProps": false,
   "muiName": "MuiMobileDateTimeRangePicker",
   "forwardsRefTo": "HTMLDivElement",

--- a/docs/pages/x/api/date-pickers/mobile-time-picker.json
+++ b/docs/pages/x/api/date-pickers/mobile-time-picker.json
@@ -247,7 +247,7 @@
     }
   ],
   "classes": [],
-  "spread": false,
+  "spread": true,
   "themeDefaultProps": false,
   "muiName": "MuiMobileTimePicker",
   "forwardsRefTo": "HTMLDivElement",

--- a/docs/pages/x/api/date-pickers/mobile-time-range-picker.json
+++ b/docs/pages/x/api/date-pickers/mobile-time-range-picker.json
@@ -283,7 +283,7 @@
     }
   ],
   "classes": [],
-  "spread": false,
+  "spread": true,
   "themeDefaultProps": false,
   "muiName": "MuiMobileTimeRangePicker",
   "forwardsRefTo": "HTMLDivElement",

--- a/docs/pages/x/api/date-pickers/static-date-picker.json
+++ b/docs/pages/x/api/date-pickers/static-date-picker.json
@@ -260,7 +260,7 @@
     }
   ],
   "classes": [],
-  "spread": false,
+  "spread": true,
   "themeDefaultProps": false,
   "muiName": "MuiStaticDatePicker",
   "forwardsRefTo": "HTMLDivElement",

--- a/docs/pages/x/api/date-pickers/static-date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/static-date-range-picker.json
@@ -210,7 +210,7 @@
     }
   ],
   "classes": [],
-  "spread": false,
+  "spread": true,
   "themeDefaultProps": false,
   "muiName": "MuiStaticDateRangePicker",
   "forwardsRefTo": "HTMLDivElement",

--- a/docs/pages/x/api/date-pickers/static-date-time-picker.json
+++ b/docs/pages/x/api/date-pickers/static-date-time-picker.json
@@ -306,7 +306,7 @@
     }
   ],
   "classes": [],
-  "spread": false,
+  "spread": true,
   "themeDefaultProps": false,
   "muiName": "MuiStaticDateTimePicker",
   "forwardsRefTo": "HTMLDivElement",

--- a/docs/pages/x/api/date-pickers/static-time-picker.json
+++ b/docs/pages/x/api/date-pickers/static-time-picker.json
@@ -166,7 +166,7 @@
     }
   ],
   "classes": [],
-  "spread": false,
+  "spread": true,
   "themeDefaultProps": false,
   "muiName": "MuiStaticTimePicker",
   "forwardsRefTo": "HTMLDivElement",

--- a/docs/pages/x/api/date-pickers/time-range-picker.json
+++ b/docs/pages/x/api/date-pickers/time-range-picker.json
@@ -312,7 +312,7 @@
     }
   ],
   "classes": [],
-  "spread": false,
+  "spread": true,
   "themeDefaultProps": false,
   "muiName": "MuiTimeRangePicker",
   "forwardsRefTo": "HTMLDivElement",

--- a/packages/x-date-pickers-pro/src/DateRangePicker/describeConformance.DateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/describeConformance.DateRangePicker.test.tsx
@@ -16,7 +16,6 @@ describe('<DateRangePicker /> - Describe Conformance', () => {
       'themeStyleOverrides',
       'themeVariants',
       'mergeClassName',
-      'propsSpread',
     ],
   }));
 });

--- a/packages/x-date-pickers-pro/src/DateTimeRangePicker/tests/describeConformance.DateTimeRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DateTimeRangePicker/tests/describeConformance.DateTimeRangePicker.test.tsx
@@ -16,7 +16,6 @@ describe('<DateTimeRangePicker /> - Describe Conformance', () => {
       'themeStyleOverrides',
       'themeVariants',
       'mergeClassName',
-      'propsSpread',
     ],
   }));
 });

--- a/packages/x-date-pickers-pro/src/DesktopDateRangePicker/tests/describeConformance.DesktopDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateRangePicker/tests/describeConformance.DesktopDateRangePicker.test.tsx
@@ -18,7 +18,6 @@ describe('<DesktopDateRangePicker /> - Describe Conformance', () => {
       'themeStyleOverrides',
       'themeVariants',
       'mergeClassName',
-      'propsSpread',
     ],
   }));
 });

--- a/packages/x-date-pickers-pro/src/DesktopDateTimeRangePicker/tests/describeConformance.DesktopDateTimeRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateTimeRangePicker/tests/describeConformance.DesktopDateTimeRangePicker.test.tsx
@@ -22,7 +22,6 @@ describe('<DesktopDateTimeRangePicker /> - Describe Conformance', () => {
       'themeStyleOverrides',
       'themeVariants',
       'mergeClassName',
-      'propsSpread',
     ],
   }));
 });

--- a/packages/x-date-pickers-pro/src/DesktopTimeRangePicker/tests/describeConformance.DesktopTimeRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopTimeRangePicker/tests/describeConformance.DesktopTimeRangePicker.test.tsx
@@ -22,7 +22,6 @@ describe('<DesktopTimeRangePicker /> - Describe Conformance', () => {
       'themeStyleOverrides',
       'themeVariants',
       'mergeClassName',
-      'propsSpread',
     ],
   }));
 });

--- a/packages/x-date-pickers-pro/src/MobileDateRangePicker/tests/describeConformance.MobileDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/MobileDateRangePicker/tests/describeConformance.MobileDateRangePicker.test.tsx
@@ -18,7 +18,6 @@ describe('<MobileDateRangePicker /> - Describe Conformance', () => {
       'themeStyleOverrides',
       'themeVariants',
       'mergeClassName',
-      'propsSpread',
     ],
   }));
 });

--- a/packages/x-date-pickers-pro/src/MobileDateTimeRangePicker/tests/describeConformance.MobileDateTimeRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/MobileDateTimeRangePicker/tests/describeConformance.MobileDateTimeRangePicker.test.tsx
@@ -22,7 +22,6 @@ describe('<MobileDateTimeRangePicker /> - Describe Conformance', () => {
       'themeStyleOverrides',
       'themeVariants',
       'mergeClassName',
-      'propsSpread',
     ],
   }));
 });

--- a/packages/x-date-pickers-pro/src/MobileTimeRangePicker/tests/describeConformance.MobileTimeRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/MobileTimeRangePicker/tests/describeConformance.MobileTimeRangePicker.test.tsx
@@ -22,7 +22,6 @@ describe('<MobileTimeRangePicker /> - Describe Conformance', () => {
       'themeStyleOverrides',
       'themeVariants',
       'mergeClassName',
-      'propsSpread',
     ],
   }));
 });

--- a/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.test.tsx
@@ -18,10 +18,6 @@ describe('<StaticDateRangePicker />', () => {
       'themeStyleOverrides',
       'themeVariants',
       'mergeClassName',
-      // Static pickers render through `PickersLayout`, which does not forward
-      // unknown props to its root `div`. Enabling `propsSpread` here requires
-      // a separate change to either `PickersLayout` or `useStaticPicker`.
-      'propsSpread',
     ],
   }));
 

--- a/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.test.tsx
@@ -18,6 +18,9 @@ describe('<StaticDateRangePicker />', () => {
       'themeStyleOverrides',
       'themeVariants',
       'mergeClassName',
+      // Static pickers render through `PickersLayout`, which does not forward
+      // unknown props to its root `div`. Enabling `propsSpread` here requires
+      // a separate change to either `PickersLayout` or `useStaticPicker`.
       'propsSpread',
     ],
   }));

--- a/packages/x-date-pickers-pro/src/TimeRangePicker/tests/describeConformance.TimeRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/TimeRangePicker/tests/describeConformance.TimeRangePicker.test.tsx
@@ -16,7 +16,6 @@ describe('<TimeRangePicker /> - Describe Conformance', () => {
       'themeStyleOverrides',
       'themeVariants',
       'mergeClassName',
-      'propsSpread',
     ],
   }));
 });

--- a/packages/x-date-pickers-pro/src/internals/hooks/useDesktopRangePicker/useDesktopRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/internals/hooks/useDesktopRangePicker/useDesktopRangePicker.tsx
@@ -8,6 +8,7 @@ import {
   DateOrTimeViewWithMeridiem,
   PickerProvider,
   PickerRangeValue,
+  extractRootForwardedProps,
 } from '@mui/x-date-pickers/internals';
 import {
   UseDesktopRangePickerParams,
@@ -69,6 +70,10 @@ export const useDesktopRangePicker = <
   const { ownerState: fieldOwnerState, ...fieldProps } = useSlotProps({
     elementType: Field,
     externalSlotProps: slotProps?.field,
+    // Forward `data-*` and `aria-*` attributes set on the Picker to the field
+    // so they land on the rendered text field root, matching standard HTML
+    // element behavior.
+    externalForwardedProps: extractRootForwardedProps(props),
     ownerState,
     additionalProps: {
       'data-active-range-position': providerProps.contextValue.open

--- a/packages/x-date-pickers-pro/src/internals/hooks/useDesktopRangePicker/useDesktopRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/internals/hooks/useDesktopRangePicker/useDesktopRangePicker.tsx
@@ -70,9 +70,6 @@ export const useDesktopRangePicker = <
   const { ownerState: fieldOwnerState, ...fieldProps } = useSlotProps({
     elementType: Field,
     externalSlotProps: slotProps?.field,
-    // Forward `data-*` and `aria-*` attributes set on the Picker to the field
-    // so they land on the rendered text field root, matching standard HTML
-    // element behavior.
     externalForwardedProps: extractRootForwardedProps(props),
     ownerState,
     additionalProps: {

--- a/packages/x-date-pickers-pro/src/internals/hooks/useMobileRangePicker/useMobileRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/internals/hooks/useMobileRangePicker/useMobileRangePicker.tsx
@@ -10,6 +10,7 @@ import {
   DateOrTimeViewWithMeridiem,
   PickerProvider,
   PickerRangeValue,
+  extractRootForwardedProps,
 } from '@mui/x-date-pickers/internals';
 import { usePickerTranslations } from '@mui/x-date-pickers/hooks';
 import { FieldOwnerState } from '@mui/x-date-pickers/models';
@@ -72,6 +73,10 @@ export const useMobileRangePicker = <
   const { ownerState: fieldOwnerState, ...fieldProps } = useSlotProps({
     elementType: Field,
     externalSlotProps: innerSlotProps?.field,
+    // Forward `data-*` and `aria-*` attributes set on the Picker to the field
+    // so they land on the rendered text field root, matching standard HTML
+    // element behavior.
+    externalForwardedProps: extractRootForwardedProps(props),
     additionalProps: {
       ...(isSingleInput &&
         isToolbarHidden && {

--- a/packages/x-date-pickers-pro/src/internals/hooks/useMobileRangePicker/useMobileRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/internals/hooks/useMobileRangePicker/useMobileRangePicker.tsx
@@ -73,9 +73,6 @@ export const useMobileRangePicker = <
   const { ownerState: fieldOwnerState, ...fieldProps } = useSlotProps({
     elementType: Field,
     externalSlotProps: innerSlotProps?.field,
-    // Forward `data-*` and `aria-*` attributes set on the Picker to the field
-    // so they land on the rendered text field root, matching standard HTML
-    // element behavior.
     externalForwardedProps: extractRootForwardedProps(props),
     additionalProps: {
       ...(isSingleInput &&

--- a/packages/x-date-pickers-pro/src/internals/hooks/useStaticRangePicker/useStaticRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/internals/hooks/useStaticRangePicker/useStaticRangePicker.tsx
@@ -8,6 +8,7 @@ import {
   DateOrTimeViewWithMeridiem,
   PickerProvider,
   PickerRangeValue,
+  extractRootForwardedProps,
   mergeSx,
 } from '@mui/x-date-pickers/internals';
 import {
@@ -63,6 +64,7 @@ export const useStaticRangePicker = <
     <PickerRangePositionContext.Provider value={rangePositionResponse}>
       <PickerProvider {...providerProps}>
         <Layout
+          {...extractRootForwardedProps(props)}
           {...slotProps?.layout}
           slots={slots}
           slotProps={slotProps}

--- a/packages/x-date-pickers/src/DatePicker/tests/describeConformance.DatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DatePicker/tests/describeConformance.DatePicker.test.tsx
@@ -16,7 +16,6 @@ describe('<DatePicker /> - Describe Conformance', () => {
       'themeStyleOverrides',
       'themeVariants',
       'mergeClassName',
-      'propsSpread',
     ],
   }));
 });

--- a/packages/x-date-pickers/src/DateTimePicker/tests/describeConformance.DateTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/DateTimePicker/tests/describeConformance.DateTimePicker.test.tsx
@@ -16,7 +16,6 @@ describe('<DateTimePicker /> - Describe Conformance', () => {
       'themeStyleOverrides',
       'themeVariants',
       'mergeClassName',
-      'propsSpread',
     ],
   }));
 });

--- a/packages/x-date-pickers/src/DesktopDatePicker/tests/describeConformance.DesktopDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/tests/describeConformance.DesktopDatePicker.test.tsx
@@ -18,7 +18,6 @@ describe('<DesktopDatePicker /> - Describe Conformance', () => {
       'themeStyleOverrides',
       'themeVariants',
       'mergeClassName',
-      'propsSpread',
     ],
   }));
 });

--- a/packages/x-date-pickers/src/DesktopDateTimePicker/tests/describeConformance.DesktopDateTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDateTimePicker/tests/describeConformance.DesktopDateTimePicker.test.tsx
@@ -31,7 +31,6 @@ describe('<DesktopDateTimePicker /> - Describe Conformance', () => {
       'themeStyleOverrides',
       'themeVariants',
       'mergeClassName',
-      'propsSpread',
     ],
   }));
 });

--- a/packages/x-date-pickers/src/DesktopTimePicker/tests/describeConformance.DesktopTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopTimePicker/tests/describeConformance.DesktopTimePicker.test.tsx
@@ -22,7 +22,6 @@ describe('<DesktopTimePicker /> - Describe Conformance', () => {
       'themeStyleOverrides',
       'themeVariants',
       'mergeClassName',
-      'propsSpread',
     ],
   }));
 });

--- a/packages/x-date-pickers/src/MobileDatePicker/tests/describeConformance.MobileDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileDatePicker/tests/describeConformance.MobileDatePicker.test.tsx
@@ -18,7 +18,6 @@ describe('<MobileDatePicker /> - Describe Conformance', () => {
       'themeStyleOverrides',
       'themeVariants',
       'mergeClassName',
-      'propsSpread',
     ],
   }));
 });

--- a/packages/x-date-pickers/src/MobileDateTimePicker/tests/describeConformance.MobileDateTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileDateTimePicker/tests/describeConformance.MobileDateTimePicker.test.tsx
@@ -18,7 +18,6 @@ describe('<MobileDateTimePicker /> - Describe Conformance', () => {
       'themeStyleOverrides',
       'themeVariants',
       'mergeClassName',
-      'propsSpread',
     ],
   }));
 });

--- a/packages/x-date-pickers/src/MobileTimePicker/tests/describeConformance.MobileTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileTimePicker/tests/describeConformance.MobileTimePicker.test.tsx
@@ -18,7 +18,6 @@ describe('<MobileTimePicker /> - Describe Conformance', () => {
       'themeStyleOverrides',
       'themeVariants',
       'mergeClassName',
-      'propsSpread',
     ],
   }));
 });

--- a/packages/x-date-pickers/src/PickersLayout/PickersLayout.tsx
+++ b/packages/x-date-pickers/src/PickersLayout/PickersLayout.tsx
@@ -114,7 +114,7 @@ const PickersLayout = React.forwardRef(function PickersLayout<TValue extends Pic
 
   const { toolbar, content, tabs, actionBar, shortcuts, ownerState } = usePickerLayout(props);
   const { orientation, variant } = usePickerContext();
-  const { sx, className, classes: classesProp } = props;
+  const { sx, className, classes: classesProp, children, slots, slotProps, ...other } = props;
 
   const classes = useUtilityClasses(classesProp, ownerState);
 
@@ -124,6 +124,7 @@ const PickersLayout = React.forwardRef(function PickersLayout<TValue extends Pic
       sx={sx}
       className={clsx(classes.root, className)}
       ownerState={ownerState}
+      {...other}
     >
       {orientation === 'landscape' ? shortcuts : toolbar}
       {orientation === 'landscape' ? toolbar : shortcuts}

--- a/packages/x-date-pickers/src/PickersLayout/PickersLayout.types.ts
+++ b/packages/x-date-pickers/src/PickersLayout/PickersLayout.types.ts
@@ -90,7 +90,10 @@ export interface PickersLayoutSlotProps<
   toolbar?: ExportedBaseToolbarProps;
 }
 
-export interface PickersLayoutProps<TValue extends PickerValidValue> {
+export interface PickersLayoutProps<TValue extends PickerValidValue> extends Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  'children' | 'className'
+> {
   className?: string;
   children?: React.ReactNode;
   /**

--- a/packages/x-date-pickers/src/StaticDatePicker/tests/describeConformance.StaticDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/StaticDatePicker/tests/describeConformance.StaticDatePicker.test.tsx
@@ -18,10 +18,6 @@ describe('<StaticDatePicker /> - Describe Conformance', () => {
       'themeStyleOverrides',
       'themeVariants',
       'mergeClassName',
-      // Static pickers render through `PickersLayout`, which does not forward
-      // unknown props to its root `div`. Enabling `propsSpread` here requires
-      // a separate change to either `PickersLayout` or `useStaticPicker`.
-      'propsSpread',
     ],
   }));
 });

--- a/packages/x-date-pickers/src/StaticDatePicker/tests/describeConformance.StaticDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/StaticDatePicker/tests/describeConformance.StaticDatePicker.test.tsx
@@ -18,6 +18,9 @@ describe('<StaticDatePicker /> - Describe Conformance', () => {
       'themeStyleOverrides',
       'themeVariants',
       'mergeClassName',
+      // Static pickers render through `PickersLayout`, which does not forward
+      // unknown props to its root `div`. Enabling `propsSpread` here requires
+      // a separate change to either `PickersLayout` or `useStaticPicker`.
       'propsSpread',
     ],
   }));

--- a/packages/x-date-pickers/src/StaticDateTimePicker/tests/describeConformance.StaticDateTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/StaticDateTimePicker/tests/describeConformance.StaticDateTimePicker.test.tsx
@@ -18,6 +18,9 @@ describe('<StaticDateTimePicker /> - Describe Conformance', () => {
       'themeStyleOverrides',
       'themeVariants',
       'mergeClassName',
+      // Static pickers render through `PickersLayout`, which does not forward
+      // unknown props to its root `div`. Enabling `propsSpread` here requires
+      // a separate change to either `PickersLayout` or `useStaticPicker`.
       'propsSpread',
     ],
   }));

--- a/packages/x-date-pickers/src/StaticDateTimePicker/tests/describeConformance.StaticDateTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/StaticDateTimePicker/tests/describeConformance.StaticDateTimePicker.test.tsx
@@ -18,10 +18,6 @@ describe('<StaticDateTimePicker /> - Describe Conformance', () => {
       'themeStyleOverrides',
       'themeVariants',
       'mergeClassName',
-      // Static pickers render through `PickersLayout`, which does not forward
-      // unknown props to its root `div`. Enabling `propsSpread` here requires
-      // a separate change to either `PickersLayout` or `useStaticPicker`.
-      'propsSpread',
     ],
   }));
 });

--- a/packages/x-date-pickers/src/StaticTimePicker/StaticTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/StaticTimePicker/StaticTimePicker.test.tsx
@@ -27,10 +27,6 @@ describe('<StaticTimePicker />', () => {
       'themeStyleOverrides',
       'themeVariants',
       'mergeClassName',
-      // Static pickers render through `PickersLayout`, which does not forward
-      // unknown props to its root `div`. Enabling `propsSpread` here requires
-      // a separate change to either `PickersLayout` or `useStaticPicker`.
-      'propsSpread',
     ],
   }));
 

--- a/packages/x-date-pickers/src/StaticTimePicker/StaticTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/StaticTimePicker/StaticTimePicker.test.tsx
@@ -27,6 +27,9 @@ describe('<StaticTimePicker />', () => {
       'themeStyleOverrides',
       'themeVariants',
       'mergeClassName',
+      // Static pickers render through `PickersLayout`, which does not forward
+      // unknown props to its root `div`. Enabling `propsSpread` here requires
+      // a separate change to either `PickersLayout` or `useStaticPicker`.
       'propsSpread',
     ],
   }));

--- a/packages/x-date-pickers/src/internals/hooks/useDesktopPicker/useDesktopPicker.tsx
+++ b/packages/x-date-pickers/src/internals/hooks/useDesktopPicker/useDesktopPicker.tsx
@@ -47,9 +47,6 @@ export const useDesktopPicker = <
   const { ownerState: fieldOwnerState, ...fieldProps } = useSlotProps({
     elementType: Field,
     externalSlotProps: innerSlotProps?.field,
-    // Forward `data-*` and `aria-*` attributes set on the Picker to the field
-    // so they land on the rendered text field root, matching standard HTML
-    // element behavior.
     externalForwardedProps: extractRootForwardedProps(props),
     additionalProps: {
       // Forwarded props

--- a/packages/x-date-pickers/src/internals/hooks/useDesktopPicker/useDesktopPicker.tsx
+++ b/packages/x-date-pickers/src/internals/hooks/useDesktopPicker/useDesktopPicker.tsx
@@ -6,6 +6,7 @@ import { PickersLayout } from '../../../PickersLayout';
 import { DateOrTimeViewWithMeridiem, PickerValue } from '../../models';
 import { PickerProvider } from '../../components/PickerProvider';
 import { createNonRangePickerStepNavigation } from '../../utils/createNonRangePickerStepNavigation';
+import { extractRootForwardedProps } from '../../utils/utils';
 
 /**
  * Hook managing all the single-date desktop pickers:
@@ -46,6 +47,10 @@ export const useDesktopPicker = <
   const { ownerState: fieldOwnerState, ...fieldProps } = useSlotProps({
     elementType: Field,
     externalSlotProps: innerSlotProps?.field,
+    // Forward `data-*` and `aria-*` attributes set on the Picker to the field
+    // so they land on the rendered text field root, matching standard HTML
+    // element behavior.
+    externalForwardedProps: extractRootForwardedProps(props),
     additionalProps: {
       // Forwarded props
       ...(isToolbarHidden && { id: labelId }),

--- a/packages/x-date-pickers/src/internals/hooks/useMobilePicker/useMobilePicker.tsx
+++ b/packages/x-date-pickers/src/internals/hooks/useMobilePicker/useMobilePicker.tsx
@@ -47,9 +47,6 @@ export const useMobilePicker = <
   const { ownerState: fieldOwnerState, ...fieldProps } = useSlotProps({
     elementType: Field,
     externalSlotProps: innerSlotProps?.field,
-    // Forward `data-*` and `aria-*` attributes set on the Picker to the field
-    // so they land on the rendered text field root, matching standard HTML
-    // element behavior.
     externalForwardedProps: extractRootForwardedProps(props),
     additionalProps: {
       // Forwarded props

--- a/packages/x-date-pickers/src/internals/hooks/useMobilePicker/useMobilePicker.tsx
+++ b/packages/x-date-pickers/src/internals/hooks/useMobilePicker/useMobilePicker.tsx
@@ -6,6 +6,7 @@ import { PickersLayout } from '../../../PickersLayout';
 import { DateOrTimeViewWithMeridiem, PickerValue } from '../../models';
 import { PickerProvider } from '../../components/PickerProvider';
 import { createNonRangePickerStepNavigation } from '../../utils/createNonRangePickerStepNavigation';
+import { extractRootForwardedProps } from '../../utils/utils';
 
 /**
  * Hook managing all the single-date mobile pickers:
@@ -46,6 +47,10 @@ export const useMobilePicker = <
   const { ownerState: fieldOwnerState, ...fieldProps } = useSlotProps({
     elementType: Field,
     externalSlotProps: innerSlotProps?.field,
+    // Forward `data-*` and `aria-*` attributes set on the Picker to the field
+    // so they land on the rendered text field root, matching standard HTML
+    // element behavior.
+    externalForwardedProps: extractRootForwardedProps(props),
     additionalProps: {
       // Forwarded props
       ...(isToolbarHidden && { id: labelId }),

--- a/packages/x-date-pickers/src/internals/hooks/useStaticPicker/useStaticPicker.tsx
+++ b/packages/x-date-pickers/src/internals/hooks/useStaticPicker/useStaticPicker.tsx
@@ -7,7 +7,7 @@ import { PickerProvider } from '../../components/PickerProvider';
 import { PickersLayout } from '../../../PickersLayout';
 import { DIALOG_WIDTH } from '../../constants/dimensions';
 import { DateOrTimeViewWithMeridiem, PickerValue } from '../../models';
-import { mergeSx } from '../../utils/utils';
+import { extractRootForwardedProps, mergeSx } from '../../utils/utils';
 import { createNonRangePickerStepNavigation } from '../../utils/createNonRangePickerStepNavigation';
 
 const PickerStaticLayout = styled(PickersLayout, {
@@ -51,6 +51,7 @@ export const useStaticPicker = <
   const renderPicker = () => (
     <PickerProvider {...providerProps}>
       <Layout
+        {...extractRootForwardedProps(props)}
         {...slotProps?.layout}
         slots={slots}
         slotProps={slotProps}

--- a/packages/x-date-pickers/src/internals/index.ts
+++ b/packages/x-date-pickers/src/internals/index.ts
@@ -179,6 +179,7 @@ export {
 export { resolveTimeViewsResponse, resolveDateTimeFormat } from './utils/date-time-utils';
 export {
   executeInTheNextEventLoopTick,
+  extractRootForwardedProps,
   getActiveElement,
   onSpaceOrEnter,
   mergeSx,

--- a/packages/x-date-pickers/src/internals/utils/utils.ts
+++ b/packages/x-date-pickers/src/internals/utils/utils.ts
@@ -73,6 +73,21 @@ export const getFocusedListItemIndex = (listElement: HTMLUListElement): number =
 
 export const DEFAULT_DESKTOP_MODE_MEDIA_QUERY = '@media (pointer: fine)';
 
+/**
+ * Picks any `data-*` and `aria-*` properties from `props` so they can be
+ * forwarded to the root DOM element rendered by the Picker. Other props stay
+ * owned by the Picker and are handled explicitly elsewhere.
+ */
+export function extractRootForwardedProps<T extends object>(props: T): Record<string, unknown> {
+  const forwardedProps: Record<string, unknown> = {};
+  for (const key of Object.keys(props)) {
+    if (key.startsWith('data-') || key.startsWith('aria-')) {
+      forwardedProps[key] = (props as Record<string, unknown>)[key];
+    }
+  }
+  return forwardedProps;
+}
+
 export function mergeSx(
   ...sxProps: (SxProps<Theme> | undefined)[]
 ): ReadonlyArray<

--- a/packages/x-date-pickers/src/internals/utils/utils.ts
+++ b/packages/x-date-pickers/src/internals/utils/utils.ts
@@ -82,7 +82,7 @@ export function extractRootForwardedProps<T extends object>(props: T): Record<st
   const forwardedProps: Record<string, unknown> = {};
   for (const key of Object.keys(props)) {
     if (key.startsWith('data-') || key.startsWith('aria-')) {
-      forwardedProps[key] = (props as Record<string, unknown>)[key];
+      forwardedProps[key] = props[key as keyof T];
     }
   }
   return forwardedProps;


### PR DESCRIPTION
## Summary

Follow-up to #22147 that actually forwards `data-*` and `aria-*` attributes on the 4 static pickers (`StaticDatePicker`, `StaticDateTimePicker`, `StaticTimePicker`, `StaticDateRangePicker`), which were left out of the previous PR.

> [!NOTE]
> Stacked on top of #22147. The first 3 commits belong to that PR and will disappear from the diff once it merges.

## What changed

- `PickersLayout` now extends `React.HTMLAttributes<HTMLDivElement>`, destructures its own known props, and spreads the rest onto the root `div` (same shape as e.g. `DayCalendarSkeleton`).
- `useStaticPicker` and `useStaticRangePicker` call `extractRootForwardedProps(props)` and forward the result to the `Layout` component, so any `data-*` / `aria-*` passed to a static picker ends up on the root.
- The `propsSpread` test is enabled on the 4 static picker conformance tests (previously skipped with a TODO pointing to this follow-up).
- Regenerated API docs flip `"spread": false` to `"spread": true` on the 4 static picker JSON files.

## Test plan

- [x] `pnpm test:unit --project "x-date-pickers" --project "x-date-pickers-pro" --run` — all 4 static picker conformance tests now pass the `spreads props to the root component` assertion
- [x] `pnpm --filter "@mui/x-date-pickers*" run typescript`
- [x] `pnpm prettier`
- [x] `pnpm docs:api`
