### PR TITLE
[DataGridPro] Fix column unpin restoring stale position after reorder

### DIFF
--- a/packages/x-data-grid-pro/src/hooks/features/columnPinning/useGridColumnPinningPreProcessors.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/columnPinning/useGridColumnPinningPreProcessors.ts
@@ -69,9 +69,15 @@ export const useGridColumnPinningPreProcessors = (
           let index = orderedFieldsBeforePinningColumns.indexOf(field);
           // If index = -1, the pinned field didn't exist in the last processing, it's possibly being added now
           // If index >= newOrderedFieldsBeforePinningColumns.length, then one or more columns were removed
-          // In both cases, use the position from the columns array
+          // If the field is newly pinned, its cache entry may be stale because column reorders bypass
+          // hydrateColumns and never update orderedFieldsBeforePinningColumns
+          // In all these cases, use the position from the columns array
           // TODO: detect removed columns and decrease the positions after it
-          if (index === -1 || index >= newOrderedFieldsBeforePinningColumns.length) {
+          if (
+            index === -1 ||
+            index >= newOrderedFieldsBeforePinningColumns.length ||
+            !prevAllPinnedColumns.current.includes(field)
+          ) {
             index = columnsState.orderedFields.indexOf(field);
           }
 

--- a/packages/x-data-grid-pro/src/tests/columnPinning.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/columnPinning.DataGridPro.test.tsx
@@ -590,6 +590,17 @@ describe('<DataGridPro /> - Column pinning', () => {
       expect(getColumnHeadersTextContent()).to.deep.equal(['id', 'price1M']);
     });
 
+    it('should restore the position when the column is reordered before being pinned', async () => {
+      const { setProps } = render(<TestCase nbCols={4} disableVirtualization />);
+      expect(getColumnHeadersTextContent()).to.deep.equal(['id', 'Currency Pair', '1M', '2M']);
+      await act(() => apiRef.current?.setColumnIndex('currencyPair', 2)); // move Currency Pair to index 2
+      expect(getColumnHeadersTextContent()).to.deep.equal(['id', '1M', 'Currency Pair', '2M']);
+      setProps({ pinnedColumns: { left: ['currencyPair'] } });
+      expect(getColumnHeadersTextContent()).to.deep.equal(['Currency Pair', 'id', '1M', '2M']);
+      setProps({ pinnedColumns: {} });
+      expect(getColumnHeadersTextContent()).to.deep.equal(['id', '1M', 'Currency Pair', '2M']); // restored to reordered position
+    });
+
     it('should restore the position when the neighboring columns are reordered', async () => {
       const { setProps } = render(<TestCase nbCols={4} disableVirtualization />);
       expect(getColumnHeadersTextContent()).to.deep.equal(['id', 'Currency Pair', '1M', '2M']); // price1M's index = 2


### PR DESCRIPTION
When a column was reordered and then pinned, unpinning it would restore the column to its pre-reorder position instead of where the user had moved it. The root cause is that `setColumnIndex` updates `orderedFields` in state directly without going through `hydrateColumns`, so `orderedFieldsBeforePinningColumns` — the cache that tracks where each column should return on unpin — is never updated by reorder operations. When the column was later pinned, the existing fallback (`index === -1`) only covered columns absent from the cache entirely; it missed columns that were present but with a stale index. The fix adds a third condition: if the field was not in the previous pinned set (`!prevAllPinnedColumns.current.includes(field)`), it is treated as newly pinned and its pre-pinning position is read from the live `columnsState.orderedFields` instead of the stale cache.

The alternative of listening to `columnIndexChange` and calling `requestPipeProcessorsApplication('hydrateColumns')` would also fix the bug, but it triggers a full `createColumnsState` + `setGridColumnsState` cycle on every reorder — including every intermediate position during drag-and-drop — causing extra renders per drag frame. A direct cache-update approach via the event is also incorrect because `orderedFields` and `orderedFieldsBeforePinningColumns` can have different orderings when pinned columns occupy different virtual positions, making index translation unreliable.

Fixes #22244 