### PR TITLE
[code-infra] Avoid overriding `renovate` `ignoredPaths`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>mui/mui-public//renovate/default"],
-  "ignorePaths": ["**/bug-reproductions/**"],
   "schedule": "* 0-4 * * 1",
   "lockFileMaintenance": {
     "schedule": "* 0-4 2 * *"


### PR DESCRIPTION
Inspired by: https://github.com/mui/mui-x/pull/22202#discussion_r3147427352.
It was initially added here in an effort to help avoid Renovate OOM issues.
Since the monorepo dep has been dropped, Renovate has recovered, and this change is causing issues with Renovate trying to affect projects in `examples/`, which should be avoided if not for this line overriding the upstream declaration.