### PR TITLE
[docs] Migrate FlightPicker overview demo to v9 slotProps shape

### DIFF
--- a/docs/src/modules/components/overview/pickers/mainDemo/FlightPicker.tsx
+++ b/docs/src/modules/components/overview/pickers/mainDemo/FlightPicker.tsx
@@ -18,12 +18,14 @@ export default function FlightPicker() {
         slotProps={{
           textField: ({ position }: FieldOwnerState & { position?: 'start' | 'end' }) => ({
             label: position === 'start' ? 'Outbound' : 'Inbound',
-            InputProps: {
-              startAdornment: (
-                <InputAdornment position="start">
-                  {position === 'start' ? <FlightTakeoffIcon /> : <FlightLandIcon />}
-                </InputAdornment>
-              ),
+            slotProps: {
+              input: {
+                startAdornment: (
+                  <InputAdornment position="start">
+                    {position === 'start' ? <FlightTakeoffIcon /> : <FlightLandIcon />}
+                  </InputAdornment>
+                ),
+              },
             },
           }),
         }}


### PR DESCRIPTION
## Summary

Opening the [Pickers overview page](https://mui.com/x/react-date-pickers/) currently throws two React warnings:

```
React does not recognize the `slotProps` prop on a DOM element.
React does not recognize the `inputRef` prop on a DOM element.
```

Root cause: the `FlightPicker` demo still uses the deprecated `InputProps` key inside `slotProps.textField`, which was removed from every Picker / Field component in v9 (see the v9 migration guide section [Drop deprecated `PickersTextField` props](https://mui.com/x/migration/migration-pickers-v8/#drop-deprecated-pickerstextfield-props)). Because `InputProps` is no longer a recognized prop on the textField slot, the resulting shape leaks `slotProps` and `inputRef` down to the underlying DOM input, producing the warnings above.

This PR wraps `startAdornment` under `slotProps.input` to match the v9 shape — the same pattern already used in the neighbouring `Birthday` demo and produced by the `v9.0.0/pickers/migrate-text-field-props` codemod.

## Comparison

| Before | After |
|--------|--------|
| <img width="687" height="272" alt="Screenshot 2026-04-30 at 15 05 22" src="https://github.com/user-attachments/assets/70ede9cc-2251-48cc-99f0-8dcc82b370ae" /> | <img width="672" height="268" alt="Screenshot 2026-04-30 at 15 15 09" src="https://github.com/user-attachments/assets/bf5b9601-7717-45bf-aa33-b8d15a8cd669" /> | 