### PR TITLE
[charts] Fix guarded throws to comply with no-guarded-throw rule

### DIFF
--- a/packages/x-charts-premium/src/BarChartPremium/RangeBar/seriesConfig/seriesProcessor.ts
+++ b/packages/x-charts-premium/src/BarChartPremium/RangeBar/seriesConfig/seriesProcessor.ts
@@ -15,11 +15,7 @@ const seriesProcessor: SeriesProcessor<'rangeBar'> = (params, dataset, isItemVis
     const seriesData = series[id];
     const datasetKeys = seriesData?.datasetKeys;
 
-    if (
-      seriesData.data === undefined &&
-      dataset === undefined &&
-      process.env.NODE_ENV !== 'production'
-    ) {
+    if (seriesData.data === undefined && dataset === undefined) {
       throw new Error(
         `MUI X Charts: range bar series with id='${id}' has no data.
 Either provide a data property to the series or use the dataset prop.`,

--- a/packages/x-charts-premium/src/RadialBarChart/seriesConfig/seriesProcessor.ts
+++ b/packages/x-charts-premium/src/RadialBarChart/seriesConfig/seriesProcessor.ts
@@ -44,7 +44,7 @@ function seriesProcessor(
           d3Dataset[dataIndex][id] = value;
         }
       });
-    } else if (dataset === undefined && process.env.NODE_ENV !== 'production') {
+    } else if (dataset === undefined) {
       throw new Error(
         `MUI X Charts: Radial bar series with id="${id}" has no data. ` +
           'The chart cannot render this series without data. ' +
@@ -52,29 +52,27 @@ function seriesProcessor(
       );
     }
 
-    if (process.env.NODE_ENV !== 'production') {
-      if (!data && dataset) {
-        const dataKey = series[id].dataKey;
+    if (!data && dataset) {
+      const dataKey = series[id].dataKey;
 
-        if (!dataKey && !series[id].valueGetter) {
-          throw new Error(
-            `MUI X Charts: Radial bar series with id="${id}" has no data, no dataKey, and no valueGetter. ` +
-              'When using the dataset prop, each series must have a dataKey or valueGetter to identify which dataset values to use. ' +
-              'Add a dataKey or valueGetter property to the series configuration.',
-          );
-        }
+      if (!dataKey && !series[id].valueGetter) {
+        throw new Error(
+          `MUI X Charts: Radial bar series with id="${id}" has no data, no dataKey, and no valueGetter. ` +
+            'When using the dataset prop, each series must have a dataKey or valueGetter to identify which dataset values to use. ' +
+            'Add a dataKey or valueGetter property to the series configuration.',
+        );
+      }
 
-        if (dataKey) {
-          dataset.forEach((entry, index) => {
-            const value = entry[dataKey];
-            if (value != null && typeof value !== 'number') {
-              warnOnce(
-                `MUI X Charts: your dataset key "${dataKey}" is used for plotting radial bars, but the dataset contains the non-null non-numerical element "${value}" at index ${index}.
+      if (process.env.NODE_ENV !== 'production' && dataKey) {
+        dataset.forEach((entry, index) => {
+          const value = entry[dataKey];
+          if (value != null && typeof value !== 'number') {
+            warnOnce(
+              `MUI X Charts: your dataset key "${dataKey}" is used for plotting radial bars, but the dataset contains the non-null non-numerical element "${value}" at index ${index}.
 Radial bar plots only support numeric and null values.`,
-              );
-            }
-          });
-        }
+            );
+          }
+        });
       }
     }
   });

--- a/packages/x-charts-premium/src/RadialLineChart/seriesConfig/seriesProcessor.ts
+++ b/packages/x-charts-premium/src/RadialLineChart/seriesConfig/seriesProcessor.ts
@@ -57,7 +57,7 @@ function seriesProcessor(
           d3Dataset[dataIndex][id] = value;
         }
       });
-    } else if (dataset === undefined && process.env.NODE_ENV !== 'production') {
+    } else if (dataset === undefined) {
       throw new Error(
         `MUI X Charts: Radial line series with id="${id}" has no data. ` +
           'The chart cannot render this series without data. ' +
@@ -65,29 +65,27 @@ function seriesProcessor(
       );
     }
 
-    if (process.env.NODE_ENV !== 'production') {
-      if (!data && dataset) {
-        const dataKey = series[id].dataKey;
+    if (!data && dataset) {
+      const dataKey = series[id].dataKey;
 
-        if (!dataKey && !series[id].valueGetter) {
-          throw new Error(
-            `MUI X Charts: Radial line series with id="${id}" has no data, no dataKey, and no valueGetter. ` +
-              'When using the dataset prop, each series must have a dataKey or valueGetter to identify which dataset values to use. ' +
-              'Add a dataKey or valueGetter property to the series configuration.',
-          );
-        }
+      if (!dataKey && !series[id].valueGetter) {
+        throw new Error(
+          `MUI X Charts: Radial line series with id="${id}" has no data, no dataKey, and no valueGetter. ` +
+            'When using the dataset prop, each series must have a dataKey or valueGetter to identify which dataset values to use. ' +
+            'Add a dataKey or valueGetter property to the series configuration.',
+        );
+      }
 
-        if (dataKey) {
-          dataset.forEach((entry, index) => {
-            const value = entry[dataKey];
-            if (value != null && typeof value !== 'number') {
-              warnOnce(
-                `MUI X Charts: your dataset key "${dataKey}" is used for plotting radial lines, but the dataset contains the non-null non-numerical element "${value}" at index ${index}.
+      if (process.env.NODE_ENV !== 'production' && dataKey) {
+        dataset.forEach((entry, index) => {
+          const value = entry[dataKey];
+          if (value != null && typeof value !== 'number') {
+            warnOnce(
+              `MUI X Charts: your dataset key "${dataKey}" is used for plotting radial lines, but the dataset contains the non-null non-numerical element "${value}" at index ${index}.
 Radial line plots only support numeric and null values.`,
-              );
-            }
-          });
-        }
+            );
+          }
+        });
       }
     }
   });

--- a/packages/x-charts/src/BarChart/seriesConfig/bar/seriesProcessor.ts
+++ b/packages/x-charts/src/BarChart/seriesConfig/bar/seriesProcessor.ts
@@ -45,29 +45,27 @@ const seriesProcessor: SeriesProcessor<'bar'> = (params, dataset, isItemVisible)
       );
     }
 
