### PR TITLE
[test] Fix flaky e2e scroll tests

### DIFF
--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -409,10 +409,8 @@ async function initializeEnvironment(
         await page.mouse.move(150, 150);
         await page.mouse.wheel(50, 0);
 
-        await page.waitForFunction(
-          () => document.querySelector('.MuiDataGrid-virtualScroller')!.scrollLeft > 0,
-          null,
-          { timeout: 2000 },
+        await page.waitForFunction(() =>
+          document.querySelector('.MuiDataGrid-virtualScroller')!.scrollLeft > 0,
         );
       });
 

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -405,14 +405,15 @@ async function initializeEnvironment(
       // https://github.com/mui/mui-x/issues/3795#issuecomment-1025628771
       it('should allow horizontal scroll when there are more columns and no rows', async () => {
         await renderFixture('DataGrid/EmptyGrid');
+        await page.locator('.MuiDataGrid-virtualScroller').waitFor();
         await page.mouse.move(150, 150);
         await page.mouse.wheel(50, 0);
-        await sleep(50);
 
-        const scrollLeft = await page.evaluate(() => {
-          return document.querySelector('.MuiDataGrid-virtualScroller')!.scrollLeft;
-        });
-        expect(scrollLeft).not.to.equal(0);
+        await page.waitForFunction(
+          () => document.querySelector('.MuiDataGrid-virtualScroller')!.scrollLeft > 0,
+          null,
+          { timeout: 2000 },
+        );
       });
 
       // https://github.com/mui/mui-x/issues/4190
@@ -589,14 +590,15 @@ async function initializeEnvironment(
       // https://github.com/mui/mui-x/issues/3524#issuecomment-2313533915
       it('should allow vertical scroll when inside of a flex parent with maxHeight', async () => {
         await renderFixture('DataGrid/MaxHeight');
+        await page.locator('.MuiDataGrid-virtualScroller').waitFor();
         await page.mouse.move(150, 150);
         await page.mouse.wheel(0, 50);
-        await sleep(50);
 
-        const scrollTop = await page.evaluate(() => {
-          return document.querySelector('.MuiDataGrid-virtualScroller')!.scrollTop;
-        });
-        expect(scrollTop).not.to.equal(0);
+        await page.waitForFunction(
+          () => document.querySelector('.MuiDataGrid-virtualScroller')!.scrollTop > 0,
+          null,
+          { timeout: 2000 },
+        );
       });
 
       // https://github.com/mui/mui-x/issues/14726

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -594,8 +594,6 @@ async function initializeEnvironment(
 
         await page.waitForFunction(
           () => document.querySelector('.MuiDataGrid-virtualScroller')!.scrollTop > 0,
-          null,
-          { timeout: 2000 },
         );
       });
 

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -409,8 +409,8 @@ async function initializeEnvironment(
         await page.mouse.move(150, 150);
         await page.mouse.wheel(50, 0);
 
-        await page.waitForFunction(() =>
-          document.querySelector('.MuiDataGrid-virtualScroller')!.scrollLeft > 0,
+        await page.waitForFunction(
+          () => document.querySelector('.MuiDataGrid-virtualScroller')!.scrollLeft > 0,
         );
       });
 


### PR DESCRIPTION
An attempt to address super flaky e2e Data Grid test: https://app.circleci.com/pipelines/github/mui/mui-x/126319/workflows/87c048e8-346a-467a-bfe0-6ffc0b79e4f1/jobs/803954


## Summary

- Two e2e tests in `test/e2e/index.test.ts` flaked frequently on CI when checking that a mouse-wheel produced a non-zero scroll offset on the DataGrid virtual scroller. Both relied on a fixed `sleep(50)` after `page.mouse.wheel`, which was not enough on CI for the wheel event to flush, React to render, and the virtual scroller to update its `scrollTop` / `scrollLeft`.
- Replaced the fixed sleep with `page.waitForFunction` that polls until `scrollTop > 0` (or `scrollLeft > 0`), with a 2s timeout. Also added a `waitFor()` on the virtual scroller locator before dispatching the wheel so the event doesn't fire before the grid has hydrated.
- Applied the same fix to both the vertical-scroll test (maxHeight flex parent, [test/e2e/index.test.ts:590](https://github.com/mui/mui-x/blob/master/test/e2e/index.test.ts#L590)) and the horizontal-scroll test (empty grid with many columns, [test/e2e/index.test.ts:406](https://github.com/mui/mui-x/blob/master/test/e2e/index.test.ts#L406)) which shared the identical race.

## Notes for reviewers

- The `waitForFunction` resolving is effectively the assertion: it only returns when the scroll offset is non-zero, and otherwise times out with a clear error. The original `expect(scrollTop).not.to.equal(0)` call became redundant and was removed.
- A similar, more robust pattern already exists just below (the scroll-jump test at [test/e2e/index.test.ts:603](https://github.com/mui/mui-x/blob/master/test/e2e/index.test.ts#L603)) — this change aligns these two tests with that style.