### PR TITLE
[DataGridPremium] Fix aggregation column header title truncation without ellipsis

### DIFF
--- a/packages/x-data-grid-premium/src/components/GridAggregationHeader.tsx
+++ b/packages/x-data-grid-premium/src/components/GridAggregationHeader.tsx
@@ -33,11 +33,15 @@ const GridAggregationHeaderRoot = styled('div', {
 })<{ ownerState: OwnerState }>({
   display: 'flex',
   flexDirection: 'column',
+  overflow: 'hidden',
+  minWidth: 0,
   [`&.${gridClasses['aggregationColumnHeader--alignRight']}`]: {
     alignItems: 'flex-end',
+    '& > *': { maxWidth: '100%' },
   },
   [`&.${gridClasses['aggregationColumnHeader--alignCenter']}`]: {
     alignItems: 'center',
+    '& > *': { maxWidth: '100%' },
   },
 });
 


### PR DESCRIPTION
Aggregation column headers were hard-clipping their title text instead of showing a `…` ellipsis when the column was too narrow. The root cause was that `GridAggregationHeaderRoot` (a flex column container) lacked `overflow: hidden` and `min-width: 0`, so it expanded to its text content width and the inner `text-overflow: ellipsis` on `GridColumnHeaderTitleRoot` never triggered — the clip happened at the outer container boundary instead.

For right- and center-aligned columns, `align-items: flex-end/center` caused the additional issue of children taking content-based widths even after the container was constrained, so `max-width: 100%` is applied to direct children in those cases to cap them at the container width and allow ellipsis to work there too.

Fixes #22225