### PR TITLE
[infra] Fix broken tag retrieval on `master` during release

### DIFF
--- a/scripts/changelogUtils.mjs
+++ b/scripts/changelogUtils.mjs
@@ -602,7 +602,8 @@ ${logOtherSection({
 async function findLatestTaggedVersionForMajor(majorVersion, upstreamRemote = 'origin') {
   // Fetch all tags from all remotes to ensure we have the latest tags.
   await $`git fetch --tags --all`;
-  const { stdout } = await $`git describe --tags --abbrev=0 --match ${`v${majorVersion || ''}*`} ${upstreamRemote}/v${majorVersion}.x`; // only include "version-tags"
+  const { stdout } =
+    await $`git describe --tags --abbrev=0 --match ${`v${majorVersion || ''}*`} ${upstreamRemote}/v${majorVersion}.x`; // only include "version-tags"
   return stdout.trim();
 }
 

--- a/scripts/changelogUtils.mjs
+++ b/scripts/changelogUtils.mjs
@@ -599,10 +599,10 @@ ${logOtherSection({
  * Fetches and returns the latest tagged version for a given major version.
  * @param {string | undefined} majorVersion
  */
-async function findLatestTaggedVersionForMajor(majorVersion) {
+async function findLatestTaggedVersionForMajor(majorVersion, upstreamRemote = 'origin') {
   // Fetch all tags from all remotes to ensure we have the latest tags.
   await $`git fetch --tags --all`;
-  const { stdout } = await $`git describe --tags --abbrev=0 --match ${`v${majorVersion || ''}*`}`; // only include "version-tags"
+  const { stdout } = await $`git describe --tags --abbrev=0 --match ${`v${majorVersion || ''}*`} ${upstreamRemote}/v${majorVersion}.x`; // only include "version-tags"
   return stdout.trim();
 }
 

--- a/scripts/createReleasePR.mjs
+++ b/scripts/createReleasePR.mjs
@@ -830,7 +830,7 @@ async function main() {
     // Always prompt for major version first
     const majorVersion = await selectMajorVersion(latestMajorVersion);
 
-    const latestTag = await findLatestTaggedVersionForMajor(majorVersion);
+    const latestTag = await findLatestTaggedVersionForMajor(majorVersion, upstreamRemote);
     const previousVersion = latestTag.startsWith('v') ? latestTag.slice(1) : latestTag;
     console.log(`Latest tag for major version ${majorVersion}: ${previousVersion}`);
 


### PR DESCRIPTION
Pass `upstreamRemote` to `findLatestTaggedVersionForMajor` and update git command to include remote tracking

This fixes a problem where the tags on a version branch are not discoverable from master, since they were created on the version branch and never got indexed on master