-    if (process.env.NODE_ENV !== 'production') {
-      if (!data && dataset) {
-        const dataKey = series[id].dataKey;
+    if (!data && dataset) {
+      const dataKey = series[id].dataKey;
 
-        if (!dataKey && !series[id].valueGetter) {
-          throw new Error(
-            `MUI X Charts: Bar series with id="${id}" has no data, no dataKey, and no valueGetter. ` +
-              'When using the dataset prop, each series must have a dataKey or valueGetter to identify which dataset values to use. ' +
-              'Add a dataKey or valueGetter property to the series configuration.',
-          );
-        }
+      if (!dataKey && !series[id].valueGetter) {
+        throw new Error(
+          `MUI X Charts: Bar series with id="${id}" has no data, no dataKey, and no valueGetter. ` +
+            'When using the dataset prop, each series must have a dataKey or valueGetter to identify which dataset values to use. ' +
+            'Add a dataKey or valueGetter property to the series configuration.',
+        );
+      }
 
-        if (dataKey) {
-          dataset.forEach((entry, index) => {
-            const value = entry[dataKey];
-            if (value != null && typeof value !== 'number') {
-              warnOnce(
-                `MUI X Charts: your dataset key "${dataKey}" is used for plotting bars, but the dataset contains the non-null non-numerical element "${value}" at index ${index}.
+      if (process.env.NODE_ENV !== 'production' && dataKey) {
+        dataset.forEach((entry, index) => {
+          const value = entry[dataKey];
+          if (value != null && typeof value !== 'number') {
+            warnOnce(
+              `MUI X Charts: your dataset key "${dataKey}" is used for plotting bars, but the dataset contains the non-null non-numerical element "${value}" at index ${index}.
 Bar plots only support numeric and null values.`,
-              );
-            }
-          });
-        }
+            );
+          }
+        });
       }
     }
   });

--- a/packages/x-charts/src/LineChart/seriesConfig/seriesProcessor.ts
+++ b/packages/x-charts/src/LineChart/seriesConfig/seriesProcessor.ts
@@ -60,7 +60,7 @@ function seriesProcessor(
           d3Dataset[dataIndex][id] = value;
         }
       });
-    } else if (dataset === undefined && process.env.NODE_ENV !== 'production') {
+    } else if (dataset === undefined) {
       throw new Error(
         `MUI X Charts: Line series with id="${id}" has no data. ` +
           'The chart cannot render this series without data. ' +
@@ -68,29 +68,27 @@ function seriesProcessor(
       );
     }
 
-    if (process.env.NODE_ENV !== 'production') {
-      if (!data && dataset) {
-        const dataKey = series[id].dataKey;
+    if (!data && dataset) {
+      const dataKey = series[id].dataKey;
 
-        if (!dataKey && !series[id].valueGetter) {
-          throw new Error(
-            `MUI X Charts: Line series with id="${id}" has no data, no dataKey, and no valueGetter. ` +
-              'When using the dataset prop, each series must have a dataKey or valueGetter to identify which dataset values to use. ' +
-              'Add a dataKey or valueGetter property to the series configuration.',
-          );
-        }
+      if (!dataKey && !series[id].valueGetter) {
+        throw new Error(
+          `MUI X Charts: Line series with id="${id}" has no data, no dataKey, and no valueGetter. ` +
+            'When using the dataset prop, each series must have a dataKey or valueGetter to identify which dataset values to use. ' +
+            'Add a dataKey or valueGetter property to the series configuration.',
+        );
+      }
 
-        if (dataKey) {
-          dataset.forEach((entry, index) => {
-            const value = entry[dataKey];
-            if (value != null && typeof value !== 'number') {
-              warnOnce(
-                `MUI X Charts: your dataset key "${dataKey}" is used for plotting lines, but the dataset contains the non-null non-numerical element "${value}" at index ${index}.
+      if (process.env.NODE_ENV !== 'production' && dataKey) {
+        dataset.forEach((entry, index) => {
+          const value = entry[dataKey];
+          if (value != null && typeof value !== 'number') {
+            warnOnce(
+              `MUI X Charts: your dataset key "${dataKey}" is used for plotting lines, but the dataset contains the non-null non-numerical element "${value}" at index ${index}.
 Line plots only support numeric and null values.`,
-              );
-            }
-          });
-        }
+            );
+          }
+        });
       }
     }
   });

