### PR TITLE
[x-license] Fix guarded throws to comply with no-guarded-throw rule

### DIFF
--- a/packages/x-license/src/useLicenseVerifier/useLicenseVerifier.ts
+++ b/packages/x-license/src/useLicenseVerifier/useLicenseVerifier.ts
@@ -91,7 +91,7 @@ export function useLicenseVerifier(packageInfo: CommercialPackageInfo): {
       showExpiredPackageVersionError({ packageName: fullPackageName });
     } else if (licenseStatus.status === LICENSE_STATUS.NotValidForPackage) {
       showLicenseKeyVersionMismatchError(licenseStatus.meta);
-    } else if (process.env.NODE_ENV !== 'production') {
+    } else {
       throw new Error('missing status handler');
     }
 

--- a/packages/x-license/src/verifyLicense/verifyLicense.ts
+++ b/packages/x-license/src/verifyLicense/verifyLicense.ts
@@ -240,16 +240,16 @@ export function verifyLicense({
     return { status: LICENSE_STATUS.Invalid };
   }
 
-  if (license.licenseModel === 'perpetual' || process.env.NODE_ENV === 'production') {
-    const pkgTimestamp = parseInt(base64Decode(releaseDate), 10);
-    if (Number.isNaN(pkgTimestamp)) {
-      throw new Error(
-        'MUI X: The release information is invalid and license validation cannot proceed. ' +
-          'The package release timestamp could not be parsed. ' +
-          'This may indicate a corrupted package. Try reinstalling the MUI X packages.',
-      );
-    }
+  const pkgTimestamp = parseInt(base64Decode(releaseDate), 10);
+  if (Number.isNaN(pkgTimestamp)) {
+    throw new Error(
+      'MUI X: The release information is invalid and license validation cannot proceed. ' +
+        'The package release timestamp could not be parsed. ' +
+        'This may indicate a corrupted package. Try reinstalling the MUI X packages.',
+    );
+  }
 
+  if (license.licenseModel === 'perpetual' || process.env.NODE_ENV === 'production') {
     if (license.expiryTimestamp < pkgTimestamp) {
       // Perpetual v8 (or older) licenses whose expiry predates this package release
       // are not valid for v9 packages.


### PR DESCRIPTION
## Summary

The new `mui/no-guarded-throw` ESLint rule, introduced via the upcoming @mui/internal-code-infra canary.32 bump (#22204), disallows `throw` statements guarded by `process.env.NODE_ENV` checks because they produce environment-dependent control flow.

- `useLicenseVerifier`: turn the missing-status-handler throw into an unconditional `else` branch.
- `verifyLicense`: hoist the corrupted-package timestamp check above the `process.env.NODE_ENV === 'production'` branch so the throw runs unconditionally when the release timestamp can't be parsed.

Required so the @mui/internal-code-infra bump (#22204) can land.