### PR TITLE
[internal] Improve release note template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 _Apr 28, 2026_
 
-We'd like to extend a big thank you to the 4 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 4 contributors who made this release possible. Here are some highlights ✨:
 
 - Fix Pickers previous (v9.0.3) release ensuring the latest `@mui/x-internals` version usage
 
@@ -91,7 +91,7 @@ Internal changes.
 
 _Apr 27, 2026_
 
-We'd like to extend a big thank you to the 16 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 16 contributors who made this release possible. Here are some highlights ✨:
 
 - ⌨️ Keyboard support for creating events in the Scheduler
 
@@ -229,7 +229,7 @@ Same changes as in `@mui/x-scheduler@9.0.0-alpha.3`.
 
 _Apr 15, 2026_
 
-We'd like to extend a big thank you to the 12 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 12 contributors who made this release possible. Here are some highlights ✨:
 
 - 📊 Added `valueGetter` to axes and series configurations, which allow for dynamically getting data out of a `dataset`.
 - 🐞 Bugfixes
@@ -350,7 +350,7 @@ Same changes as in `@mui/x-scheduler@9.0.0-alpha.2`.
 
 _Apr 8, 2026_
 
-We'd like to extend a big thank you to the 8 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 8 contributors who made this release possible. Here are some highlights ✨:
 
 - Docs updates 📚
 - Chat release 🥳
