### PR TITLE
[charts] Fix closest series detection for line charts

### DIFF
--- a/packages/x-charts/src/LineChart/seriesConfig/curveEvaluation.ts
+++ b/packages/x-charts/src/LineChart/seriesConfig/curveEvaluation.ts
@@ -152,10 +152,17 @@ export function evaluateCurveY(
 
   // Find the segment containing targetX.
   for (const segment of capture.segments) {
+    if (targetX < segment.x0 + 0.5 && targetX > segment.x0 - 0.5) {
+      return segment.y0;
+    }
+    if (targetX < segment.x1 + 0.5 && targetX > segment.x1 - 0.5) {
+      return segment.y1;
+    }
+
     const xMin = Math.min(segment.x0, segment.x1);
     const xMax = Math.max(segment.x0, segment.x1);
 
-    if (targetX >= xMin - 0.5 && targetX <= xMax + 0.5) {
+    if (targetX >= xMin && targetX <= xMax) {
       const t = findTForX(segment, targetX);
       return evaluateSegmentY(segment, t);
     }

--- a/packages/x-charts/src/LineChart/seriesConfig/getItemAtPosition.ts
+++ b/packages/x-charts/src/LineChart/seriesConfig/getItemAtPosition.ts
@@ -33,7 +33,13 @@ function getBracketIndices(
     if (index === -1) {
       return null;
     }
-    return { left: index, right: index };
+
+    const axisPointValue = getValueToPositionMapper(xAxis.scale)(axisData[index]);
+
+    if (axisPointValue <= pointX) {
+      return index === axisData.length - 1 ? null : { left: index, right: index + 1 };
+    }
+    return index === 0 ? null : { left: index - 1, right: index };
   }
 
   // For continuous axes, find the two adjacent data points surrounding pointX.

--- a/packages/x-charts/src/LineChart/seriesConfig/getItemAtPosition.ts
+++ b/packages/x-charts/src/LineChart/seriesConfig/getItemAtPosition.ts
@@ -58,7 +58,11 @@ function getBracketIndices(
   }
 
   if (leftIndex === axisData.length - 1) {
-    // Pointer is at or after the last data point — check if it's close enough.
+    if (getAsNumber(axisData[leftIndex]) < xAsNumber) {
+      // Pointer is strictly past the last data point — out of range.
+      return null;
+    }
+    // Pointer is exactly on the last data point.
     return { left: leftIndex, right: leftIndex };
   }
 

--- a/packages/x-charts/src/internals/index.ts
+++ b/packages/x-charts/src/internals/index.ts
@@ -106,3 +106,5 @@ export * from './constants';
 export * from './scales';
 export * from './identifierSerializer';
 export * from './identifierCleaner';
+
+export { default as getLineItemAtPosition } from '../LineChart/seriesConfig/getItemAtPosition';


### PR DESCRIPTION
## Before

That's just a screen shot of the closest item result on master.
Each point has the color of the series from which they are the closest according to the function

<img width="1900" height="470" alt="Capture d’écran du 2026-04-23 10-21-23" src="https://github.com/user-attachments/assets/e98b94eb-ce0e-48bf-af92-658742f01967" />

## Handle outside right

Points that are outside of segment on, the left are returning `null`. I'm modifying the function such that it does the same when too far on the right

<img width="1900" height="470" alt="Capture d’écran du 2026-04-23 10-21-47" src="https://github.com/user-attachments/assets/145bf2ee-56fa-4917-ac9a-5f17bb064b25" />

## Fix approximation

When x is on a point, we got issues. The estimated y position was not correct.

I suspect that accepting point with 0.5 outside the segment is an issue to find the $t$ parameter and so evaluate the $y$ value.

As a solution I handle the range of 0.5 pixels by setting their value directly. Assuming that if the cursore is at less tha 0.5px from the point, we can use the point $y$ value directly.

<img width="1900" height="470" alt="Capture d’écran du 2026-04-23 10-22-03" src="https://github.com/user-attachments/assets/e8944f09-91ba-460a-805d-0c6563f2ac67" />

## Fix ordinal

The idea that ordinal axes should return a single bracket looks wrong. I replaced it by using the x coorinate of the mark that is the one used to draw lines. And add the next (resp. previous) index if the pointer is on the right (resp left) of this x-coordinate

<img width="1900" height="470" alt="Capture d’écran du 2026-04-23 10-22-21" src="https://github.com/user-attachments/assets/631f3e0b-d7aa-44fd-938d-3d8d17400283" />

## Tests

I'm wondering if there are more edge case we would like to test