### PR TITLE
[code-infra] Bump browser testTimeout to absorb React 19 slowness

### DIFF
--- a/vitest.shared.mts
+++ b/vitest.shared.mts
@@ -114,7 +114,10 @@ export default defineConfig({
       // Important to avoid timeouts on CI.
       fileParallelism: false,
       // Increase the timeout for the tests due to slow CI machines.
-      testTimeout: 30000,
+      // Tests run ~3x slower under React 19 stable than React 18 (CPU-bound,
+      // mostly @testing-library/user-event async timing); the slowest legitimate
+      // tests touch ~17s in CI, so 30s leaves no headroom for noise.
+      testTimeout: 60000,
       // Retry failed tests up to 3 times. This is useful for flaky tests.
       retry: 3,
       // Reduce the number of workers to avoid CI timeouts.


### PR DESCRIPTION
## Summary

Doubles `vitest.shared.mts`'s CI `testTimeout` from 30s to 60s. That's the entire change.

## Context

This PR started out trying to fix the intermittent `Browser page crashed!` renderer OOM in `test_browser`. After several wrong turns (external sharding broke on shared esbuild state; vitest worker pool with `--max-workers=4` regressed wall-clock from ~12 min to >32 min on the React 19 path because four Chromium trees on a 4-vCPU runner starved each other), the right diagnosis became visible after [JCQuintas's comment](https://github.com/mui/mui-x/pull/22236#issuecomment-4336199560) — the shared Chromium architecture in `playwrightLaunchServer.mjs` is intentional, not accidental, and changing it is a perf regression.

While reviewing master 809076 ([failed run](https://app.circleci.com/pipelines/gh/mui/mui-x/126972/workflows/86a9a417-9415-4853-b39b-32bfafea985e/jobs/809076)), the actual failure mode wasn't an OOM at all:

```
✓ should apply minDate when only second field is filled  17222ms   <- one test, 17 seconds
✓ should apply maxDate                                    5285ms
...
FAIL  describeValueSingleInput.MobileTimeRangePicker > should not call onClose or onAccept ...
    Error: Test timed out in 30000ms.
    AssertionError: expected 5 to equal 3
```

The 30s `testTimeout` dates from the React 18 + sync `user-event` era. Under React 19 stable, individual tests run roughly 3x slower (the per-file ratio I quantified earlier in this thread: 1,470,842 ms total stable vs 488,048 ms total r18 across 572 common files). Slow but legitimate tests now touch ~17s in CI, leaving no headroom for noise — the next bit of CI loadiness tips them past 30s, retries hit the same wall, and after retries vitest reports a derived assertion mismatch from the React-19-renders-extra-times effect.

## What this fixes

- Direct cause of master 809076's failure (test timeout → assertion miscount).
- Almost-tipped slow tests across the run (any test that's already 15-25s in stable now has 2x headroom).

## What this does not fix

- The renderer OOM `Browser page crashed!` flake. That has the same root cause as the perf gap (memory accumulating over a 12 min React-19 run in one shared Chromium) but a different mechanism, and architectural fixes for it conflict with the perf-conservation reasons the shared Chromium exists. Best handled as a separate change once the React-19-tests-are-3x-slower issue is investigated upstream.

## Why doubling and not 90s/2 min

If any test legitimately needs >60s, that's a genuine regression in the test or component worth surfacing — not something we should silently absorb. 60s is enough for the React 19 multiplier without crossing into "anything goes" territory.

## Test plan

- [x] CI passes on this branch
- [x] No legitimate test exceeds the new 60s budget (if one does, it's a real bug to investigate, not a CI infra concern)
- [x] The `Mobile{Time,Date}RangePicker` describeValue tests that have been timing out on master complete cleanly here