@@ -458,7 +458,7 @@ This major release includes many new features and improvements. Here are some hi
 - Tree View – [Virtualization](https://mui.com/x/react-tree-view/rich-tree-view/virtualization/) [Pro]
 - New [Scheduler](https://mui.com/x/react-scheduler/) packages [Alpha]
 
-We'd like to extend a big thank you to the 5 contributors who made this release possible.
+A big thanks to the 5 contributors who made this release possible.
 The following team members contributed to this release:
 @DanailH, @LukasTy, @MBilalShafi, @oliviertassinari, @siriwatknp
 
@@ -555,7 +555,7 @@ Internal changes.
 
 _Apr 7, 2026_
 
-We'd like to extend a big thank you to the 18 contributors who made this release possible.
+A big thanks to the 18 contributors who made this release possible.
 
 Special thanks go out to these community members for their valuable contributions:
 @mixelburg, @sibananda485, @youjin-hong
@@ -709,7 +709,7 @@ Internal changes.
 
 _Mar 27, 2026_
 
-We'd like to extend a big thank you to the 10 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 10 contributors who made this release possible. Here are some highlights ✨:
 
 - 🔊 New Charts voiceover component for improved screen reader support
 - ⌨️ Charts keyboard navigation improvements: axis tooltip now shows when navigating with the keyboard
@@ -813,7 +813,7 @@ Internal changes.
 
 _Mar 19, 2026_
 
-We'd like to extend a big thank you to the 12 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 12 contributors who made this release possible. Here are some highlights ✨:
 
 - 🐞 Bugfixes and internal improvements
 
@@ -936,7 +936,7 @@ Internal changes.
 
 _Mar 12, 2026_
 
-We'd like to extend a big thank you to the 13 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 13 contributors who made this release possible. Here are some highlights ✨:
 
 - 🐞 Bugfixes and internal improvements
 
@@ -1058,7 +1058,7 @@ Internal changes.
 
 _Mar 5, 2026_
 
-We'd like to extend a big thank you to the 12 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 12 contributors who made this release possible. Here are some highlights ✨:
 
 - ✅ Stabilize Sankey chart
 - 🐞 Bugfixes and internal improvements
@@ -1176,7 +1176,7 @@ Internal changes.
 
 _Feb 26, 2026_
 
-We'd like to extend a big thank you to the 18 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 18 contributors who made this release possible. Here are some highlights ✨:
 
 - ⚡️ Improved dynamic data support and cache invalidation in lazy loading for Data Grid Pro
 - ⌨️ Keyboard support for selecting day, month, and year in Date Pickers
@@ -1294,7 +1294,7 @@ Internal changes.
 
 _Feb 16, 2026_
 
-We'd like to extend a big thank you to the 21 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 21 contributors who made this release possible. Here are some highlights ✨:
 
 - Add support for virtualized items on `<RichTreeViewPro />`:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@ A big thanks to the 4 contributors who made this release possible. Here are some
 
 - Fix Pickers previous (v9.0.3) release ensuring the latest `@mui/x-internals` version usage
 
-The following team members contributed to this release:
-@alexfauquette, @JCQuintas, @LukasTy, @mj12albert
+The following team members contributed to this release: @alexfauquette, @JCQuintas, @LukasTy, @mj12albert
 
 ### Data Grid
 
@@ -83,7 +82,7 @@ Internal changes.
 
 - [docs] Update WCAG links (#22234) @mj12albert
 
-### Core
+### Internal
 
 - [code-infra] Avoid overriding `renovate` `ignoredPaths` (#22228) @LukasTy
 
@@ -98,8 +97,7 @@ A big thanks to the 16 contributors who made this release possible. Here are som
 Special thanks go out to these community members for their valuable contributions:
 @supunsathsara, @ZAKIURREHMAN
 
-The following team members contributed to this release:
-@aemartos, @alexfauquette, @arminmeh, @brijeshb42, @Janpot, @JCQuintas, @LukasTy, @MBilalShafi, @michelengelen, @oliviertassinari, @rita-codes, @romgrk, @sai6855, @siriwatknp
+The following team members contributed to this release: @aemartos, @alexfauquette, @arminmeh, @brijeshb42, @Janpot, @JCQuintas, @LukasTy, @MBilalShafi, @michelengelen, @oliviertassinari, @rita-codes, @romgrk, @sai6855, @siriwatknp
 
 ### Data Grid
 
@@ -206,7 +204,7 @@ Same changes as in `@mui/x-scheduler@9.0.0-alpha.3`.
 - [docs] Document picker behavior inside MUI `Dialog` and provide recommended solutions (#22144) @michelengelen
 - [docs] Improve v9 license key version mismatch error guidance (#22180) @aemartos
 
-### Core
+### Internal
 
 - [code-infra] Reduce concurrency for package build to 5 (#22115) @Janpot
 - [code-infra] Rename `docsx` alias to `docs` (#22155) @brijeshb42
@@ -238,8 +236,7 @@ A big thanks to the 12 contributors who made this release possible. Here are som
 Special thanks go out to these community members for their valuable contributions:
 @Anexus5919, @nk10nikhil
 
-The following team members contributed to this release:
-@aemartos, @alexfauquette, @brijeshb42, @Janpot, @JCQuintas, @LukasTy, @MBilalShafi, @michelengelen, @rita-codes, @sai6855
+The following team members contributed to this release: @aemartos, @alexfauquette, @brijeshb42, @Janpot, @JCQuintas, @LukasTy, @MBilalShafi, @michelengelen, @rita-codes, @sai6855
 
 ### Data Grid
 
@@ -332,7 +329,7 @@ Same changes as in `@mui/x-scheduler@9.0.0-alpha.2`.
 - [docs] Split charts axis page (#22069) @alexfauquette
 - [docs] Update `ChartsRadialDataProvider` API page imports (#22072) @JCQuintas
 
-### Core
+### Internal
 
 - [code-infra] Fix lock file (#22053) @JCQuintas
 - [code-infra] Limit `release:build` lerna concurrency to 6 (#22077) @Janpot
@@ -357,8 +354,7 @@ A big thanks to the 8 contributors who made this release possible. Here are some
 
 Special thanks go out to community member @mixelburg for their valuable contribution.
 
-The following team members contributed to this release:
-@alexfauquette, @cherniavskii, @hasdfa, @Janpot, @LukasTy, @MBilalShafi, @rita-codes
+The following team members contributed to this release: @alexfauquette, @cherniavskii, @hasdfa, @Janpot, @LukasTy, @MBilalShafi, @rita-codes
 
 ### Data Grid
 
@@ -425,7 +421,7 @@ Same changes as in `@mui/x-scheduler@9.0.0-alpha.1`.
 - [docs] Signal BC severity in v8 to v9 pickers migration guide (#22026) @LukasTy
 - [docs] Use the same heading level data grid packages (#22024) @cherniavskii
 
-### Core
+### Internal
 
 - [code-infra] Fix changelog generator for Premium-without-Pro products (#22029) @LukasTy
 - [code-infra] Remove `@mui/x-charts-vendor` check in ci (#22030) @alexfauquette
@@ -459,8 +455,7 @@ This major release includes many new features and improvements. Here are some hi
 - New [Scheduler](https://mui.com/x/react-scheduler/) packages [Alpha]
 
 A big thanks to the 5 contributors who made this release possible.
-The following team members contributed to this release:
-@DanailH, @LukasTy, @MBilalShafi, @oliviertassinari, @siriwatknp
+The following team members contributed to this release: @DanailH, @LukasTy, @MBilalShafi, @oliviertassinari, @siriwatknp
 
 ### Data Grid
 
@@ -543,7 +538,7 @@ Internal changes.
 
 - [docs] Add explanation for v8 -> v9 license migration (#22004) @DanailH
 
-### Core
+### Internal
 
 - [code-infra] Optimize dependency definition (#22006) @LukasTy
 - [internal] Prepare v9 stable (#22018) @siriwatknp
@@ -560,8 +555,7 @@ A big thanks to the 18 contributors who made this release possible.
 Special thanks go out to these community members for their valuable contributions:
 @mixelburg, @sibananda485, @youjin-hong
 
-The following team members contributed to this release:
-@aemartos, @alexfauquette, @arminmeh, @brijeshb42, @flaviendelangle, @JCQuintas, @LukasTy, @mapache-salvaje, @MBilalShafi, @michelengelen, @noraleonte, @rita-codes, @romgrk, @siriwatknp, @ZeeshanTamboli
+The following team members contributed to this release: @aemartos, @alexfauquette, @arminmeh, @brijeshb42, @flaviendelangle, @JCQuintas, @LukasTy, @mapache-salvaje, @MBilalShafi, @michelengelen, @noraleonte, @rita-codes, @romgrk, @siriwatknp, @ZeeshanTamboli
 
 ### Data Grid
 
@@ -686,7 +680,7 @@ Internal changes.
 - [docs] Revise the Sankey doc (#21678) @mapache-salvaje
 - [docs] Revise the Scatter chart docs (#21564) @mapache-salvaje
 
-### Core
+### Internal
 
 - [docs-infra] Update to the latest monorepo (#21971) @brijeshb42
 - [internal] Remove checks for `materialVersion >= 6` (#21975) @LukasTy
@@ -718,8 +712,7 @@ A big thanks to the 10 contributors who made this release possible. Here are som
 - ⚡️ `fetchRows()` API in Data Grid Pro now defaults `start` and `end` based on scroll position with lazy loading
 - 🐞 Bugfixes and internal improvements
 
-The following team members contributed to this release:
-@aemartos, @alexfauquette, @arminmeh, @cherniavskii, @Janpot, @JCQuintas, @mapache-salvaje, @michelengelen, @noraleonte, @rita-codes
+The following team members contributed to this release: @aemartos, @alexfauquette, @arminmeh, @cherniavskii, @Janpot, @JCQuintas, @mapache-salvaje, @michelengelen, @noraleonte, @rita-codes
 
 ### Data Grid
 
@@ -797,7 +790,7 @@ Internal changes.
 - [docs] Revise the Gauge doc (#21673) @mapache-salvaje
 - [docs] Revise the Heatmap doc (#21676) @mapache-salvaje
 
-### Core
+### Internal
 
 - [code-infra] Remove unused deps and unify es-toolkit via catalog (#21840) @Janpot
 - [code-infra] Update @mui/internal-bundle-size-checker to canary.68 (#21836) @Janpot
@@ -817,8 +810,7 @@ A big thanks to the 12 contributors who made this release possible. Here are som
 
 - 🐞 Bugfixes and internal improvements
 
-The following team members contributed to this release:
-@aemartos, @alexfauquette, @bernardobelchior, @Janpot, @JCQuintas, @LukasTy, @mapache-salvaje, @michelengelen, @noraleonte, @rita-codes, @sai6855, @siriwatknp
+The following team members contributed to this release: @aemartos, @alexfauquette, @bernardobelchior, @Janpot, @JCQuintas, @LukasTy, @mapache-salvaje, @michelengelen, @noraleonte, @rita-codes, @sai6855, @siriwatknp
 
 ### Data Grid
 
@@ -920,7 +912,7 @@ Internal changes.
 - [docs] Revise the Bar Chart docs (#21482) @mapache-salvaje
 - [docs] Removed a `console.log` from an aggregation demo (#21698) @michelengelen
 
-### Core
+### Internal
 
 - [code-infra] Add pkg-pr-new as dev dependency (#21754) @Janpot
 - [code-infra] Prevent `combiner` to have default parameters (#21707) @JCQuintas
@@ -940,8 +932,7 @@ A big thanks to the 13 contributors who made this release possible. Here are som
 
 - 🐞 Bugfixes and internal improvements
 
-The following team members contributed to this release:
-@aemartos, @alexfauquette, @bernardobelchior, @brijeshb42, @cherniavskii, @flaviendelangle, @Janpot, @JCQuintas, @MBilalShafi, @michelengelen, @rita-codes, @sai6855, @siriwatknp
+The following team members contributed to this release: @aemartos, @alexfauquette, @bernardobelchior, @brijeshb42, @cherniavskii, @flaviendelangle, @Janpot, @JCQuintas, @MBilalShafi, @michelengelen, @rita-codes, @sai6855, @siriwatknp
 
 ### Data Grid
 
@@ -1042,7 +1033,7 @@ Internal changes.
 - [docs] Migrate internal Material UI deprecated APIs (#21680) @siriwatknp
 - [docs] Remove `New` flag on Tree View and Date and Time Pickers features released before v9 alpha (#21585) @flaviendelangle
 
-### Core
+### Internal
 
 - [code-infra] Remove checkout step (#21688) @Janpot
 - [code-infra] Fix contributor generation in changelog (#21718) @brijeshb42
@@ -1063,8 +1054,7 @@ A big thanks to the 12 contributors who made this release possible. Here are som
 - ✅ Stabilize Sankey chart
 - 🐞 Bugfixes and internal improvements
 
-The following team members contributed to this release:
-@aemartos, @alelthomas, @alexfauquette, @arminmeh, @bernardobelchior, @brijeshb42, @Janpot, @JCQuintas, @mapache-salvaje, @michelengelen, @mj12albert, @sai6855, @siriwatknp
+The following team members contributed to this release: @aemartos, @alelthomas, @alexfauquette, @arminmeh, @bernardobelchior, @brijeshb42, @Janpot, @JCQuintas, @mapache-salvaje, @michelengelen, @mj12albert, @sai6855, @siriwatknp
 
 ### Data Grid
 
@@ -1150,7 +1140,7 @@ Internal changes.
 - [docs] Add tutorial and example app for aggregation with row grouping (DX-162) (#21102) @mapache-salvaje
 - [docs] Fix missing codemod docs (#21604) @JCQuintas
 
-### Core
+### Internal
 
 - [code-infra] Add eslint rule to prevent `Math.random` in docs (#21505) @JCQuintas
 - [code-infra] Avoid static props for pageContent (#21038) @Janpot
@@ -1186,8 +1176,7 @@ A big thanks to the 18 contributors who made this release possible. Here are som
 Special thanks go out to these community members for their valuable contributions:
 @EllGree, @lion1963
 
-The following team members contributed to this release:
-@alexfauquette, @arminmeh, @brijeshb42, @cherniavskii, @dav-is, @flaviendelangle, @Janpot, @JCQuintas, @mapache-salvaje, @MBilalShafi, @michelengelen, @noraleonte, @rita-codes, @sai6855, @siriwatknp, @ZeeshanTamboli
+The following team members contributed to this release: @alexfauquette, @arminmeh, @brijeshb42, @cherniavskii, @dav-is, @flaviendelangle, @Janpot, @JCQuintas, @mapache-salvaje, @MBilalShafi, @michelengelen, @noraleonte, @rita-codes, @sai6855, @siriwatknp, @ZeeshanTamboli
 
 ### Data Grid
 
@@ -1270,7 +1259,7 @@ Internal changes.
 - [docs][charts] Revise the useDataset doc (#21336) @mapache-salvaje
 - [docs][charts] Revise the useDrawingArea doc (#21333) @mapache-salvaje
 
-### Core
+### Internal
 
 - [core] Update docs deploy script to the `docs-next` branch (#21341) @siriwatknp
 - [code-infra] Cleanup unused babel plugins (#21453) @brijeshb42
@@ -1310,8 +1299,7 @@ A big thanks to the 21 contributors who made this release possible. Here are som
 Special thanks go out to these community members for their valuable contributions:
 @jhe-iqbis
 
-The following team members contributed to this release:
-@alexfauquette, @arminmeh, @bernardobelchior, @brijeshb42, @cherniavskii, @dav-is, @flaviendelangle, @Janpot, @JCQuintas, @mapache-salvaje, @MBilalShafi, @michelengelen, @mj12albert, @noraleonte, @oliviertassinari, @rita-codes, @romgrk, @sai6855, @siriwatknp
+The following team members contributed to this release: @alexfauquette, @arminmeh, @bernardobelchior, @brijeshb42, @cherniavskii, @dav-is, @flaviendelangle, @Janpot, @JCQuintas, @mapache-salvaje, @MBilalShafi, @michelengelen, @mj12albert, @noraleonte, @oliviertassinari, @rita-codes, @romgrk, @sai6855, @siriwatknp
 
 ### Data Grid
 
@@ -1464,7 +1452,7 @@ Same changes as in `@mui/x-tree-view@9.0.0-alpha.0`, plus:
 - [DataGrid][docs] Add high-level competitor comparison to Overview doc (DX-117) (#20870) @mapache-salvaje
 - [DataGrid][docs] Remove Bundling section from quickstart (#21177) @MBilalShafi
 
-### Core
+### Internal
 
 - [code-infra] Add `MUI_TEST_ENV` global (#21187) @Janpot
 - [code-infra] Fix `material-ui/disallow-react-api-in-server-components` (#20909) @JCQuintas

--- a/CHANGELOG.v8.md
+++ b/CHANGELOG.v8.md
@@ -12,8 +12,7 @@ A big thanks to the 6 contributors who made this release possible. Here are some
 Special thanks go out to these community members for their valuable contributions:
 @sai6855
 
-The following team members contributed to this release:
-@arminmeh, @cherniavskii, @flaviendelangle, @mj12albert, @MBilalShafi
+The following team members contributed to this release: @arminmeh, @cherniavskii, @flaviendelangle, @mj12albert, @MBilalShafi
 
 ### Data Grid
 
@@ -47,7 +46,7 @@ Same changes as in `@mui/x-data-grid-pro@8.27.1`, plus:
 
 Same changes as in `@mui/x-tree-view@8.27.1`.
 
-### Core
+### Internal
 
 - [internal] Add CLI for translation using LLM (#21299) @cherniavskii
 
@@ -59,8 +58,7 @@ A big thanks to the 8 contributors who made this release possible. Here are some
 
 - 📝 Data Grid supports new `longText` [column type](https://mui.com/x/react-data-grid/column-definition/#column-types)
 
-The following team members contributed to this release:
-@alexfauquette, @arminmeh, @bernardobelchior, @cherniavskii, @flaviendelangle, @JCQuintas, @MBilalShafi, @siriwatknp
+The following team members contributed to this release: @alexfauquette, @arminmeh, @bernardobelchior, @cherniavskii, @flaviendelangle, @JCQuintas, @MBilalShafi, @siriwatknp
 
 ### Data Grid
 
@@ -130,7 +128,7 @@ Internal changes.
 
 - [docs] Fix DataGrid's cell edit renderers (@arminmeh) (#21041) @github-actions[bot]
 
-### Core
+### Internal
 
 - [code-infra] Add `consistent-type-imports` rule to the grid packages (#21119) @arminmeh
 - [code-infra] Allow user to select target branch if it exists for current major (#21005) @JCQuintas
@@ -163,8 +161,7 @@ A big thanks to the 6 contributors who made this release possible. Here are some
 Special thanks go out to these community members for their valuable contributions:
 @jhe-iqbis
 
-The following team members contributed to this release:
-@arminmeh, @cherniavskii, @flaviendelangle, @JCQuintas, @romgrk
+The following team members contributed to this release: @arminmeh, @cherniavskii, @flaviendelangle, @JCQuintas, @romgrk
 
 ### Data Grid
 
@@ -227,7 +224,7 @@ Internal changes.
 
 - [docs] Recipe for lazy loading DataGrid's detail panels with auto height (#20995) @arminmeh
 
-### Core
+### Internal
 
 - [code-infra] Update `master` to `v8` references (#20864) @JCQuintas
 - [code-infra] Update v8 branch tags (#20926) @JCQuintas
@@ -250,8 +247,7 @@ A big thanks to the 8 contributors who made this release possible. Here are some
 - 🐞 Bugfixes
 - 📚 Documentation improvements
 
-The following team members contributed to this release:
-@alexfauquette, @arminmeh, @bernardobelchior, @cherniavskii, @JCQuintas, @mapache-salvaje, @rita-codes, @Janpot
+The following team members contributed to this release: @alexfauquette, @arminmeh, @bernardobelchior, @cherniavskii, @JCQuintas, @mapache-salvaje, @rita-codes, @Janpot
 
 ### Data Grid
 
@@ -337,7 +333,7 @@ Internal changes.
 - [docs] Revise the Charts Stacking doc (#20830) @mapache-salvaje
 - [docs] Fix broken links (#20914) @Janpot
 
-### Core
+### Internal
 
 - [code-infra] Fix `material-ui/disallow-react-api-in-server-components` (#20909) @JCQuintas
 - [code-infra] Prepare for v9 (#20860) @JCQuintas
@@ -358,8 +354,7 @@ A big thanks to the 12 contributors who made this release possible. Here are som
 Special thanks go out to these community members for their valuable contributions:
 @anders-noerrelykke, @auloin, @sai6855, @yuito-it
 
-The following team members contributed to this release:
-@alelthomas, @alexfauquette, @arminmeh, @bernardobelchior, @flaviendelangle, @JCQuintas, @mapache-salvaje, @siriwatknp
+The following team members contributed to this release: @alelthomas, @alexfauquette, @arminmeh, @bernardobelchior, @flaviendelangle, @JCQuintas, @mapache-salvaje, @siriwatknp
 
 ### Data Grid
 
@@ -443,7 +438,7 @@ Internal changes.
 - [docs] Revise the Charts Label doc (#20794) @mapache-salvaje
 - [docs] Revise the Charts Export doc (#20779) @mapache-salvaje
 
-### Core
+### Internal
 
 - [code-infra] Fix v8.23.0 release date (#20767) @bernardobelchior
 - [code-infra] Remove `glob-gitignore` (#20801) @bernardobelchior
@@ -466,8 +461,7 @@ A big thanks to the 12 contributors who made this release possible. Here are som
 Special thanks go out to these community members for their valuable contributions:
 @henkerik, @sai6855
 
-The following team members contributed to this release:
-@alelthomas, @alexfauquette, @arminmeh, @bernardobelchior, @brijeshb42, @flaviendelangle, @JCQuintas, @mapache-salvaje, @MBilalShafi, @siriwatknp
+The following team members contributed to this release: @alelthomas, @alexfauquette, @arminmeh, @bernardobelchior, @brijeshb42, @flaviendelangle, @JCQuintas, @mapache-salvaje, @MBilalShafi, @siriwatknp
 
 ### Data Grid
 
@@ -550,7 +544,7 @@ Internal changes.
 - [docs] Clean up Charts docs sidebar (DX-97) (#20700) @alelthomas
 - [docs] Fix tick labels not being shown on a demo (#20718) @sai6855
 
-### Core
+### Internal
 
 - [code-infra] Bump prettier to 3.7.4 (#20709) @JCQuintas
 - [code-infra] Fix contributor generation logic in changelog script (#20705) @brijeshb42
@@ -567,8 +561,7 @@ A big thanks to the 13 contributors who made this release possible. Here are som
 Special thanks go out to the community members for their valuable contributions:
 @KyeongJooni, @VismaAndreasIvarsson
 
-The following team members contributed to this release:
-@alelthomas, @alexfauquette, @arminmeh, @bernardobelchior, @Janpot, @JCQuintas, @mapache-salvaje, @michelengelen, @mj12albert, @prakhargupta1, @romgrk, @siriwatknp
+The following team members contributed to this release: @alelthomas, @alexfauquette, @arminmeh, @bernardobelchior, @Janpot, @JCQuintas, @mapache-salvaje, @michelengelen, @mj12albert, @prakhargupta1, @romgrk, @siriwatknp
 
 ### Data Grid
 
@@ -650,7 +643,7 @@ Internal changes.
 - [docs] Revise the Data Grid's API object doc for clarity and style (#20649) @mapache-salvaje
 - [docs] Update list of charts (#20479) @prakhargupta1
 
-### Core
+### Internal
 
 - [code-infra] Regression tests improvements (#20441) @Janpot
 - [code-infra] Test utils upgrade (#20592) @Janpot
@@ -687,8 +680,7 @@ A big thanks to the 11 contributors who made this release possible. Here are som
 Special thanks go out to this community member for their valuable contributions:
 @kzhgit
 
-The following team members contributed to this release:
-@alexfauquette, @arminmeh, @bernardobelchior, @cherniavskii, @flaviendelangle, @JCQuintas, @mapache-salvaje, @michelengelen, @noraleonte, @oliviertassinari
+The following team members contributed to this release: @alexfauquette, @arminmeh, @bernardobelchior, @cherniavskii, @flaviendelangle, @JCQuintas, @mapache-salvaje, @michelengelen, @noraleonte, @oliviertassinari
 
 ### Data Grid
 
@@ -770,7 +762,7 @@ Internal changes.
 - [docs] Revise the Charts Custom Components doc (#19793) @mapache-salvaje
 - [docs] Remove copy-pasted `aria-label` (#20620) @alexfauquette
 
-### Core
+### Internal
 
 - [internal] Remove unsafe dependency version from range (#20574) @oliviertassinari
 
@@ -800,8 +792,7 @@ A big thanks to the 8 contributors who made this release possible. Here are some
 
 - ✨ Add [tick spacing property](https://mui.com/x/react-charts/axis/#tick-spacing) to charts axis to control the distance between ticks.
 
-The following team members contributed to this release:
-@alexfauquette, @bernardobelchior, @ElliottMiller, @Janpot, @JCQuintas, @romgrk, @sai6855, @siriwatknp
+The following team members contributed to this release: @alexfauquette, @bernardobelchior, @ElliottMiller, @Janpot, @JCQuintas, @romgrk, @sai6855, @siriwatknp
 
 ### Data Grid
 
@@ -878,7 +869,7 @@ Internal changes.
 
 - [docs] Migrate to `next/font` for fonts loading (#20407) @Copilot
 
-### Core
+### Internal
 
 - [code-infra] Enable vitest eslint plugin (#20530) @Janpot
 - [code-infra] Fix missing font loading for local fonts (#20480) @Janpot
@@ -913,8 +904,7 @@ A big thanks to the 8 contributors who made this release possible. Here are some
 - 🔃 Data Grid tree data now supports row reordering. See the [Drag-and-drop tree data reordering](https://mui.com/x/react-data-grid/tree-data/#drag-and-drop-tree-data-reordering) section for more details.
 - 🐞 Bugfixes
 
-The following team members contributed to this release:
-@alexfauquette, @arminmeh, @bernardobelchior, @cherniavskii, @siriwatknp, @JCQuintas, @MBilalShafi, @prakhargupta1
+The following team members contributed to this release: @alexfauquette, @arminmeh, @bernardobelchior, @cherniavskii, @siriwatknp, @JCQuintas, @MBilalShafi, @prakhargupta1
 
 ### Data Grid
 
@@ -981,8 +971,7 @@ A big thanks to the 15 contributors who made this release possible. Here are som
 Special thanks go out to these community members for their valuable contributions:
 @lauri865, @noobyogi0010, @sai6855
 
-The following team members contributed to this release:
-@alexfauquette, @arminmeh, @bernardobelchior, @cherniavskii, @flaviendelangle, @Janpot, @JCQuintas, @mj12albert, @noraleonte, @rita-codes, @siriwatknp, @ZeeshanTamboli
+The following team members contributed to this release: @alexfauquette, @arminmeh, @bernardobelchior, @cherniavskii, @flaviendelangle, @Janpot, @JCQuintas, @mj12albert, @noraleonte, @rita-codes, @siriwatknp, @ZeeshanTamboli
 
 ### Data Grid
 
@@ -1066,7 +1055,7 @@ Internal changes.
 - [docs] Fix separator opacity in demo (#20293) @sai6855
 - [docs] Replace deprecated `LoadingButton` with `Button` component (#20208) @Janpot
 
-### Core
+### Internal
 
 - [code-infra] Add new broken links checker (#20120) @Janpot
 - [code-infra] Disable Codspeed pipeline (#20370) @JCQuintas
@@ -1098,8 +1087,7 @@ A big thanks to the 14 contributors who made this release possible. Here are som
 Special thanks go out to these community members for their valuable contributions:
 @htollefsen, @sai6855, @Sigdriv
 
-The following team members contributed to this release:
-@arminmeh, @bernardobelchior, @brijeshb42, @cherniavskii, @flaviendelangle, @JCQuintas, @michelengelen, @noraleonte, @prakhargupta1, @rita-codes, @siriwatknp
+The following team members contributed to this release: @arminmeh, @bernardobelchior, @brijeshb42, @cherniavskii, @flaviendelangle, @JCQuintas, @michelengelen, @noraleonte, @prakhargupta1, @rita-codes, @siriwatknp
 
 ### Data Grid
 
@@ -1175,7 +1163,7 @@ Internal changes.
 - [Data Grid] Add recipe for cursor pagination with data source (#19700) @siriwatknp
 - [Data Grid] Add a demo for pinned rows aggregation (#20198) @cherniavskii
 
-### Core
+### Internal
 
 - [docs-infra] Use deployment config from docs-infra package (#20243) @brijeshb42
 
@@ -1197,8 +1185,7 @@ A big thanks to the 13 contributors who made this release possible. Here are som
 Special thanks go out to these community members for their valuable contributions:
 @frncesc, @Methuselah96, @samuelwalk, @htollefsen
 
-The following team members contributed to this release:
-@alexfauquette, @bernardobelchior, @flaviendelangle, @Janpot, @JCQuintas, @mnajdova, @rita-codes, @arminmeh, @brijeshb42
+The following team members contributed to this release: @alexfauquette, @bernardobelchior, @flaviendelangle, @Janpot, @JCQuintas, @mnajdova, @rita-codes, @arminmeh, @brijeshb42
 
 ### Data Grid
 
@@ -1276,7 +1263,7 @@ Internal changes.
 - [docs] Remove hidden Tree View headless page (#20119) @flaviendelangle
 - [docs] Fix some external redirects (#20211) @Janpot
 
-### Core
+### Internal
 
 - [code-infra] Fix cci job timeout due to buffered test output (#20193) @Janpot
 - [code-infra] Fix publish workflow (#20140) @bernardobelchior
@@ -1375,7 +1362,7 @@ Same changes as in `@mui/x-tree-view@8.16.0`.
 
 Internal changes.
 
-### Core
+### Internal
 
 - [code-infra] Setup eslint compat plugin (#20105) @brijeshb42
 - [code-infra] Improve store types (#20129) @JCQuintas
@@ -1485,7 +1472,7 @@ Internal changes.
 - [docs] Add grouped multiple fields for Data Grid row grouping recipe (#19964) @siriwatknp
 - [docs] Add Data Grid loading state recipe (#19958) @siriwatknp
 
-### Core
+### Internal
 
 - [code-infra] Remove @mui/monorepo usage for react versioning (#19894) @Janpot
 - [code-infra] Remove invalid `environment: 'browser'` from vitest browser config (#19993) @bernardobelchior
@@ -1582,7 +1569,7 @@ Internal changes.
 - [docs] Correctly describe Data Grid's row selection behavior (#19968) @arminmeh
 - [docs] Fix `isExpanded` type in tree view docs (#19092) @mellis481
 
-### Core
+### Internal
 
 - [code-infra] Disable Netlify cache plugin (#19950) @Janpot
 - [code-infra] Lint json through eslint (#19890) @Janpot
@@ -1677,7 +1664,7 @@ Internal changes.
 - [docs] Fix demo title knob keys (#19843) @JCQuintas
 - [docs] Hide UI elements of unsupported features in the data source demos (#19849) @arminmeh
 
-### Core
+### Internal
 
 - [code-infra] Cleanup unused dependencies (#19788) @brijeshb42
 - [code-infra] Fix pnpm-lock issue (#19861) @JCQuintas
@@ -1871,7 +1858,7 @@ Internal changes.
 - [docs] Revise the Axis doc (#19052) @mapache-salvaje
 - [docs] Remove reference to nonexistent `FocusedMark` API page (#19773) @bernardobelchior
 
-### Core
+### Internal
 
 - [code-infra] Change charts codspeed integration to use walltime (#19729) @JCQuintas
 - [code-infra] Port stylelint from core repo (#19633) @Janpot
@@ -2029,7 +2016,7 @@ Same changes as in `@mui/x-tree-view@8.12.0`.
 - [docs] Show how to customize drawing area background (#19682) @alexfauquette
 - [docs] Add hook documentation pages (#19334) @Copilot
 
-### Core
+### Internal
 
 - [code-infra] Add copilot instructions specific to x repo (#19623) @JCQuintas
 - [code-infra] Load `tsx` files in visual regression (#19595) @JCQuintas
@@ -2128,7 +2115,7 @@ Internal changes.
 - [docs] Group demos data into the dataset folder (#19549) @alexfauquette
 - [docs] Add `shiny` bar chart example at the top (#19416) @JCQuintas
 
-### Core
+### Internal
 
 - [code-infra] Axios update (#19577) @Janpot
 - [code-infra] Remove usage of copy-files command from code-infra (#19518) @brijeshb42
@@ -2219,7 +2206,7 @@ Internal changes.
 
 - [docs] Add recipe for save and manage filters from the panel (#19361) @siriwatknp
 
-### Core
+### Internal
 
 - [code-infra] Remove log when restarting dev server (#19490) @bernardobelchior
 - [code-infra] Store test results in CI (#19507) @Janpot
@@ -2297,7 +2284,7 @@ Internal changes.
 - [docs] Fix grammar and spelling mistakes on the Date and Time Pickers pages (#19300) @mapache-salvaje
 - [docs] Remove wrong legend info (#19383) @JCQuintas
 
-### Core
+### Internal
 
 - [internal] Fix action alert (#19388) @oliviertassinari
 - [internal] Fix pnpm valelint to have 0 errors @oliviertassinari
@@ -2404,7 +2391,7 @@ Internal changes.
 - [docs][DataGrid] Correct grammar mistakes (#19298) @mapache-salvaje
 - [docs][DataGrid] Make it clear that the API key for AI Assistant must be private (#19244) @oliviertassinari
 
-### Core
+### Internal
 
 - [code-infra] Remove unnecessary triggers from publish workflow (#19348) @Janpot
 - [code-infra] Set up publishing from GitHub actions (#19264) @Janpot
@@ -2496,7 +2483,7 @@ Internal changes.
 
 - [docs] Fix links to the pyramid chart (#19250) @alexfauquette
 
-### Core
+### Internal
 
 - [internal] Avoid script for CI only @oliviertassinari
 - [internal] Fix `renovate.json` @oliviertassinari
@@ -2594,7 +2581,7 @@ Internal changes.
 - [docs] Remove preview from Toolbar & Funnel (#19131) @mnajdova
 - [docs] Reproduce npm sparkline (#19089) @alexfauquette
 
-### Core
+### Internal
 
 - [core] Fix licensing model name (#19025) @oliviertassinari
 - [core] Fix usage of `:catalog` for `@babel/runtime` (#19028) @oliviertassinari
@@ -2715,7 +2702,7 @@ Internal changes.
 - [docs] Improve bundling instructions for the Data Grid (#19065) @romgrk
 - [docs] Reduce image size in the inventory grid demo (#19004) @arminmeh
 
-### Core
+### Internal
 
 - [core] Fix ESLint reference name @oliviertassinari
 
@@ -2847,7 +2834,7 @@ Same changes as in `@mui/x-data-grid@8.9.1`.
 
 Same changes as in `@mui/x-data-grid-pro@8.9.1`.
 
-### Core
+### Internal
 
 - [core] Follow yml syntax convention @oliviertassinari
 
@@ -3132,7 +3119,7 @@ Same changes as in `@mui/x-tree-view@8.7.0`, plus:
 - [docs][data grid] Audit and revise the Pro row docs (#17926) @mapache-salvaje
 - [docs][pickers] Add mention of theme augmentation in relevant migration section (#18608) @LukasTy
 
-### Core
+### Internal
 
 - [core] Avoid stringifying `document` object (#18657) @vadimkuragkovskiy
 
@@ -3245,7 +3232,7 @@ Internal changes.
 - [docs] Update indeterminate checkbox section in migration guide (#18229) @michelengelen
 - [docs] Data source nested pagination recipe (#14777) @MBilalShafi
 
-### Core
+### Internal
 
 - [core] Avoid json stringify whole window object (#18512) @vadimka123
 
@@ -3337,7 +3324,7 @@ Internal changes.
 - [docs] Fix 404 in charts docs (#18440) @alexfauquette
 - [docs][pickers] Fix adapter version resolving when opening demo to edit (#18363) @LukasTy
 
-### Core
+### Internal
 
 - [core] Fix pnpm valelint error (#18420) @oliviertassinari
 
@@ -3532,7 +3519,7 @@ Same changes as in `@mui/x-tree-view@8.5.1`.
 
 - [docs] Update `valueFormatter` signature in migration guide (#18226) @michelengelen
 
-### Core
+### Internal
 
 - [code-infra] Different approach to console testing for `processRowUpdate` (#18213) @JCQuintas
 - [code-infra] Fix act warnings in DataGrid/toolbar (#18207) @JCQuintas
@@ -3640,7 +3627,7 @@ Same changes as in `@mui/x-tree-view@8.5.0`.
 - [docs] Fix light/dark mode blink on pickers overview (#18002) @alexfauquette
 - [docs] Fix scatter shape demo causing horizontal overflow (#17974) @bernardobelchior
 
-### Core
+### Internal
 
 - [code-infra] Add bundle size monitor (#17754) @Janpot
 - [code-infra] Enable `babel-plugin-display-name` in vitest (#17903) @JCQuintas
@@ -3750,7 +3737,7 @@ Same changes as in `@mui/x-tree-view@8.4.0`.
 - [docs][pickers] Fix migration guide references to range fields (#17861) @LukasTy
 - [docs][charts] Reorganize the Tooltip documentation (#17917) @alexfauquette
 
-### Core
+### Internal
 
 - [core] refactor: remove manual `displayName` (#17845) @romgrk
 - [code-infra] Document how to use `vitest` cli (#17847) @JCQuintas
@@ -3841,7 +3828,7 @@ Same changes as in `@mui/x-tree-view@8.3.1`.
 - [docs] Fix translation keys documentation (#17811) @JanPretzel
 - [docs] Improve CHANGELOG format @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Apply YAML convention, blank line only at top level @oliviertassinari
 - [code-infra] Fix dynamic import missing extensions (#17767) @Janpot
@@ -3945,7 +3932,7 @@ Same changes as in `@mui/x-tree-view@8.3.0`.
 - [charts] Fix randomised argos test (#17658) @JCQuintas
 - [docs] Make preview messaging consistent in charts @bernardobelchior
 
-### Core
+### Internal
 
 - [code-infra] Avoid `node` types in the built packages (#17533) @LukasTy
 - [code-infra] Add `pkg.pr.new` publishing (#17402) @Janpot
@@ -4047,7 +4034,7 @@ Same changes as in `@mui/x-tree-view@8.2.0`.
 - [docs] Improve data grid export docs (#17551) @MBilalShafi
 - [docs] Remove leftover `@next` usages (#17542) @LukasTy
 
-### Core
+### Internal
 
 - [core] Add security label to dependabot PRs @oliviertassinari
 - [core] Allow post-install vale @oliviertassinari
@@ -4165,7 +4152,7 @@ Same changes as in `@mui/x-tree-view@8.1.0`.
 - [docs] Refine charts demos (#17417) @alexfauquette
 - [tree view][docs] Copyedit the Tree View Overview page (#17498) @mapache-salvaje
 
-### Core
+### Internal
 
 - [core] Bump `@types/node` (#17444) @LukasTy
 - [core] Remove `react-is` dependency (#17470) @LukasTy
@@ -4338,7 +4325,7 @@ Same changes as in `@mui/x-tree-view@8.0.0`.
 - [docs] Fix some 301 redirections @oliviertassinari
 - [docs] Update supported versions table (#17287) @joserodolfofreitas
 
-### Core
+### Internal
 
 - [core] Always use the correct babel runtime (#17241) @alexfauquette
 - [core] Document `TelemetryContextType` (#17282) @oliviertassinari
@@ -4488,7 +4475,7 @@ Same changes as in `@mui/x-tree-view@8.0.0-beta.3`.
 - [docs] Sync Stack Overflow docs with reality (#17198) @oliviertassinari
 - [docs] Update Localization Provider JSDoc link (#17207) @LukasTy
 
-### Core
+### Internal
 
 - [core] Cleanup `@mui` dependency versions (#17160) @LukasTy
 - [core] Sync scorecards.yml across codebase @oliviertassinari
@@ -4579,7 +4566,7 @@ Same changes as in `@mui/x-tree-view@8.0.0-beta.2`.
 
 - [docs] Fix example import for `ExportExcel` component (#17110) @KenanYusuf
 
-### Core
+### Internal
 
 - [code-infra] Remove `@mui/styles` dependency & patches (#17071) @mnajdova
 - [code-infra] Add more tests to slow screenshot tests (#17075) @JCQuintas
@@ -4838,7 +4825,7 @@ Same changes as in `@mui/x-tree-view@8.0.0-beta.0`.
 - [docs] Improve sparkline demo (#16911) @alexfauquette
 - [docs] Remove `showQuickFilter: true` toolbar prop from demos (#17003) @KenanYusuf
 
-### Core
+### Internal
 
 - [core] Fix proptypes and API docs after merge (#16934) @LukasTy
 - [core] Update `@mui/utils` dependency to only v7 (#16928) @Janpot
@@ -4975,7 +4962,7 @@ Same changes as in `@mui/x-tree-view@8.0.0-alpha.14`.
 - [docs] Fix padding package install on mobile (#16794) @oliviertassinari
 - [docs] Typo fixes (#16835) @alexfauquette
 
-### Core
+### Internal
 
 - [code-infra] Fix console warning in telemetry package (#16816) @JCQuintas
 - [code-infra] Split date-picker test files (#16825) @JCQuintas
@@ -5429,7 +5416,7 @@ Same changes as in `@mui/x-tree-view@8.0.0-alpha.12`.
 - [docs] Improve license installation page (#16403) @michelengelen
 - [docs] Standardize getting started docs across all packages (#16302) @mapache-salvaje
 
-### Core
+### Internal
 
 - [core] Update charts folder structure (#16471) @alexfauquette
 - [code-infra] Bump @mui/monorepo (#16422) @LukasTy
@@ -5536,7 +5523,7 @@ Same changes as in `@mui/x-tree-view@8.0.0-alpha.11`.
 
 - [docs] Update charts colors default value (#16484) @bernardobelchior
 
-### Core
+### Internal
 
 - [core] Fix corepack and pnpm installation in CircleCI (#16434) @flaviendelangle
 - [code-infra] Update monorepo (#16112) @Janpot
@@ -5678,7 +5665,7 @@ Same changes as in `@mui/x-tree-view@8.0.0-alpha.10`.
 
 - [docs] Improve release documentation (#16321) @MBilalShafi
 
-### Core
+### Internal
 
 - [core] Reduce chart perf benchmark weight (#16374) @alexfauquette
 - [test] Fix console warnings while executing tests with React 18 (#16386) @arminmeh
@@ -5882,7 +5869,7 @@ Same changes as in `@mui/x-tree-view@8.0.0-alpha.8`.
 - [docs] Split the Data Grid editing page (#14931) @MBilalShafi
 - [docs] Fix wrong props warnings (#16119) @JCQuintas
 
-### Core
+### Internal
 
 - [core] Type all references as `RefObject` (#16124) @arminmeh
 - [code-infra] Refactor `react` and `react-dom` definitions to simplify dep resolving (#16160) @LukasTy
@@ -6008,7 +5995,7 @@ Same changes as in `@mui/x-tree-view@8.0.0-alpha.7`.
 - [docs] Refactor Data Grid with Date Pickers example (#15992) @LukasTy
 - [docs] Unify the wording of the pickers slots breaking changes (#16036) @flaviendelangle
 
-### Core
+### Internal
 
 - [core] Clarify the release strategy (#16014) @MBilalShafi
 - [core] Small fixes on docs @oliviertassinari
@@ -6193,7 +6180,7 @@ No changes since `@mui/x-tree-view-pro@v8.0.0-alpha.4`.
 
 Same changes as in `@mui/x-tree-view@8.0.0-alpha.5`.
 
-### Core
+### Internal
 
 - [code-infra] Remove `@mui/material-nextjs` dependency (#15925) @LukasTy
 
@@ -6319,7 +6306,7 @@ Releasing to benefit from license package fix (#15814).
 - [docs] Use `updateRows` method for list view demos (#15732) @KenanYusuf
 - [docs] Use date library version from package dev dependencies for sandboxes (#15762) @LukasTy
 
-### Core
+### Internal
 
 - [code-infra] Add Charts sandbox generation (#15830) @JCQuintas
 - [code-infra] Remove redundant `@type/react-test-renderer` dep (#15766) @LukasTy
@@ -6418,7 +6405,7 @@ Same changes as in `@mui/x-tree-view@8.0.0-alpha.3`.
 - [docs] Fix typo in charts axis documentation (#15743) @JCQuintas
 - [docs] Improve SEO titles for the Data Grid (#15695) @MBilalShafi
 
-### Core
+### Internal
 
 - [core] Add `@mui/x-tree-view-pro` to `releaseChangelog` (#15316) @flaviendelangle
 - [code-infra] Lock file maintenance (#11894)
@@ -6552,7 +6539,7 @@ Same changes as in `@mui/x-tree-view@v8.0.0-alpha.2`.
 
 <!-- vale MUI.CorrectRererenceCased = YES -->
 
-### Core
+### Internal
 
 - [core] Follow `()` function convention for docs @oliviertassinari
 - [core] Remove dead translation key (#15566) @oliviertassinari
@@ -6687,7 +6674,7 @@ Same changes as in `@mui/x-charts@v8.0.0-alpha.1`.
 - [docs] Polish Server-side data section (#15330) @oliviertassinari
 - [docs] Use loading state in the demos (#15512) @cherniavskii
 
-### Core
+### Internal
 
 - [core] Keep OpenSSF badge up-to-date @oliviertassinari
 - [code-infra] Add `'DensitySelectorGrid'` to time-sensitive argos tests (#15425) @JCQuintas
@@ -6869,7 +6856,7 @@ Same changes as in `@mui/x-charts@8.0.0-alpha.0`.
 - [docs] Use `PickersTextField` in the customization playground (#15288) @LukasTy
 - [docs] Use `next` instead of `^8.0.0` in the migration guides (#15091) @flaviendelangle
 
-### Core
+### Internal
 
 - [core] Adjust the `cherry-pick` GitHub actions (#15099) @LukasTy
 - [core] Add `()` at the name of function name in the doc (#15075) @oliviertassinari

--- a/CHANGELOG.v8.md
+++ b/CHANGELOG.v8.md
@@ -4,7 +4,7 @@
 
 _Feb 13, 2026_
 
-We'd like to extend a big thank you to the 6 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 6 contributors who made this release possible. Here are some highlights ✨:
 
 - 📝 CSS bundler support is no longer needed for the Data Grid
 - 🐞 Bugfixes
@@ -55,7 +55,7 @@ Same changes as in `@mui/x-tree-view@8.27.1`.
 
 _Feb 2, 2026_
 
-We'd like to extend a big thank you to the 8 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 8 contributors who made this release possible. Here are some highlights ✨:
 
 - 📝 Data Grid supports new `longText` [column type](https://mui.com/x/react-data-grid/column-definition/#column-types)
 
@@ -155,7 +155,7 @@ Release highlight ✨:
 
 _Jan 22, 2026_
 
-We'd like to extend a big thank you to the 6 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 6 contributors who made this release possible. Here are some highlights ✨:
 
 - 🔄 Data Grid now supports undo and redo actions. See the [Undo and redo](https://mui.com/x/react-data-grid/undo-redo/) page for details about out-of-the-box support and customization options.
 - 🐞 Bugfixes
@@ -241,7 +241,7 @@ Internal changes.
 
 _Jan 14, 2026_
 
-We'd like to extend a big thank you to the 8 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 8 contributors who made this release possible. Here are some highlights ✨:
 
 - 📊 The Chart legend now has an option that enables [click to toggle visibility](https://mui.com/x/react-charts/legend/#toggle-visibility) of series.
 
@@ -348,7 +348,7 @@ Internal changes.
 
 _Jan 8, 2026_
 
-We'd like to extend a big thank you to the 12 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 12 contributors who made this release possible. Here are some highlights ✨:
 
 - ⚡️Add bar [batch renderer](https://mui.com/x/react-charts/bars/#performance), result in a significant performance improvement when rendering thousands of bars
 - 📊 Add [range bar chart](https://mui.com/x/react-charts/range-bar/) to render
@@ -458,7 +458,7 @@ Internal changes.
 
 _Dec 24, 2025_
 
-We'd like to extend a big thank you to the 12 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 12 contributors who made this release possible. Here are some highlights ✨:
 
 - 🧮 Support Data Grid `size`, `size(true)`, and `size(false)` [aggregations for `'boolean'` column type](https://mui.com/x/react-data-grid/aggregation/#usage-with-row-grouping)
 - 🔎 Allow zooming a heatmap
@@ -559,7 +559,7 @@ Internal changes.
 
 _Dec 17, 2025_
 
-We'd like to extend a big thank you to the 13 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 13 contributors who made this release possible. Here are some highlights ✨:
 
 - 🌎 Improve Swedish (sv-SE) locale on the Data Grid
 - 🐞 Bugfixes
@@ -660,7 +660,7 @@ Internal changes.
 
 _Dec 11, 2025_
 
-We'd like to extend a big thank you to the 11 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 11 contributors who made this release possible. Here are some highlights ✨:
 
 - Each Tree View component now exposes its own hook to initialize the `apiRef` object with accurate typing:
 
@@ -796,7 +796,7 @@ Internal changes.
 
 _Dec 3, 2025_
 
-We'd like to extend a big thank you to the 8 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 8 contributors who made this release possible. Here are some highlights ✨:
 
 - ✨ Add [tick spacing property](https://mui.com/x/react-charts/axis/#tick-spacing) to charts axis to control the distance between ticks.
 
@@ -908,7 +908,7 @@ Internal changes.
 
 _Nov 26, 2025_
 
-We'd like to extend a big thank you to the 8 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 8 contributors who made this release possible. Here are some highlights ✨:
 
 - 🔃 Data Grid tree data now supports row reordering. See the [Drag-and-drop tree data reordering](https://mui.com/x/react-data-grid/tree-data/#drag-and-drop-tree-data-reordering) section for more details.
 - 🐞 Bugfixes
@@ -970,7 +970,7 @@ Same changes as in `@mui/x-charts-pro@8.20.0`, plus:
 
 _Nov 20, 2025_
 
-We'd like to extend a big thank you to the 15 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 15 contributors who made this release possible. Here are some highlights ✨:
 
 - 🔎 Add pan on `wheel` to the charts zoom
 - ⌨️ Allow opt-in to [tab navigation](https://mui.com/x/react-data-grid/accessibility/#tab-navigation) inside the Data Grid.
@@ -1085,7 +1085,7 @@ Internal changes.
 
 _Nov 13, 2025_
 
-We'd like to extend a big thank you to the 14 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 14 contributors who made this release possible. Here are some highlights ✨:
 
 - Add `barLabelPlacement` property to customize the bar label position in bar charts, enabling labels to be placed above bars.
 
@@ -1183,7 +1183,7 @@ Internal changes.
 
 _Nov 5, 2025_
 
-We'd like to extend a big thank you to the 13 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 13 contributors who made this release possible. Here are some highlights ✨:
 
 - Add `colorGetter` prop to cartesian charts series
 
@@ -1290,7 +1290,7 @@ Internal changes.
 
 _Oct 29, 2025_
 
-We'd like to extend a big thank you to the 14 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 14 contributors who made this release possible. Here are some highlights ✨:
 
 - 🖌️ Add `brush` zoom interaction to charts
 - 🔁 [Server-side update](https://mui.com/x/react-data-grid/server-side-data/#updating-server-side-data) in a grid with tree data/row grouping and aggregation will trigger re-fetch for all parent levels of that row to update aggregated values. See the [demo](https://mui.com/x/react-data-grid/server-side-data/aggregation/#usage-with-tree-data).
@@ -1390,7 +1390,7 @@ Internal changes.
 
 _Oct 23, 2025_
 
-We'd like to extend a big thank you to the 14 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 14 contributors who made this release possible. Here are some highlights ✨:
 
 - 🖌️ Add new [`brush` charts interaction](https://mui.com/x/react-charts/brush/) for building custom behavior.
   ![brush visualization example](https://github.com/user-attachments/assets/60c382a1-e418-4736-8dcb-1567c4e361e3)
@@ -1497,7 +1497,7 @@ Internal changes.
 
 _Oct 16, 2025_
 
-We'd like to extend a big thank you to the 14 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 14 contributors who made this release possible. Here are some highlights ✨:
 
 - 🚀 Charts have optimized data structures for closest point calculations — initial render times reduced by ~25% for 1,000+ data points, with greater gains at larger scales (#19790) @bernardobelchior
 - 🐞 Bugfixes
@@ -1592,7 +1592,7 @@ Internal changes.
 
 _Oct 9, 2025_
 
-We'd like to extend a big thank you to the 14 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 14 contributors who made this release possible. Here are some highlights ✨:
 
 - 📊 The [Chart zoom now supports the `pressAndDrag` gesture](https://mui.com/x/react-charts/zoom-and-pan/#zoom-interactions-configuration). Pan by pressing and dragging.
 - 🔄 [Server-side pivoting](https://mui.com/x/react-data-grid/server-side-data/pivoting/) support for the Data Grid
@@ -1762,7 +1762,7 @@ Internal changes.
 
 _Oct 1, 2025_
 
-We'd like to extend a big thank you to the 14 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 14 contributors who made this release possible. Here are some highlights ✨:
 
 - 📊 The chart zoom now supports the `tapAndDrag` gesture. Zoom in/out by tapping twice and dragging vertically.
 - 🔎 Charts now allow [fine-grained control for zoom interactions](https://mui.com/x/react-charts/zoom-and-pan/#zoom-interactions-configuration).
@@ -1907,7 +1907,7 @@ Same changes as in `@mui/x-data-grid-pro@8.12.1`, plus:
 
 _Sep 25, 2025_
 
-We'd like to extend a big thank you to the 15 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 15 contributors who made this release possible. Here are some highlights ✨:
 
 - 🤝 Grid-Charts integration
 
@@ -2052,7 +2052,7 @@ Same changes as in `@mui/x-tree-view@8.12.0`.
 
 _Sep 16, 2025_
 
-We'd like to extend a big thank you to the 11 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 11 contributors who made this release possible. Here are some highlights ✨:
 
 - 🐞 Bugfixes
 - 📚 Documentation improvements
@@ -2138,7 +2138,7 @@ Internal changes.
 
 _Sep 10, 2025_
 
-We'd like to extend a big thank you to the 13 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 13 contributors who made this release possible. Here are some highlights ✨:
 
 - 🐞 Bugfixes
 - 📚 Documentation improvements
@@ -2233,7 +2233,7 @@ Internal changes.
 
 _Sep 4, 2025_
 
-We'd like to extend a big thank you to the 6 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 6 contributors who made this release possible. Here are some highlights ✨:
 
 Special thanks go out to the community members for their valuable contributions:
 @sai6855
@@ -2307,7 +2307,7 @@ Internal changes.
 
 _Aug 29, 2025_
 
-We'd like to extend a big thank you to the 19 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 19 contributors who made this release possible. Here are some highlights ✨:
 
 - 📊 Add new `SankeyChart`
 
@@ -2428,7 +2428,7 @@ Internal changes.
 
 _Aug 20, 2025_
 
-We'd like to extend a big thank you to the 10 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 10 contributors who made this release possible. Here are some highlights ✨:
 
 - 🌎 Improve Finnish (fi-FI) locale on the Data Grid
 
@@ -2514,7 +2514,7 @@ Internal changes.
 
 _Aug 15, 2025_
 
-We'd like to extend a big thank you to the 11 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 11 contributors who made this release possible. Here are some highlights ✨:
 
 - 📊 Y-axes can now be grouped by category when using `band` and `point` scales.
 - 📚 Documentation improvements
@@ -2616,7 +2616,7 @@ Internal changes.
 
 _Aug 8, 2025_
 
-We'd like to extend a big thank you to the 17 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 17 contributors who made this release possible. Here are some highlights ✨:
 
 - 📊 [`FunnelChart`](https://mui.com/x/react-charts/funnel/) marked as stable
 - 📈 [Zoom slider](https://mui.com/x/react-charts/zoom-and-pan/#zoom-slider) and [Preview](https://mui.com/x/react-charts/zoom-and-pan/#preview) marked as stable
@@ -2731,7 +2731,7 @@ Internal changes.
 
 _Jul 31, 2025_
 
-We'd like to extend a big thank you to the 23 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 23 contributors who made this release possible. Here are some highlights ✨:
 
 - 🌎 Improve French (fr-FR), Hebrew (he-IL) and Polish (pl-PL) locales on the Data Grid
 - 🌎 Improve Korean (ko-KR) locale on the Date and Time Pickers
@@ -2825,7 +2825,7 @@ Internal changes.
 
 _Jul 21, 2025_
 
-We'd like to extend a big thank you to the 2 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 2 contributors who made this release possible. Here are some highlights ✨:
 
 🐞 Fix package publish issue
 
@@ -2855,7 +2855,7 @@ Same changes as in `@mui/x-data-grid-pro@8.9.1`.
 
 _Jul 17, 2025_
 
-We'd like to extend a big thank you to the 10 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 10 contributors who made this release possible. Here are some highlights ✨:
 
 - ✨ Improve the drag and drop interaction for Data Grid [row reordering](https://mui.com/x/react-data-grid/row-ordering/) feature. It uses a drop indicator to point to the position the row would be moving to.
 
@@ -2950,7 +2950,7 @@ Internal changes.
 
 _Jul 11, 2025_
 
-We'd like to extend a big thank you to the 13 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 13 contributors who made this release possible. Here are some highlights ✨:
 
 - 📊 Chart zoom preview can be enabled
 
@@ -3048,7 +3048,7 @@ Internal changes.
 
 _Jul 4, 2025_
 
-We'd like to extend a big thank you to the 15 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 15 contributors who made this release possible. Here are some highlights ✨:
 
 - 📊 Add `useChartProApiRef` for easier access to the API
 - 📆 Support different start and end `referenceDate` props on range components
@@ -3151,7 +3151,7 @@ Same changes as in `@mui/x-tree-view@8.7.0`, plus:
 
 _Jun 27, 2025_
 
-We'd like to extend a big thank you to the 12 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 12 contributors who made this release possible. Here are some highlights ✨:
 
 - 📊 Add export menu to charts toolbar
 - 📅 Add `usePickerAdapter` hook to access the date adapter.
@@ -3259,7 +3259,7 @@ Internal changes.
 
 _Jun 19, 2025_
 
-We'd like to extend a big thank you to the 10 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 10 contributors who made this release possible. Here are some highlights ✨:
 
 - 📚 Documentation improvements
 - 🐞 Bugfixes
@@ -3354,7 +3354,7 @@ Internal changes.
 
 _Jun 12, 2025_
 
-We'd like to extend a big thank you to the 15 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 15 contributors who made this release possible. Here are some highlights ✨:
 
 - 📊 Improve Data Grid selectors performance
 - 🐞 Fix `useSyncExternalStore` import error in React 17
@@ -3448,7 +3448,7 @@ Same changes as in `@mui/x-tree-view@8.5.2`.
 
 _Jun 5, 2025_
 
-We'd like to extend a big thank you to the 9 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 9 contributors who made this release possible. Here are some highlights ✨:
 
 - 📊 Allow exporting pie charts
 - 📚 Documentation improvements

--- a/changelogOld/CHANGELOG.v4.md
+++ b/changelogOld/CHANGELOG.v4.md
@@ -79,7 +79,7 @@ A big thanks to the 6 contributors who made this release possible. Here are some
 - [docs] Fix docs links and pagination sentence (#2381) @ZeeshanTamboli
 - [docs] Update the icons for the new branding (#2339) @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Keep prop-types in the same file (#2345) @oliviertassinari
 - [core] Reduce `options` internal usage (#2318) @flaviendelangle
@@ -142,7 +142,7 @@ This is the last alpha release. We are moving to beta in the next release, next 
 - [docs] Fix page size warnings (#2301) @oliviertassinari
 - [docs] Sort events alphabetically (#2278) @flaviendelangle
 
-### Core
+### Internal
 
 - [core] Assert that `event.defaultMuiPrevented` is called (#2302) @oliviertassinari
 - [core] Reduce options usage in feature hooks (#2275, #2284) @flaviendelangle
@@ -223,7 +223,7 @@ Big thanks to the 6 contributors who made this release possible. Here are some h
 - [docs] Improve slot API docs (#2219) @oliviertassinari
 - [docs] Document virtualization APIs in virtualization section (#2247) @ZeeshanTamboli
 
-### Core
+### Internal
 
 - [core] Isolate Data Grid Pro and `XGrid` (#2176) @dtassone
 - [core] Move `GridFilterModel` in the models directory (#2243) @flaviendelangle
@@ -308,7 +308,7 @@ Big thanks to the 8 contributors who made this release possible. Here are some h
 - [docs] Generate API doc for the GridExportCSVOptions interface (#2102) @flaviendelangle
 - [docs] Handle generics in API doc generation (#2210) @flaviendelangle
 
-### Core
+### Internal
 
 - [core] Don't export the internal utils (#2233) @flaviendelangle
 - [core] Receive patch and minor dependency updates (#2221) @flaviendelangle
@@ -471,7 +471,7 @@ Big thanks to the 11 contributors who made this release possible. Here are some 
 - [docs] Fix small typos in the documentation (#2169) @BrandonOldenhof
 - [docs] Fix typo in README (#2150) @studyhog
 
-### Core
+### Internal
 
 - [core] Add @material-ui/lab and @material-ui/icons as peer dependencies (#2012) @m4theushw
 - [core] Add additional test case for `onSelectionModelChange` (#1966) @DanailH
@@ -576,7 +576,7 @@ Big thanks to the 6 contributors who made this release possible. Here are some h
 - [docs] Fix changing Dataset not working (#1965) @m4theushw
 - [docs] Fix description of union types (#2003) @m4theushw
 
-### Core
+### Internal
 
 - [core] Polish filtering internals (#1760) @ZeeshanTamboli
 - [core] Upgrade actions-cool/issues-helper (#1962) @oliviertassinari
@@ -687,7 +687,7 @@ Big thanks to the 10 contributors who made this release possible. Here are some 
 - [docs] Make cells editable in demos (#1817) @m4theushw
 - [docs] Polish `disableDensitySelector` description (#1884) @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Batch small changes (#1901) @oliviertassinari
 - [core] Remove dead logic (#1900) @oliviertassinari
@@ -740,7 +740,7 @@ Big thanks to the 6 contributors who made this release possible. Here are some h
 - [docs] Add docs for `disableDensitySelector` option (#1856) @DanailH
 - [docs] Automatically generate API docs (#1529) @m4theushw
 
-### Core
+### Internal
 
 - [core] Batch small changes (#1848) @oliviertassinari
 - [core] Add `yarn docs:api` @oliviertassinari
@@ -856,7 +856,7 @@ Big thanks to the 8 contributors who made this release possible. Here are some h
 - [docs] Remove redundant customizable pagination section (#1774) @ZeeshanTamboli
 - [docs] Improve `GridApi` descriptions (#1767) @m4theushw
 
-### Core
+### Internal
 
 - [core] Batch updates of storybook (#1751) @oliviertassinari
 - [core] Help support different documents (#1754) @oliviertassinari
@@ -970,7 +970,7 @@ Big thanks to the 11 contributors who made this release possible. Here are some 
 - [docs] Refine the descriptions to be clearer (#1589) @oliviertassinari
 - [docs] Reshuffle columns and rows styling sections (#1622) @DanailH
 
-### Core
+### Internal
 
 - [core] Fix dependabot config (#1619) @oliviertassinari
 - [core] Remove `makeStyles` dependency on `@material-ui/core/styles` (#1627) @mnajdova
@@ -1026,7 +1026,7 @@ Big thanks to the 5 contributors who made this release possible. Here are some h
 - [docs] Header convention for controllable prop (#1531) @oliviertassinari
 - [docs] Fix errors in the docs (#1585) @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Add security policy (#1588) @oliviertassinari
 - [core] Improve `GridApi` type structure (#1566) @oliviertassinari
@@ -1103,7 +1103,7 @@ Big thanks to the 9 contributors who made this release possible. Here are some h
 - [docs] Fix typos (#1447) @ZeeshanTamboli
 - [docs] No ads for commercial license (#1489) @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Label our packages as side effect free (#1466) @oliviertassinari
 - [core] Reduce work in Data Grid (#1520) @oliviertassinari
@@ -1144,7 +1144,7 @@ Big thanks to the 7 contributors who made this release possible. Here are some h
 - [docs] Improve PropType to cover required props (#1419) @ZeeshanTamboli
 - [docs] Remove duplicate rendering page (#1375) @dtassone
 
-### Core
+### Internal
 
 - [core] Setup e2e tests (#1443) @DanailH
 
@@ -1221,7 +1221,7 @@ Big thanks to the 5 contributors who made this release possible. Here are some h
 - [docs] Move density to accessibility page (#1374) @dtassone
 - [Docs] Fix GitHub references in API docs (#1411) @SaskiaKeil
 
-### Core
+### Internal
 
 - [core] Update to React 17 (#1331) @m4theushw
 - [core] Variable convention (#1397) @oliviertassinari
@@ -1262,7 +1262,7 @@ Big thanks to the 8 contributors who made this release possible. Here are some h
 - [DataGrid] Fix rendering issues (#1319, #1253) @dtassone
 - [DataGrid] Refactor edit events to allow stop propagation (#1304) @dtassone
 
-### Core
+### Internal
 
 - [core] Batch small changes (#1310) @oliviertassinari
 
@@ -1296,7 +1296,7 @@ Big thanks to the 7 contributors who made this release possible. Here are some h
 - [docs] Fix linking to sorting component in data-grid overview page (#1237) @SaskiaKeil
 - [docs] Fix typos (#1198) @cthogg
 
-### Core
+### Internal
 
 - [core] Improve the handling of events (rm capture, add event, add new props) (#1158) @dtassone
 - [core] Reinforce that columns are definitions (#1210) @oliviertassinari
@@ -1331,7 +1331,7 @@ Big thanks to the 6 contributors who made this release possible. Here are some h
 - [docs] Improve the description of the individual packages (#1139) @oliviertassinari
 - [docs] Fix rendering docs to solve custom pagination issue (#1159) @consDev
 
-### Core
+### Internal
 
 - [core] Add build in eslintignore (#1171) @dtassone
 - [core] Increase timeout for XGrid demo (#1150) @oliviertassinari
@@ -1380,7 +1380,7 @@ Big thanks to the 7 contributors who made this release possible. Here are some h
 - [docs] Clarify align is separate from headerAlign (#1074) @alexdanilowicz
 - [docs] Clarify product split (#1080) @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Fix storybook pagination stories (#1099) @dtassone
 - [core] Pin playwright image to known working version (#1110) @oliviertassinari
@@ -1475,7 +1475,7 @@ Big thanks to the 4 contributors who made this release possible. Here are some h
 - [docs] Reduce fears around license upfront @oliviertassinari
 - [docs] Update streaming docs (#1013) @dtassone
 
-### Core
+### Internal
 
 - [core] Batch small changes (#991) @oliviertassinari
 - [core] Save/restore actual yarn cache folder (#1039) @oliviertassinari
@@ -1519,7 +1519,7 @@ Big thanks to the 5 contributors who made this release possible. Here are some h
 - [docs] Improve docs of DataGrid about filter operators (#973) @SaskiaKeil
 - [docs] Improve the docs for the filtering feature (#945) @dtassone
 
-### core
+### Internal
 
 - [core] Add 'Order id 💳' section in issues (#952) @oliviertassinari
 - [core] Improve prop-types handling (#978) @oliviertassinari
@@ -1605,7 +1605,7 @@ Big thanks to the 5 contributors who made this release possible. Here are some h
 - [docs] Skip download of playwright for docs @oliviertassinari
 - [changelog] Polish @oliviertassinari
 
-### core
+### Internal
 
 - [core] Automation for duplicate issues (#878) @oliviertassinari
 - [core] Replace commander with yargs (#872) @dependabot-preview
@@ -1637,7 +1637,7 @@ Big thanks to the 4 contributors who made this release possible. Here are some h
 - [docs] Add docs for Data Grid column selector (#837) @DanailH
 - [docs] Clarify feature split between Pro and Premium (#779) @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Add tests for Column selector feature (#845) @DanailH
 
@@ -1658,7 +1658,7 @@ Big thanks to the 2 contributors who made this release possible. Here are some h
 
 - [docs] Add documentation for the column menu (#815) @DanailH
 
-### Core
+### Internal
 
 - [core] Update peer dependencies for React 17 (#814) @DanailH
 - [core] Batch small changes (#800) @oliviertassinari
@@ -1693,7 +1693,7 @@ Big thanks to the 5 contributors who made this release possible. Here are some h
 - [docs] Start documentation for the Data Grid filter features (#754) @dtassone
 - [docs] Sync with docs to fix images (#776) @oliviertassinari
 
-### Core
+### Internal
 
 - [test] We don't need to wait 100ms (#773) @oliviertassinari
 - [core] Remove useless clone (#757) @oliviertassinari
@@ -1719,7 +1719,7 @@ Big thanks to the 4 contributors who made this release possible. Here are some h
 - [docs] Fix wrong link anchor @oliviertassinari
 - [docs] Proxy production version @oliviertassinari
 
-### Core
+### Internal
 
 - [security] Bump ini from 1.3.5 to 1.3.7 (#719) @dependabot-preview
 - [core] Update monorepository (#725) @oliviertassinari
@@ -1758,7 +1758,7 @@ Big thanks to the 6 contributors who made this release possible. Here are some h
 
 - [docs] Enable CodeSandbox preview in PRs (#613) @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Batch small changes (#683) @oliviertassinari
 - [test] Add regression test (#705) @oliviertassinari
@@ -1814,7 +1814,7 @@ Big thanks to the 8 contributors who made this release possible. Here are some h
 - [docs] Fix typo in columns.md @stojy
 - [docs] Reduce confusion on /export page (#646) @SerdarMustafa1
 
-### Core
+### Internal
 
 - [core] Introduce a feature toggle (#637) @oliviertassinari
 - [core] Remove gitHead (#669) @oliviertassinari
@@ -1838,7 +1838,7 @@ _Nov 20, 2020_
 
 - [docs] Update feature comparison table for Column reorder @DanailH
 
-### Core
+### Internal
 
 - [core] Prepare work for a future public state API (#533) @dtassone
 - [core] Fix yarn prettier write @oliviertassinari
@@ -1874,7 +1874,7 @@ _Nov 9, 2020_
 - [docs] Fix the Netlify proxy for localization of X (#536) @oliviertassinari
 - [docs] Add deploy script command @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Batch small changes (#546) @oliviertassinari
 - [core] Improve types (#448) @oliviertassinari
@@ -1894,7 +1894,7 @@ _Oct 23, 2020_
 - [XGrid] Second iteration on resizing logic (#436) @oliviertassinari
   Fix 8 bugs with the resizing.
 
-### Core
+### Internal
 
 - [core] Remove usage of LESS (#467) @dependabot-preview
 - [core] Update to the latest version of the main repo (#456) @oliviertassinari
@@ -1915,7 +1915,7 @@ _Oct 19, 2020_
 - [docs] Remove id columns (#355) @oliviertassinari
 - [docs] Swap words to better match users' query (#354) @oliviertassinari
 
-### Core
+### Internal
 
 - [storybook] Fix warning and improve perf (#407) @dtassone
 - [core] Batch small changes (#403) @oliviertassinari

--- a/changelogOld/CHANGELOG.v5.md
+++ b/changelogOld/CHANGELOG.v5.md
@@ -74,7 +74,7 @@ We'd like to offer a big thanks to the 6 contributors who made this release poss
 - [docs] Add messages in v5 doc to inform people about v6 (#7838) @flaviendelangle
 - [docs] Fix 301 link @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Upgrade monorepo (#7849) @cherniavskii
 
@@ -216,7 +216,7 @@ We'd like to offer a big thanks to the 3 contributors who made this release poss
 
 - [docs] Redirect translated pages (#7370) @cherniavskii
 
-### Core
+### Internal
 
 - [core] Fix release date (#7314) @DanailH
 - [core] Fix the product license reference name (#7367) @oliviertassinari
@@ -348,7 +348,7 @@ We'd like to offer a big thanks to the 7 contributors who made this release poss
 - [docs] Fix live edit @oliviertassinari
 - [docs] Upgrade to Next 13 (#6911) @cherniavskii
 
-### Core
+### Internal
 
 - [core] Upgrade monorepo (#6906) @cherniavskii
 - [core] Upgrade node to v14.21 (#6939) @piwysocki
@@ -375,7 +375,7 @@ We'd like to offer a big thanks to the 5 contributors who made this release poss
 
 - [docs] Clarify DataGrid Row Pinning docs (#6891) @cherniavskii
 
-### Core
+### Internal
 
 - [core] Upgrade monorepo (#6864) @m4theushw
 - [license] Polish error messages (#6881) @oliviertassinari
@@ -405,7 +405,7 @@ We'd like to offer a big thanks to the 5 contributors who made this release poss
 
 - [docs] Fix link to localization page (#6766) @alexfauquette
 
-### Core
+### Internal
 
 - [license] Add new license status 'Out of scope' (#6774) @oliviertassinari
 
@@ -467,7 +467,7 @@ We'd like to offer a big thanks to the 6 contributors who made this release poss
 - [docs] Fix code edit for when v6 will be stable (#6600) @oliviertassinari
 - [docs] Fix typo in DataGrid demo page (#6632) (#6634) @LukasTy
 
-### Core
+### Internal
 
 - [core] Upgrade monorepo (#6570) @cherniavskii
 
@@ -572,7 +572,7 @@ We'd like to offer a big thanks to the 2 contributors who made this release poss
 
 - [docs] Pass model change callbacks in controlled grid editing demos (#6306) @cherniavskii
 
-### Core
+### Internal
 
 - [core] Reduce the amount of updated screenshots reported by Argos (#6310) @cherniavskii
 
@@ -606,7 +606,7 @@ We'd like to offer a big thanks to the 5 contributors who made this release poss
 
 - [docs] Fix 301 link (#6239) @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Use the official repository for `@mui/monorepo` instead of a fork (#6189) @oliviertassinari
 
@@ -639,7 +639,7 @@ We'd like to offer a big thanks to the 6 contributors who made this release poss
 
 - [docs] Improve main demo to show new functionalities (#5292) @joserodolfofreitas
 
-### Core
+### Internal
 
 - [core] Update to TypeScript 4.8.3 (#6136) @flaviendelangle
 - [core] Update RFC template (#6100) @bytasv
@@ -683,7 +683,7 @@ We'd like to offer a big thanks to the 6 contributors who made this release poss
 
 - [docs] Add Recipes section
 
-### Core
+### Internal
 
 - [core] Add `yarn release:tag` script (#5169) @DanailH
 - [core] Upgrade monorepo (#6072) @m4theushw
@@ -769,7 +769,7 @@ We'd like to offer a big thanks to the 9 contributors who made this release poss
 - [docs] Update `GridCellParams`'s `value` description (#5849) @cherniavskii
 - [docs] Update `README.md` to match Introduction section of the docs (#5754) @samuelsycamore
 
-### Core
+### Internal
 
 - [core] Fix typo (#5990) @flaviendelangle
 - [core] Remove old babel resolve rule (#5939) @oliviertassinari
@@ -829,7 +829,7 @@ We'd like to offer a big thanks to the 11 contributors who made this release pos
 - [docs] Fix typo in `migration from lab` (#5277) @chuckwired
 - [docs] Use `dayjs` instead of `date-fns` in doc examples (#5481) @flaviendelangle
 
-### Core
+### Internal
 
 - [core] Clarify the scope of the license key used for tests and documentation (#5824) @oliviertassinari
 - [core] Fix TypeScript error on field hooks (#5892) @flaviendelangle
@@ -871,7 +871,7 @@ We'd like to offer a big thanks to the 9 contributors who made this release poss
 - [docs] Update packages README files (#5835) @cherniavskii
 - [docs] Use `InputBase` for pickers inputs (#5597) @cherniavskii
 
-### Core
+### Internal
 
 - [core] Upgrade monorepo (#5771, #5797) @cherniavskii
 - [core] Various TypeScript improvements (#5556) @flaviendelangle
@@ -916,7 +916,7 @@ We'd like to offer a big thanks to the 7 contributors who made this release poss
 - [docs] Improve the Events page (#5413) @flaviendelangle
 - [docs] Use new editing API in the introduction demos (#5728) @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Remove duplicated `FUNDING.yml` file (#5656) @oliviertassinari
 - [core] Remove outdated Next.js options (#5727) @oliviertassinari
@@ -958,7 +958,7 @@ We'd like to offer a big thanks to the 10 contributors who made this release pos
 - [docs] Update description of `maxDateTime` prop (#5639) @jurecuhalev
 - [docs] Add missing `date-fns` dependency when opening CodeSandbox demo (#5692) @cherniavskii
 
-### Core
+### Internal
 
 - [core] Drop usage of `GRID_EXPERIMENTAL_ENABLED` env variable (#5669) @ar7casper
 - [core] Isolate asset loading under /x/ (#5594) @oliviertassinari
@@ -1017,7 +1017,7 @@ We'd like to offer a big thanks to the 6 contributors who made this release poss
 - [docs] Correct slot CSS classes for Pro and Premium components (#5452) @alexfauquette
 - [docs] Fix internal link to `valueParser` (#5450) @alexfauquette
 
-### Core
+### Internal
 
 - [core] Upgrade monorepo (#5560) @m4theushw
 
@@ -1058,7 +1058,7 @@ We'd like to offer a big thanks to the 10 contributors who made this release pos
 - [docs] New page presenting the `apiRef` (#5273) @flaviendelangle
 - [docs] Remove blank line @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Add missing comments on zh-TW translation (#5559) @flaviendelangle
 - [core] Polish on the bug issue template (#5525) @oliviertassinari
@@ -1106,7 +1106,7 @@ We'd like to offer a big thanks to the 13 contributors who made this release pos
 - [docs] Update pickers README files (#5456) @cherniavskii
 - [docs] Clarify the scope of support for MUI X (#5423) @joserodolfofreitas
 
-### Core
+### Internal
 
 - [core] Add technical support link to \_redirects (#5428) @joserodolfofreitas
 - [core] Improve GitHub bug reproduction template (#5067) @joserodolfofreitas
@@ -1207,7 +1207,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 - [docs] Disable ad on main demo page (#5301) @joserodolfofreitas
 - [docs] Fix typo in the `DateRangePicker` documentation (#5259) @flaviendelangle
 
-### Core
+### Internal
 
 - [core] Allow having multiple playgrounds (#5288) @alexfauquette
 - [core] Improve typing of `GridFilterInputMultipleSingleSelect` (#5206) @flaviendelangle
@@ -1252,7 +1252,7 @@ We'd like to offer a big thanks to the 7 contributors who made this release poss
 - [docs] Use redirection in the code (#5114) @oliviertassinari
 - [docs] Add demo of how to use the Data Grid with date pickers (#5053) @cherniavskii
 
-### Core
+### Internal
 
 - [core] Improve inline code rendering within the details tag (#5166) @Harmouch101
 - [core] Remove unused props from plugin typing (#5185) @flaviendelangle
@@ -1308,7 +1308,7 @@ We'd like to offer a big thanks to the 10 contributors who made this release pos
 - [docs] Section for overwriting core components i18n keys (#4998) @DanailH
 - [docs] Small grammar and format fixes for Dynamic Row Height section (#5098) @samuelsycamore
 
-### Core
+### Internal
 
 - [core] Allows to run tests with different date adapters (#5055) @alexfauquette
 - [core] Prettify the l10n issue (#4928) @alexfauquette
@@ -1385,7 +1385,7 @@ We'd like to offer a big thanks to the 15 contributors who made this release pos
 - [docs] Fix docs feedback widget not working (#4905) @cherniavskii
 - [docs] Replace custom notes and warning with callouts (#5008) @flaviendelangle
 
-### Core
+### Internal
 
 - [core] Avoid Order ID to refer to GitHub issues/PRs (#5005) @oliviertassinari
 - [core] Improve the workflow for incomplete issues (#5012) @mnajdova
@@ -1477,7 +1477,7 @@ We'd like to offer a big thanks to the 6 contributors who made this release poss
 - [docs] Typo on OrderId @oliviertassinari
 - [docs] Update feature comparison table (#4918) @cherniavskii
 
-### Core
+### Internal
 
 - [core] Add new script to generate tree data rows from file tree (#4902) @flaviendelangle
 - [core] Fix code style (#4874) @oliviertassinari
@@ -1618,7 +1618,7 @@ We'd like to offer a big thanks to the 15 contributors who made this release pos
 - [docs] Update the feature table in the Getting Started page of the Data Grid (#4619) @flaviendelangle
 - [docs] Add demo for Premium (#4750) @m4theushw
 
-### Core
+### Internal
 
 - [core] Check if `process` is available (#4193) @m4theushw
 - [core] Fix naming collision (#4853) @alexfauquette
@@ -1666,7 +1666,7 @@ We'd like to offer a big thanks to the 6 contributors who made this release poss
 - [docs] Include date-fns dependency when opening demos in CodeSandbox (#4508) @m4theushw
 - [docs] Split the 'Group & Pivot' page (#4441) @flaviendelangle
 
-### Core
+### Internal
 
 - [core] Fix the README of the X packages (#4590) @flaviendelangle
 - [test] Fix test to not depend on screen resolution (#4587) @m4theushw
@@ -1733,7 +1733,7 @@ We'd like to offer a big thanks to the 9 contributors who made this release poss
 - [docs] Go live with the new URLs (#4313) @siriwatknp
 - [docs] Update the product names to be in sync @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Add technical doc for pipe processing and family processing (#4322) @flaviendelangle
 - [core] Don't upgrade CircleCI node (#4457) @m4theushw
@@ -1814,7 +1814,7 @@ We'd like to offer a big thanks to the 7 contributors who made this release poss
 - [docs] Update installation docs (#4259) @cherniavskii
 - [docs] New page for the migration of date and time pickers from the lab (#4327) @flaviendelangle
 
-### Core
+### Internal
 
 - [core] Fix typo in issue template @oliviertassinari
 - [core] Move last variables outside of the models folder (#4303) @flaviendelangle
@@ -1878,7 +1878,7 @@ We'd like to offer a big thanks to the 12 contributors who made this release pos
 - [docs] Remove useless `apiRef` from demos (#4221) @flaviendelangle
 - [docs] Sync the headers with core (#4195) @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Add CLI to decode license key (#4126) @flaviendelangle
 - [core] Fix Lerna package change detection (#4202) @oliviertassinari
@@ -1924,7 +1924,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 - [docs] Neglect e2e tests related to search (#4118) @siriwatknp
 - [docs] Use regex instead of specific url in e2e-website-tests (#4121) @siriwatknp
 
-### Core
+### Internal
 
 - [core] Enforce `noImplicitAny` (#4084) @cherniavskii
 - [core] Improve the Pro support issue template (#4082) @oliviertassinari
@@ -2034,7 +2034,7 @@ We'd like to offer a big thanks to the 15 contributors who made this release pos
 - [docs] Fix typo in client-side validation example (#4066) @krallj
 - [docs] Remove useless hide id column (#4021) @alexfauquette
 
-### Core
+### Internal
 
 - [core] Allows to add custom export item (#3891) @alexfauquette
 - [core] Remove the `_modules_` folder (#3953) @flaviendelangle
@@ -2094,7 +2094,7 @@ A big thanks to the 6 contributors who made this release possible. Here are some
 - [docs] Move row grouping to Premium plan (#3827) @alexfauquette
 - [docs] Reorganize export docs to prepare Excel export doc (#3822) @alexfauquette
 
-### Core
+### Internal
 
 - [core] Add hook `useGridPagination` to call `onGridPage` and `onGridPageSize` (#3880) @flaviendelangle
 - [core] Fix docs deploy script (#3874) @oliviertassinari
@@ -2138,7 +2138,7 @@ A big thanks to the 10 contributors who made this release possible. Here are som
 - [docs] Mention row `id` requirement and document `getRowId` prop (#3765) @cherniavskii
 - [docs] Refresh the license key documentation (#3529) @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Clean `filtering.DataGrid.test.tsx` (#3768) @flaviendelangle
 - [core] Improve GitHub label workflows (#3680) @DanailH
@@ -2205,7 +2205,7 @@ A big thanks to the 9 contributors who made this release possible. Here are some
 - [docs] Prepare scripts and E2E tests for migration (#3515) @siriwatknp
 - [docs] Clarify what is the professional support (#3530) @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Add ESLint rule to force default export equals to filename in documentation (#3674) @alexfauquette
 - [core] Fix `l10n` script not updating `cs-CZ` locale (#3748) @cherniavskii
@@ -2345,7 +2345,7 @@ A big thanks to the 9 contributors who made this release possible. Here are some
 - [docs] Replace `@mui/styles` in `x-data-grid-generator` (#3560) @m4theushw
 - [docs] Update usage of prop/property naming (#3649) @cherniavskii
 
-### Core
+### Internal
 
 - [core] Log the output of the script (#3527) @oliviertassinari
 - [core] Add ESLint rule to prevent direct state access (#3521) @m4theushw
@@ -2403,7 +2403,7 @@ A big thanks to the 9 contributors who made this release possible. Here are some
 - [docs] Generate imports dynamically from the packages export list (#3488) @flaviendelangle
 - [docs] Make demos compatible with `preProcessEditCellProps` (#3453) @m4theushw
 
-### Core
+### Internal
 
 - [test] Add test for row checkbox toggling using the Space key (#3262) @alexfauquette
 - [core] Increase CI efficiency (#3441) @oliviertassinari
@@ -2445,7 +2445,7 @@ A big thanks to the 8 contributors who made this release possible. Here are some
 - [docs] Stop using TypeDoc to generate the API documentation (#3320) @flaviendelangle
 - [docs] Remove column pinning from "Upcoming features" (#3443) @alexfauquette
 
-### Core
+### Internal
 
 - [core] Add sections to some of the feature hooks (#3391) @flaviendelangle
 - [core] Generate exports snapshot for both `x-data-grid` and `x-data-grid-pro` packages (#3427) @flaviendelangle
@@ -2519,7 +2519,7 @@ A big thanks to the 5 contributors who made this release possible. Here are some
 - [docs] Fix duplicate "the" (#3365) @noam-honig
 - [docs] Update branch to deploy docs (#3321) @m4theushw
 
-### Core
+### Internal
 
 - [core] Add funding field (#3331) @oliviertassinari
 - [core] Fix missing LICENSE file (#3330) @oliviertassinari
@@ -2595,7 +2595,7 @@ A big thanks to the 11 contributors who made this release possible. Here are som
 - [DataGrid] Improve Korean (ko-KR) locale (#3232, #3273) @zzossig
 - [DataGrid] Improve Greek (el-GR) locale (#3169) @clytras
 
-### Core
+### Internal
 
 - [core] Add script to sync translation files (#3201) @m4theushw
 - [core] Create dedicated `InputComponent` for `singleSelect` and `date` columns #3227 @alexfauquette
@@ -2671,7 +2671,7 @@ A big thanks to the 3 contributors who made this release possible. Here are some
 
 - [docs] Move sentence about disabling multi rows selection (#3167) @alexfauquette
 
-### Core
+### Internal
 
 - [core] Drop `useGridContainerProps` (#3007) @flaviendelangle
 - [core] Move `getRowIdFromRowIndex` and `getRowIndex` to the sorting API (#3126) @flaviendelangle
@@ -2737,7 +2737,7 @@ A big thanks to the 7 contributors who made this release possible. Here are some
 - [DataGrid] Remove unused rendering state and selectors (#3133) @flaviendelangle
 - [DataGrid] Rename `Checkbox` component and props slots to `BaseCheckbox` (#3142) @DanailH
 
-### Core
+### Internal
 
 - [core] Adapt changelog script to GitHub DOM modification (#3087) @alexfauquette
 - [core] Automatically close issues that are incomplete and inactive (#3029) @oliviertassinari
@@ -2810,7 +2810,7 @@ _Nov 4, 2021_
 - [DataGrid] Prevents bubbling in menu header (#3000) @alexfauquette
 - [DataGrid] Fix wrong params provided to `cellModeChange` when `setCellMode` is called (#3025) @flaviendelangle
 
-### Core
+### Internal
 
 - [core] Adapt `useDemoData` for Tree Data (#2978) @flaviendelangle
 - [core] Group update of MUI Core (#3055) @oliviertassinari
@@ -2927,7 +2927,7 @@ A big thanks to the 7 contributors who made this release possible. Here are some
 - [docs] Improve `scrollEndThreshold` API docs (#3001) @ZeeshanTamboli
 - [docs] Fix CodeSandbox and feature request templates (#2986) @flaviendelangle
 
-### Core
+### Internal
 
 - [core] Add step for announcing the releases on Twitter (#2997) @DanailH
 - [core] Apply all filters to a row before moving to the next one (#2870) @flaviendelangle
@@ -3055,7 +3055,7 @@ A big thanks to the 5 contributors who made this release possible. Here are some
 - [docs] Fix to not commit changes when clicking outside the cell (#2906) @ZeeshanTamboli
 - [docs] Update link to Quick Filter issue (#2909) @m4theushw
 
-### Core
+### Internal
 
 - [core] Small fixes on the Components page (#2877) @flaviendelangle
 - [core] Make each feature hook responsible for its column pre-processing (#2839) @flaviendelangle
@@ -3238,7 +3238,7 @@ A big thanks to the 7 contributors who made this release possible. Here are some
 - [docs] Fix pagination in Ant Design demo (#2787) @ZeeshanTamboli
 - [docs] Update the `page` prop docs (#2812) @m4theushw
 
-### Core
+### Internal
 
 - [core] Update hooks to initialize their state synchronously (#2782) @flaviendelangle
 - [core] Fix rollup external warnings (#2736) @eps1lon
@@ -3302,7 +3302,7 @@ A big thanks to the 9 contributors who made this release possible. Here are some
 - [docs] Fix demo throwing error (#2719) @m4theushw
 - [docs] Fix index and improve playground page (#2755) @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Add benchmark script (#2683) @m4theushw
 - [core] Clean error messages prefix (#2676) @flaviendelangle
@@ -3366,7 +3366,7 @@ A big thanks to the 5 contributors who made this release possible. Here are some
 - [docs] Improve the search results relevance (#2656) @oliviertassinari
 - [docs] Update installation instructions (#2663) @m4theushw
 
-### Core
+### Internal
 
 - [core] Upgrade JSS plugins to 10.8.0 (#2667) @m4theushw
 
@@ -3386,7 +3386,7 @@ This is a hotfix to fix an important regression with `v5.0.0-beta.0`.
 - [docs] Fix formatting (#2626) @m4theushw
 - [docs] Include packages from next tag (#2628) @m4theushw
 
-### Core
+### Internal
 
 - [core] Copy bin folder when building the libraries (#2627) @flaviendelangle
 - [core] Remove prop-types during build (#2586) @m4theushw

--- a/changelogOld/CHANGELOG.v6.md
+++ b/changelogOld/CHANGELOG.v6.md
@@ -68,7 +68,7 @@ Same changes as in `@mui/x-data-grid@6.19.10`.
 
 Same changes as in `@mui/x-data-grid-pro@6.19.10`.
 
-### Core
+### Internal
 
 - [core] Update the docs release source branch (#12685) @LukasTy
 
@@ -110,7 +110,7 @@ No changes.
 - [docs] Add a recipe for the `checkboxSelectionVisibleOnly` prop (#12667) @michelengelen
 - [docs] Explain the use of `_action: 'delete'` in `processRowUpdate` (#12673) @michelengelen
 
-### Core
+### Internal
 
 - [core] Use Circle CI context (#12607) @cherniavskii
 
@@ -259,7 +259,7 @@ Same changes as in `@mui/x-date-pickers@6.19.5`.
 - [docs] Add more illustrations to the Overview page (#12041) @danilo-leal
 - [docs] Avoid use of shorthand (#12009) @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Fix CI @oliviertassinari
 - [core] Fix docs link check (#12137) @LukasTy
@@ -813,7 +813,7 @@ Same changes as in `@mui/x-date-pickers@6.18.1`.
 - [docs] Fix charts docs as stable (#10888) @alexfauquette
 - [docs] Document how to hide the legend (#10954) @alexfauquette
 
-### Core
+### Internal
 
 - [core] Adds new alpha version to version select on the docs (#10944) @michelengelen
 - [core] Fix GitHub title tag consistency @oliviertassinari
@@ -875,7 +875,7 @@ Same changes as in `@mui/x-date-pickers@6.18.0`.
 - [docs] Add demo about how to use charts margin (#10886) @alexfauquette
 - [docs] Improve custom field input demos readability (#10559) @LukasTy
 
-### Core
+### Internal
 
 - [core] Generate `slot` API descriptions based on `slots` or `components` (#10879) @LukasTy
 
@@ -1005,7 +1005,7 @@ Same changes as in `@mui/x-date-pickers@6.16.3`, plus:
 - [docs] Improve meta description @oliviertassinari
 - [docs] Make overview demo work in codesandbox (#10661) @alexfauquette
 
-### Core
+### Internal
 
 - [core] Update React renovate group with `@types` (#10723) @LukasTy
 - [core] Update `styled-components` (#10733) @LukasTy
@@ -1106,7 +1106,7 @@ This comes with some breaking changes.
 - [docs] Avoid Pickers playground error due to empty views (#10654) @LukasTy
 - [docs] Fix DataGrid[Pro/Premium] reference links (#10620) @michelengelen
 
-### Core
+### Internal
 
 - [core] Bump monorepo (#10619) @alexfauquette
 - [core] Update `no-response` workflow (#10491) @MBilalShafi
@@ -1169,7 +1169,7 @@ Same changes as in `@mui/x-date-pickers@6.16.1`, plus:
 - [docs] Add "What's new" page listing all release announcements (#9727) @joserodolfofreitas
 - [docs] Update RTL Support section of the grid localization docs (#10561) @MBilalShafi
 
-### Core
+### Internal
 
 - [core] Fix casing consistency with legal and marketing content @oliviertassinari
 - [core] Revert the link in the priority support ticket description (#10517) @michelengelen
@@ -1247,7 +1247,7 @@ Same changes as in `@mui/x-date-pickers@6.16.0`.
 - [docs] Fix mobile scrollbar column resize (#10455) @oliviertassinari
 - [docs] Fix usage of `GridRenderCellParams` interface (#10435) @cherniavskii
 
-### Core
+### Internal
 
 - [core] Fix typo in header Data Grid quick filter @oliviertassinari
 - [core] Group D3 renovate PRs (#10480) @flaviendelangle
@@ -1329,7 +1329,7 @@ Same changes as in `@mui/x-date-pickers@6.15.0`.
 - [docs] Polish typescript ref usage (#10359) @oliviertassinari
 - [docs] Improve charts tooltip wording (#10406) @alexfauquette
 
-### Core
+### Internal
 
 - [core] Cleanup GitHub issues template (#10372) @romgrk
 - [core] Fix Circle CI OOM (#10385) @romgrk
@@ -1413,7 +1413,7 @@ Same changes as in `@mui/x-date-pickers@6.14.0`.
 - [docs] Keep installation readme simple @oliviertassinari
 - [docs] Make each component feel more standalone @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Add types extension for clarity @oliviertassinari
 - [core] Set logo height to fix layout shift in GitHub @oliviertassinari
@@ -1491,7 +1491,7 @@ Same changes as in `@mui/x-date-pickers@6.13.0`, plus:
 - [docs] Polish page for SEO (#10216) @oliviertassinari
 - [docs] Use `Base UI` `Portal` for the quick filter recipe (#10188) @DanailH
 
-### Core
+### Internal
 
 - [core] Finish migration to GA4 @oliviertassinari
 - [core] Fix yarn docs:create-playground script @oliviertassinari
@@ -1552,7 +1552,7 @@ Same changes as in `@mui/x-date-pickers@6.12.1`.
 - [docs] Precise expired license key condition (#10165) @oliviertassinari
 - [docs] Reorganize the page menu (#10139) @alexfauquette
 
-### Core
+### Internal
 
 - [core] Update babel configs (#9713) @romgrk
 - [test] Disable false positive e2e test on webkit (#10187) @LukasTy
@@ -1615,7 +1615,7 @@ Same changes as in `@mui/x-date-pickers@6.12.0`.
 - [docs] Fix typo in quick filter @oliviertassinari
 - [docs] Fix typo in the timezone page (#10073) @flaviendelangle
 
-### Core
+### Internal
 
 - [core] Bump monorepo (#10129) @LukasTy
 - [core] Document a bit `useLazyRef` @oliviertassinari
@@ -1674,7 +1674,7 @@ Same changes as in `@mui/x-date-pickers@6.11.2`.
 - [docs] Fix en-US changelog @oliviertassinari
 - [docs] Update column types (#10040) @romgrk
 
-### Core
+### Internal
 
 - [core] Remove unnecessary Box (#9831) @oliviertassinari
 - [core] Set GitHub Action top level permission @oliviertassinari
@@ -1737,7 +1737,7 @@ Same changes as in `@mui/x-date-pickers@6.11.1`.
 
 - [docs] Clarify the `shouldDisableClock` migration code options (#9920) @LukasTy
 
-### Core
+### Internal
 
 - [core] Port GitHub workflow for ensuring triage label is present (#9924) @DanailH
 - [docs-infra] Fix the import samples in Api pages (#9898) @alexfauquette
@@ -1820,7 +1820,7 @@ Same changes as in `@mui/x-date-pickers@6.11.0`.
 - [docs] Get ready for next docs-infra change @oliviertassinari
 - [docs] Improve the slots documentation `Recommended usage` section (#9892) @flaviendelangle
 
-### Core
+### Internal
 
 - [core] Fix font loading issue dev-mode (#9843) @oliviertassinari
 - [core] Fix pipeline (#9894) @LukasTy
@@ -1890,7 +1890,7 @@ Same changes as in `@mui/x-date-pickers@6.10.2`.
 - [docs] New component API page and side nav design (#9187) @alexfauquette
 - [docs] Update overview page with up to date information about the plans (#9512) @joserodolfofreitas
 
-### Core
+### Internal
 
 - [core] Use PR charts version in preview (#9787) @alexfauquette
 - [license] Allow overriding the license on specific parts of the page (#9717) @Janpot
@@ -1962,7 +1962,7 @@ Same changes as in `@mui/x-date-pickers@6.10.1`.
 - [docs] Localization progress, polish (#9672) @oliviertassinari
 - [docs] Normalize the WIP items (#9671) @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Add `validate` command (#9714) @romgrk
 - [changelog] Update generator to new format @oliviertassinari
@@ -2019,7 +2019,7 @@ Same changes as in `@mui/x-date-pickers@6.10.0`.
 - [docs] Add slot components usage alert (#9660) @LukasTy
 - [docs] Fix casing Cell selection @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Disambiguate ESLint plugin name @oliviertassinari
 - [core] Update priority support issue template and prompt (#9574) @DanailH
@@ -2094,7 +2094,7 @@ Same changes as in `@mui/x-date-pickers@6.9.2`.
 - [docs] New page: Components lifecycle (#8372) @flaviendelangle
 - [docs] Remove outdated header tag @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Fix typo in priority support @oliviertassinari
 - [core] Remove mention of Crowdin @oliviertassinari
@@ -2166,7 +2166,7 @@ Same changes as in `@mui/x-date-pickers@6.9.1`.
 - [docs] Display plan icon in ToC (#9490) @cherniavskii
 - [docs] Remove "product" markdown header (#9517) @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Add `edit-mode` to priority support action (#9483) @DanailH
 - [core] Fix priority support prompt action (#9472) @DanailH
@@ -2248,7 +2248,7 @@ Same changes as in `@mui/x-date-pickers@6.9.0`.
 - [docs] Sync h1 with sidenav link (#9252) @oliviertassinari
 - [docs] Use the mui-x Stack Overflow tag (#9352) @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Add PR template and update the contributions guide (#9329) @DanailH
 - [core] Bump monorepo (#9420) @LukasTy
@@ -2318,7 +2318,7 @@ Same changes as in `@mui/x-date-pickers@6.8.0`.
 - [docs] Improve and reorganize sections on editing page (#8431) @joserodolfofreitas
 - [docs] Add clipboard paste to popular features demo (#9029) @cherniavskii
 
-### Core
+### Internal
 
 - [core] Polish event name (#9336) @oliviertassinari
 - [core] Re-enable `Argos` CI step (#9301) @LukasTy
@@ -2409,7 +2409,7 @@ Same changes as in `@mui/x-date-pickers@6.7.0`, plus:
 - [docs] Fix overview page typo (#9230) @LukasTy
 - [docs] Fix version redirect (#9273) @alexfauquette
 
-### Core
+### Internal
 
 - [core] Temporarily remove the Argos upload on the regression testing (#9267) @flaviendelangle
 - [charts] Add clip-path to avoid charts overflow (#9012) @alexfauquette
@@ -2479,7 +2479,7 @@ We'd like to offer a big thanks to the 15 contributors who made this release pos
 - [docs] Fix tree data children lazy-loading demo (#8840) @yaredtsy
 - [docs] Improve filtering docs discoverability (#9074) @MBilalShafi
 
-### Core
+### Internal
 
 - [core] Allow string literals as keys in `localesText` (#9045) @MBilalShafi
 - [core] Fix `randomInt` producing values exceeding `max` value (#9086) @cherniavskii
@@ -2540,7 +2540,7 @@ We'd like to offer a big thanks to the 10 contributors who made this release pos
 - [docs] Fix docs using wrong service worker (#9030) @cherniavskii
 - [docs] Remove prop-types from JS demos (#9008) @flaviendelangle
 
-### Core
+### Internal
 
 - [core] Add assertion about checkbox rerenders (#8974) @oliviertassinari
 - [core] Allow selecting a section by type in field tests (#9009) @flaviendelangle
@@ -2598,7 +2598,7 @@ We'd like to offer a big thanks to the 12 contributors who made this release pos
 - [docs] Fix typo in clipboard docs (#8971) @MBilalShafi
 - [docs] Reduce list of dependencies in CodeSandbox/StackBlitz demos (#8535) @cherniavskii
 
-### Core
+### Internal
 
 - [core] Improve testing of the adapters (#8789) @flaviendelangle
 - [core] Update license key for tests (#8917) @LukasTy
@@ -2642,7 +2642,7 @@ We'd like to offer a big thanks to the 7 contributors who made this release poss
 - [docs] Update demo to support agregation on popular feature cell (#8617) @BalaM314
 - [docs] Clarify what `<path>` is (#8764) @alexfauquette
 
-### Core
+### Internal
 
 - [core] Do not include playground pages in `yarn typescript` script (#8822) @cherniavskii
 - [core] Limit `typescript:ci` step memory limit (#8796) @LukasTy
@@ -2715,7 +2715,7 @@ We'd like to offer a big thanks to the 15 contributors who made this release pos
 - [docs] Use community version of Data Grid for column grouping demo (#7346) @ASchwad
 - [docs] Use new `slots` / `slotProps` props in the pickers migration guide (#8341) @flaviendelangle
 
-### Core
+### Internal
 
 - [core] Cleanup picker tests (#8652) @flaviendelangle
 - [core] Use `adapter.lib` instead of `adapterName` in `describeAdapters` (#8779) @flaviendelangle
@@ -2764,7 +2764,7 @@ We'd like to offer a big thanks to the 9 contributors who made this release poss
 - [docs] Improve section title in Getting Started page (#8648) @flaviendelangle
 - [docs] Inform about input format modification (#8458) @alexfauquette
 
-### Core
+### Internal
 
 - [core] Fix release date (#8618) @flaviendelangle
 - [core] Upgrade monorepo (#8668) @MBilalShafi
@@ -2816,7 +2816,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 - [docs] Fix "Custom day rendering" demo alignment (#8541) @LukasTy
 - [docs] Fix **below** typo (#8576) @alexfauquette
 
-### Core
+### Internal
 
 - [core] Optimize `renovate` rules (#8575) @LukasTy
 - [core] Upgrade monorepo (#8578) @cherniavskii
@@ -2872,7 +2872,7 @@ We'd like to offer a big thanks to the 15 contributors who made this release pos
 - [docs] Fix 404 links (#8454) @alexfauquette
 - [docs] Fix broken API reference link (#8460) @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Avoid 301 links (#8383) @oliviertassinari
 - [core] Fix the l10n helper by using danger instead of actions (#8512) @alexfauquette
@@ -2937,7 +2937,7 @@ We'd like to offer a big thanks to the 9 contributors who made this release poss
 - [docs] Remove `label` from demos where it reduces clarity (#8416) @LukasTy
 - [docs] Update slots' references in Data Grid migration guide (#8159) @MBilalShafi
 
-### Core
+### Internal
 
 - [charts] Work on typing (#8421) @flaviendelangle
 
@@ -2988,7 +2988,7 @@ We'd like to offer a big thanks to the 11 contributors who made this release pos
 - [docs] Update shortcuts page to use slotProps (#8288) @dcorb
 - [docs] Explain the `shouldDisableTime` migration in more depth (#8348) @LukasTy
 
-### Core
+### Internal
 
 - [core] Remove unused `visx` chart package (#8259) @LukasTy
 - [core] Upgrade monorepo (#8331) @cherniavskii
@@ -3043,7 +3043,7 @@ We'd like to offer a big thanks to the 10 contributors who made this release pos
 - [docs] Change **What's new** page url to point to announcement blog post (#8186) @joserodolfofreitas
 - [docs] Resolve 301 in changelog @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Regen api docs (#8220) @flaviendelangle
 - [core] Remove duplicated `/` (#8223) @alexfauquette
@@ -3082,7 +3082,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 - [docs] Improve link from npm to docs (#8141) @oliviertassinari
 - [docs] Remove test sections (#8177) @m4theushw
 
-### Core
+### Internal
 
 - [core] Upgrade monorepo (#8162) @m4theushw
 
@@ -3176,7 +3176,7 @@ It can be overridden by specifying `ampmInClock` prop.
 - [docs] Update the DataGrid demo to leverage the latest features (#7863) @joserodolfofreitas
 - [docs] Update migration guide for stable release (#8092) @joserodolfofreitas
 
-### Core
+### Internal
 
 - [core] Add modified docs page links in the PR (#7848) @alexfauquette
 - [core] Add test on value timezone (#7867) @alexfauquette
@@ -3235,7 +3235,7 @@ We'd like to offer a big thanks to the 6 contributors who made this release poss
 - [docs] Fix a few scroll issues on mobile (#7900) @oliviertassinari
 - [docs] Fix inconsistency in the Data Grid migration guide (#7963) @MBilalShafi
 
-### Core
+### Internal
 
 - [core] Fix `moment` locale on adapter tests (#8020) @flaviendelangle
 - [test] Support all adapters on the field tests about the formats (#7996) @flaviendelangle
@@ -3283,7 +3283,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 - [docs] Improve Data Grid migration guide (#7861) @MBilalShafi
 - [docs] Update `LocalizationProvider` `dateAdapter` with a link to the doc (#7872) @LukasTy
 
-### Core
+### Internal
 
 - [core] Run editing field tests on all major adapters (#7868) @flaviendelangle
 
@@ -3341,7 +3341,7 @@ We'd like to offer a big thanks to the 11 contributors who made this release pos
 - [docs] Remove no longer relevant range shortcuts section (#7840) @LukasTy
 - [docs] Use `@next` tag in grid and pickers installation instructions (#7814) @cherniavskii
 
-### Core
+### Internal
 
 - [core] Remove `tslint` package leftovers (#7841) @LukasTy
 - [test] Use `createDescribes` for `describeValue` and `describeValidation` (#7866) @flaviendelangle
@@ -3392,7 +3392,7 @@ We'd like to offer a big thanks to the 11 contributors who made this release pos
 - [docs] Polish pickers migration docs (#7737) @LukasTy
 - [docs] Rename `next` translation docs and remove duplicates with `-next` (#7729) @LukasTy
 
-### Core
+### Internal
 
 - [core] Fix l10n data file (#7804) @flaviendelangle
 - [core] Fix Next.js warning (#7754) @oliviertassinari
@@ -3459,7 +3459,7 @@ We'd like to offer a big thanks to the 17 contributors who made this release pos
 - [docs] Fix 404 links to picker API page @oliviertassinari
 - [docs] Update `DemoContainer` `components` prop using a codemod (#7574) @alexfauquette
 
-### Core
+### Internal
 
 - [core] Fix `innerslotProps` typo (#7697) @LukasTy
 - [core] Upgrade monorepo (#7676) @cherniavskii
@@ -3670,7 +3670,7 @@ We'd like to offer a big thanks to the 10 contributors who made this release pos
 - [docs] Remove "Flex layout" docs section and demo (#7477) @cherniavskii
 - [docs] Rework the pickers "Getting Started" page (#7140) @flaviendelangle
 
-### Core
+### Internal
 
 - [core] Add missing `status: needs triage` label on RFC @oliviertassinari
 - [core] Add release documentation step detailing `x-codemod` package tag change (#7617) @LukasTy
@@ -3825,7 +3825,7 @@ We'd like to offer a big thanks to the 9 contributors who made this release poss
 - [docs] Update the migration guide with the breaking changes between the legacy and the new pickers (#7345) @flaviendelangle
 - [docs] Use new pickers on "Custom components" demos (#7194) @flaviendelangle
 
-### Core
+### Internal
 
 - [core] Handle selection edge case (#7350) @oliviertassinari
 - [core] Improve license message @oliviertassinari
@@ -3901,7 +3901,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 - [docs] Redirect translated pages (#7341) @cherniavskii
 - [docs] Reorganize v6 pickers migration guide (#7257) @flaviendelangle
 
-### Core
+### Internal
 
 - [core] Apply ESLint rule for React component @oliviertassinari
 - [core] Apply title capitalization convention @oliviertassinari
@@ -4041,7 +4041,7 @@ We'd like to offer a big thanks to the 10 contributors who made this release pos
 - [docs] New page for `DateCalendar` (#7053) @flaviendelangle
 - [docs] Split selection docs (#7213) @m4theushw
 
-### Core
+### Internal
 
 - [core] Fix API demos callout spacing @oliviertassinari
 
@@ -4113,7 +4113,7 @@ We'd like to offer a big thanks to the 6 contributors who made this release poss
 - [docs] Fix errors and warning in demos (#7209) @LukasTy
 - [docs] Use `DemoContainer` and `DemoItem` on every picker demo (#7149) @flaviendelangle
 
-### Core
+### Internal
 
 - [core] Fix broken test (#7179) @flaviendelangle
 
@@ -4221,7 +4221,7 @@ We'd like to offer a big thanks to the 7 contributors who made this release poss
 - [docs] Fix API page ad space regression (#7051) @oliviertassinari
 - [docs] Update localization doc to use existing locale (#7102) @LukasTy
 
-### Core
+### Internal
 
 - [core] Add codemod to move l10n translation (#7027) @alexfauquette
 - [core] Add notes to remove the legacy pickers internals (#7133) @flaviendelangle
@@ -4317,7 +4317,7 @@ We'd like to offer a big thanks to the 10 contributors who made this release pos
 - [docs] Update API links from clock-picker to time-clock (#6993) @alexfauquette
 - [docs] Use new pickers on the validation page (#7047) @flaviendelangle
 
-### Core
+### Internal
 
 - [core] Remove useless type casting in field hooks (#7045) @flaviendelangle
 - [test] Sync `test:unit` with monorepo (#6907) @oliviertassinari
@@ -4387,7 +4387,7 @@ We'd like to offer a big thanks to the 14 contributors who made this release pos
 - [docs] Fix toggle button bug in demos in Custom Components page (#6913) @01zulfi
 - [docs] Remove partial Portuguese and Chinese translations of the pickers pages (#6893) @flaviendelangle
 
-### Core
+### Internal
 
 - [core] Cleanup `describeValidation` (#6942) @flaviendelangle
 - [core] Group renovate GitHub Action dependency updates @oliviertassinari
@@ -4456,7 +4456,7 @@ We'd like to offer a big thanks to the 12 contributors who made this release pos
 - [docs] Remove default prop and improve format (#6781) @oliviertassinari
 - [docs] Sync prism-okaidia.css with source (#6820) @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Convert scripts to ESM (#6789) @LukasTy
 - [core] Feedback on branch protection @oliviertassinari
@@ -4501,7 +4501,7 @@ We'd like to offer a big thanks to the 5 contributors who made this release poss
 - [docs] Add missing Pro header suffix (#6775) @oliviertassinari
 - [docs] Upgrade to Next.js 13 (#6790) @cherniavskii
 
-### Core
+### Internal
 
 - [core] Add OSSF Scorecard action (#6760) @oliviertassinari
 - [core] Fix Pinned-Dependencies @oliviertassinari
@@ -4556,7 +4556,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 - [pickers] New `StaticDatePicker` component (#6708) @flaviendelangle
 - [pickers] Rename `inputFormat` prop to `format` on the new pickers (#6722) @flaviendelangle
 
-### Core
+### Internal
 
 - [core] Fix `typescript:ci` failures (#6705) @LukasTy
 - [core] Fixes for upcoming ESLint upgrade (#6667) @Janpot
@@ -4667,7 +4667,7 @@ We'd like to offer a big thanks to the 9 contributors who made this release poss
 - [docs] Mark Data Grid column group as available (#6660) @alexfauquette
 - [docs] Fix double space @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Fix duplicate CodeQL build @oliviertassinari
 - [core] Fix spreading on validation page (#6624) @flaviendelangle
@@ -4796,7 +4796,7 @@ We'd like to offer a big thanks to the 9 contributors who made this release poss
 - [docs] Fix broken links on field pages (#6501) @flaviendelangle
 - [docs] Improve markdownlint (#6518) @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Run CodeQL only on schedule @oliviertassinari
 - [core] Fix trailing spaces and git diff format (#6523) @oliviertassinari
@@ -5004,7 +5004,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 - [docs] New page for the pickers: Validation (#6064) @flaviendelangle
 - [docs] Organize migration pages (#6480) @flaviendelangle
 
-### Core
+### Internal
 
 - [core] Add CodeQL workflow (#6387) @DanailH
 - [core] Add missing breaking change to the changelog (#6471) @flaviendelangle
@@ -5086,7 +5086,7 @@ We'd like to offer a big thanks to the 10 contributors who made this release pos
 - [docs] Use components instead of demos for `SelectorsDocs` (#6103) @flaviendelangle
 - [license] Add new license status 'Out of scope' (#5260) @flaviendelangle
 
-### Core
+### Internal
 
 - [core] Speedup of yarn install in the CI (#6395) @oliviertassinari
 - [test] Remove redundant test clean-ups (#6377) @oliviertassinari
@@ -5216,7 +5216,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 - [docs] Pass model change callbacks in controlled grid editing demos (#6296) @cherniavskii
 - [docs] Update the CodeSandbox to use the `next` branch (#6275) @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Fix typing error (#6291) @flaviendelangle
 - [core] Fix typo in the state updater of `useField` (#6311) @flaviendelangle
@@ -5395,7 +5395,7 @@ You can find more information about the new api, including how to set those tran
 - [docs] Improve Upgrade plan docs (#6018) @oliviertassinari
 - [docs] Link the OpenSSF Best Practices card (#6171) @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Add `v5.17.3` changelog to next branch (#6250) @flaviendelangle
 - [core] Add link to the security page on the `README` (#6073) @oliviertassinari

--- a/changelogOld/CHANGELOG.v7.md
+++ b/changelogOld/CHANGELOG.v7.md
@@ -323,7 +323,7 @@ Same changes as in `@mui/x-date-pickers@7.29.2`.
 - [docs] Fix MUI X v7 install instructions (#17537) @oliviertassinari
 - [docs] Improve data grid export docs (#17553) @MBilalShafi
 
-### Core
+### Internal
 
 - [core] Fix root package 7.29.1 (#17523) @JCQuintas
 
@@ -400,7 +400,7 @@ Same changes as in `@mui/x-tree-view@7.29.1`, plus:
 
 - [docs] Use MUI X v7 packages in CodeSandbox and StackBlitz (#17516) @cherniavskii
 
-### Core
+### Internal
 
 - [core] Bump monorepo (#17437) @LukasTy
 
@@ -472,7 +472,7 @@ Internal changes.
 
 Same changes as in `@mui/x-tree-view@7.29.0`.
 
-### Core
+### Internal
 
 - [core] Cleanup `@mui` dependency versions (#17390) @LukasTy
 
@@ -563,7 +563,7 @@ Same changes as in `@mui/x-data-grid-pro@7.28.2`.
 
 Same changes as in `@mui/x-date-pickers@7.28.2`.
 
-### Core
+### Internal
 
 - [code-infra] Remove `test_regressions` step from React 18 pipeline (#17109) @LukasTy
 
@@ -699,7 +699,7 @@ Same changes as in `@mui/x-tree-view@7.28.0`.
 
 - [docs] Fix link to the lazy loading demo for the DataGrid (#16912) @nusr
 
-### Core
+### Internal
 
 - [core] Allow `@mui/material` v7 in dependencies (#16951) @LukasTy
 - [infra] Make tests on React 18 part of pipeline (#16958) @LukasTy
@@ -742,7 +742,7 @@ Same changes as in `@mui/x-data-grid-pro@7.27.3`.
 
 Same changes as in `@mui/x-date-pickers@7.27.3`.
 
-### Core
+### Internal
 
 - [infra] Update contributor acknowledgment wording (#16753) @michelengelen
 
@@ -893,7 +893,7 @@ Internal changes.
 
 - [charts-pro] Fix automatic type overloads (#16579) @JCQuintas
 
-### Core
+### Internal
 
 - [test] Fix Data Grid data source error test on React 18 (#16565) @arminmeh
 
@@ -964,7 +964,7 @@ Internal changes.
 
 Same changes as in `@mui/x-tree-view@7.26.0`.
 
-### Core
+### Internal
 
 - [core] Fix corepack and pnpm installation in CircleCI (#16452) @flaviendelangle
 
@@ -1041,7 +1041,7 @@ Same changes as in `@mui/x-tree-view@7.25.0`.
 
 - [docs] Improve release documentation (#16322) @MBilalShafi
 
-### Core
+### Internal
 
 - [test] Fix flaky data source tests in DataGrid (#16382) @lauri865
 
@@ -1110,7 +1110,7 @@ Same changes as in `@mui/x-tree-view@7.24.1`.
 
 - [docs] Fix `domainLimit` definition (#16271) @alexfauquette
 
-### Core
+### Internal
 
 - [core] Make `@mui/x-internals` a dependency of `@mui/x-license` (#16265) @alexfauquette
 - [test] Fix flaky column pinning tests (#16228) @cherniavskii
@@ -1188,7 +1188,7 @@ Same changes as in `@mui/x-tree-view@7.24.0`.
 - [docs] Copyedit the Data Grid cell selection page (#16213) @samuelsycamore
 - [docs] Fix demo rendering issue on Codesandbox (#16129) @arminmeh
 
-### Core
+### Internal
 
 - [core] Type all references as `RefObject` (#16125) @arminmeh
 - [code-infra] Refactor `react` and `react-dom` definitions to simplify dep resolving (#16214) @LukasTy
@@ -1270,7 +1270,7 @@ Same changes as in `@mui/x-tree-view@7.23.6`.
 - [docs] Fix doc warning for automatic children selection on tree view (#16037) @flaviendelangle
 - [docs] Fix non-existing "adapter" property of `LocalizationProvider` (#16088) @tomashauser
 
-### Core
+### Internal
 
 - [core] Clarify the release strategy (#16012) @MBilalShafi
 - [core] Update the `release:version` docs (#16040) @cherniavskii
@@ -1461,7 +1461,7 @@ Releasing to benefit from license package fix (#15818).
 - [docs] Use `updateRows` method for list view demos (#15824) @KenanYusuf
 - [docs] Use date library version from package dev dependencies for sandboxes (#15767) @LukasTy
 
-### Core
+### Internal
 
 - [core] Add `@mui/x-tree-view-pro` to `releaseChangelog` (#15747) @flaviendelangle
 - [license] Use `console.log` for the error message on CodeSandbox to avoid rendering error (#15818) @arminmeh
@@ -1528,7 +1528,7 @@ Same changes as in `@mui/x-charts@7.23.1`.
 - [docs-infra] Bump `@mui/internal-markdown` to support nested demo imports (#15738) @alexfauquette
 - [docs] Improve SEO titles for the Data Grid (#15695) @MBilalShafi
 
-### Core
+### Internal
 
 - [core] Add `@mui/x-tree-view-pro` to `releaseChangelog` (#15747) @flaviendelangle
 
@@ -1622,7 +1622,7 @@ Same changes as in `@mui/x-tree-view@7.23.0`.
 - [docs] Remove selectors section from list view docs (#15639) @KenanYusuf
 - [docs] Add documentation for the list view feature (#15344) @KenanYusuf
 
-### Core
+### Internal
 
 - [core] Update @mui/monorepo (#15574) @oliviertassinari
 
@@ -1900,7 +1900,7 @@ Same changes as in `@mui/x-charts@7.22.0`.
 
 - [docs] Fix typo in Tree View docs (#15047) @yash49
 
-### Core
+### Internal
 
 - [core] Adjust cherry-pick GH actions (#15101) @LukasTy
 - [core] Update prettier target branch (#15100) @MBilalShafi
@@ -1988,7 +1988,7 @@ Same changes as in `@mui/x-charts@7.21.0`.
 - [docs] Update v5 migration CodeSandbox @oliviertassinari
 - [docs] Enforce component style rules for the Tree View (#14963) @samuelsycamore
 
-### Core
+### Internal
 
 - [core] Fix shortcut with localization keyboard (#14220) @rotembarsela
 - [core] Fix docs deploy command (#14920) @arminmeh
@@ -2078,7 +2078,7 @@ Same changes as in `@mui/x-charts@7.20.0`.
 - [docs] New recipe of a read-only field (#14606) @flaviendelangle
 - [docs] Change demo name example (#14822) @alelthomas
 
-### Core
+### Internal
 
 - [core] Support `@mui/utils` v6 (#14867) @siriwatknp
 - [code-infra] Remove deprecated `data-mui-test` in favour of `data-testid` (#14882) @JCQuintas
@@ -2186,7 +2186,7 @@ Same changes as in `@mui/x-charts@7.19.0`.
 - [docs] Fix typo in usage of Moment guide for UTC and timezones (#14780) @AWAIS97
 - [docs] Fix what's new link to use absolute URL (#14543) @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Fix class name composition order (#14775) @oliviertassinari
 - [core] Replace minWidth, maxWidth with width (#14776) @oliviertassinari
@@ -2280,7 +2280,7 @@ Same changes as in `@mui/x-charts@7.18.0`.
 - [docs] Polish code formatting (#14603) @oliviertassinari
 - [test] Spy on `observe` method to avoid flaky wait for a callback (#14640) @arminmeh
 
-### Core
+### Internal
 
 - [core] Fix 301 link to Next.js and git diff @oliviertassinari
 - [core] Fix failing CI on `master` (#14644) @cherniavskii
@@ -2366,7 +2366,7 @@ Same changes as in `@mui/x-charts@7.17.0`.
 - [docs] Fixed typo in Row Grouping recipes (#14549) @Miodini
 - [docs] Match title with blog posts @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Move warning methods to `@mui/x-internals` (#14528) @k-rajat19
 - [core] Sync with core release flow @oliviertassinari
@@ -2461,7 +2461,7 @@ Same changes as in `@mui/x-charts@7.16.0`, plus:
 - [docs] Remove notion of seats (#14351) @oliviertassinari
 - [docs] Use real world data for `PieChart` examples (#14297) @JCQuintas
 
-### Core
+### Internal
 
 - [core] Fix changelog spelling @oliviertassinari
 - [core] Fix failing tests on the pickers (#14457) @flaviendelangle
@@ -2531,7 +2531,7 @@ Same changes as in `@mui/x-charts@7.15.0`, plus:
 - [docs] Fix use of Material UI @oliviertassinari
 - [docs] Update deprecated props in docs (#14295) @JCQuintas
 
-### Core
+### Internal
 
 - [core] Allow only v5.x for `MUI Core` renovate group (#14382) @LukasTy
 - [core] Avoid visual regression when using `@mui/material@6` (#14357) @cherniavskii
@@ -2615,7 +2615,7 @@ Same changes as in `@mui/x-charts@7.14.0`, plus:
 - [docs] Fix missing leading slashes in URLs (#14249) @oliviertassinari
 - [docs] Dash usage revision on pickers pages (#14260) @arthurbalduini
 
-### Core
+### Internal
 
 - [core] Follow JSDocs convention @oliviertassinari
 - [core] Prepare for material v6 (#14143) @LukasTy
@@ -2695,7 +2695,7 @@ Same changes as in `@mui/x-charts@7.13.0`.
 - [docs] Use Netflix financial results to document bar charts (#13991) @alexfauquette
 - [docs] Remove relience of abbreviations (#14226) @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Bump monorepo (#14141) @Janpot
 - [core] Fix ESLint issue (#14207) @LukasTy
@@ -2868,7 +2868,7 @@ Same changes as in `@mui/x-date-pickers@7.12.0`.
 - [docs] Fix Vale errors (#14025) @oliviertassinari
 - [docs] Update on `renderCell` & autogenerated rows (#13879) @romgrk
 
-### Core
+### Internal
 
 - [core] Fix event naming convention @oliviertassinari
 - [core] Replace @mui/base with @mui/utils + @mui/material (#13823) @mnajdova
@@ -2952,7 +2952,7 @@ Same changes as in `@mui/x-date-pickers@7.11.1`.
 - [docs] Update `SparkLineChart` reference not being correctly capitalised (#13960) @duckboy81
 - [docs] Fix scroll demos disorientation (#13909) @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Add `@mui/material-nextjs` to `MUI Core` renovate group (#13966) @LukasTy
 - [core] Remove warning message in production (#13911) @oliviertassinari
@@ -3037,7 +3037,7 @@ Same changes as in `@mui/x-date-pickers@7.11.0`, plus:
 - [docs] Replace company name with project name @oliviertassinari
 - [docs] Sort Pickers & Charts API slots alphabetically (#13843) @LukasTy
 
-### Core
+### Internal
 
 - [core] Add MUI Internal `renovate` group (#13846) @LukasTy
 - [core] Link GitHub issue for `import/prefer-default-export` rule @oliviertassinari
@@ -3116,7 +3116,7 @@ Same changes as in `@mui/x-date-pickers@7.10.0`, plus:
 - [docs] Fix Pickers customization playground overflow (#13742) @LukasTy
 - [docs] Move Pickers dialog guidelines to accessibility page (#13778) @arthurbalduini
 
-### Core
+### Internal
 
 - [core] Sort `DATA_GRID_PROPS_DEFAULT_VALUES` alphabetically (#13783) @oliviertassinari
 - [test] Fix split infinitive use in tests @oliviertassinari
@@ -3179,7 +3179,7 @@ Same changes as in `@mui/x-date-pickers@7.9.0`.
 
 - [docs] Fix custom "no results overlay" demo in dark mode (#13715) @KenanYusuf
 
-### Core
+### Internal
 
 - [core] Add `react_next` workflow in CircleCI (#13360) @cherniavskii
 - [core] Create a new package to share utils across X packages (#13528) @flaviendelangle
@@ -3280,7 +3280,7 @@ Same changes as in `@mui/x-date-pickers@7.8.0`.
 - [docs] Add callout for `Luxon` `throwOnInvalid` support (#13621) @LukasTy
 - [docs] Add "Overlays" section to the Data Grid documentation (#13624) @KenanYusuf
 
-### Core
+### Internal
 
 - [core] Add ESLint rule to restrict import from `../internals` root (#13633) @JCQuintas
 - [docs-infra] Sync `\_app` folder with monorepo (#13582) @Janpot
@@ -3363,7 +3363,7 @@ Same changes as in `@mui/x-date-pickers@7.7.1`, plus:
 - [docs] Use dedicated tab for weather dataset (#13513) @alexfauquette
 - [x-license] license update proposal (#13459) @michelengelen
 
-### Core
+### Internal
 
 - [core] Fix failing CI test (#13574) @alexfauquette
 - [infra] Remove explicit `@testing-library/react` dependency (#13478) @LukasTy
@@ -3442,7 +3442,7 @@ Same changes as in `@mui/x-date-pickers@7.7.0`.
 - [docs] Update a11y pages description (#13417) @danilo-leal
 - [docs] improve the writing on the "Quick filter outside of the grid" example (#13155) @michelengelen
 
-### Core
+### Internal
 
 - [core] Add `eslint-plugin-react-compiler` experimental version and rules (#13415) @JCQuintas
 - [core] Minor setup cleanup (#13467) @LukasTy
@@ -3506,7 +3506,7 @@ Same changes as in `@mui/x-date-pickers@7.6.2`.
 - [docs] Adjust the code example for `quickFilterValues` (#12919) @michelengelen
 - [docs] Create Pickers accessibility page (#13274) @arthurbalduini
 
-### Core
+### Internal
 
 - [core] Comment on `CSS.escape` for the future @oliviertassinari
 - [core] Fix `l10n` action setup (#13382) @LukasTy
@@ -3615,7 +3615,7 @@ Same changes as in `@mui/x-date-pickers@7.6.0`.
 - [docs] Small improvements on accessibility Data Grid doc (#13233) @arthurbalduini
 - [docs] Update Pickers demo configurations (#13303) @LukasTy
 
-### Core
+### Internal
 
 - [core] Add comment on why logic to sync column header (#13248) @oliviertassinari
 - [core] Fix `l10n` script execution with arguments (#13297) @LukasTy
@@ -3672,7 +3672,7 @@ Same changes as in `@mui/x-date-pickers@7.5.1`.
 - [docs] Improve Tree View selection doc (#13105) @flaviendelangle
 - [docs] Unify Tree View `apiRef` methods doc examples (#13193) @flaviendelangle
 
-### Core
+### Internal
 
 - [core] Remove `raw-loader` package (#13160) @LukasTy
 - [core] Remove outdated prop-types (#13181) @flaviendelangle
@@ -3749,7 +3749,7 @@ Same changes as in `@mui/x-date-pickers@7.5.0`.
 
 - [docs] Document missing Charts API's (#12875) @alexfauquette
 
-### Core
+### Internal
 
 - [core] Avoid root level `@mui/x-date-pickers` imports (#13120) @LukasTy
 - [core] Refactor ESLint config to disallow root level imports (#13130) @LukasTy
@@ -3817,7 +3817,7 @@ Same changes as in `@mui/x-date-pickers@7.4.0`.
 - [docs] Fix legal link to EULA free trial (#13013) @oliviertassinari
 - [docs] Update interface name in pinned columns docs (#13070) @cherniavskii
 
-### Core
+### Internal
 
 - [core] Improve release process docs (#12977) @JCQuintas
 - [core] Prepare React 19 (#12991) @oliviertassinari
@@ -3884,7 +3884,7 @@ Same changes as in `@mui/x-date-pickers@7.3.2`.
 - [docs] Improve Data Grid migration guide (#12969) @MBilalShafi
 - [docs] Polish references to the plans (#12922) @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Fix dependencies (#12951) @LukasTy
 - [core] Remove inconsistent blank lines (#12966) @oliviertassinari
@@ -3959,7 +3959,7 @@ Same changes as in `@mui/x-date-pickers@7.3.1`.
 - [docs] Improve Data Grid migration guide (#12879) @MBilalShafi
 - [docs] Update Column features availability (#12865) @DanailH
 
-### Core
+### Internal
 
 - [core] Fix `l10n` GH workflow (#12895) @LukasTy
 - [core] Match Base UI and Toolpad @oliviertassinari
@@ -4041,7 +4041,7 @@ A typo fix:
 - [docs] Fix layout shift on demos (#12816) @zanivan
 - [test] Increase timeout for test that sometimes fail on `DateTimeRangePicker` (#12786) @LukasTy
 
-### Core
+### Internal
 
 - [docs-infra] Prepare infra to document charts interfaces (#12653) @alexfauquette
 
@@ -4124,7 +4124,7 @@ Same changes as in `@mui/x-date-pickers@7.2.0`, plus:
 - [docs] Fix typo in Data Grid v7 migration page (#12720) @bfaulk96
 - [docs] Fix typo in Pickers v7 migration page (#12721) @bfaulk96
 
-### Core
+### Internal
 
 - [core] Support multiple resolved `l10n` PR packages (#12735) @LukasTy
 - [core] Update Netlify release references in release README (#12687) @LukasTy
@@ -4216,7 +4216,7 @@ Same changes as in `@mui/x-date-pickers@7.1.1`, plus:
 - [docs] Remove `day` from the default `dayOfWeekFormatter` function params (#12644) @LukasTy
 - [docs] Use `<TreeItem2 />` for icon expansion example on `<RichTreeView />` (#12563) @flaviendelangle
 
-### Core
+### Internal
 
 - [core] Add cherry-pick `master` to `v6` action (#12648) @LukasTy
 - [core] Fix typo in `@mui/x-tree-view-pro/themeAugmentation` (#12674) @flaviendelangle
@@ -4297,7 +4297,7 @@ Same changes as in `@mui/x-date-pickers@7.1.0`, plus:
 - [docs] Reduce noise in migration docs side navigation (#12552) @cherniavskii
 - [docs] Sync static images from core repository (#12525) @LukasTy
 
-### Core
+### Internal
 
 - [core] Fix `l10n` script on Windows (#12550) @LukasTy
 - [core] Include `DateTimeRangePicker` tag in `releaseChangelog` (#12526) @LukasTy
@@ -4474,7 +4474,7 @@ Same changes as in `@mui/x-date-pickers@7.0.0`, plus:
 - [docs] Update supported versions (#12508) @joserodolfofreitas
 - [docs] Update "What's new in MUI X" page #12527 @cherniavskii
 
-### Core
+### Internal
 
 - [core] Bump `@mui/material` peer dependency for all packages (#12516) @LukasTy
 - [core] Fix `no-restricted-imports` ESLint rule not working for Data Grid packages (#12477) @cherniavskii
@@ -4576,7 +4576,7 @@ The `onNodeFocus` callback has been renamed to `onItemFocus` for consistency:
 - [docs] Replace `rel="noreferrer"` by `rel="noopener"` @oliviertassinari
 - [docs] Update `date-fns` `weekStarsOn` overriding example (#12416) @LukasTy
 
-### Core
+### Internal
 
 - [core] Fix CI (#12414) @flaviendelangle
 - [core] Fix PR deploy link for Tree View doc pages (#12411) @flaviendelangle
@@ -4663,7 +4663,7 @@ Same changes as in `@mui/x-data-grid-pro@7.0.0-beta.6`.
 - [docs] Add a note about `z-index` usage in SVG (#12337) @alexfauquette
 - [docs] Rich Tree View customization docs (#12231) @noraleonte
 
-### Core
+### Internal
 
 - [test] Add `Charts` test (#11551) @alexfauquette
 
@@ -4739,7 +4739,7 @@ Same changes as in `@mui/x-date-pickers@7.0.0-beta.5`.
 - [docs] Polish the Date Picker playground (#11869) @zanivan
 - [docs] Standardize WAI-ARIA references @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Allow local docs next.js settings (#12227) @romgrk
 - [core] Remove grid folder from `getComponentInfo` RegExp (#12241) @flaviendelangle
@@ -4885,7 +4885,7 @@ These components are no longer exported from `@mui/x-charts`:
 - [docs] Reduce number of Vale errors @oliviertassinari
 - [docs] Remove default value set to `undefined` (#12128) @alexfauquette
 
-### Core
+### Internal
 
 - [core] Fix docs link check (#12135) @LukasTy
 - [core] Fix missing context display names (#12124) @oliviertassinari
@@ -4957,7 +4957,7 @@ Same changes as in `@mui/x-data-grid-pro@7.0.0-beta.3`.
 - [docs] Fix typo for `AdapterDateFnsV3` (#12036) @flaviendelangle
 - [docs] Removed `focused` prop from demo (#12092) @michelengelen
 
-### Core
+### Internal
 
 - [core] Fix CodeSandbox CI template @oliviertassinari
 - [core] Sort prop asc (#12033) @oliviertassinari
@@ -5049,7 +5049,7 @@ Same changes as in `@mui/x-date-pickers@7.0.0-beta.2`.
 - [docs] Follow blank line convention with use client @oliviertassinari
 - [docs] Stable layout between light and dark mode @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Add `docs:serve` script (#11935) @cherniavskii
 - [core] Bump monorepo (#12001) @cherniavskii
@@ -5222,7 +5222,7 @@ Same changes as in `@mui/x-date-pickers@7.0.0-beta.1`.
 - [docs] Sync support page with core @oliviertassinari
 - [docs] Update whats new page with "v7 Beta blogpost" content (#11879) @joserodolfofreitas
 
-### Core
+### Internal
 
 - [core] Rely on immutable ref when possible (#11847) @oliviertassinari
 - [core] Bump monorepo (#11897) @alexfauquette
@@ -5321,7 +5321,7 @@ Same changes as in `@mui/x-date-pickers@7.0.0-beta.0`, plus:
 - [docs] Include `DateTimeRangePicker` in relevant demos (#11815) @LukasTy
 - [docs] Add recipe for sorting row groups by the number of child rows (#11164) @cherniavskii
 
-### Core
+### Internal
 
 - [core] Cleanup script and alias setup (#11749) @LukasTy
 - [core] Polish issue templates @oliviertassinari
@@ -5654,7 +5654,7 @@ Same changes as in `@mui/x-date-pickers@7.0.0-alpha.9`.
 - [docs] Uplift Simple Tree View customization examples (#11424) @noraleonte
 - [docs] Uplift the Date Pickers playground (#11555) @danilo-leal
 
-### Core
+### Internal
 
 - [core] Bump `@mui/material` peer dependency for all packages (#11692) @LukasTy
 - [core] Make `karma` run in parallel (#11571) @romgrk
@@ -5740,7 +5740,7 @@ Same changes as in `@mui/x-date-pickers@7.0.0-alpha.8`.
 - [docs] Improve Server-side Data Grid docs (#11589) @oliviertassinari
 - [docs] Improve charts landing page (#11570) @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Lock `jsdom` version (#11652) @cherniavskii
 - [core] Remove PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD (#11608) @oliviertassinari
@@ -5878,7 +5878,7 @@ Same changes as in `@mui/x-date-pickers@7.0.0-alpha.7`.
 - [docs] Fix over page fetching @oliviertassinari
 - [docs] Lint `next.config.js` (#11514) @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Fix release changelog (#11496) @romgrk
 - [core] Fix use of ::before & ::after (#11515) @oliviertassinari
@@ -5970,7 +5970,7 @@ Same changes as in `@mui/x-date-pickers@7.0.0-alpha.6`.
 - [docs] Improve Pickers `name` prop examples (#11422) @LukasTy
 - [docs] Limit `date-fns` package to v2 in CodeSandbox (#11463) @LukasTy
 
-### Core
+### Internal
 
 - [core] Add missing breaking changes to changelog (#11420) @MBilalShafi
 - [core] Cherry pick follow up (#11469) @LukasTy
@@ -6133,7 +6133,7 @@ Same changes as in `@mui/x-date-pickers@7.0.0-alpha.5`, plus:
 
 - [docs] Respect GoT books (@janoma) (#11387) @alexfauquette
 
-### Core
+### Internal
 
 - [core] Automate cherry-pick of PRs from `next` -> `master` (#11382) @MBilalShafi
 - [infra] Update `no-response` workflow (#11369) @MBilalShafi
@@ -6396,7 +6396,7 @@ Same changes as in `@mui/x-date-pickers@7.0.0-alpha.3`.
 - [docs] Standardize the usage of callouts in the MUI X docs (#7127) @samuelsycamore
 - [docs] Adjust the Data Grid demo page design (#11231) @danilo-leal
 
-### Core
+### Internal
 
 - [core] Make `@mui/system` a direct dependency (#11128) @LukasTy
 - [core] Remove blank lines, coding style @oliviertassinari
@@ -6518,7 +6518,7 @@ Same changes as in `@mui/x-date-pickers@7.0.0-alpha.2`.
 - [docs] Fix version links (#11001) @LukasTy
 - [docs] Point to the source of `@mui/x-data-grid-generator` (#11134) @oliviertassinari
 
-### Core
+### Internal
 
 - [core] Bump monorepo (#11160) @LukasTy
 - [core] Fix comment in doc generation (#11098) @flaviendelangle
@@ -6939,7 +6939,7 @@ And if you need the exact same output you can apply the following transformation
 - [docs] Fix incorrect component name in the "Custom slots and subcomponents" page (#11024) @flaviendelangle
 - [docs] Fix typos in pickers migration guide (#11057) @flaviendelangle
 
-### Core
+### Internal
 
 - [core] Clean the component slots doc generation (#11021) @flaviendelangle
 - [core] Fix script to release with `next` tag (#10996) @LukasTy
@@ -7083,7 +7083,7 @@ Here is an example of the renaming for the `<ChartsTooltip />` component.
 - [docs] Document how to hide the legend (#10951) @alexfauquette
 - [docs] Fix typo in the migration guide (#10972) @flaviendelangle
 
-### Core
+### Internal
 
 - [core] Adds migration docs for Charts, Pickers, and Tree View (#10926) @michelengelen
 - [core] Bump monorepo (#10959) @LukasTy

--- a/changelogOld/CHANGELOG.v7.md
+++ b/changelogOld/CHANGELOG.v7.md
@@ -4,7 +4,7 @@
 
 _Sep 25, 2025_
 
-We'd like to extend a big thank you to the 1 contributor who made this release possible. Here are some highlights ✨:
+A big thanks to the 1 contributor who made this release possible. Here are some highlights ✨:
 
 - 🐞 Bugfixes
 
@@ -27,7 +27,7 @@ Same changes as in `@mui/x-tree-view@7.29.10`.
 
 _Aug 7, 2025_
 
-We'd like to extend a big thank you to the 5 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 5 contributors who made this release possible. Here are some highlights ✨:
 
 - 🐞 Bugfixes
 
@@ -68,7 +68,7 @@ Same changes as in `@mui/x-data-grid-pro@7.29.9`.
 
 _Jul 4, 2025_
 
-We'd like to extend a big thank you to the 3 contributors who made this release possible. Here are some highlights ✨:
+A big thanks to the 3 contributors who made this release possible. Here are some highlights ✨:
 
 - 🐞 Bugfixes
 
@@ -104,7 +104,7 @@ Same changes as in `@mui/x-data-grid-pro@7.29.8`.
 
 _Jun 26, 2025_
 
-We'd like to extend a big thank you to the 4 contributors who made this release possible.
+A big thanks to the 4 contributors who made this release possible.
 
 Special thanks go out to the community members for their valuable contributions:
 @alisasanib

--- a/scripts/changelogUtils.mjs
+++ b/scripts/changelogUtils.mjs
@@ -458,7 +458,7 @@ async function generateChangelog({
       lines.push(...changeLogMessages[sectionName]);
     }
 
-    lines.push(logCommitEntries(commits) || 'Internal changes.');
+    lines.push(logCommitEntries(commits));
 
     return lines.join('\n\n');
   };
@@ -468,7 +468,7 @@ async function generateChangelog({
     const authorsCount =
       community.contributors.size + community.firstTimers.size + community.team.size;
     const lines = [
-      `We'd like to extend a big thank you to the ${authorsCount} contributors who made this release possible. Here are some highlights ✨:`,
+      `A big thanks to the ${authorsCount} contributors who made this release possible. Here are some highlights ✨:`,
       'TODO INSERT HIGHLIGHTS',
     ];
 
@@ -476,6 +476,10 @@ async function generateChangelog({
       lines.push(...changeLogMessages.general);
     }
 
+    return lines.join('\n\n');
+  };
+
+  const logContributorsSection = () => {
     // TODO: separate first timers and regular contributors
     const contributors = [
       ...Array.from(community.contributors),
@@ -486,9 +490,11 @@ async function generateChangelog({
       a.toLowerCase().localeCompare(b.toLowerCase()),
     );
 
+    const lines = [];
+
     if (contributors.length > 1) {
       lines.push(
-        `Special thanks go out to these community members for their valuable contributions:\n${contributors.join(', ')}`,
+        `Special thanks go out to these community members for their valuable contributions: ${contributors.join(', ')}`,
       );
     } else if (contributors.length === 1) {
       lines.push(
@@ -498,12 +504,12 @@ async function generateChangelog({
 
     if (community.team.size > 0) {
       lines.push(
-        `The following team members contributed to this release:\n${teamMembers.join(', ')}`,
+        `The following team members contributed to this release: ${teamMembers.join(', ')}`,
       );
     }
 
     return lines.join('\n\n');
-  };
+  }
 
   const changelog = removeDuplicateEmptyLines(`
 ## ${nextVersion || '__VERSION__'}
@@ -567,7 +573,7 @@ ${logOtherSection({
 })}
 
 ${logOtherSection({
-  sectionName: 'Core',
+  sectionName: 'Internal',
   commits: internalCommits,
 })}
 
@@ -575,6 +581,8 @@ ${logOtherSection({
   sectionName: 'Miscellaneous',
   commits: otherCommits,
 })}
+
+${logContributorsSection()}
 `);
 
   try {

--- a/scripts/changelogUtils.mjs
+++ b/scripts/changelogUtils.mjs
@@ -509,7 +509,7 @@ async function generateChangelog({
     }
 
     return lines.join('\n\n');
-  }
+  };
 
   const changelog = removeDuplicateEmptyLines(`
 ## ${nextVersion || '__VERSION__'}


### PR DESCRIPTION
This change is meant to align the changelog generated to be closer to https://github.com/mui/material-ui/releases and https://github.com/mui/base-ui/releases. I'm trying to keep the best stuff from each. The changes:

- "Core" -> "Internal". It better reflects what the changes are about. 
- Who contributed: secondary information, people who read the changelog don't care THAT much
- Show the contributor's name on one line when possible.
- "We'd like to extend a big thank you to the 8 contributors who made this release possible" feels too verbose: https://gemini.google.com/share/811685fd920d

Related work: #20861