### PR TITLE
[code-infra] Use vale rules from code-infra package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  code-infra: https://raw.githubusercontent.com/mui/mui-public/99fb0c874daeabc34c61c849cfea313a45a2466a/.circleci/orbs/code-infra.yml
+  code-infra: https://raw.githubusercontent.com/mui/mui-public/12844f2b6b11babab17bd3d1f799359ea25d1db7/.circleci/orbs/code-infra.yml
 
 parameters:
   browserstack-force:

--- a/.github/workflows/vale-action.yml
+++ b/.github/workflows/vale-action.yml
@@ -18,11 +18,6 @@ jobs:
         run: |
           VERSION=$(node -p "(require('./package.json').config && require('./package.json').config.valeVersion) || ''")
           echo "vale_version=$VERSION" >> $GITHUB_OUTPUT
-      - name: Cache Vale binary
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-        with:
-          path: node_modules/.cache/mui-vale
-          key: ${{ runner.os }}-mui-vale-${{ steps.vale-version.outputs.vale_version }}
       - uses: vale-cli/vale-action@d89dee975228ae261d22c15adcd03578634d429c # v2.1.1
         continue-on-error: true # GitHub Action flag needed until https://github.com/errata-ai/vale-action/issues/89 is fixed
         with:

--- a/.github/workflows/vale-action.yml
+++ b/.github/workflows/vale-action.yml
@@ -13,14 +13,17 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Extract Vale version from pnpm-lock.yaml
+      - name: Extract Vale version
         id: vale-version
         run: |
-          # Extract version from lock file
-          VERSION=$(awk -F"@|'" '/@vvago\/vale@/ {print $4}' pnpm-lock.yaml | head -n1)
-          echo "Extracted Vale version: $VERSION"
+          VERSION=$(node -p "(require('./package.json').config && require('./package.json').config.valeVersion) || ''")
           echo "vale_version=$VERSION" >> $GITHUB_OUTPUT
-      - uses: errata-ai/vale-action@d89dee975228ae261d22c15adcd03578634d429c # v2.1.1
+      - name: Cache Vale binary
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: node_modules/.cache/mui-vale
+          key: ${{ runner.os }}-mui-vale-${{ steps.vale-version.outputs.vale_version }}
+      - uses: vale-cli/vale-action@d89dee975228ae261d22c15adcd03578634d429c # v2.1.1
         continue-on-error: true # GitHub Action flag needed until https://github.com/errata-ai/vale-action/issues/89 is fixed
         with:
           version: ${{ steps.vale-version.outputs.vale_version }}

--- a/.vale.ini
+++ b/.vale.ini
@@ -2,12 +2,7 @@
 StylesPath = .github/styles
 MinAlertLevel = warning
 
-# To update mui-vale package:
-# 1. Go to the docs folder in the material-ui repo
-# 2. Update/create YAML files
-# 3. Run `pnpm docs:zipRules` to generate the zip files
-# 4. You can test locally by replacing the url with the file path of the generated zip
-Packages = Google, https://github.com/mui/material-ui/raw/HEAD/docs/mui-vale.zip
+Packages = Google, ./node_modules/@mui/internal-code-infra/vale
 
 [formats]
 mdx = md

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "eslint:ci": "eslint . --report-unused-disable-directives --max-warnings 0",
     "stylelint": "stylelint --reportInvalidScopeDisables --reportNeedlessDisables \"docs/**/*.?(c|m)[jt]s?(x)\" \"**/*.css\" --ignore-path .lintignore",
     "markdownlint": "markdownlint-cli2 \"**/*.md\"",
-    "valelint": "pnpm dlx --package @vvago/vale vale sync && git ls-files | grep -E \"\\.(md|mdx)$\" | xargs pnpm dlx --package @vvago/vale vale --filter='.Level==\"error\"'",
+    "vale:fix": "pnpm code-infra vale sync --vale-version $npm_package_config_valeVersion && git ls-files | grep -E \"\\.(md|mdx)$\" | xargs pnpm code-infra vale --vale-version $npm_package_config_valeVersion --filter='.Level==\"error\"' --auto-fix all",
+    "valelint": "pnpm code-infra vale sync --vale-version $npm_package_config_valeVersion && git ls-files | grep -E \"\\.(md|mdx)$\" | xargs pnpm code-infra vale --vale-version $npm_package_config_valeVersion --filter='.Level==\"error\"'",
     "prettier": "pretty-quick --ignore-path .lintignore --branch master",
     "prettier:all": "prettier --write . --ignore-path .lintignore",
     "proptypes": "tsx ./docs/scripts/generateProptypes.ts",
@@ -141,6 +142,9 @@
     "vitest": "catalog:",
     "yargs": "catalog:",
     "zod": "4.3.6"
+  },
+  "config": {
+    "valeVersion": "3.14.1"
   },
   "packageManager": "pnpm@10.30.1",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "eslint:ci": "eslint . --report-unused-disable-directives --max-warnings 0",
     "stylelint": "stylelint --reportInvalidScopeDisables --reportNeedlessDisables \"docs/**/*.?(c|m)[jt]s?(x)\" \"**/*.css\" --ignore-path .lintignore",
     "markdownlint": "markdownlint-cli2 \"**/*.md\"",
-    "vale:fix": "pnpm code-infra vale sync --vale-version $npm_package_config_valeVersion && git ls-files | grep -E \"\\.(md|mdx)$\" | xargs pnpm code-infra vale --vale-version $npm_package_config_valeVersion --filter='.Level==\"error\"' --auto-fix all",
+    "vale:fix": "pnpm valelint --auto-fix all",
     "valelint": "pnpm code-infra vale sync --vale-version $npm_package_config_valeVersion && git ls-files | grep -E \"\\.(md|mdx)$\" | xargs pnpm code-infra vale --vale-version $npm_package_config_valeVersion --filter='.Level==\"error\"'",
     "prettier": "pretty-quick --ignore-path .lintignore --branch master",
     "prettier:all": "prettier --write . --ignore-path .lintignore",


### PR DESCRIPTION
Mirrors https://github.com/mui/material-ui/pull/48173 for this repo.

## Summary
- Use the bundled vale rules from `@mui/internal-code-infra` instead of fetching the zip from the material-ui repo.
- Pin the Vale binary version via `package.json#config.valeVersion` and run it through the `code-infra` CLI instead of `pnpm dlx @vvago/vale`.
- Update `vale-action.yml` to source the version from `package.json`. The standalone workflow file is kept (rather than merged into `ci.yml`) since `ci.yml` here only delegates to a reusable workflow.
- Deduplicate the `vale:fix` script to call `valelint --auto-fix all` (mirrors https://github.com/mui/base-ui-mosaic/pull/218).

🤖 Generated with [Claude Code](https://claude.com/claude-code)