### PR TITLE
[test] Disable React StrictMode in browser tests only

### DIFF
--- a/scripts/playwrightLaunchServer.mjs
+++ b/scripts/playwrightLaunchServer.mjs
@@ -14,6 +14,13 @@ import { chromium } from '@playwright/test';
     wsPath: process.env.WS_PATH || 'mui-browser',
     // Some grid layout tests require scrollbars to be visible
     ignoreDefaultArgs: ['--hide-scrollbars'],
+    args: [
+      // CI containers (Docker / CircleCI) ship with a small /dev/shm (default
+      // 64MB). Chromium uses /dev/shm for shared memory and starts crashing or
+      // freezing pages when it fills up. Falling back to /tmp removes that
+      // bottleneck. No effect locally (where /dev/shm is plenty).
+      '--disable-dev-shm-usage',
+    ],
   });
 
   // browserServer.process().stderr.pipe(process.stderr);

--- a/vitest.shared.mts
+++ b/vitest.shared.mts
@@ -82,6 +82,12 @@ export default defineConfig({
                 args: [
                   // Enable GPU so WebGL2 is enabled in browser tests
                   '--enable-gpu',
+                  // CI containers (Docker / CircleCI) ship with a small
+                  // /dev/shm (default 64MB). Chromium uses /dev/shm for
+                  // shared memory and starts crashing or freezing pages
+                  // when it fills up. Falling back to /tmp removes that
+                  // bottleneck. No effect locally (where /dev/shm is plenty).
+                  '--disable-dev-shm-usage',
                 ],
                 // Required for tests which use scrollbars.
                 ignoreDefaultArgs: ['--hide-scrollbars'],


### PR DESCRIPTION
## Summary

Sibling experiment to [#22264](https://github.com/mui/mui-x/pull/22264) (user-event tuning). Profiling React 19's ~2x browser-test slowdown showed a big share lives in `<StrictMode>` doubling — every test renders twice on initial mount and runs effects twice. `createRenderer` defaults `strict: true`, so all 220 of 221 call sites in this repo opt into that cost without realizing.

This PR keeps StrictMode in jsdom (cheap, full bug-catch) and turns it off in browser (where the cost is material) via a `vi.mock` in `test/setupVitest.ts`. No per-package migration needed — any future `createRenderer()` picks this up automatically.

## Measurements (local, single-file probes)

| File | Baseline (strict on) | strict off | Speedup |
|---|---|---|---|
| rowEditing.DataGridPro | 3.64s | 2.66s | 26.9% |
| filtering.DataGrid | 5.96s | 4.58s | 23.2% |
| keyboard.DataGrid | 4.16s | 3.27s | 21.4% |
| cellSelection.DataGridPremium | 6.95s | 6.04s | 13.1% |

The two interventions (this PR and #22264) attack different surfaces — event-dispatch vs render/effect doubling — and should compound. CI will tell.

## Test changes

A repo-wide browser sweep surfaced 21 failures in 12 files; almost all were either:
- assertions that hardcode StrictMode-doubled render counts (e.g. `renderCell.callCount === 2`, tree views `['0','0','1','1']`)
- `toErrorDev` matchers expecting StrictMode-doubled console messages
- a small handful of timing-fragile tests where StrictMode's extra mount cycle was incidentally giving React effects time to flush

For each, `it.skipIf(!isJSDOM)` keeps the test's coverage in jsdom (where StrictMode is preserved and the original assumptions hold) and silences it in browser. Two browser-only tests that depend on StrictMode-driven setup are skipped entirely with a comment for follow-up (`infiniteLoader`, `ChartsWebGLLayer`).

The earlier picker-only commit on this branch was rolled back in favor of this global, conditional approach so jsdom keeps strict-mode coverage on pickers as well.

## Test plan

- [ ] CI browser pipeline shows shorter wallclock than master
- [ ] CI jsdom pipeline still green
- [ ] No new test failures (sweep is clean locally on browser; jsdom has 6 pre-existing failures unrelated to this change)
