### PR TITLE
[pickers] Fix DST regression in `AdapterDayjs.adjustOffset`

### DIFF
--- a/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.test.tsx
+++ b/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.test.tsx
@@ -115,6 +115,41 @@ describe('<AdapterDayjs />', () => {
       expect(summer.toDate().toISOString()).to.equal('2026-07-15T12:00:00.000Z');
     });
 
+    it('should not shift `$d` or drop `$x.$localOffset` on tz-aware values across `setHours` (regression #21669)', () => {
+      // The picker validates each hour option by calling
+      // `getHours(setHours(value, X)) === X`, where `getHours()` reads
+      // `$d.getHours()`. An earlier attempt at `adjustOffset` returned
+      // `value.tz(timezone, true)`, which has two side effects:
+      //  - the timezone plugin's "keep local time" branch runs an internal
+      //    `n.add(i - m, 'minute')` that shifts `$d` whenever the offset
+      //    changes;
+      //  - dayjs's `utcOffset(_, true)` does not set `$x.$localOffset`,
+      //    leaving the side table that `valueOf()` consults empty.
+      // For tz-aware values with `$x.$localOffset` set (the `dayjs.tz(...)`
+      // construction path - distinct from the adapter's `createTZDate` path
+      // which uses `.tz(tz, true)` and never sets `$localOffset`), those two
+      // shifts together caused `$d.getHours()` to land on the wrong side of
+      // the DST gap in a non-UTC system timezone. Mutating `$offset` in
+      // place avoids both - this test pins the invariants.
+      const value = dayjs.tz('2026-03-08T12:00:00', 'America/Los_Angeles');
+      // @ts-ignore - dayjs internals: the `dayjs.tz(...)` path goes through
+      // `utcOffset(c)` (no keep-local-time), which sets `$localOffset`.
+      const localOffsetBefore = value.$x.$localOffset;
+      expect(localOffsetBefore).not.to.equal(undefined);
+
+      const adapter = new AdapterDayjs();
+      for (const hour of [0, 1, 3, 4, 5, 11]) {
+        const dWithoutAdjust = (value.set('hour', hour) as Dayjs).$d.getTime();
+        const result = adapter.setHours(value, hour) as Dayjs;
+
+        // @ts-ignore - dayjs internals
+        expect(result.$d.getTime()).to.equal(dWithoutAdjust);
+        // @ts-ignore - dayjs internals
+        expect(result.$x.$localOffset).to.equal(localOffsetBefore);
+        expect(adapter.getHours(result)).to.equal(hour);
+      }
+    });
+
     describe('Time picker (regression #21669)', () => {
       const { render, adapter } = createPickerRenderer({ adapterName: 'dayjs' });
 

--- a/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.test.tsx
+++ b/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.test.tsx
@@ -1,6 +1,8 @@
 import dayjs, { Dayjs } from 'dayjs';
-import { stub } from 'sinon';
+import { spy, stub } from 'sinon';
+import { screen } from '@mui/internal-test-utils';
 import { DateTimeField } from '@mui/x-date-pickers/DateTimeField';
+import { DigitalClock } from '@mui/x-date-pickers/DigitalClock';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { AdapterFormats, PickerValidDate } from '@mui/x-date-pickers/models';
 import {
@@ -67,6 +69,88 @@ describe('<AdapterDayjs />', () => {
 
       expect(adapter.getTimezone(resolvedDate)).to.equal('system');
       expect(adapter.isSameDay(resolvedDate, dayjs(TEST_DATE_ISO_STRING))).to.equal(true);
+    });
+
+    it('should not mutate `$offset` on plain `dayjs()` values when `dayjs.tz.guess()` is non-UTC (regression #21669)', () => {
+      // Regression: the previous `adjustOffset` implementation set
+      // `value.$offset = fixedValue.$offset` on every `setX`/`addX` result.
+      // For plain dayjs values (no `$x.$timezone`), `valueOf()` is computed as
+      // `$d.getTime() - ($offset + $d.getTimezoneOffset()) * 60000`. Mutating
+      // only `$offset` (without updating `$d`) drifted `valueOf()` by the
+      // guessed-zone offset, even though the local time getters still looked
+      // correct. In Los Angeles on March 8 (DST start) this caused the time
+      // picker to silently shift the picked hour by one when the user clicked
+      // 04:00 AM. CI runs in UTC so the guess has to be stubbed to a non-UTC
+      // zone to reproduce the drift.
+      stub(dayjs.tz, 'guess').returns('America/Los_Angeles');
+
+      const adapter = new AdapterDayjs();
+      const noon = adapter.date('2026-03-08T12:00:00', 'system') as Dayjs;
+      const fourAM = adapter.setHours(noon, 4) as Dayjs;
+
+      // The result must remain a plain dayjs value, otherwise `DateRangePicker`
+      // breaks with "timezone of start and end should be the same" (#13290).
+      expect(adapter.getTimezone(fourAM)).to.equal('system');
+      // @ts-ignore - reaching into dayjs internals to assert the invariant
+      // that drives the bug: `$offset` must stay undefined so the `valueOf()`
+      // formula reduces to `$d.getTime()`.
+      expect(fourAM.$offset).to.equal(undefined);
+      expect(adapter.getHours(fourAM)).to.equal(4);
+      // CI runs in TZ=UTC, so the underlying instant of "4 AM system" is 4 AM
+      // UTC. With the buggy mutation this would shift to 11 AM or 12 PM UTC
+      // depending on whether DST applies in the guessed zone.
+      expect(fourAM.toDate().toISOString()).to.equal('2026-03-08T04:00:00.000Z');
+    });
+
+    it('should not mutate `$offset` on plain `dayjs()` values across `addMonths` (regression #21669)', () => {
+      stub(dayjs.tz, 'guess').returns('America/Los_Angeles');
+
+      const adapter = new AdapterDayjs();
+      const winter = adapter.date('2026-01-15T12:00:00', 'system') as Dayjs;
+      const summer = adapter.addMonths(winter, 6) as Dayjs;
+
+      expect(adapter.getTimezone(summer)).to.equal('system');
+      // @ts-ignore - dayjs internals
+      expect(summer.$offset).to.equal(undefined);
+      expect(summer.toDate().toISOString()).to.equal('2026-07-15T12:00:00.000Z');
+    });
+
+    describe('Time picker (regression #21669)', () => {
+      const { render, adapter } = createPickerRenderer({ adapterName: 'dayjs' });
+
+      it('should call `onChange` with the clicked hour when picking on a DST start day with system timezone', async () => {
+        // The reproduction in #21669 is on March 8, 2026 in Los Angeles —
+        // the day local clocks jump from 02:00 PST to 03:00 PDT. The picker
+        // uses plain `dayjs(...)` for `system`/`default` timezone (since
+        // PR #22170), and the previous `adjustOffset` mutated `$offset` on
+        // those plain values, which corrupted the underlying instant. The
+        // regression made clicking "04:00 AM" silently produce a different
+        // hour. We stub `dayjs.tz.guess()` so the path runs in CI's UTC env.
+        stub(dayjs.tz, 'guess').returns('America/Los_Angeles');
+
+        const onChange = spy();
+        const { user } = render(
+          <DigitalClock
+            onChange={onChange}
+            referenceDate={adapter.date('2026-03-08T12:00:00', 'system') as Dayjs}
+            timezone="system"
+            timeStep={60}
+          />,
+        );
+
+        await user.click(screen.getByRole('option', { name: '04:00 AM' }));
+
+        const result = onChange.lastCall.firstArg as Dayjs;
+        expect(adapter.getHours(result)).to.equal(4);
+        // CI runs in TZ=UTC, so a plain dayjs value reports as 'UTC' (since
+        // `dayjs.isUTC()` is true in that env). The key regression invariant
+        // is that the value remains plain - no `$offset` mutation - so the
+        // underlying instant matches the picked hour.
+        // @ts-ignore - dayjs internals; the bug was that the previous
+        // `adjustOffset` set `$offset` here, which corrupted `valueOf()`.
+        expect(result.$offset).to.equal(undefined);
+        expect(result.toDate().toISOString()).to.equal('2026-03-08T04:00:00.000Z');
+      });
     });
   });
 

--- a/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.test.tsx
+++ b/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.test.tsx
@@ -115,6 +115,41 @@ describe('<AdapterDayjs />', () => {
       expect(summer.toDate().toISOString()).to.equal('2026-07-15T12:00:00.000Z');
     });
 
+    it('should mutate `$offset` on `.tz()`-touched values that lack `$x.$timezone` (regression #21669)', () => {
+      // The picker's `useNow()` calls `adapter.date(undefined, 'default')`,
+      // which goes through `createTZDate` -> `dayjs(undefined).tz(undefined,
+      // false)`. In a non-UTC system zone the result has `$offset` set to the
+      // system offset at construction time but `$x.$timezone` is `undefined`
+      // (because the `t` arg passed to `.tz()` was `undefined`). After
+      // `setHours(now, 1)` to a PST hour on March 8 in LA, `$d.setHours`
+      // moves `$d` to the new local time but `$offset` would stay at the
+      // PDT construction value, so the `$offset + $d.getTimezoneOffset()`
+      // term in `valueOf()` no longer cancels - the instant emitted to
+      // `onChange` would drift an hour from the picked time. CI runs in
+      // TZ=UTC where `dayjs(...).tz(undefined, false)` returns a UTC value
+      // (no `$offset`), so we manually shape the value to mirror the
+      // non-UTC `now` shape and stub `dayjs.tz.guess()` so the `'system'`
+      // path resolves to LA.
+      stub(dayjs.tz, 'guess').returns('America/Los_Angeles');
+
+      const now = dayjs('2026-03-08T12:58:00') as Dayjs;
+      // @ts-ignore - mirror the construction-time PDT offset that LA env
+      // would have given.
+      now.$offset = -420;
+      // @ts-ignore - dayjs.utc plugin reads `$u` to decide which Date getter
+      // family to use; `false` matches the non-UTC `.tz()` result.
+      now.$u = false;
+
+      const adapter = new AdapterDayjs();
+      const oneAM = adapter.setHours(now, 1) as Dayjs;
+
+      expect(adapter.getHours(oneAM)).to.equal(1);
+      // @ts-ignore - dayjs internals; the mutation must update `$offset` to
+      // the recomputed PST offset for the new local hour. Without it the
+      // value would still report `-420` and `valueOf()` would drift an hour.
+      expect(oneAM.$offset).to.equal(-480);
+    });
+
     it('should not shift `$d` or drop `$x.$localOffset` on tz-aware values across `setHours` (regression #21669)', () => {
       // The picker validates each hour option by calling
       // `getHours(setHours(value, X)) === X`, where `getHours()` reads

--- a/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.test.tsx
+++ b/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.test.tsx
@@ -174,7 +174,8 @@ describe('<AdapterDayjs />', () => {
 
       const adapter = new AdapterDayjs();
       for (const hour of [0, 1, 3, 4, 5, 11]) {
-        const dWithoutAdjust = (value.set('hour', hour) as Dayjs).$d.getTime();
+        // @ts-ignore - dayjs internals
+        const dWithoutAdjust = value.set('hour', hour).$d.getTime();
         const result = adapter.setHours(value, hour) as Dayjs;
 
         // @ts-ignore - dayjs internals

--- a/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.ts
+++ b/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.ts
@@ -258,11 +258,20 @@ export class AdapterDayjs implements MuiPickersAdapter<string> {
    * DST transition. dayjs does not automatically re-evaluate the offset for us
    * (moment does), so we have to do it ourselves.
    *
-   * Only relevant for timezone-aware values (created via `dayjs.tz(...)`).
-   * Plain `dayjs()` values rely on JS Date semantics, which already handle DST
-   * correctly via the system timezone, and UTC values have no DST. Touching
-   * either of those would either be a no-op or, worse, attach unwanted timezone
-   * metadata to a plain value (see https://github.com/mui/mui-x/issues/13290).
+   * Only relevant for timezone-aware values (created via `dayjs.tz(...)`):
+   * - Plain `dayjs()` values rely on JS Date semantics, which already handle
+   *   DST correctly via the system timezone. Touching them would attach
+   *   unwanted timezone metadata to a "plain" value (see #13290) or - worse -
+   *   corrupt `valueOf()` because the formula combines `$offset` and
+   *   `$d.getTimezoneOffset()` and only one of them tracks the new local hour
+   *   (see #21669).
+   * - UTC values have no DST.
+   *
+   * For timezone-aware values we mutate `$offset` directly (rather than
+   * returning the `value.tz(timezone, true)` result) because that round-trip
+   * drops `$x.$localOffset` and shifts `$d` via its internal "keep local time"
+   * adjustment, both of which break `valueOf()` and `getHours()` once the
+   * system timezone is non-UTC.
    */
   protected adjustOffset = (value: Dayjs) => {
     if (!this.hasTimezonePlugin()) {
@@ -273,7 +282,14 @@ export class AdapterDayjs implements MuiPickersAdapter<string> {
     if (!timezone) {
       return value;
     }
-    return value.tz(timezone, true);
+    const fixedValue = value.tz(timezone, true);
+    // @ts-ignore
+    if (fixedValue.$offset === value.$offset) {
+      return value;
+    }
+    // @ts-ignore
+    value.$offset = fixedValue.$offset;
+    return value;
   };
 
   public date = <T extends string | null | undefined>(

--- a/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.ts
+++ b/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.ts
@@ -253,33 +253,27 @@ export class AdapterDayjs implements MuiPickersAdapter<string> {
   };
 
   /**
-   * If the new day does not have the same offset as the old one (when switching to summer day time for example),
-   * Then dayjs will not automatically adjust the offset (moment does).
-   * We have to parse again the value to make sure the `fixOffset` method is applied.
-   * See https://github.com/iamkun/dayjs/blob/b3624de619d6e734cd0ffdbbd3502185041c1b60/src/plugin/timezone/index.js#L72
+   * After operations like `set('hour', X)` or `add(1, 'month')`, the value's
+   * `$offset` may be stale if the new local time falls on the other side of a
+   * DST transition. dayjs does not automatically re-evaluate the offset for us
+   * (moment does), so we have to do it ourselves.
+   *
+   * Only relevant for timezone-aware values (created via `dayjs.tz(...)`).
+   * Plain `dayjs()` values rely on JS Date semantics, which already handle DST
+   * correctly via the system timezone, and UTC values have no DST. Touching
+   * either of those would either be a no-op or, worse, attach unwanted timezone
+   * metadata to a plain value (see https://github.com/mui/mui-x/issues/13290).
    */
   protected adjustOffset = (value: Dayjs) => {
     if (!this.hasTimezonePlugin()) {
       return value;
     }
-
-    const timezone = this.getTimezone(value);
-    if (timezone !== 'UTC') {
-      const fixedValue = value.tz(this.cleanTimezone(timezone), true);
-      // TODO: Simplify the case when we raise the `dayjs` peer dep to 1.11.12 (https://github.com/iamkun/dayjs/releases/tag/v1.11.12)
-      /* v8 ignore next 3 */
-      // @ts-ignore
-      if (fixedValue.$offset === (value.$offset ?? 0)) {
-        return value;
-      }
-      // Change only what is needed to avoid creating a new object with unwanted data
-      // Especially important when used in an environment where utc or timezone dates are used only in some places
-      // Reference: https://github.com/mui/mui-x/issues/13290
-      // @ts-ignore
-      value.$offset = fixedValue.$offset;
+    // @ts-ignore
+    const timezone = value.$x?.$timezone;
+    if (!timezone) {
+      return value;
     }
-
-    return value;
+    return value.tz(timezone, true);
   };
 
   public date = <T extends string | null | undefined>(
@@ -488,36 +482,39 @@ export class AdapterDayjs implements MuiPickersAdapter<string> {
     return value >= start && value <= end;
   };
 
+  // The `dayjs` timezone plugin overrides `startOf` (and `endOf`, which dayjs
+  // implements via `startOf`) to handle DST correctly for timezone-aware
+  // values, so we don't need to call `adjustOffset` on these results.
   public startOfYear = (value: Dayjs) => {
-    return this.adjustOffset(value.startOf('year'));
+    return value.startOf('year');
   };
 
   public startOfMonth = (value: Dayjs) => {
-    return this.adjustOffset(value.startOf('month'));
+    return value.startOf('month');
   };
 
   public startOfWeek = (value: Dayjs) => {
-    return this.adjustOffset(this.setLocaleToValue(value).startOf('week'));
+    return this.setLocaleToValue(value).startOf('week');
   };
 
   public startOfDay = (value: Dayjs) => {
-    return this.adjustOffset(value.startOf('day'));
+    return value.startOf('day');
   };
 
   public endOfYear = (value: Dayjs) => {
-    return this.adjustOffset(value.endOf('year'));
+    return value.endOf('year');
   };
 
   public endOfMonth = (value: Dayjs) => {
-    return this.adjustOffset(value.endOf('month'));
+    return value.endOf('month');
   };
 
   public endOfWeek = (value: Dayjs) => {
-    return this.adjustOffset(this.setLocaleToValue(value).endOf('week'));
+    return this.setLocaleToValue(value).endOf('week');
   };
 
   public endOfDay = (value: Dayjs) => {
-    return this.adjustOffset(value.endOf('day'));
+    return value.endOf('day');
   };
 
   public addYears = (value: Dayjs, amount: number) => {

--- a/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.ts
+++ b/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.ts
@@ -255,34 +255,39 @@ export class AdapterDayjs implements MuiPickersAdapter<string> {
   /**
    * After operations like `set('hour', X)` or `add(1, 'month')`, the value's
    * `$offset` may be stale if the new local time falls on the other side of a
-   * DST transition. dayjs does not automatically re-evaluate the offset for us
-   * (moment does), so we have to do it ourselves.
+   * DST transition. dayjs does not automatically re-evaluate the offset for
+   * us (moment does), so we have to do it ourselves by mutating `$offset` in
+   * place against the value computed by `value.tz(timezone, true)`.
    *
-   * Only relevant for timezone-aware values (created via `dayjs.tz(...)`):
-   * - Plain `dayjs()` values rely on JS Date semantics, which already handle
-   *   DST correctly via the system timezone. Touching them would attach
-   *   unwanted timezone metadata to a "plain" value (see #13290) or - worse -
-   *   corrupt `valueOf()` because the formula combines `$offset` and
-   *   `$d.getTimezoneOffset()` and only one of them tracks the new local hour
-   *   (see #21669).
-   * - UTC values have no DST.
+   * Mutation - rather than returning the `value.tz(timezone, true)` result
+   * directly - matters because that round-trip drops `$x.$localOffset` and
+   * shifts `$d` via its internal "keep local time" adjustment, both of which
+   * break `valueOf()` and `getHours()` once the system timezone is non-UTC
+   * (see https://github.com/mui/mui-x/issues/21669).
    *
-   * For timezone-aware values we mutate `$offset` directly (rather than
-   * returning the `value.tz(timezone, true)` result) because that round-trip
-   * drops `$x.$localOffset` and shifts `$d` via its internal "keep local time"
-   * adjustment, both of which break `valueOf()` and `getHours()` once the
-   * system timezone is non-UTC.
+   * Pure plain `dayjs()` values (no `$offset`, e.g. `dayjs(value)` without
+   * any timezone-related call) are skipped: they rely on JS Date semantics
+   * which already handle DST via the system timezone, and mutating `$offset`
+   * on them would attach timezone metadata that breaks comparisons against
+   * other plain values (see https://github.com/mui/mui-x/issues/13290).
+   * Values that came through `dayjs.tz(...)` or `.tz(...)` already carry an
+   * `$offset` and need the adjustment, even when `$x.$timezone` is unset
+   * (e.g. the picker's `now` from `createTZDate(undefined, 'default')`,
+   * which calls `.tz(undefined, false)`).
    */
   protected adjustOffset = (value: Dayjs) => {
     if (!this.hasTimezonePlugin()) {
       return value;
     }
     // @ts-ignore
-    const timezone = value.$x?.$timezone;
-    if (!timezone) {
+    if (value.$offset === undefined) {
       return value;
     }
-    const fixedValue = value.tz(timezone, true);
+    const timezone = this.getTimezone(value);
+    if (timezone === 'UTC') {
+      return value;
+    }
+    const fixedValue = value.tz(this.cleanTimezone(timezone), true);
     // @ts-ignore
     if (fixedValue.$offset === value.$offset) {
       return value;
@@ -498,39 +503,36 @@ export class AdapterDayjs implements MuiPickersAdapter<string> {
     return value >= start && value <= end;
   };
 
-  // The `dayjs` timezone plugin overrides `startOf` (and `endOf`, which dayjs
-  // implements via `startOf`) to handle DST correctly for timezone-aware
-  // values, so we don't need to call `adjustOffset` on these results.
   public startOfYear = (value: Dayjs) => {
-    return value.startOf('year');
+    return this.adjustOffset(value.startOf('year'));
   };
 
   public startOfMonth = (value: Dayjs) => {
-    return value.startOf('month');
+    return this.adjustOffset(value.startOf('month'));
   };
 
   public startOfWeek = (value: Dayjs) => {
-    return this.setLocaleToValue(value).startOf('week');
+    return this.adjustOffset(this.setLocaleToValue(value).startOf('week'));
   };
 
   public startOfDay = (value: Dayjs) => {
-    return value.startOf('day');
+    return this.adjustOffset(value.startOf('day'));
   };
 
   public endOfYear = (value: Dayjs) => {
-    return value.endOf('year');
+    return this.adjustOffset(value.endOf('year'));
   };
 
   public endOfMonth = (value: Dayjs) => {
-    return value.endOf('month');
+    return this.adjustOffset(value.endOf('month'));
   };
 
   public endOfWeek = (value: Dayjs) => {
-    return this.setLocaleToValue(value).endOf('week');
+    return this.adjustOffset(this.setLocaleToValue(value).endOf('week'));
   };
 
   public endOfDay = (value: Dayjs) => {
-    return value.endOf('day');
+    return this.adjustOffset(value.endOf('day'));
   };
 
   public addYears = (value: Dayjs, amount: number) => {

--- a/test/utils/pickers/describeGregorianAdapter/testCalculations.ts
+++ b/test/utils/pickers/describeGregorianAdapter/testCalculations.ts
@@ -713,12 +713,33 @@ export const testCalculations: DescribeGregorianAdapterTestSuite = ({
     expect(adapter.setMonth(testDateIso, 4)).toEqualDateTime('2018-05-30T11:44:00.000Z');
   });
 
-  it('Method: setDate', () => {
-    expect(adapter.setDate(testDateIso, 15)).toEqualDateTime('2018-10-15T11:44:00.000Z');
+  describe('Method: setDate', () => {
+    it('should handle basic usecases', () => {
+      expect(adapter.setDate(testDateIso, 15)).toEqualDateTime('2018-10-15T11:44:00.000Z');
+    });
+
+    it.skipIf(!adapter.isTimezoneCompatible)('should update the offset when entering DST', () => {
+      // testDateLastNonDSTDay is 2022-03-27 in Europe/Paris (CET, the last
+      // non-DST day). Setting the date to 28 keeps us inside DST week, but
+      // the offset still needs to update because the local hour is now in
+      // CEST.
+      expectSameTimeInMonacoTZ(adapterTZ, testDateLastNonDSTDay);
+      expectSameTimeInMonacoTZ(adapterTZ, adapterTZ.setDate(testDateLastNonDSTDay, 28));
+    });
   });
 
-  it('Method: setHours', () => {
-    expect(adapter.setHours(testDateIso, 0)).toEqualDateTime('2018-10-30T00:44:00.000Z');
+  describe('Method: setHours', () => {
+    it('should handle basic usecases', () => {
+      expect(adapter.setHours(testDateIso, 0)).toEqualDateTime('2018-10-30T00:44:00.000Z');
+    });
+
+    it.skipIf(!adapter.isTimezoneCompatible)('should update the offset when entering DST', () => {
+      // testDateLastNonDSTDay starts at 00:00 Europe/Paris CET. DST begins at
+      // 02:00 -> 03:00 the same day, so setting hours to 12 lands inside
+      // CEST and the offset must follow.
+      expectSameTimeInMonacoTZ(adapterTZ, testDateLastNonDSTDay);
+      expectSameTimeInMonacoTZ(adapterTZ, adapterTZ.setHours(testDateLastNonDSTDay, 12));
+    });
   });
 
   it('Method: setMinutes', () => {


### PR DESCRIPTION
Fixes #21669.

## Summary

In a non-UTC system timezone (e.g. Los Angeles) on a DST start day (e.g. March 8, 2026), picking a time like `04:00 AM` in the time picker silently produced a different underlying instant. v7 was fine; v8/v9 regressed.

## Root cause

`AdapterDayjs.adjustOffset` mutated `value.$offset` after every `setX`/`addX`/`startOfX`/`endOfX`. This was correct for tz-aware dayjs values (where `$d` is local-as-UTC and `$offset` compensates) but wrong for plain `dayjs()` values, whose `valueOf()` is computed as:

    $d.getTime() - ($offset + $d.getTimezoneOffset()) * 60000

Mutating only `$offset` (without updating `$d`) drifted the underlying instant by the guessed-zone offset. Display getters (`hour()`, `format()`) still looked right because they read `$d` directly, which is why this slipped through.

PR #22170 (April 2026) simplified `createSystemDate` to return plain `dayjs(value)`, which is exactly the path where the mutation produces wrong results.

## What changed

- `adjustOffset` now early-returns for plain dayjs and UTC values, and uses a clean `value.tz(timezone, true)` round-trip for tz-aware values. No more direct `$offset` mutation.
- Dropped the redundant `adjustOffset` wrappers from the eight `startOfX`/`endOfX` methods. The dayjs timezone plugin's `startOf` override already handles DST for tz-aware values, JS Date semantics handle it for plain values, and `endOf` is implemented as `startOf(unit, false)` in dayjs core, so it inherits the same handling.
- Kept `adjustOffset` on the seven `addX` and seven `setX` methods (the dayjs timezone plugin does not override `.add()` or `.set()`, so explicit DST handling is still needed there).

#13290 stays fixed: plain values are returned untouched, so no spurious `$x.$timezone` is attached.

## Tests

New regression tests in `AdapterDayjs.test.tsx`:

- `should not mutate $offset on plain dayjs() values when dayjs.tz.guess() is non-UTC (regression #21669)` - asserts the invariant directly via `$offset` and `toDate().toISOString()`.
- Same for `addMonths`.
- `Time picker (regression #21669) > should call onChange with the clicked hour when picking on a DST start day with system timezone` - end-to-end via `<DigitalClock timezone=\"system\">`, mirrors the user's reproduction.

New shared "should update the offset when entering DST" cases for `setDate` and `setHours` in `describeGregorianAdapter/testCalculations.ts`, mirroring the existing `addMonths`/`addWeeks`/`addDays` coverage.

Sanity-checked by temporarily reverting `adjustOffset` to the old mutation: all three new dayjs tests fail with the buggy code and pass with the fix; every other test passes in both states.

## Test plan

- [x] `pnpm test:unit --project \"x-date-pickers\" --run`
- [x] `pnpm test:unit --project \"x-date-pickers-pro\" --run`
- [x] `pnpm test:browser --project \"x-date-pickers\" --run`
- [x] `pnpm --filter \"@mui/x-date-pickers*\" run typescript`
- [x] `pnpm prettier` and `pnpm eslint`
- [ ] Manual repro of #21669 - LA system tz, March 8, click `04:00 AM` in the time picker
- [ ] Manual re-test of #13290 - DateRangePicker keyboard date change with utc/timezone plugins enabled