--- a/packages/x-charts/src/LineChart/useAreaPlotData.ts
+++ b/packages/x-charts/src/LineChart/useAreaPlotData.ts
@@ -67,25 +67,23 @@ export function useAreaPlotData(
           (xAxes[xAxisId].colorScale && getGradientId(xAxisId)) ||
           undefined;
 
-        if (process.env.NODE_ENV !== 'production') {
-          if (xData === undefined) {
-            throw new Error(
-              `MUI X Charts: ${
-                xAxisId === DEFAULT_X_AXIS_KEY
-                  ? 'The first `xAxis`'
-                  : `The x-axis with id "${xAxisId}"`
-              } should have a data property to be able to display a line plot. ` +
-                'The x-axis data defines the positions for each point in the line. ' +
-                'Provide a data array to the x-axis configuration.',
-            );
-          }
-          if (xData.length < stackedData.length) {
-            throw new Error(
-              `MUI X Charts: The data length of the x-axis (${xData.length} items) is less than the length of series data (${stackedData.length} items). ` +
-                'Some data points will not be displayed because they have no corresponding x-axis value. ' +
-                'Ensure the x-axis data has at least as many items as the series data.',
-            );
-          }
+        if (xData === undefined) {
+          throw new Error(
+            `MUI X Charts: ${
+              xAxisId === DEFAULT_X_AXIS_KEY
+                ? 'The first `xAxis`'
+                : `The x-axis with id "${xAxisId}"`
+            } should have a data property to be able to display a line plot. ` +
+              'The x-axis data defines the positions for each point in the line. ' +
+              'Provide a data array to the x-axis configuration.',
+          );
+        }
+        if (xData.length < stackedData.length) {
+          throw new Error(
+            `MUI X Charts: The data length of the x-axis (${xData.length} items) is less than the length of series data (${stackedData.length} items). ` +
+              'Some data points will not be displayed because they have no corresponding x-axis value. ' +
+              'Ensure the x-axis data has at least as many items as the series data.',
+          );
         }
 
         const shouldExpand = curve?.includes('step') && !strictStepCurve && isOrdinalScale(xScale);

--- a/packages/x-charts/src/LineChart/useLinePlotData.ts
+++ b/packages/x-charts/src/LineChart/useLinePlotData.ts
@@ -66,24 +66,22 @@ export function useLinePlotData(
           (xAxes[xAxisId].colorScale && getGradientId(xAxisId)) ||
           undefined;
 
-        if (process.env.NODE_ENV !== 'production') {
-          if (xData === undefined) {
-            throw new Error(
-              `MUI X Charts: ${
-                xAxisId === DEFAULT_X_AXIS_KEY
-                  ? 'The first `xAxis`'
-                  : `The x-axis with id "${xAxisId}"`
-              } should have a data property to be able to display a line plot. ` +
-                'The x-axis data defines the positions for each point in the line. ' +
-                'Provide a data array to the x-axis configuration.',
-            );
-          }
-          if (xData.length < stackedData.length) {
-            warnOnce(
-              `MUI X Charts: The data length of the x axis (${xData.length} items) is lower than the length of series (${stackedData.length} items).`,
-              'error',
-            );
-          }
+        if (xData === undefined) {
+          throw new Error(
+            `MUI X Charts: ${
+              xAxisId === DEFAULT_X_AXIS_KEY
+                ? 'The first `xAxis`'
+                : `The x-axis with id "${xAxisId}"`
+            } should have a data property to be able to display a line plot. ` +
+              'The x-axis data defines the positions for each point in the line. ' +
+              'Provide a data array to the x-axis configuration.',
+          );
+        }
+        if (process.env.NODE_ENV !== 'production' && xData.length < stackedData.length) {
+          warnOnce(
+            `MUI X Charts: The data length of the x axis (${xData.length} items) is lower than the length of series (${stackedData.length} items).`,
+            'error',
+          );
         }
 
         const shouldExpand = curve?.includes('step') && !strictStepCurve && isOrdinalScale(xScale);

--- a/packages/x-charts/src/LineChart/useMarkPlotData.ts
+++ b/packages/x-charts/src/LineChart/useMarkPlotData.ts
@@ -75,18 +75,16 @@ export function useMarkPlotData(
         const yScale = yAxes[yAxisId].scale;
         const xData = xAxes[xAxisId].data;
 
-        if (process.env.NODE_ENV !== 'production') {
-          if (xData === undefined) {
-            throw new Error(
-              `MUI X Charts: ${
-                xAxisId === DEFAULT_X_AXIS_KEY
-                  ? 'The first `xAxis`'
-                  : `The x-axis with id "${xAxisId}"`
-              } should have a data property to be able to display a line plot. ` +
-                'The x-axis data defines the positions for each point in the line. ' +
-                'Provide a data array to the x-axis configuration.',
-            );
-          }
+        if (xData === undefined) {
+          throw new Error(
+            `MUI X Charts: ${
+              xAxisId === DEFAULT_X_AXIS_KEY
+                ? 'The first `xAxis`'
+                : `The x-axis with id "${xAxisId}"`
+            } should have a data property to be able to display a line plot. ` +
+              'The x-axis data defines the positions for each point in the line. ' +
+              'Provide a data array to the x-axis configuration.',
+          );
         }
 
         const clipId = cleanId(`${chartId}-${seriesId}-line-clip`);


### PR DESCRIPTION
## Summary

The new `mui/no-guarded-throw` ESLint rule, introduced via the upcoming @mui/internal-code-infra canary.32 bump (#22204), disallows `throw` statements guarded by `process.env.NODE_ENV` checks because they produce environment-dependent control flow.

This PR lifts the affected throws in `x-charts` and `x-charts-premium` out of the `process.env.NODE_ENV !== 'production'` blocks, while keeping dev-only `warnOnce` calls behind their NODE_ENV guards.

Required so the @mui/internal-code-infra bump (#22204) can land.