### PR TITLE
[pickers] Fix guarded throws to comply with no-guarded-throw rule

### DIFF
--- a/packages/x-date-pickers/src/AdapterDateFns/AdapterDateFns.ts
+++ b/packages/x-date-pickers/src/AdapterDateFns/AdapterDateFns.ts
@@ -82,20 +82,18 @@ export class AdapterDateFns
 {
   constructor({ locale, formats }: AdapterOptions<DateFnsLocale, never> = {}) {
     /* v8 ignore start */
-    if (process.env.NODE_ENV !== 'production') {
-      if (typeof addDays !== 'function') {
-        throw new Error(
-          [
-            'MUI: The `date-fns` package v2.x is not compatible with this adapter.',
-            'Please, install v3.x or v4.x of the package or use the `AdapterDateFnsV2` instead.',
-          ].join('\n'),
-        );
-      }
-      if (!longFormatters) {
-        throw new Error(
-          'MUI: The minimum supported `date-fns` package version compatible with this adapter is `3.2.x`.',
-        );
-      }
+    if (typeof addDays !== 'function') {
+      throw new Error(
+        [
+          'MUI: The `date-fns` package v2.x is not compatible with this adapter.',
+          'Please, install v3.x or v4.x of the package or use the `AdapterDateFnsV2` instead.',
+        ].join('\n'),
+      );
+    }
+    if (!longFormatters) {
+      throw new Error(
+        'MUI: The minimum supported `date-fns` package version compatible with this adapter is `3.2.x`.',
+      );
     }
     /* v8 ignore stop */
     super({ locale: locale ?? enUS, formats, longFormatters });

--- a/packages/x-date-pickers/src/AdapterDateFnsJalali/AdapterDateFnsJalali.ts
+++ b/packages/x-date-pickers/src/AdapterDateFnsJalali/AdapterDateFnsJalali.ts
@@ -121,20 +121,18 @@ export class AdapterDateFnsJalali
 {
   constructor({ locale, formats }: AdapterOptions<DateFnsLocale, never> = {}) {
     /* v8 ignore start */
-    if (process.env.NODE_ENV !== 'production') {
-      if (typeof addDays !== 'function') {
-        throw new Error(
-          [
-            'MUI: The `date-fns-jalali` package v2.x is not compatible with this adapter.',
-            'Please, install v3.x or v4.x of the package or use the `AdapterDateFnsJalaliV2` instead.',
-          ].join('\n'),
-        );
-      }
-      if (!longFormatters) {
-        throw new Error(
-          'MUI: The minimum supported `date-fns-jalali` package version compatible with this adapter is `3.2.x`.',
-        );
-      }
+    if (typeof addDays !== 'function') {
+      throw new Error(
+        [
+          'MUI: The `date-fns-jalali` package v2.x is not compatible with this adapter.',
+          'Please, install v3.x or v4.x of the package or use the `AdapterDateFnsJalaliV2` instead.',
+        ].join('\n'),
+      );
+    }
+    if (!longFormatters) {
+      throw new Error(
+        'MUI: The minimum supported `date-fns-jalali` package version compatible with this adapter is `3.2.x`.',
+      );
     }
     /* v8 ignore stop */
     super({

--- a/packages/x-date-pickers/src/AdapterDateFnsJalaliV2/AdapterDateFnsJalaliV2.ts
+++ b/packages/x-date-pickers/src/AdapterDateFnsJalaliV2/AdapterDateFnsJalaliV2.ts
@@ -128,15 +128,13 @@ export class AdapterDateFnsJalali
 {
   constructor({ locale, formats }: AdapterOptions<DateFnsLocale, never> = {}) {
     /* v8 ignore start */
-    if (process.env.NODE_ENV !== 'production') {
-      if (typeof addDays !== 'function') {
-        throw new Error(
-          [
-            'MUI: This adapter is only compatible with `date-fns-jalali` v2.x package versions.',
-            'Please, install v2.x of the package or use the `AdapterDateFnsJalali` instead.',
-          ].join('\n'),
-        );
-      }
+    if (typeof addDays !== 'function') {
+      throw new Error(
+        [
+          'MUI: This adapter is only compatible with `date-fns-jalali` v2.x package versions.',
+          'Please, install v2.x of the package or use the `AdapterDateFnsJalali` instead.',
+        ].join('\n'),
+      );
     }
     /* v8 ignore stop */
     super({

--- a/packages/x-date-pickers/src/AdapterDateFnsV2/AdapterDateFnsV2.ts
+++ b/packages/x-date-pickers/src/AdapterDateFnsV2/AdapterDateFnsV2.ts
@@ -89,15 +89,13 @@ export class AdapterDateFns
 {
   constructor({ locale, formats }: AdapterOptions<DateFnsLocale, never> = {}) {
     /* v8 ignore start */
-    if (process.env.NODE_ENV !== 'production') {
-      if (typeof addDays !== 'function') {
-        throw new Error(
-          [
-            'MUI: This adapter is only compatible with `date-fns` v2.x package versions.',
-            'Please, install v2.x of the package or use the `AdapterDateFns` instead.',
-          ].join('\n'),
-        );
-      }
+    if (typeof addDays !== 'function') {
+      throw new Error(
+        [
+          'MUI: This adapter is only compatible with `date-fns` v2.x package versions.',
+          'Please, install v2.x of the package or use the `AdapterDateFns` instead.',
+        ].join('\n'),
+      );
     }
     /* v8 ignore stop */
     super({ locale: locale ?? defaultLocale, formats, longFormatters });

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.utils.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.utils.ts
@@ -177,15 +177,13 @@ export const cleanDigitSectionValue = (
     | 'maxLength'
   >,
 ) => {
-  if (process.env.NODE_ENV !== 'production') {
-    if (section.type !== 'day' && section.contentType === 'digit-with-letter') {
-      throw new Error(
-        [
-          `MUI X: The token "${section.format}" is a digit format with letter in it.'
+  if (section.type !== 'day' && section.contentType === 'digit-with-letter') {
+    throw new Error(
+      [
+        `MUI X: The token "${section.format}" is a digit format with letter in it.'
              This type of format is only supported for 'day' sections`,
-        ].join('\n'),
-      );
-    }
+      ].join('\n'),
+    );
   }
 
   if (section.type === 'day' && section.contentType === 'digit-with-letter') {
@@ -252,10 +250,8 @@ export const changeSectionValueFormat = (
   currentFormat: string,
   newFormat: string,
 ) => {
-  if (process.env.NODE_ENV !== 'production') {
-    if (getDateSectionConfigFromFormatToken(adapter, currentFormat).type === 'weekDay') {
-      throw new Error("changeSectionValueFormat doesn't support week day formats");
-    }
+  if (getDateSectionConfigFromFormatToken(adapter, currentFormat).type === 'weekDay') {
+    throw new Error("changeSectionValueFormat doesn't support week day formats");
   }
 
   return adapter.formatByString(adapter.parse(valueStr, currentFormat)!, newFormat);


### PR DESCRIPTION
## Summary

The new `mui/no-guarded-throw` ESLint rule, introduced via the upcoming @mui/internal-code-infra canary.32 bump (#22204), disallows `throw` statements guarded by `process.env.NODE_ENV` checks because they produce environment-dependent control flow.

This PR lifts the affected throws in `x-date-pickers` (date-fns adapters and `useField.utils`) out of the `process.env.NODE_ENV !== 'production'` blocks.

Required so the @mui/internal-code-infra bump (#22204) can land.