### PR TITLE
[data grid] Fix accessibility violation in detail panel toggle column header

### DIFF
--- a/packages/x-data-grid-pro/src/hooks/features/detailPanel/gridDetailPanelToggleColDef.tsx
+++ b/packages/x-data-grid-pro/src/hooks/features/detailPanel/gridDetailPanelToggleColDef.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+import visuallyHidden from '@mui/utils/visuallyHidden';
 import type { RefObject } from '@mui/x-internals/types';
 import { GRID_STRING_COL_DEF, type GridColDef, gridRowIdSelector } from '@mui/x-data-grid';
 import { GRID_DETAIL_PANEL_TOGGLE_FIELD } from '@mui/x-data-grid/internals';
@@ -30,5 +32,5 @@ export const GRID_DETAIL_PANEL_TOGGLE_COL_DEF: GridColDef = {
   },
   rowSpanValueGetter: (_, row, __, apiRef) => gridRowIdSelector(apiRef, row),
   renderCell: (params) => <GridDetailPanelToggleCell {...params} />,
-  renderHeader: ({ colDef }) => <div aria-label={colDef.headerName} role="presentation" />,
+  renderHeader: ({ colDef }) => <span style={visuallyHidden}>{colDef.headerName}</span>,
 };


### PR DESCRIPTION
The detail panel toggle column header had conflicting ARIA attributes that violated WAI-ARIA 1.2 in two successive ways:

  - Before #21634: `<div aria-label="Detail panel toggle" />` — `aria-label` is not a supported property on `role="generic"` elements, which axe flags per WCAG F59.
  - After #21634: `<div aria-label="..." role="presentation" />` — WAI-ARIA requires user agents to ignore `role="presentation"` when `aria-label` is present, making the combination invalid and causing inconsistent screen reader behavior (reported in #22140).

This PR replaces both patterns with `<span style={visuallyHidden}>{colDef.headerName}</span>`. The visually-hidden `span` contains no ARIA attributes. The columnheader's accessible name is computed from its text content via the standard accname algorithm. The text remains invisible in the narrow column header, so there is no visual regression and no risk of re-triggering the VoiceOver double-reading issue fixed in #14482.

Fixes #22140 