### PR TITLE
[scheduler] Fix guarded throws to comply with no-guarded-throw rule

### DIFF
--- a/packages/x-scheduler-headless-premium/src/internals/utils/useTimelineGridRowKeyboard.ts
+++ b/packages/x-scheduler-headless-premium/src/internals/utils/useTimelineGridRowKeyboard.ts
@@ -27,13 +27,11 @@ export function useTimelineGridRowKeyboard(params: { columnType: TimelineGridCol
   const { ref: listItemRef, index } = useCompositeListItem();
   const { elementsRef } = useCompositeListContext();
 
-  if (process.env.NODE_ENV !== 'production') {
-    if (columnTypes.indexOf(columnType) === -1) {
-      throw new Error(
-        `MUI X Scheduler: The column type "${columnType}" is not listed in the \`columnTypes\` prop of <TimelineGrid.Root />. ` +
-          `Add "${columnType}" to \`columnTypes\` so the row can participate in arrow-key navigation.`,
-      );
-    }
+  if (columnTypes.indexOf(columnType) === -1) {
+    throw new Error(
+      `MUI X Scheduler: The column type "${columnType}" is not listed in the \`columnTypes\` prop of <TimelineGrid.Root />. ` +
+        `Add "${columnType}" to \`columnTypes\` so the row can participate in arrow-key navigation.`,
+    );
   }
 
   const rowRef = React.useRef<HTMLDivElement>(null);

--- a/packages/x-scheduler-headless-premium/src/timeline-grid/root/TimelineGridRoot.tsx
+++ b/packages/x-scheduler-headless-premium/src/timeline-grid/root/TimelineGridRoot.tsx
@@ -26,18 +26,16 @@ export const TimelineGridRoot = React.forwardRef(function TimelineGridRoot(
     ...elementProps
   } = componentProps;
 
-  if (process.env.NODE_ENV !== 'production') {
-    const seen = new Set<TimelineGridColumnType>();
-    for (const type of columnTypes) {
-      if (seen.has(type)) {
-        throw new Error(
-          `MUI X Scheduler: The \`columnTypes\` prop of <TimelineGrid.Root /> contains a duplicate entry "${type}". ` +
-            'Arrow-key navigation relies on each column type appearing exactly once. ' +
-            'Remove the duplicate entry.',
-        );
-      }
-      seen.add(type);
+  const seen = new Set<TimelineGridColumnType>();
+  for (const type of columnTypes) {
+    if (seen.has(type)) {
+      throw new Error(
+        `MUI X Scheduler: The \`columnTypes\` prop of <TimelineGrid.Root /> contains a duplicate entry "${type}". ` +
+          'Arrow-key navigation relies on each column type appearing exactly once. ' +
+          'Remove the duplicate entry.',
+      );
     }
+    seen.add(type);
   }
 
   // Context hooks

--- a/packages/x-scheduler-headless-premium/src/use-event-timeline-premium/EventTimelinePremiumStore.ts
+++ b/packages/x-scheduler-headless-premium/src/use-event-timeline-premium/EventTimelinePremiumStore.ts
@@ -32,24 +32,22 @@ export const DEFAULT_PRESET: EventTimelinePremiumPreset = PRESET_ZOOM_ORDER[0];
 function sortPresetsByZoomOrder(
   presets: EventTimelinePremiumPreset[],
 ): EventTimelinePremiumPreset[] {
-  if (process.env.NODE_ENV !== 'production') {
-    if (presets.length === 0) {
-      throw new Error(
-        `MUI X Scheduler: EventTimelinePremium received an empty \`presets\` prop. ` +
-          `This leaves the timeline without any preset to render. ` +
-          `Pass at least one preset, or omit the prop to use the default set (${PRESET_ZOOM_ORDER.join(', ')}). ` +
-          `See https://mui.com/x/react-scheduler/event-timeline/presets/ for more details.`,
-      );
-    }
-    const unknown = presets.filter((preset) => !PRESET_ZOOM_ORDER.includes(preset));
-    if (unknown.length > 0) {
-      throw new Error(
-        `MUI X Scheduler: EventTimelinePremium received unknown preset(s) in the \`presets\` prop: ${unknown.join(', ')}. ` +
-          `These entries have no associated configuration, so the timeline cannot render them. ` +
-          `Remove the unknown preset(s), or use one of the built-in values (${PRESET_ZOOM_ORDER.join(', ')}). ` +
-          `See https://mui.com/x/react-scheduler/event-timeline/presets/ for more details.`,
-      );
-    }
+  if (presets.length === 0) {
+    throw new Error(
+      `MUI X Scheduler: EventTimelinePremium received an empty \`presets\` prop. ` +
+        `This leaves the timeline without any preset to render. ` +
+        `Pass at least one preset, or omit the prop to use the default set (${PRESET_ZOOM_ORDER.join(', ')}). ` +
+        `See https://mui.com/x/react-scheduler/event-timeline/presets/ for more details.`,
+    );
+  }
+  const unknown = presets.filter((preset) => !PRESET_ZOOM_ORDER.includes(preset));
+  if (unknown.length > 0) {
+    throw new Error(
+      `MUI X Scheduler: EventTimelinePremium received unknown preset(s) in the \`presets\` prop: ${unknown.join(', ')}. ` +
+        `These entries have no associated configuration, so the timeline cannot render them. ` +
+        `Remove the unknown preset(s), or use one of the built-in values (${PRESET_ZOOM_ORDER.join(', ')}). ` +
+        `See https://mui.com/x/react-scheduler/event-timeline/presets/ for more details.`,
+    );
   }
   // Iterating over `PRESET_ZOOM_ORDER` (instead of the input) yields a canonical,
   // duplicate-free output even when runtime inputs (storage, URL params, dynamic

--- a/packages/x-scheduler-headless/src/base-ui-copy/utils/useRenderElement.tsx
+++ b/packages/x-scheduler-headless/src/base-ui-copy/utils/useRenderElement.tsx
@@ -156,20 +156,16 @@ function evaluateRenderProp<T extends React.ElementType, S>(
 
     // There is a high number of indirections, the error message thrown by React.cloneElement() is
     // hard to use for developers, this logic provides a better context.
-    //
-    // Our general guideline is to never change the control flow depending on the environment.
-    // However, React.cloneElement() throws if React.isValidElement() is false,
+    // React.cloneElement() throws if React.isValidElement() is false,
     // so we can throw before with custom message.
-    if (process.env.NODE_ENV !== 'production') {
-      if (!React.isValidElement(newElement)) {
-        throw new Error(
-          [
-            'Base UI: The `render` prop was provided an invalid React element as `React.isValidElement(render)` is `false`.',
-            'A valid React element must be provided to the `render` prop because it is cloned with props to replace the default element.',
-            'https://base-ui.com/r/invalid-render-prop',
-          ].join('\n'),
-        );
-      }
+    if (!React.isValidElement(newElement)) {
+      throw new Error(
+        [
+          'Base UI: The `render` prop was provided an invalid React element as `React.isValidElement(render)` is `false`.',
+          'A valid React element must be provided to the `render` prop because it is cloned with props to replace the default element.',
+          'https://base-ui.com/r/invalid-render-prop',
+        ].join('\n'),
+      );
     }
 
     return React.cloneElement(newElement, mergedProps);

--- a/packages/x-scheduler-headless/src/get-day-list/getDayList.ts
+++ b/packages/x-scheduler-headless/src/get-day-list/getDayList.ts
@@ -9,12 +9,10 @@ export function getDayList(parameters: GetDaytListParameters): GetDaytListReturn
   const start = adapter.startOfDay(rawStart);
   const end = adapter.endOfDay(rawEnd);
 
-  if (process.env.NODE_ENV !== 'production') {
-    if (adapter.isBefore(adapter.startOfDay(end), adapter.startOfDay(start))) {
-      throw new Error(
-        `MUI: getDayList: The 'end' parameter must be a day after the 'start' parameter.`,
-      );
-    }
+  if (adapter.isBefore(adapter.startOfDay(end), adapter.startOfDay(start))) {
+    throw new Error(
+      `MUI: getDayList: The 'end' parameter must be a day after the 'start' parameter.`,
+    );
   }
 
   let current = start;

--- a/packages/x-scheduler-headless/src/use-event-calendar/EventCalendarStore.ts
+++ b/packages/x-scheduler-headless/src/use-event-calendar/EventCalendarStore.ts
@@ -38,7 +38,7 @@ const deriveStateFromParameters = <TEvent extends object, TResource extends obje
   parameters: EventCalendarParameters<TEvent, TResource>,
 ) => {
   const views = parameters.views ?? DEFAULT_VIEWS;
-  if (process.env.NODE_ENV !== 'production' && views.length === 0) {
+  if (views.length === 0) {
     throw new Error(
       `MUI X Scheduler: EventCalendar received an empty \`views\` prop. ` +
         `This leaves the calendar without any view to render. ` +


### PR DESCRIPTION
## Summary

The new `mui/no-guarded-throw` ESLint rule, introduced via the upcoming @mui/internal-code-infra canary.32 bump (#22204), disallows `throw` statements guarded by `process.env.NODE_ENV` checks because they produce environment-dependent control flow.

This PR lifts the affected throws in `x-scheduler-headless` and `x-scheduler-headless-premium` out of the `process.env.NODE_ENV !== 'production'` blocks.

Required so the @mui/internal-code-infra bump (#22204) can land.