### PR TITLE
[test] Revert async user-event migration in Pickers tests (#22043)

### DIFF
--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.test.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.test.tsx
@@ -81,19 +81,19 @@ describe('<DateRangeCalendar />', () => {
       expect(rangeOn2ndCall[1]).to.toEqualDateTime(new Date(2019, 2, 19));
     });
 
-    it('should continue start selection if selected "end" date is before start', async () => {
+    it('should continue start selection if selected "end" date is before start', () => {
       const onChange = spy();
 
-      const { user } = render(
+      render(
         <DateRangeCalendar onChange={onChange} referenceDate={adapterToUse.date('2019-01-01')} />,
       );
 
-      await user.click(getPickerDay('30', 'January 2019'));
-      await user.click(getPickerDay('19', 'January 2019'));
+      fireEvent.click(getPickerDay('30', 'January 2019'));
+      fireEvent.click(getPickerDay('19', 'January 2019'));
 
       expect(screen.queryByTestId('DateRangeHighlight')).to.equal(null);
 
-      await user.click(getPickerDay('30', 'January 2019'));
+      fireEvent.click(getPickerDay('30', 'January 2019'));
 
       expect(onChange.callCount).to.equal(3);
       const range = onChange.lastCall.firstArg;
@@ -533,14 +533,14 @@ describe('<DateRangeCalendar />', () => {
     });
 
     it('should not go to the month of the end date when changing the start date and props.disableAutoMonthSwitching = true', async () => {
-      const { user } = render(
+      render(
         <DateRangeCalendar
           defaultValue={[adapterToUse.date('2018-01-01'), adapterToUse.date('2018-07-01')]}
           disableAutoMonthSwitching
         />,
       );
 
-      await user.click(getPickerDay('5', 'January 2018'));
+      fireEvent.click(getPickerDay('5', 'January 2018'));
       await waitFor(() => {
         expect(getPickerDay('1', 'January 2018')).not.to.equal(null);
       });
@@ -582,9 +582,9 @@ describe('<DateRangeCalendar />', () => {
   });
 
   ['readOnly', 'disabled'].forEach((prop) => {
-    it(`prop: ${prop}="true" should not allow date editing`, async () => {
+    it(`prop: ${prop}="true" should not allow date editing`, () => {
       const handleChange = spy();
-      const { user } = render(
+      render(
         <DateRangeCalendar
           value={[adapterToUse.date('2018-01-01'), adapterToUse.date('2018-01-10')]}
           onChange={handleChange}
@@ -603,7 +603,7 @@ describe('<DateRangeCalendar />', () => {
           'disabled',
         );
       }
-      await user.setup({ pointerEventsCheck: 0 }).click(getPickerDay('2'));
+      fireEvent.click(getPickerDay('2'));
       expect(handleChange.callCount).to.equal(0);
     });
   });
@@ -628,7 +628,6 @@ describe('<DateRangeCalendar />', () => {
       );
 
       const renderCountBeforeChange = RenderCount.callCount;
-      // sticking with `fireEvent` for simplified performance test
       fireEvent.click(getPickerDay('2'));
       expect(RenderCount.callCount - renderCountBeforeChange).to.equal(2); // 2 render * 1 day
     });
@@ -648,7 +647,6 @@ describe('<DateRangeCalendar />', () => {
       fireEvent.click(getPickerDay('2'));
 
       const renderCountBeforeChange = RenderCount.callCount;
-      // sticking with `fireEvent` for simplified performance test
       fireEvent.click(getPickerDay('4'));
       expect(RenderCount.callCount - renderCountBeforeChange).to.equal(6); // 2 render * 3 day
     });

--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/timezone.DateRangeCalendar.test.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/timezone.DateRangeCalendar.test.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
-import { screen } from '@mui/internal-test-utils';
+import { screen, fireEvent } from '@mui/internal-test-utils';
 import { describeAdapters } from 'test/utils/pickers';
 import { DateRangeCalendar } from './DateRangeCalendar';
 
 describe('<DateRangeCalendar /> - Timezone', () => {
   describeAdapters('Timezone prop', DateRangeCalendar, ({ adapter, render }) => {
     describe.skipIf(!adapter.isTimezoneCompatible)('timezoneCompatible', () => {
-      it('should correctly render month days when timezone changes', async () => {
+      it('should correctly render month days when timezone changes', () => {
         function DateCalendarWithControlledTimezone() {
           const [timezone, setTimezone] = React.useState('Europe/Paris');
           return (
@@ -16,7 +16,7 @@ describe('<DateRangeCalendar /> - Timezone', () => {
             </React.Fragment>
           );
         }
-        const { user } = render(<DateCalendarWithControlledTimezone />);
+        render(<DateCalendarWithControlledTimezone />);
 
         expect(
           screen.getAllByRole('gridcell', {
@@ -25,7 +25,7 @@ describe('<DateRangeCalendar /> - Timezone', () => {
           }).length,
         ).to.equal(30);
 
-        await user.click(screen.getByRole('button', { name: 'Switch timezone' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Switch timezone' }));
 
         // the amount of rendered days should remain the same after changing timezone
         expect(
@@ -36,7 +36,7 @@ describe('<DateRangeCalendar /> - Timezone', () => {
         ).to.equal(30);
       });
 
-      it('should not produce invalidRange error when selecting same day after timezone change', async () => {
+      it('should not produce invalidRange error when selecting same day after timezone change', () => {
         function DateRangeCalendarWithTimezoneChange() {
           const [timezone, setTimezone] = React.useState<string>('UTC');
           const [value, setValue] = React.useState<any>([null, null]);
@@ -64,15 +64,15 @@ describe('<DateRangeCalendar /> - Timezone', () => {
           );
         }
 
-        const { user } = render(<DateRangeCalendarWithTimezoneChange />);
+        render(<DateRangeCalendarWithTimezoneChange />);
 
         // Switch timezone to Los Angeles
-        await user.click(screen.getByRole('button', { name: 'Switch to Los Angeles' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Switch to Los Angeles' }));
 
         // Select Nov 12, 2025 as both start and end date
         const nov12Cells = screen.getAllByRole('gridcell', { name: '12' });
-        await user.click(nov12Cells[0]);
-        await user.click(nov12Cells[0]);
+        fireEvent.click(nov12Cells[0]);
+        fireEvent.click(nov12Cells[0]);
 
         // Step 4: Verify that the range is valid (both dates should be Nov 12)
         // The value should not have an invalidRange error, which would prevent onChange from being called

--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.test.tsx
@@ -18,25 +18,17 @@ describe('<DateRangePicker />', () => {
     Component: DateRangePicker,
   });
 
-  it('should not use the mobile picker by default', async () => {
+  it('should not use the mobile picker by default', () => {
     stubMatchMedia(true);
-    const { user } = renderWithProps({});
-    await openPicker(user, {
-      type: 'date-range',
-      initialFocus: 'start',
-      fieldType: 'single-input',
-    });
+    renderWithProps({});
+    openPicker({ type: 'date-range', initialFocus: 'start', fieldType: 'single-input' });
     expect(screen.queryByRole('dialog')).to.have.class(pickerPopperClasses.root);
   });
 
-  it('should use the mobile picker when `useMediaQuery` returns `false`', async () => {
+  it('should use the mobile picker when `useMediaQuery` returns `false`', () => {
     stubMatchMedia(false);
-    const { user } = renderWithProps({});
-    await openPicker(user, {
-      type: 'date-range',
-      initialFocus: 'start',
-      fieldType: 'single-input',
-    });
+    renderWithProps({});
+    openPicker({ type: 'date-range', initialFocus: 'start', fieldType: 'single-input' });
     expect(screen.queryByRole('dialog')).not.to.have.class(pickerPopperClasses.root);
   });
 

--- a/packages/x-date-pickers-pro/src/DesktopDateRangePicker/tests/DesktopDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateRangePicker/tests/DesktopDateRangePicker.test.tsx
@@ -11,7 +11,7 @@ import {
   createPickerRenderer,
   adapterToUse,
   AdapterClassToUse,
-  openPicker,
+  openPickerAsync,
   getFieldSectionsContainer,
 } from 'test/utils/pickers';
 import { vi } from 'vitest';
@@ -31,14 +31,14 @@ describe('<DesktopDateRangePicker />', () => {
       />,
     );
 
-    await openPicker(user, {
+    await openPickerAsync(user, {
       type: 'date-range',
       initialFocus: 'start',
       fieldType: 'multi-input',
     });
     expect(screen.getByText('May 2019')).toBeVisible();
 
-    await openPicker(user, {
+    await openPickerAsync(user, {
       type: 'date-range',
       initialFocus: 'end',
       fieldType: 'multi-input',
@@ -46,7 +46,7 @@ describe('<DesktopDateRangePicker />', () => {
     expect(screen.getByText('October 2019')).toBeVisible();
 
     // scroll back
-    await openPicker(user, {
+    await openPickerAsync(user, {
       type: 'date-range',
       initialFocus: 'start',
       fieldType: 'multi-input',
@@ -59,7 +59,7 @@ describe('<DesktopDateRangePicker />', () => {
       <DesktopDateRangePicker defaultValue={[new Date(NaN), adapterToUse.date('2019-01-31')]} />,
     );
 
-    await openPicker(user, {
+    await openPickerAsync(user, {
       type: 'date-range',
       initialFocus: 'start',
       fieldType: 'single-input',
@@ -112,6 +112,33 @@ describe('<DesktopDateRangePicker />', () => {
     expect(screen.getByRole<HTMLInputElement>('textbox', { hidden: true }).name).to.equal('test');
   });
 
+  describe('Component slot: Popper', () => {
+    it('should forward onClick and onTouchStart', async () => {
+      const handleClick = spy();
+      const handleTouchStart = spy();
+      render(
+        <DesktopDateRangePicker
+          open
+          slotProps={{
+            popper: {
+              onClick: handleClick,
+              onTouchStart: handleTouchStart,
+              // @ts-expect-error `data-*` attributes are not recognized in props objects
+              'data-testid': 'popper',
+            },
+          }}
+        />,
+      );
+      const popper = screen.getByTestId('popper');
+
+      fireEvent.click(popper);
+      fireEvent.touchStart(popper);
+
+      expect(handleClick.callCount).to.equal(1);
+      expect(handleTouchStart.callCount).to.equal(1);
+    });
+  });
+
   describe('picker state', () => {
     it('should open when clicking the start input (multi input field)', async () => {
       const onOpen = spy();
@@ -120,7 +147,7 @@ describe('<DesktopDateRangePicker />', () => {
         <DesktopDateRangePicker onOpen={onOpen} slots={{ field: MultiInputDateRangeField }} />,
       );
 
-      await openPicker(user, {
+      await openPickerAsync(user, {
         type: 'date-range',
         initialFocus: 'start',
         fieldType: 'multi-input',
@@ -137,7 +164,7 @@ describe('<DesktopDateRangePicker />', () => {
         <DesktopDateRangePicker onOpen={onOpen} slots={{ field: MultiInputDateRangeField }} />,
       );
 
-      await openPicker(user, {
+      await openPickerAsync(user, {
         type: 'date-range',
         initialFocus: 'end',
         fieldType: 'multi-input',
@@ -201,7 +228,7 @@ describe('<DesktopDateRangePicker />', () => {
       );
 
       // Open the picker
-      await openPicker(user, {
+      await openPickerAsync(user, {
         type: 'date-range',
         initialFocus: 'start',
         fieldType: 'multi-input',
@@ -248,7 +275,7 @@ describe('<DesktopDateRangePicker />', () => {
       );
 
       // Open the picker
-      await openPicker(user, {
+      await openPickerAsync(user, {
         type: 'date-range',
         initialFocus: 'end',
         fieldType: 'multi-input',
@@ -258,9 +285,6 @@ describe('<DesktopDateRangePicker />', () => {
       expect(onClose.callCount).to.equal(0);
 
       // Change the end date
-      // `fireEvent.click` preserves the exact synthetic-event sequence that
-      // the callback-count assertions below depend on. `user.click` fires a
-      // full pointer sequence that can trigger an extra `onClose`.
       fireEvent.click(getPickerDay('3'));
       expect(onChange.callCount).to.equal(1);
       expect(onChange.lastCall.args[0][0]).toEqualDateTime(defaultValue[0]);
@@ -289,7 +313,7 @@ describe('<DesktopDateRangePicker />', () => {
         />,
       );
 
-      await openPicker(user, {
+      await openPickerAsync(user, {
         type: 'date-range',
         initialFocus: 'end',
         fieldType: 'multi-input',
@@ -320,7 +344,7 @@ describe('<DesktopDateRangePicker />', () => {
         />,
       );
 
-      await openPicker(user, {
+      await openPickerAsync(user, {
         type: 'date-range',
         initialFocus: 'start',
         fieldType: 'single-input',
@@ -355,7 +379,7 @@ describe('<DesktopDateRangePicker />', () => {
         </div>,
       );
 
-      await openPicker(user, {
+      await openPickerAsync(user, {
         type: 'date-range',
         initialFocus: 'start',
         fieldType: 'multi-input',
@@ -393,7 +417,7 @@ describe('<DesktopDateRangePicker />', () => {
         </div>,
       );
 
-      await openPicker(user, {
+      await openPickerAsync(user, {
         type: 'date-range',
         initialFocus: 'start',
         fieldType: 'multi-input',
@@ -456,7 +480,7 @@ describe('<DesktopDateRangePicker />', () => {
         </React.Fragment>,
       );
 
-      await openPicker(user, {
+      await openPickerAsync(user, {
         type: 'date-range',
         initialFocus: 'start',
         fieldType: 'multi-input',
@@ -494,7 +518,7 @@ describe('<DesktopDateRangePicker />', () => {
         </div>,
       );
 
-      await openPicker(user, {
+      await openPickerAsync(user, {
         type: 'date-range',
         initialFocus: 'start',
         fieldType: 'multi-input',
@@ -535,7 +559,7 @@ describe('<DesktopDateRangePicker />', () => {
         />,
       );
 
-      await openPicker(user, {
+      await openPickerAsync(user, {
         type: 'date-range',
         initialFocus: 'start',
         fieldType: 'single-input',
@@ -565,7 +589,7 @@ describe('<DesktopDateRangePicker />', () => {
         />,
       );
 
-      await openPicker(user, {
+      await openPickerAsync(user, {
         type: 'date-range',
         initialFocus: 'start',
         fieldType: 'single-input',
@@ -601,14 +625,14 @@ describe('<DesktopDateRangePicker />', () => {
       );
 
       // Open the picker (already tested)
-      await openPicker(user, {
+      await openPickerAsync(user, {
         type: 'date-range',
         initialFocus: 'start',
         fieldType: 'multi-input',
       });
 
       // Switch to end date
-      await openPicker(user, {
+      await openPickerAsync(user, {
         type: 'date-range',
         initialFocus: 'end',
         fieldType: 'multi-input',
@@ -634,14 +658,14 @@ describe('<DesktopDateRangePicker />', () => {
       );
 
       // Open the picker (already tested)
-      await openPicker(user, {
+      await openPickerAsync(user, {
         type: 'date-range',
         initialFocus: 'end',
         fieldType: 'multi-input',
       });
 
       // Switch to start date
-      await openPicker(user, {
+      await openPickerAsync(user, {
         type: 'date-range',
         initialFocus: 'start',
         fieldType: 'multi-input',
@@ -659,7 +683,7 @@ describe('<DesktopDateRangePicker />', () => {
         />,
       );
 
-      await openPicker(user, {
+      await openPickerAsync(user, {
         type: 'date-range',
         initialFocus: 'start',
         fieldType: 'single-input',
@@ -681,7 +705,7 @@ describe('<DesktopDateRangePicker />', () => {
     it('should respect the disablePast prop', async () => {
       const { user } = render(<DesktopDateRangePicker disablePast />);
 
-      await openPicker(user, {
+      await openPickerAsync(user, {
         type: 'date-range',
         initialFocus: 'start',
         fieldType: 'single-input',
@@ -697,7 +721,7 @@ describe('<DesktopDateRangePicker />', () => {
     it('should respect the disableFuture prop', async () => {
       const { user } = render(<DesktopDateRangePicker disableFuture />);
 
-      await openPicker(user, {
+      await openPickerAsync(user, {
         type: 'date-range',
         initialFocus: 'start',
         fieldType: 'single-input',
@@ -713,7 +737,7 @@ describe('<DesktopDateRangePicker />', () => {
     it('should respect the minDate prop', async () => {
       const { user } = render(<DesktopDateRangePicker minDate={adapterToUse.date('2018-01-15')} />);
 
-      await openPicker(user, {
+      await openPickerAsync(user, {
         type: 'date-range',
         initialFocus: 'start',
         fieldType: 'single-input',
@@ -729,7 +753,7 @@ describe('<DesktopDateRangePicker />', () => {
     it('should respect the maxDate prop', async () => {
       const { user } = render(<DesktopDateRangePicker maxDate={adapterToUse.date('2018-01-15')} />);
 
-      await openPicker(user, {
+      await openPickerAsync(user, {
         type: 'date-range',
         initialFocus: 'start',
         fieldType: 'single-input',
@@ -751,7 +775,7 @@ describe('<DesktopDateRangePicker />', () => {
       </React.Fragment>,
     );
 
-    await openPicker(user, {
+    await openPickerAsync(user, {
       type: 'date-range',
       initialFocus: 'start',
       fieldType: 'single-input',

--- a/packages/x-date-pickers-pro/src/DesktopDateRangePicker/tests/describeValueMultiInput.DesktopDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateRangePicker/tests/describeValueMultiInput.DesktopDateRangePicker.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@mui/internal-test-utils';
+import { fireEvent, screen } from '@mui/internal-test-utils';
 import {
   adapterToUse,
   createPickerRenderer,
@@ -43,9 +43,9 @@ describe('<DesktopDateRangePicker /> - Describe Value', () => {
         : 'MM/DD/YYYY';
       expectFieldValue(endSectionsContainer, expectedEndValueStr);
     },
-    setNewValue: async (
+    setNewValue: (
       value,
-      { isOpened, applySameValue, setEndDate = false, selectSection, pressKey, user },
+      { isOpened, applySameValue, setEndDate = false, selectSection, pressKey },
     ) => {
       let newValue: PickerNonNullableRangeValue;
       if (applySameValue) {
@@ -57,14 +57,14 @@ describe('<DesktopDateRangePicker /> - Describe Value', () => {
       }
 
       if (isOpened) {
-        await user.click(
+        fireEvent.click(
           screen.getAllByRole('gridcell', {
             name: adapterToUse.getDate(newValue[setEndDate ? 1 : 0]).toString(),
           })[0],
         );
       } else {
-        await selectSection('day');
-        await pressKey('ArrowUp');
+        selectSection('day');
+        pressKey(undefined, 'ArrowUp');
       }
 
       return newValue;

--- a/packages/x-date-pickers-pro/src/DesktopDateRangePicker/tests/describeValueSingleInput.DesktopDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateRangePicker/tests/describeValueSingleInput.DesktopDateRangePicker.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@mui/internal-test-utils';
+import { fireEvent, screen } from '@mui/internal-test-utils';
 import {
   adapterToUse,
   createPickerRenderer,
@@ -42,9 +42,9 @@ describe('<DesktopDateRangePicker /> - Describe Value', () => {
 
       expectFieldValue(fieldRoot, expectedValueStr);
     },
-    setNewValue: async (
+    setNewValue: (
       value,
-      { isOpened, applySameValue, setEndDate = false, selectSection, pressKey, user },
+      { isOpened, applySameValue, setEndDate = false, selectSection, pressKey },
     ) => {
       let newValue: PickerNonNullableRangeValue;
       if (applySameValue) {
@@ -56,14 +56,14 @@ describe('<DesktopDateRangePicker /> - Describe Value', () => {
       }
 
       if (isOpened) {
-        await user.click(
+        fireEvent.click(
           screen.getAllByRole('gridcell', {
             name: adapterToUse.getDate(newValue[setEndDate ? 1 : 0]).toString(),
           })[0],
         );
       } else {
-        await selectSection('day');
-        await pressKey('ArrowUp');
+        selectSection('day');
+        pressKey(undefined, 'ArrowUp');
       }
 
       return newValue;

--- a/packages/x-date-pickers-pro/src/DesktopDateRangePicker/tests/keepOpenDuringFieldFocus.clickFieldDoesNotClose.DesktopDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateRangePicker/tests/keepOpenDuringFieldFocus.clickFieldDoesNotClose.DesktopDateRangePicker.test.tsx
@@ -1,7 +1,11 @@
 import { screen } from '@mui/internal-test-utils';
 import { DesktopDateRangePicker } from '@mui/x-date-pickers-pro/DesktopDateRangePicker';
 import { MultiInputDateRangeField } from '@mui/x-date-pickers-pro/MultiInputDateRangeField';
-import { createPickerRenderer, getFieldSectionsContainer, openPicker } from 'test/utils/pickers';
+import {
+  createPickerRenderer,
+  getFieldSectionsContainer,
+  openPickerAsync,
+} from 'test/utils/pickers';
 
 describe('DesktopDateRangePicker keepOpenDuringFieldFocus - clicking field should not close', () => {
   const { render } = createPickerRenderer();
@@ -9,7 +13,7 @@ describe('DesktopDateRangePicker keepOpenDuringFieldFocus - clicking field shoul
   it('keeps popper open when clicking back into the field (single input)', async () => {
     const { user } = render(<DesktopDateRangePicker keepOpenDuringFieldFocus />);
 
-    await openPicker(user, {
+    await openPickerAsync(user, {
       type: 'date-range',
       fieldType: 'single-input',
       initialFocus: 'start',
@@ -31,7 +35,7 @@ describe('DesktopDateRangePicker keepOpenDuringFieldFocus - clicking field shoul
       />,
     );
 
-    await openPicker(user, {
+    await openPickerAsync(user, {
       type: 'date-range',
       fieldType: 'multi-input',
       initialFocus: 'start',
@@ -48,7 +52,7 @@ describe('DesktopDateRangePicker keepOpenDuringFieldFocus - clicking field shoul
   it('after selecting a start date (single input), clicking the field focuses it and keeps popper open', async () => {
     const { user } = render(<DesktopDateRangePicker keepOpenDuringFieldFocus />);
 
-    await openPicker(user, {
+    await openPickerAsync(user, {
       type: 'date-range',
       fieldType: 'single-input',
       initialFocus: 'start',

--- a/packages/x-date-pickers-pro/src/DesktopDateTimeRangePicker/tests/DesktopDateTimeRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateTimeRangePicker/tests/DesktopDateTimeRangePicker.test.tsx
@@ -2,7 +2,7 @@ import { screen } from '@mui/internal-test-utils';
 import {
   createPickerRenderer,
   adapterToUse,
-  openPicker,
+  openPickerAsync,
   getFieldSectionsContainer,
   expectFieldValue,
 } from 'test/utils/pickers';
@@ -24,7 +24,7 @@ describe('<DesktopDateTimeRangePicker />', () => {
     it('should allow to select range within the same day', async () => {
       const { user } = render(<DesktopDateTimeRangePicker />);
 
-      await openPicker(user, {
+      await openPickerAsync(user, {
         type: 'date-time-range',
         initialFocus: 'start',
         fieldType: 'single-input',
@@ -52,7 +52,7 @@ describe('<DesktopDateTimeRangePicker />', () => {
         <DesktopDateTimeRangePicker referenceDate={adapterToUse.date('2022-04-14T14:15:00')} />,
       );
 
-      await openPicker(user, {
+      await openPickerAsync(user, {
         type: 'date-time-range',
         initialFocus: 'start',
         fieldType: 'single-input',
@@ -70,7 +70,7 @@ describe('<DesktopDateTimeRangePicker />', () => {
     it('should cycle focused views among the visible step after selection', async () => {
       const { user } = render(<DesktopDateTimeRangePicker />);
 
-      await openPicker(user, {
+      await openPickerAsync(user, {
         type: 'date-time-range',
         initialFocus: 'start',
         fieldType: 'single-input',
@@ -104,7 +104,7 @@ describe('<DesktopDateTimeRangePicker />', () => {
         />,
       );
 
-      await openPicker(user, {
+      await openPickerAsync(user, {
         type: 'date-time-range',
         initialFocus: 'start',
         fieldType: 'single-input',

--- a/packages/x-date-pickers-pro/src/DesktopDateTimeRangePicker/tests/describeValue.DesktopDateTimeRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateTimeRangePicker/tests/describeValue.DesktopDateTimeRangePicker.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@mui/internal-test-utils';
+import { fireEvent, screen } from '@mui/internal-test-utils';
 import { PickerNonNullableRangeValue, PickerRangeValue } from '@mui/x-date-pickers/internals';
 import {
   createPickerRenderer,
@@ -57,9 +57,9 @@ describe('<DesktopDateTimeRangePicker /> - Describe Value', () => {
         : expectedPlaceholder;
       expectFieldValue(endSectionsContainer, expectedEndValueStr);
     },
-    setNewValue: async (
+    setNewValue: (
       value,
-      { isOpened, applySameValue, setEndDate = false, selectSection, pressKey, user },
+      { isOpened, applySameValue, setEndDate = false, selectSection, pressKey },
     ) => {
       let newValue: PickerNonNullableRangeValue;
       if (applySameValue) {
@@ -79,10 +79,10 @@ describe('<DesktopDateTimeRangePicker /> - Describe Value', () => {
         const nextButton = screen.queryByRole('button', { name: 'Next' });
         // if we want to set the end date, we firstly need to switch to end date "range position"
         if (setEndDate && nextButton) {
-          await user.click(nextButton);
+          fireEvent.click(nextButton);
         }
 
-        await user.click(
+        fireEvent.click(
           screen.getByRole('gridcell', {
             name: adapterToUse.getDate(newValue[setEndDate ? 1 : 0]).toString(),
           }),
@@ -93,42 +93,41 @@ describe('<DesktopDateTimeRangePicker /> - Describe Value', () => {
           hasMeridiem ? 'hours12h' : 'hours24h',
         );
         const hoursNumber = adapterToUse.getHours(newValue[setEndDate ? 1 : 0]);
-        await user.click(screen.getByRole('option', { name: `${parseInt(hours, 10)} hours` }));
-        await user.click(
+        fireEvent.click(screen.getByRole('option', { name: `${parseInt(hours, 10)} hours` }));
+        fireEvent.click(
           screen.getByRole('option', {
             name: `${adapterToUse.getMinutes(newValue[setEndDate ? 1 : 0])} minutes`,
           }),
         );
         if (hasMeridiem) {
-          await user.click(screen.getByRole('option', { name: hoursNumber >= 12 ? 'PM' : 'AM' }));
+          fireEvent.click(screen.getByRole('option', { name: hoursNumber >= 12 ? 'PM' : 'AM' }));
         }
         if (setEndDate) {
           // Switch back to start date "range position" in case we'd need to repeat selection
           let previousViewButton = screen.queryByRole('button', { name: 'Open previous view' });
           while (previousViewButton) {
-            // eslint-disable-next-line no-await-in-loop
-            await user.click(previousViewButton);
+            fireEvent.click(previousViewButton);
             previousViewButton = screen.queryByRole('button', { name: 'Open previous view' });
           }
         }
       } else {
-        await selectSection('day');
-        await pressKey('ArrowUp');
+        selectSection('day');
+        pressKey(undefined, 'ArrowUp');
 
-        await selectSection('hours');
-        await pressKey('ArrowUp');
+        selectSection('hours');
+        pressKey(undefined, 'ArrowUp');
 
-        await selectSection('minutes');
-        await pressKey('PageUp'); // increment by 5 minutes
+        selectSection('minutes');
+        pressKey(undefined, 'PageUp'); // increment by 5 minutes
 
         const hasMeridiem = adapterToUse.is12HourCycleInCurrentLocale();
         if (hasMeridiem) {
-          await selectSection('meridiem');
+          selectSection('meridiem');
           const previousHours = adapterToUse.getHours(value[setEndDate ? 1 : 0]);
           const newHours = adapterToUse.getHours(newValue[setEndDate ? 1 : 0]);
           // update meridiem section if it changed
           if ((previousHours < 12 && newHours >= 12) || (previousHours >= 12 && newHours < 12)) {
-            await pressKey('ArrowUp');
+            pressKey(undefined, 'ArrowUp');
           }
         }
       }

--- a/packages/x-date-pickers-pro/src/DesktopTimeRangePicker/tests/DesktopTimeRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopTimeRangePicker/tests/DesktopTimeRangePicker.test.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@mui/internal-test-utils';
-import { createPickerRenderer, adapterToUse, openPicker } from 'test/utils/pickers';
+import { createPickerRenderer, adapterToUse, openPickerAsync } from 'test/utils/pickers';
 import { vi } from 'vitest';
 import { DesktopTimeRangePicker } from '@mui/x-date-pickers-pro/DesktopTimeRangePicker';
 
@@ -25,7 +25,7 @@ describe('<DesktopTimeRangePicker />', () => {
         />,
       );
 
-      await openPicker(user, {
+      await openPickerAsync(user, {
         type: 'time-range',
         initialFocus: 'start',
         fieldType: 'single-input',

--- a/packages/x-date-pickers-pro/src/DesktopTimeRangePicker/tests/describeValueMultiInput.DesktopTimeRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopTimeRangePicker/tests/describeValueMultiInput.DesktopTimeRangePicker.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@mui/internal-test-utils';
+import { fireEvent, screen } from '@mui/internal-test-utils';
 import { PickerNonNullableRangeValue, PickerRangeValue } from '@mui/x-date-pickers/internals';
 import {
   createPickerRenderer,
@@ -51,9 +51,9 @@ describe('<DesktopTimeRangePicker /> - Describe Value Multi Input', () => {
         : expectedPlaceholder;
       expectFieldValue(endSectionsContainer, expectedEndValueStr);
     },
-    setNewValue: async (
+    setNewValue: (
       value,
-      { isOpened, applySameValue, setEndDate = false, selectSection, pressKey, user },
+      { isOpened, applySameValue, setEndDate = false, selectSection, pressKey },
     ) => {
       let newValue: PickerNonNullableRangeValue;
       if (applySameValue) {
@@ -67,7 +67,7 @@ describe('<DesktopTimeRangePicker /> - Describe Value Multi Input', () => {
         const nextButton = screen.queryByRole('button', { name: 'Next' });
         // if we want to set the end date, we firstly need to switch to end date "range position"
         if (setEndDate && nextButton) {
-          await user.click(nextButton);
+          fireEvent.click(nextButton);
         }
 
         const hasMeridiem = adapterToUse.is12HourCycleInCurrentLocale();
@@ -76,34 +76,34 @@ describe('<DesktopTimeRangePicker /> - Describe Value Multi Input', () => {
           hasMeridiem ? 'hours12h' : 'hours24h',
         );
         const hoursNumber = adapterToUse.getHours(newValue[setEndDate ? 1 : 0]);
-        await user.click(screen.getByRole('option', { name: `${parseInt(hours, 10)} hours` }));
-        await user.click(
+        fireEvent.click(screen.getByRole('option', { name: `${parseInt(hours, 10)} hours` }));
+        fireEvent.click(
           screen.getByRole('option', {
             name: `${adapterToUse.getMinutes(newValue[setEndDate ? 1 : 0])} minutes`,
           }),
         );
         if (hasMeridiem) {
-          await user.click(screen.getByRole('option', { name: hoursNumber >= 12 ? 'PM' : 'AM' }));
+          fireEvent.click(screen.getByRole('option', { name: hoursNumber >= 12 ? 'PM' : 'AM' }));
         }
         if (setEndDate) {
           // Switch back to start date "range position" in case we'd need to repeat selection
-          await user.click(screen.getByRole('tab', { name: 'Start' }));
+          fireEvent.click(screen.getByRole('tab', { name: 'Start' }));
         }
       } else {
-        await selectSection('hours');
-        await pressKey('ArrowUp');
+        selectSection('hours');
+        pressKey(undefined, 'ArrowUp');
 
-        await selectSection('minutes');
-        await pressKey('PageUp'); // increment by 5 minutes
+        selectSection('minutes');
+        pressKey(undefined, 'PageUp'); // increment by 5 minutes
 
         const hasMeridiem = adapterToUse.is12HourCycleInCurrentLocale();
         if (hasMeridiem) {
-          await selectSection('meridiem');
+          selectSection('meridiem');
           const previousHours = adapterToUse.getHours(value[setEndDate ? 1 : 0]);
           const newHours = adapterToUse.getHours(newValue[setEndDate ? 1 : 0]);
           // update meridiem section if it changed
           if ((previousHours < 12 && newHours >= 12) || (previousHours >= 12 && newHours < 12)) {
-            await pressKey('ArrowUp');
+            pressKey(undefined, 'ArrowUp');
           }
         }
       }

--- a/packages/x-date-pickers-pro/src/DesktopTimeRangePicker/tests/describeValueSingleInput.DesktopTimeRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopTimeRangePicker/tests/describeValueSingleInput.DesktopTimeRangePicker.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@mui/internal-test-utils';
+import { fireEvent, screen } from '@mui/internal-test-utils';
 import { PickerNonNullableRangeValue, PickerRangeValue } from '@mui/x-date-pickers/internals';
 import {
   createPickerRenderer,
@@ -50,9 +50,9 @@ describe('<DesktopTimeRangePicker /> - Describe Value Single Input', () => {
 
       expectFieldValue(fieldRoot, expectedValueStr);
     },
-    setNewValue: async (
+    setNewValue: (
       value,
-      { isOpened, applySameValue, setEndDate = false, selectSection, pressKey, user },
+      { isOpened, applySameValue, setEndDate = false, selectSection, pressKey },
     ) => {
       let newValue: PickerNonNullableRangeValue;
       if (applySameValue) {
@@ -66,7 +66,7 @@ describe('<DesktopTimeRangePicker /> - Describe Value Single Input', () => {
         const nextButton = screen.queryByRole('button', { name: 'Next' });
         // if we want to set the end date, we firstly need to switch to end date "range position"
         if (setEndDate && nextButton) {
-          await user.click(nextButton);
+          fireEvent.click(nextButton);
         }
 
         const hasMeridiem = adapterToUse.is12HourCycleInCurrentLocale();
@@ -75,34 +75,34 @@ describe('<DesktopTimeRangePicker /> - Describe Value Single Input', () => {
           hasMeridiem ? 'hours12h' : 'hours24h',
         );
         const hoursNumber = adapterToUse.getHours(newValue[setEndDate ? 1 : 0]);
-        await user.click(screen.getByRole('option', { name: `${parseInt(hours, 10)} hours` }));
-        await user.click(
+        fireEvent.click(screen.getByRole('option', { name: `${parseInt(hours, 10)} hours` }));
+        fireEvent.click(
           screen.getByRole('option', {
             name: `${adapterToUse.getMinutes(newValue[setEndDate ? 1 : 0])} minutes`,
           }),
         );
         if (hasMeridiem) {
-          await user.click(screen.getByRole('option', { name: hoursNumber >= 12 ? 'PM' : 'AM' }));
+          fireEvent.click(screen.getByRole('option', { name: hoursNumber >= 12 ? 'PM' : 'AM' }));
         }
         if (setEndDate) {
           // Switch back to start date "range position" in case we'd need to repeat selection
-          await user.click(screen.getByRole('tab', { name: 'Start' }));
+          fireEvent.click(screen.getByRole('tab', { name: 'Start' }));
         }
       } else {
-        await selectSection('hours');
-        await pressKey('ArrowUp');
+        selectSection('hours');
+        pressKey(undefined, 'ArrowUp');
 
-        await selectSection('minutes');
-        await pressKey('PageUp'); // increment by 5 minutes
+        selectSection('minutes');
+        pressKey(undefined, 'PageUp'); // increment by 5 minutes
 
         const hasMeridiem = adapterToUse.is12HourCycleInCurrentLocale();
         if (hasMeridiem) {
-          await selectSection('meridiem');
+          selectSection('meridiem');
           const previousHours = adapterToUse.getHours(value[setEndDate ? 1 : 0]);
           const newHours = adapterToUse.getHours(newValue[setEndDate ? 1 : 0]);
           // update meridiem section if it changed
           if ((previousHours < 12 && newHours >= 12) || (previousHours >= 12 && newHours < 12)) {
-            await pressKey('ArrowUp');
+            pressKey(undefined, 'ArrowUp');
           }
         }
       }

--- a/packages/x-date-pickers-pro/src/MobileDateRangePicker/tests/MobileDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/MobileDateRangePicker/tests/MobileDateRangePicker.test.tsx
@@ -5,6 +5,7 @@ import {
   createPickerRenderer,
   adapterToUse,
   openPicker,
+  openPickerAsync,
   getFieldSectionsContainer,
 } from 'test/utils/pickers';
 import { DateRange } from '@mui/x-date-pickers-pro/models';
@@ -30,7 +31,7 @@ describe('<MobileDateRangePicker />', () => {
         <MobileDateRangePicker onOpen={onOpen} slots={{ field: MultiInputDateRangeField }} />,
       );
 
-      await openPicker(user, {
+      await openPickerAsync(user, {
         type: 'date-range',
         initialFocus: 'start',
         fieldType: 'multi-input',
@@ -47,7 +48,7 @@ describe('<MobileDateRangePicker />', () => {
         <MobileDateRangePicker onOpen={onOpen} slots={{ field: MultiInputDateRangeField }} />,
       );
 
-      await openPicker(user, {
+      await openPickerAsync(user, {
         type: 'date-range',
         initialFocus: 'end',
         fieldType: 'multi-input',
@@ -76,7 +77,7 @@ describe('<MobileDateRangePicker />', () => {
       );
 
       // Open the picker
-      await openPicker(user, {
+      await openPickerAsync(user, {
         type: 'date-range',
         initialFocus: 'start',
         fieldType: 'single-input',
@@ -86,13 +87,13 @@ describe('<MobileDateRangePicker />', () => {
       expect(onClose.callCount).to.equal(0);
 
       // Change the start date
-      await user.click(screen.getByRole('gridcell', { name: '3' }));
+      fireEvent.click(screen.getByRole('gridcell', { name: '3' }));
       expect(onChange.callCount).to.equal(1);
       expect(onChange.lastCall.args[0][0]).toEqualDateTime(new Date(2018, 0, 3));
       expect(onChange.lastCall.args[0][1]).toEqualDateTime(defaultValue[1]);
 
       // Change the end date
-      await user.click(screen.getByRole('gridcell', { name: '5' }));
+      fireEvent.click(screen.getByRole('gridcell', { name: '5' }));
       expect(onChange.callCount).to.equal(2);
       expect(onChange.lastCall.args[0][0]).toEqualDateTime(new Date(2018, 0, 3));
       expect(onChange.lastCall.args[0][1]).toEqualDateTime(new Date(2018, 0, 5));
@@ -121,7 +122,7 @@ describe('<MobileDateRangePicker />', () => {
       );
 
       // Open the picker
-      await openPicker(user, {
+      await openPickerAsync(user, {
         type: 'date-range',
         initialFocus: 'end',
         fieldType: 'multi-input',
@@ -131,7 +132,7 @@ describe('<MobileDateRangePicker />', () => {
       expect(onClose.callCount).to.equal(0);
 
       // Change the end date
-      await user.click(screen.getByRole('gridcell', { name: '3' }));
+      fireEvent.click(screen.getByRole('gridcell', { name: '3' }));
       expect(onChange.callCount).to.equal(1);
       expect(onChange.lastCall.args[0][0]).toEqualDateTime(defaultValue[0]);
       expect(onChange.lastCall.args[0][1]).toEqualDateTime(new Date(2018, 0, 3));
@@ -139,7 +140,7 @@ describe('<MobileDateRangePicker />', () => {
       expect(onClose.callCount).to.equal(0);
     });
 
-    it('should call onClose and onAccept when selecting the end date if props.closeOnSelect = true (multi input field)', async () => {
+    it('should call onClose and onAccept when selecting the end date if props.closeOnSelect = true (multi input field)', () => {
       const onAccept = spy();
       const onClose = spy();
       const defaultValue: DateRange<PickerValidDate> = [
@@ -147,7 +148,7 @@ describe('<MobileDateRangePicker />', () => {
         adapterToUse.date('2018-01-06'),
       ];
 
-      const { user } = render(
+      render(
         <MobileDateRangePicker
           onAccept={onAccept}
           onClose={onClose}
@@ -157,14 +158,10 @@ describe('<MobileDateRangePicker />', () => {
         />,
       );
 
-      await openPicker(user, {
-        type: 'date-range',
-        initialFocus: 'end',
-        fieldType: 'multi-input',
-      });
+      openPicker({ type: 'date-range', initialFocus: 'end', fieldType: 'multi-input' });
 
       // Change the end date
-      await user.click(screen.getByRole('gridcell', { name: '3' }));
+      fireEvent.click(screen.getByRole('gridcell', { name: '3' }));
 
       expect(onAccept.callCount).to.equal(1);
       expect(onAccept.lastCall.args[0][0]).toEqualDateTime(defaultValue[0]);
@@ -172,7 +169,7 @@ describe('<MobileDateRangePicker />', () => {
       expect(onClose.callCount).to.equal(1);
     });
 
-    it('should call onClose and onChange with the initial value when clicking "Cancel" button', async () => {
+    it('should call onClose and onChange with the initial value when clicking "Cancel" button', () => {
       const onChange = spy();
       const onAccept = spy();
       const onClose = spy();
@@ -181,7 +178,7 @@ describe('<MobileDateRangePicker />', () => {
         adapterToUse.date('2018-01-06'),
       ];
 
-      const { user } = render(
+      render(
         <MobileDateRangePicker
           onChange={onChange}
           onAccept={onAccept}
@@ -191,17 +188,13 @@ describe('<MobileDateRangePicker />', () => {
         />,
       );
 
-      await openPicker(user, {
-        type: 'date-range',
-        initialFocus: 'start',
-        fieldType: 'single-input',
-      });
+      openPicker({ type: 'date-range', initialFocus: 'start', fieldType: 'single-input' });
 
       // Change the start date (already tested)
-      await user.click(screen.getByRole('gridcell', { name: '3' }));
+      fireEvent.click(screen.getByRole('gridcell', { name: '3' }));
 
       // Cancel the modifications
-      await user.click(screen.getByText(/cancel/i));
+      fireEvent.click(screen.getByText(/cancel/i));
       expect(onChange.callCount).to.equal(2); // Start date change + reset
       expect(onChange.lastCall.args[0][0]).toEqualDateTime(defaultValue[0]);
       expect(onChange.lastCall.args[0][1]).toEqualDateTime(defaultValue[1]);
@@ -209,7 +202,7 @@ describe('<MobileDateRangePicker />', () => {
       expect(onClose.callCount).to.equal(1);
     });
 
-    it('should call onClose and onAccept with the live value and onAccept with the live value when clicking the "OK"', async () => {
+    it('should call onClose and onAccept with the live value and onAccept with the live value when clicking the "OK"', () => {
       const onChange = spy();
       const onAccept = spy();
       const onClose = spy();
@@ -218,7 +211,7 @@ describe('<MobileDateRangePicker />', () => {
         adapterToUse.date('2018-01-06'),
       ];
 
-      const { user } = render(
+      render(
         <MobileDateRangePicker
           onChange={onChange}
           onAccept={onAccept}
@@ -227,17 +220,13 @@ describe('<MobileDateRangePicker />', () => {
         />,
       );
 
-      await openPicker(user, {
-        type: 'date-range',
-        initialFocus: 'start',
-        fieldType: 'single-input',
-      });
+      openPicker({ type: 'date-range', initialFocus: 'start', fieldType: 'single-input' });
 
       // Change the start date (already tested)
-      await user.click(screen.getByRole('gridcell', { name: '3' }));
+      fireEvent.click(screen.getByRole('gridcell', { name: '3' }));
 
       // Accept the modifications
-      await user.click(screen.getByText(/ok/i));
+      fireEvent.click(screen.getByText(/ok/i));
       expect(onChange.callCount).to.equal(1); // Start date change
       expect(onAccept.callCount).to.equal(1);
       expect(onAccept.lastCall.args[0][0]).toEqualDateTime(new Date(2018, 0, 3));
@@ -245,7 +234,7 @@ describe('<MobileDateRangePicker />', () => {
       expect(onClose.callCount).to.equal(1);
     });
 
-    it('should call onClose, onChange with empty value and onAccept with empty value when pressing the "Clear" button', async () => {
+    it('should call onClose, onChange with empty value and onAccept with empty value when pressing the "Clear" button', () => {
       const onChange = spy();
       const onAccept = spy();
       const onClose = spy();
@@ -254,7 +243,7 @@ describe('<MobileDateRangePicker />', () => {
         adapterToUse.date('2018-01-06'),
       ];
 
-      const { user } = render(
+      render(
         <MobileDateRangePicker
           onChange={onChange}
           onAccept={onAccept}
@@ -264,14 +253,10 @@ describe('<MobileDateRangePicker />', () => {
         />,
       );
 
-      await openPicker(user, {
-        type: 'date-range',
-        initialFocus: 'start',
-        fieldType: 'single-input',
-      });
+      openPicker({ type: 'date-range', initialFocus: 'start', fieldType: 'single-input' });
 
       // Clear the date
-      await user.click(screen.getByText(/clear/i));
+      fireEvent.click(screen.getByText(/clear/i));
       expect(onChange.callCount).to.equal(1); // Start date change
       expect(onChange.lastCall.args[0]).to.deep.equal([null, null]);
       expect(onAccept.callCount).to.equal(1);
@@ -279,12 +264,12 @@ describe('<MobileDateRangePicker />', () => {
       expect(onClose.callCount).to.equal(1);
     });
 
-    it('should not call onChange or onAccept when pressing "Clear" button with an already null value', async () => {
+    it('should not call onChange or onAccept when pressing "Clear" button with an already null value', () => {
       const onChange = spy();
       const onAccept = spy();
       const onClose = spy();
 
-      const { user } = render(
+      render(
         <MobileDateRangePicker
           onChange={onChange}
           onAccept={onAccept}
@@ -294,14 +279,10 @@ describe('<MobileDateRangePicker />', () => {
         />,
       );
 
-      await openPicker(user, {
-        type: 'date-range',
-        initialFocus: 'start',
-        fieldType: 'single-input',
-      });
+      openPicker({ type: 'date-range', initialFocus: 'start', fieldType: 'single-input' });
 
       // Clear the date
-      await user.click(screen.getByText(/clear/i));
+      fireEvent.click(screen.getByText(/clear/i));
       expect(onChange.callCount).to.equal(0);
       expect(onAccept.callCount).to.equal(0);
       expect(onClose.callCount).to.equal(1);
@@ -317,8 +298,8 @@ describe('<MobileDateRangePicker />', () => {
     });
   });
 
-  it('should ignore "currentMonthCalendarPosition" prop value and have expected selection behavior', async () => {
-    const { user } = render(
+  it('should ignore "currentMonthCalendarPosition" prop value and have expected selection behavior', () => {
+    render(
       <MobileDateRangePicker
         currentMonthCalendarPosition={2}
         open
@@ -326,8 +307,8 @@ describe('<MobileDateRangePicker />', () => {
       />,
     );
 
-    await user.click(screen.getByRole('gridcell', { name: '3' }));
-    await user.click(screen.getByRole('gridcell', { name: '5' }));
+    fireEvent.click(screen.getByRole('gridcell', { name: '3' }));
+    fireEvent.click(screen.getByRole('gridcell', { name: '5' }));
 
     expect(screen.getByText('Apr 3')).not.to.equal(null);
     expect(screen.getByText('Apr 5')).not.to.equal(null);

--- a/packages/x-date-pickers-pro/src/MobileDateRangePicker/tests/describeValue.MobileDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/MobileDateRangePicker/tests/describeValue.MobileDateRangePicker.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@mui/internal-test-utils';
+import { screen, fireEvent } from '@mui/internal-test-utils';
 import { MobileDateRangePicker } from '@mui/x-date-pickers-pro/MobileDateRangePicker';
 import { PickerNonNullableRangeValue, PickerRangeValue } from '@mui/x-date-pickers/internals';
 import {
@@ -45,7 +45,7 @@ describe('<MobileDateRangePicker /> - Describes', () => {
         : 'MM/DD/YYYY';
       expectFieldValue(endFieldRoot, expectedEndValueStr);
     },
-    setNewValue: async (value, { isOpened, applySameValue, setEndDate = false, user }) => {
+    setNewValue: (value, { isOpened, applySameValue, setEndDate = false }) => {
       let newValue: PickerNonNullableRangeValue;
       if (applySameValue) {
         newValue = value;
@@ -56,14 +56,10 @@ describe('<MobileDateRangePicker /> - Describes', () => {
       }
 
       if (!isOpened) {
-        await openPicker(user, {
-          type: 'date-range',
-          initialFocus: 'start',
-          fieldType: 'multi-input',
-        });
+        openPicker({ type: 'date-range', initialFocus: 'start', fieldType: 'multi-input' });
       }
 
-      await user.click(
+      fireEvent.click(
         screen.getByRole('gridcell', {
           name: adapterToUse.getDate(newValue[setEndDate ? 1 : 0]).toString(),
         }),
@@ -71,7 +67,8 @@ describe('<MobileDateRangePicker /> - Describes', () => {
 
       // Close the picker
       if (!isOpened) {
-        await user.keyboard('{Escape}');
+        // eslint-disable-next-line mui/disallow-active-element-as-key-event-target
+        fireEvent.keyDown(document.activeElement!, { key: 'Escape' });
       }
 
       return newValue;
@@ -108,9 +105,9 @@ describe('<MobileDateRangePicker /> - Describes', () => {
 
       expectFieldValue(fieldRoot, expectedValueStr);
     },
-    setNewValue: async (
+    setNewValue: (
       value,
-      { isOpened, applySameValue, setEndDate = false, selectSection, pressKey, user },
+      { isOpened, applySameValue, setEndDate = false, selectSection, pressKey },
     ) => {
       let newValue: PickerNonNullableRangeValue;
       if (applySameValue) {
@@ -122,14 +119,14 @@ describe('<MobileDateRangePicker /> - Describes', () => {
       }
 
       if (isOpened) {
-        await user.click(
+        fireEvent.click(
           screen.getAllByRole('gridcell', {
             name: adapterToUse.getDate(newValue[setEndDate ? 1 : 0]).toString(),
           })[0],
         );
       } else {
-        await selectSection('day');
-        await pressKey('ArrowUp');
+        selectSection('day');
+        pressKey(undefined, 'ArrowUp');
       }
 
       return newValue;

--- a/packages/x-date-pickers-pro/src/MobileDateTimeRangePicker/tests/MobileDateTimeRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/MobileDateTimeRangePicker/tests/MobileDateTimeRangePicker.test.tsx
@@ -1,7 +1,7 @@
 import { screen } from '@mui/internal-test-utils';
 import {
   createPickerRenderer,
-  openPicker,
+  openPickerAsync,
   getFieldSectionsContainer,
   expectFieldValue,
 } from 'test/utils/pickers';
@@ -23,7 +23,7 @@ describe('<MobileDateTimeRangePicker />', () => {
     it('should cycle focused views among the visible step after selection', async () => {
       const { user } = render(<MobileDateTimeRangePicker />);
 
-      await openPicker(user, {
+      await openPickerAsync(user, {
         type: 'date-time-range',
         initialFocus: 'start',
         fieldType: 'single-input',

--- a/packages/x-date-pickers-pro/src/MobileDateTimeRangePicker/tests/describeValueMultiInput.MobileDateTimeRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/MobileDateTimeRangePicker/tests/describeValueMultiInput.MobileDateTimeRangePicker.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@mui/internal-test-utils';
+import { fireEvent, screen } from '@mui/internal-test-utils';
 import { PickerNonNullableRangeValue, PickerRangeValue } from '@mui/x-date-pickers/internals';
 import {
   createPickerRenderer,
@@ -53,9 +53,9 @@ describe('<MobileDateTimeRangePicker /> - Describe Value Multi Input', () => {
         : expectedPlaceholder;
       expectFieldValue(endSectionsContainer, expectedEndValueStr);
     },
-    setNewValue: async (value, { isOpened, applySameValue, setEndDate = false, user }) => {
+    setNewValue: (value, { isOpened, applySameValue, setEndDate = false }) => {
       if (!isOpened) {
-        await openPicker(user, {
+        openPicker({
           type: 'date-time-range',
           initialFocus: setEndDate ? 'end' : 'start',
           fieldType: 'multi-input',
@@ -77,19 +77,19 @@ describe('<MobileDateTimeRangePicker /> - Describe Value Multi Input', () => {
       }
 
       // Go to the start date or the end date
-      await user.click(
+      fireEvent.click(
         screen.getByRole('button', {
           name: adapterToUse.format(value[setEndDate ? 1 : 0], 'shortDate'),
         }),
       );
 
-      await user.click(
+      fireEvent.click(
         screen.getByRole('gridcell', {
           name: adapterToUse.getDate(newValue[setEndDate ? 1 : 0]).toString(),
         }),
       );
 
-      await user.click(screen.getByRole('button', { name: 'Next' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Next' }));
 
       const hasMeridiem = adapterToUse.is12HourCycleInCurrentLocale();
       const hours = adapterToUse.format(
@@ -97,21 +97,22 @@ describe('<MobileDateTimeRangePicker /> - Describe Value Multi Input', () => {
         hasMeridiem ? 'hours12h' : 'hours24h',
       );
       const hoursNumber = adapterToUse.getHours(newValue[setEndDate ? 1 : 0]);
-      await user.click(screen.getByRole('option', { name: `${parseInt(hours, 10)} hours` }));
-      await user.click(
+      fireEvent.click(screen.getByRole('option', { name: `${parseInt(hours, 10)} hours` }));
+      fireEvent.click(
         screen.getByRole('option', {
           name: `${adapterToUse.getMinutes(newValue[setEndDate ? 1 : 0])} minutes`,
         }),
       );
       if (hasMeridiem) {
-        await user.click(screen.getByRole('option', { name: hoursNumber >= 12 ? 'PM' : 'AM' }));
+        fireEvent.click(screen.getByRole('option', { name: hoursNumber >= 12 ? 'PM' : 'AM' }));
       }
       // Close the picker
       if (!isOpened) {
-        await user.keyboard('{Escape}');
+        // eslint-disable-next-line mui/disallow-active-element-as-key-event-target
+        fireEvent.keyDown(document.activeElement!, { key: 'Escape' });
       } else {
         // return to the start date view in case we'd like to repeat the selection process
-        await user.click(
+        fireEvent.click(
           screen.getByRole('button', { name: adapterToUse.format(newValue[0], 'shortDate') }),
         );
       }

--- a/packages/x-date-pickers-pro/src/MobileDateTimeRangePicker/tests/describeValueSingleInput.MobileDateTimeRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/MobileDateTimeRangePicker/tests/describeValueSingleInput.MobileDateTimeRangePicker.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@mui/internal-test-utils';
+import { fireEvent, screen } from '@mui/internal-test-utils';
 import { PickerNonNullableRangeValue, PickerRangeValue } from '@mui/x-date-pickers/internals';
 import {
   createPickerRenderer,
@@ -50,12 +50,9 @@ describe('<MobileDateTimeRangePicker /> - Describe Value Single Input', () => {
 
       expectFieldValue(fieldRoot, expectedValueStr);
     },
-    setNewValue: async (
-      value,
-      { isOpened, applySameValue, setEndDate = false, closeMobilePicker, user },
-    ) => {
+    setNewValue: (value, { isOpened, applySameValue, setEndDate = false, closeMobilePicker }) => {
       if (!isOpened) {
-        await openPicker(user, {
+        openPicker({
           type: 'date-time-range',
           initialFocus: setEndDate ? 'end' : 'start',
           fieldType: 'single-input',
@@ -78,19 +75,19 @@ describe('<MobileDateTimeRangePicker /> - Describe Value Single Input', () => {
       }
 
       // Go to the start date or the end date
-      await user.click(
+      fireEvent.click(
         screen.getByRole('button', {
           name: adapterToUse.format(value[setEndDate ? 1 : 0], 'shortDate'),
         }),
       );
 
-      await user.click(
+      fireEvent.click(
         screen.getByRole('gridcell', {
           name: adapterToUse.getDate(newValue[setEndDate ? 1 : 0]).toString(),
         }),
       );
 
-      await user.click(screen.getByRole('button', { name: 'Next' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Next' }));
 
       const hasMeridiem = adapterToUse.is12HourCycleInCurrentLocale();
       const hours = adapterToUse.format(
@@ -98,21 +95,22 @@ describe('<MobileDateTimeRangePicker /> - Describe Value Single Input', () => {
         hasMeridiem ? 'hours12h' : 'hours24h',
       );
       const hoursNumber = adapterToUse.getHours(newValue[setEndDate ? 1 : 0]);
-      await user.click(screen.getByRole('option', { name: `${parseInt(hours, 10)} hours` }));
-      await user.click(
+      fireEvent.click(screen.getByRole('option', { name: `${parseInt(hours, 10)} hours` }));
+      fireEvent.click(
         screen.getByRole('option', {
           name: `${adapterToUse.getMinutes(newValue[setEndDate ? 1 : 0])} minutes`,
         }),
       );
       if (hasMeridiem) {
-        await user.click(screen.getByRole('option', { name: hoursNumber >= 12 ? 'PM' : 'AM' }));
+        fireEvent.click(screen.getByRole('option', { name: hoursNumber >= 12 ? 'PM' : 'AM' }));
       }
 
       if (closeMobilePicker) {
         if (setEndDate) {
-          await user.click(screen.getByRole('button', { name: /ok/i }));
+          fireEvent.click(screen.getByRole('button', { name: /ok/i }));
         } else {
-          await user.keyboard('{Escape}');
+          // eslint-disable-next-line mui/disallow-active-element-as-key-event-target
+          fireEvent.keyDown(document.activeElement!, { key: 'Escape' });
         }
       }
 

--- a/packages/x-date-pickers-pro/src/MobileTimeRangePicker/tests/describeValueMultiInput.MobileTimeRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/MobileTimeRangePicker/tests/describeValueMultiInput.MobileTimeRangePicker.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@mui/internal-test-utils';
+import { fireEvent, screen } from '@mui/internal-test-utils';
 import { PickerNonNullableRangeValue, PickerRangeValue } from '@mui/x-date-pickers/internals';
 import {
   createPickerRenderer,
@@ -47,9 +47,9 @@ describe('<MobileTimeRangePicker /> - Describe Value Multi Input', () => {
         : expectedPlaceholder;
       expectFieldValue(endSectionsContainer, expectedEndValueStr);
     },
-    setNewValue: async (value, { isOpened, applySameValue, setEndDate = false, user }) => {
+    setNewValue: (value, { isOpened, applySameValue, setEndDate = false }) => {
       if (!isOpened) {
-        await openPicker(user, {
+        openPicker({
           type: 'time-range',
           initialFocus: setEndDate ? 'end' : 'start',
           fieldType: 'multi-input',
@@ -65,7 +65,7 @@ describe('<MobileTimeRangePicker /> - Describe Value Multi Input', () => {
       }
 
       // Go to the start date or the end date
-      await user.click(screen.getByRole('tab', { name: setEndDate ? 'End' : 'Start' }));
+      fireEvent.click(screen.getByRole('tab', { name: setEndDate ? 'End' : 'Start' }));
 
       const hasMeridiem = adapterToUse.is12HourCycleInCurrentLocale();
       const hours = adapterToUse.format(
@@ -73,24 +73,25 @@ describe('<MobileTimeRangePicker /> - Describe Value Multi Input', () => {
         hasMeridiem ? 'hours12h' : 'hours24h',
       );
       const hoursNumber = adapterToUse.getHours(newValue[setEndDate ? 1 : 0]);
-      await user.click(screen.getByRole('option', { name: `${parseInt(hours, 10)} hours` }));
-      await user.click(
+      fireEvent.click(screen.getByRole('option', { name: `${parseInt(hours, 10)} hours` }));
+      fireEvent.click(
         screen.getByRole('option', {
           name: `${adapterToUse.getMinutes(newValue[setEndDate ? 1 : 0])} minutes`,
         }),
       );
       if (hasMeridiem) {
-        await user.click(screen.getByRole('option', { name: hoursNumber >= 12 ? 'PM' : 'AM' }));
+        fireEvent.click(screen.getByRole('option', { name: hoursNumber >= 12 ? 'PM' : 'AM' }));
       }
       // Close the picker
       if (!isOpened) {
-        await user.keyboard('{Escape}');
+        // eslint-disable-next-line mui/disallow-active-element-as-key-event-target
+        fireEvent.keyDown(document.activeElement!, { key: 'Escape' });
       } else {
         const toolbarHourButtons = screen.getAllByRole('button', {
           name: adapterToUse.format(newValue[0], hasMeridiem ? 'hours12h' : 'hours24h'),
         });
         // return to the start time view in case we'd like to repeat the selection process
-        await user.click(toolbarHourButtons[0]);
+        fireEvent.click(toolbarHourButtons[0]);
       }
 
       return newValue;

--- a/packages/x-date-pickers-pro/src/MobileTimeRangePicker/tests/describeValueSingleInput.MobileTimeRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/MobileTimeRangePicker/tests/describeValueSingleInput.MobileTimeRangePicker.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@mui/internal-test-utils';
+import { fireEvent, screen } from '@mui/internal-test-utils';
 import { PickerNonNullableRangeValue, PickerRangeValue } from '@mui/x-date-pickers/internals';
 import {
   createPickerRenderer,
@@ -44,12 +44,9 @@ describe('<MobileTimeRangePicker /> - Describe Value Single Input', () => {
 
       expectFieldValue(fieldRoot, expectedValueStr);
     },
-    setNewValue: async (
-      value,
-      { isOpened, applySameValue, setEndDate = false, closeMobilePicker, user },
-    ) => {
+    setNewValue: (value, { isOpened, applySameValue, setEndDate = false, closeMobilePicker }) => {
       if (!isOpened) {
-        await openPicker(user, {
+        openPicker({
           type: 'time-range',
           initialFocus: setEndDate ? 'end' : 'start',
           fieldType: 'single-input',
@@ -66,7 +63,7 @@ describe('<MobileTimeRangePicker /> - Describe Value Single Input', () => {
       }
 
       // Go to the start date or the end date
-      await user.click(screen.getByRole('tab', { name: setEndDate ? 'End' : 'Start' }));
+      fireEvent.click(screen.getByRole('tab', { name: setEndDate ? 'End' : 'Start' }));
 
       const hasMeridiem = adapterToUse.is12HourCycleInCurrentLocale();
       const hours = adapterToUse.format(
@@ -74,21 +71,22 @@ describe('<MobileTimeRangePicker /> - Describe Value Single Input', () => {
         hasMeridiem ? 'hours12h' : 'hours24h',
       );
       const hoursNumber = adapterToUse.getHours(newValue[setEndDate ? 1 : 0]);
-      await user.click(screen.getByRole('option', { name: `${parseInt(hours, 10)} hours` }));
-      await user.click(
+      fireEvent.click(screen.getByRole('option', { name: `${parseInt(hours, 10)} hours` }));
+      fireEvent.click(
         screen.getByRole('option', {
           name: `${adapterToUse.getMinutes(newValue[setEndDate ? 1 : 0])} minutes`,
         }),
       );
       if (hasMeridiem) {
-        await user.click(screen.getByRole('option', { name: hoursNumber >= 12 ? 'PM' : 'AM' }));
+        fireEvent.click(screen.getByRole('option', { name: hoursNumber >= 12 ? 'PM' : 'AM' }));
       }
 
       if (closeMobilePicker) {
         if (setEndDate) {
-          await user.click(screen.getByRole('button', { name: /ok/i }));
+          fireEvent.click(screen.getByRole('button', { name: /ok/i }));
         } else {
-          await user.keyboard('{Escape}');
+          // eslint-disable-next-line mui/disallow-active-element-as-key-event-target
+          fireEvent.keyDown(document.activeElement!, { key: 'Escape' });
         }
       }
 

--- a/packages/x-date-pickers-pro/src/SingleInputDateRangeField/tests/editing.SingleInputDateRangeField.test.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputDateRangeField/tests/editing.SingleInputDateRangeField.test.tsx
@@ -1,6 +1,6 @@
 import { spy } from 'sinon';
 import { SingleInputDateRangeField } from '@mui/x-date-pickers-pro/SingleInputDateRangeField';
-import { waitFor } from '@mui/internal-test-utils';
+import { fireEvent, waitFor } from '@mui/internal-test-utils';
 import { expectFieldValue, describeAdapters } from 'test/utils/pickers';
 
 describe('<SingleInputDateRangeField /> - Editing', () => {
@@ -86,9 +86,9 @@ describe('<SingleInputDateRangeField /> - Editing', () => {
           onChange,
         });
 
-        await view.selectSection('year');
+        await view.selectSectionAsync('year');
 
-        await view.pressKey('ArrowUp');
+        view.pressKey(2, 'ArrowUp');
         expectFieldValue(view.getSectionsContainer(), '06/04/2022 – 06/05/2022');
 
         expect(onChange.callCount).to.equal(1);
@@ -103,9 +103,9 @@ describe('<SingleInputDateRangeField /> - Editing', () => {
           onChange,
         });
 
-        await view.selectSection('year');
+        await view.selectSectionAsync('year');
 
-        await view.pressKey('ArrowUp');
+        view.pressKey(2, 'ArrowUp');
         expectFieldValue(view.getSectionsContainer(), '06/04/2023 – 06/05/2022');
 
         expect(onChange.callCount).to.equal(1);
@@ -121,13 +121,13 @@ describe('<SingleInputDateRangeField /> - Editing', () => {
           format: `${adapter.formats.dayOfMonth} ${adapter.formats.monthShort}`,
         });
 
-        await view.selectSection('day');
+        await view.selectSectionAsync('day');
 
-        await view.pressKey('4');
+        view.pressKey(0, '4');
         expect(onChange.callCount).to.equal(0);
         expectFieldValue(view.getSectionsContainer(), '04 MMMM – DD MMMM');
 
-        await view.pressKey('S');
+        view.pressKey(1, 'S');
         // // We reset the value displayed because the `onChange` callback did not update the controlled value.
         expect(onChange.callCount).to.equal(1);
         expect(onChange.lastCall.firstArg[0]).toEqualDateTime(new Date(2022, 8, 4));
@@ -146,12 +146,16 @@ describe('<SingleInputDateRangeField /> - Editing', () => {
         format: `${adapter.formats.month} ${adapter.formats.year}`,
       });
 
-      await view.selectSection('month');
+      await view.selectSectionAsync('month');
 
       // Select all sections
-      await view.user.keyboard('{Control>}a{/Control}');
+      fireEvent.keyDown(view.getActiveSection(0), {
+        key: 'a',
+        keyCode: 65,
+        ctrlKey: true,
+      });
 
-      await view.user.keyboard('{Delete}');
+      fireEvent.keyDown(view.getSectionsContainer(), { key: 'Delete' });
       expectFieldValue(view.getSectionsContainer(), 'MMMM YYYY – MMMM YYYY');
     });
 
@@ -160,16 +164,20 @@ describe('<SingleInputDateRangeField /> - Editing', () => {
         format: `${adapter.formats.month} ${adapter.formats.year}`,
       });
 
-      await view.selectSection('month');
+      await view.selectSectionAsync('month');
 
       // Set a value for the "month" section
-      await view.user.keyboard('j');
+      fireEvent.input(view.getActiveSection(0), { target: { innerHTML: 'j' } });
       expectFieldValue(view.getSectionsContainer(), 'January YYYY – MMMM YYYY');
 
       // Select all sections
-      await view.user.keyboard('{Control>}a{/Control}');
+      fireEvent.keyDown(view.getActiveSection(0), {
+        key: 'a',
+        keyCode: 65,
+        ctrlKey: true,
+      });
 
-      await view.user.keyboard('{Delete}');
+      fireEvent.keyDown(view.getSectionsContainer(), { key: 'Delete' });
       expectFieldValue(view.getSectionsContainer(), 'MMMM YYYY – MMMM YYYY');
     });
 
@@ -181,12 +189,16 @@ describe('<SingleInputDateRangeField /> - Editing', () => {
         onChange,
       });
 
-      await view.selectSection('month');
+      await view.selectSectionAsync('month');
 
       // Select all sections
-      await view.user.keyboard('{Control>}a{/Control}');
+      fireEvent.keyDown(view.getActiveSection(0), {
+        key: 'a',
+        keyCode: 65,
+        ctrlKey: true,
+      });
 
-      await view.user.keyboard('{Delete}');
+      fireEvent.keyDown(view.getSectionsContainer(), { key: 'Delete' });
       expect(onChange.callCount).to.equal(0);
     });
 
@@ -198,35 +210,35 @@ describe('<SingleInputDateRangeField /> - Editing', () => {
         onChange,
       });
 
-      await view.selectSection('month');
+      await view.selectSectionAsync('month');
 
       // Start date
-      await view.user.keyboard('{Delete}');
+      fireEvent.keyDown(view.getActiveSection(0), { key: 'Delete' });
       expect(onChange.callCount).to.equal(1);
       expect(onChange.lastCall.firstArg[0]).to.equal(null);
       expect(onChange.lastCall.firstArg[1]).toEqualDateTime(adapter.addYears(adapter.date(), 1));
 
-      await view.user.keyboard('{ArrowRight}');
-      await view.user.keyboard('{Delete}');
+      fireEvent.keyDown(view.getActiveSection(0), { key: 'ArrowRight' });
+      fireEvent.keyDown(view.getActiveSection(1), { key: 'Delete' });
       expect(onChange.callCount).to.equal(1);
 
-      await view.user.keyboard('{ArrowRight}');
-      await view.user.keyboard('{Delete}');
+      fireEvent.keyDown(view.getActiveSection(1), { key: 'ArrowRight' });
+      fireEvent.keyDown(view.getActiveSection(2), { key: 'Delete' });
       expect(onChange.callCount).to.equal(1);
 
       // End date
-      await view.user.keyboard('{ArrowRight}');
-      await view.user.keyboard('{Delete}');
+      fireEvent.keyDown(view.getActiveSection(2), { key: 'ArrowRight' });
+      fireEvent.keyDown(view.getActiveSection(3), { key: 'Delete' });
       expect(onChange.callCount).to.equal(2);
       expect(onChange.lastCall.firstArg[0]).to.equal(null);
       expect(onChange.lastCall.firstArg[1]).to.equal(null);
 
-      await view.user.keyboard('{ArrowRight}');
-      await view.user.keyboard('{Delete}');
+      fireEvent.keyDown(view.getActiveSection(3), { key: 'ArrowRight' });
+      fireEvent.keyDown(view.getActiveSection(4), { key: 'Delete' });
       expect(onChange.callCount).to.equal(2);
 
-      await view.user.keyboard('{ArrowRight}');
-      await view.user.keyboard('{Delete}');
+      fireEvent.keyDown(view.getActiveSection(4), { key: 'ArrowRight' });
+      fireEvent.keyDown(view.getActiveSection(5), { key: 'Delete' });
       expect(onChange.callCount).to.equal(2);
     });
 
@@ -239,12 +251,12 @@ describe('<SingleInputDateRangeField /> - Editing', () => {
         onChange,
       });
 
-      await view.selectSection('month');
+      await view.selectSectionAsync('month');
 
-      await view.user.keyboard('{Delete}');
+      fireEvent.keyDown(view.getActiveSection(0), { key: 'Delete' });
       expect(onChange.callCount).to.equal(1);
 
-      await view.user.keyboard('{Delete}');
+      fireEvent.keyDown(view.getActiveSection(0), { key: 'Delete' });
       expect(onChange.callCount).to.equal(1);
     });
   });
@@ -259,12 +271,16 @@ describe('<SingleInputDateRangeField /> - Editing', () => {
           format: `${adapter.formats.month} ${adapter.formats.year}`,
         });
 
-        await view.selectSection('month');
+        await view.selectSectionAsync('month');
 
         // Select all sections
-        await view.user.keyboard('{Control>}a{/Control}');
+        fireEvent.keyDown(view.getActiveSection(0), {
+          key: 'a',
+          keyCode: 65,
+          ctrlKey: true,
+        });
 
-        await view.user.keyboard('{Backspace}');
+        view.pressKey(null, '');
         expectFieldValue(view.getSectionsContainer(), 'MMMM YYYY – MMMM YYYY');
       });
 
@@ -273,16 +289,20 @@ describe('<SingleInputDateRangeField /> - Editing', () => {
           format: `${adapter.formats.month} ${adapter.formats.year}`,
         });
 
-        await view.selectSection('month');
+        await view.selectSectionAsync('month');
 
         // Set a value for the "month" section
-        await view.user.keyboard('j');
+        fireEvent.input(view.getActiveSection(0), { target: { innerHTML: 'j' } });
         expectFieldValue(view.getSectionsContainer(), 'January YYYY – MMMM YYYY');
 
         // Select all sections
-        await view.user.keyboard('{Control>}a{/Control}');
+        fireEvent.keyDown(view.getActiveSection(0), {
+          key: 'a',
+          keyCode: 65,
+          ctrlKey: true,
+        });
 
-        await view.user.keyboard('{Backspace}');
+        view.pressKey(null, '');
         expectFieldValue(view.getSectionsContainer(), 'MMMM YYYY – MMMM YYYY');
       });
 
@@ -294,12 +314,16 @@ describe('<SingleInputDateRangeField /> - Editing', () => {
           onChange,
         });
 
-        await view.selectSection('month');
+        await view.selectSectionAsync('month');
 
         // Select all sections
-        await view.user.keyboard('{Control>}a{/Control}');
+        fireEvent.keyDown(view.getActiveSection(0), {
+          key: 'a',
+          keyCode: 65,
+          ctrlKey: true,
+        });
 
-        await view.user.keyboard('{Backspace}');
+        view.pressKey(null, '');
         expect(onChange.callCount).to.equal(0);
       });
 
@@ -311,35 +335,35 @@ describe('<SingleInputDateRangeField /> - Editing', () => {
           onChange,
         });
 
-        await view.selectSection('month');
+        await view.selectSectionAsync('month');
 
         // Start date
-        await view.user.keyboard('{Backspace}');
+        view.pressKey(0, '');
         expect(onChange.callCount).to.equal(1);
         expect(onChange.lastCall.firstArg[0]).to.equal(null);
         expect(onChange.lastCall.firstArg[1]).toEqualDateTime(adapter.addYears(adapter.date(), 1));
 
-        await view.user.keyboard('{ArrowRight}');
-        await view.user.keyboard('{Backspace}');
+        fireEvent.keyDown(view.getActiveSection(0), { key: 'ArrowRight' });
+        view.pressKey(1, '');
         expect(onChange.callCount).to.equal(1);
 
-        await view.user.keyboard('{ArrowRight}');
-        await view.user.keyboard('{Backspace}');
+        fireEvent.keyDown(view.getActiveSection(1), { key: 'ArrowRight' });
+        view.pressKey(2, '');
         expect(onChange.callCount).to.equal(1);
 
         // End date
-        await view.user.keyboard('{ArrowRight}');
-        await view.user.keyboard('{Backspace}');
+        fireEvent.keyDown(view.getActiveSection(2), { key: 'ArrowRight' });
+        view.pressKey(3, '');
         expect(onChange.callCount).to.equal(2);
         expect(onChange.lastCall.firstArg[0]).to.equal(null);
         expect(onChange.lastCall.firstArg[1]).to.equal(null);
 
-        await view.user.keyboard('{ArrowRight}');
-        await view.user.keyboard('{Backspace}');
+        fireEvent.keyDown(view.getActiveSection(3), { key: 'ArrowRight' });
+        view.pressKey(4, '');
         expect(onChange.callCount).to.equal(2);
 
-        await view.user.keyboard('{ArrowRight}');
-        await view.user.keyboard('{Backspace}');
+        fireEvent.keyDown(view.getActiveSection(4), { key: 'ArrowRight' });
+        view.pressKey(5, '');
         expect(onChange.callCount).to.equal(2);
       });
 
@@ -352,7 +376,7 @@ describe('<SingleInputDateRangeField /> - Editing', () => {
           onChange,
         });
 
-        await view.selectSection('month');
+        await view.selectSectionAsync('month');
 
         await view.user.keyboard('{Backspace}');
         expect(onChange.callCount).to.equal(1);

--- a/packages/x-date-pickers-pro/src/SingleInputDateRangeField/tests/selection.SingleInputDateRangeField.test.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputDateRangeField/tests/selection.SingleInputDateRangeField.test.tsx
@@ -1,4 +1,5 @@
 import { SingleInputDateRangeField } from '@mui/x-date-pickers-pro/SingleInputDateRangeField';
+import { fireEvent } from '@mui/internal-test-utils';
 import {
   adapterToUse,
   buildFieldInteractions,
@@ -31,17 +32,17 @@ describe('<SingleInputDateRangeField /> - Selection', () => {
       });
 
       // Start date
-      await view.selectSection('day');
+      await view.selectSectionAsync('day');
       expect(getCleanedSelectedContent()).to.equal('DD');
 
-      await view.selectSection('month');
+      await view.selectSectionAsync('month');
       expect(getCleanedSelectedContent()).to.equal('MM');
 
       // End date
-      await view.selectSection('month', 'last');
+      await view.selectSectionAsync('month', 'last');
       expect(getCleanedSelectedContent()).to.equal('02');
 
-      await view.selectSection('day', 'last');
+      await view.selectSectionAsync('day', 'last');
       expect(getCleanedSelectedContent()).to.equal('24');
     });
 
@@ -51,17 +52,17 @@ describe('<SingleInputDateRangeField /> - Selection', () => {
       });
 
       // Start date
-      await view.selectSection('day');
+      await view.selectSectionAsync('day');
       expect(getCleanedSelectedContent()).to.equal('DD');
 
-      await view.selectSection('day');
+      await view.selectSectionAsync('day');
       expect(getCleanedSelectedContent()).to.equal('DD');
 
       // End date
-      await view.selectSection('day', 'last');
+      await view.selectSectionAsync('day', 'last');
       expect(getCleanedSelectedContent()).to.equal('24');
 
-      await view.selectSection('day', 'last');
+      await view.selectSectionAsync('day', 'last');
       expect(getCleanedSelectedContent()).to.equal('24');
     });
   });
@@ -70,31 +71,31 @@ describe('<SingleInputDateRangeField /> - Selection', () => {
     it('should allow to move from left to right with ArrowRight', async () => {
       const view = renderWithProps({});
 
-      await view.selectSection('month');
+      await view.selectSectionAsync('month');
       expect(getCleanedSelectedContent()).to.equal('MM');
 
-      await view.user.keyboard('{ArrowRight}');
+      fireEvent.keyDown(view.getActiveSection(0), { key: 'ArrowRight' });
       expect(getCleanedSelectedContent()).to.equal('DD');
 
-      await view.user.keyboard('{ArrowRight}');
+      fireEvent.keyDown(view.getActiveSection(1), { key: 'ArrowRight' });
       expect(getCleanedSelectedContent()).to.equal('YYYY');
 
-      await view.user.keyboard('{ArrowRight}');
+      fireEvent.keyDown(view.getActiveSection(2), { key: 'ArrowRight' });
       expect(getCleanedSelectedContent()).to.equal('MM');
 
-      await view.user.keyboard('{ArrowRight}');
+      fireEvent.keyDown(view.getActiveSection(3), { key: 'ArrowRight' });
       expect(getCleanedSelectedContent()).to.equal('DD');
 
-      await view.user.keyboard('{ArrowRight}');
+      fireEvent.keyDown(view.getActiveSection(4), { key: 'ArrowRight' });
       expect(getCleanedSelectedContent()).to.equal('YYYY');
     });
 
     it('should stay on the current section when the last section is selected', async () => {
       const view = renderWithProps({});
 
-      await view.selectSection('year', 'last');
+      await view.selectSectionAsync('year', 'last');
       expect(getCleanedSelectedContent()).to.equal('YYYY');
-      await view.user.keyboard('{ArrowRight}');
+      fireEvent.keyDown(view.getActiveSection(5), { key: 'ArrowRight' });
       expect(getCleanedSelectedContent()).to.equal('YYYY');
     });
   });
@@ -103,30 +104,30 @@ describe('<SingleInputDateRangeField /> - Selection', () => {
     it('should allow to move from right to left with ArrowLeft', async () => {
       const view = renderWithProps({});
 
-      await view.selectSection('year', 'last');
+      await view.selectSectionAsync('year', 'last');
       expect(getCleanedSelectedContent()).to.equal('YYYY');
-      await view.user.keyboard('{ArrowLeft}');
+      fireEvent.keyDown(view.getActiveSection(5), { key: 'ArrowLeft' });
       expect(getCleanedSelectedContent()).to.equal('DD');
 
-      await view.user.keyboard('{ArrowLeft}');
+      fireEvent.keyDown(view.getActiveSection(4), { key: 'ArrowLeft' });
       expect(getCleanedSelectedContent()).to.equal('MM');
 
-      await view.user.keyboard('{ArrowLeft}');
+      fireEvent.keyDown(view.getActiveSection(3), { key: 'ArrowLeft' });
       expect(getCleanedSelectedContent()).to.equal('YYYY');
 
-      await view.user.keyboard('{ArrowLeft}');
+      fireEvent.keyDown(view.getActiveSection(2), { key: 'ArrowLeft' });
       expect(getCleanedSelectedContent()).to.equal('DD');
 
-      await view.user.keyboard('{ArrowLeft}');
+      fireEvent.keyDown(view.getActiveSection(1), { key: 'ArrowLeft' });
       expect(getCleanedSelectedContent()).to.equal('MM');
     });
 
     it('should stay on the current section when the first section is selected', async () => {
       const view = renderWithProps({});
 
-      await view.selectSection('month');
+      await view.selectSectionAsync('month');
       expect(getCleanedSelectedContent()).to.equal('MM');
-      await view.user.keyboard('{ArrowLeft}');
+      fireEvent.keyDown(view.getActiveSection(0), { key: 'ArrowLeft' });
       expect(getCleanedSelectedContent()).to.equal('MM');
     });
   });

--- a/packages/x-date-pickers/src/DateCalendar/tests/DateCalendar.test.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/tests/DateCalendar.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { screen, waitFor } from '@mui/internal-test-utils';
+import { fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
 import { PickerDay } from '@mui/x-date-pickers/PickerDay';
 import { createPickerRenderer, adapterToUse } from 'test/utils/pickers';
@@ -612,10 +612,10 @@ describe('<DateCalendar />', () => {
   });
 
   describe('Performance', () => {
-    it('should only render newly selected day when selecting a day without a previously selected day', async () => {
+    it('should only render newly selected day when selecting a day without a previously selected day', () => {
       const RenderCount = spy((props) => <PickerDay {...props} />);
 
-      const { user } = render(
+      render(
         <DateCalendar
           referenceDate={adapterToUse.date('2019-01-02')}
           slots={{
@@ -625,15 +625,14 @@ describe('<DateCalendar />', () => {
       );
 
       const renderCountBeforeChange = RenderCount.callCount;
-      await user.click(screen.getByRole('gridcell', { name: '2' }));
-      // 2 render (one to update tabIndex + autoFocus, one to update selection) * 2 (because dev mode)
-      expect(RenderCount.callCount - renderCountBeforeChange).to.equal(4);
+      fireEvent.click(screen.getByRole('gridcell', { name: '2' }));
+      expect(RenderCount.callCount - renderCountBeforeChange).to.equal(2); // 2 render * 1 day
     });
 
-    it('should only re-render previously selected day and newly selected day when selecting a day', async () => {
+    it('should only re-render previously selected day and newly selected day when selecting a day', () => {
       const RenderCount = spy((props) => <PickerDay {...props} />);
 
-      const { user } = render(
+      render(
         <DateCalendar
           defaultValue={adapterToUse.date('2019-04-29')}
           slots={{
@@ -643,7 +642,9 @@ describe('<DateCalendar />', () => {
       );
 
       const renderCountBeforeChange = RenderCount.callCount;
-      await user.click(screen.getByRole('gridcell', { name: '2' }));
+      // TODO: Use userEvent.click instead.
+      fireEvent.focus(screen.getByRole('gridcell', { name: '2' }));
+      fireEvent.click(screen.getByRole('gridcell', { name: '2' }));
       // 2 render (one to update tabIndex + autoFocus, one to update selection) * 2 days * 2 (because dev mode)
       expect(RenderCount.callCount - renderCountBeforeChange).to.equal(8);
     });

--- a/packages/x-date-pickers/src/DateCalendar/tests/describeValue.DateCalendar.test.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/tests/describeValue.DateCalendar.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@mui/internal-test-utils';
+import { fireEvent, screen } from '@mui/internal-test-utils';
 import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
 import { pickerDayClasses } from '@mui/x-date-pickers/PickerDay';
 import { PickerValue } from '@mui/x-date-pickers/internals';
@@ -21,9 +21,9 @@ describe('<DateCalendar /> - Describe Value', () => {
         expect(selectedCells[0]).to.have.text(adapterToUse.getDate(expectedValue).toString());
       }
     },
-    setNewValue: async (value, { user }) => {
+    setNewValue: (value) => {
       const newValue = adapterToUse.addDays(value!, 1);
-      await user.click(
+      fireEvent.click(
         screen.getByRole('gridcell', { name: adapterToUse.getDate(newValue).toString() }),
       );
 

--- a/packages/x-date-pickers/src/DateCalendar/tests/keyboard.DateCalendar.test.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/tests/keyboard.DateCalendar.test.tsx
@@ -1,4 +1,4 @@
-import { act, screen } from '@mui/internal-test-utils';
+import { act, fireEvent, screen } from '@mui/internal-test-utils';
 import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
 import { adapterToUse, createPickerRenderer } from 'test/utils/pickers';
 
@@ -21,10 +21,12 @@ describe('<DateCalendar /> keyboard interactions', () => {
       { key: 'ArrowDown', expectFocusedDay: '20' },
     ].forEach(({ key, expectFocusedDay }) => {
       it(`${key}`, async () => {
-        const { user } = render(<DateCalendar defaultValue={adapterToUse.date('2020-08-13')} />);
+        render(<DateCalendar defaultValue={adapterToUse.date('2020-08-13')} />);
 
         await act(async () => screen.getByText('13').focus());
-        await user.keyboard(`{${key}}`);
+        // Don't care about what's focused.
+        // eslint-disable-next-line mui/disallow-active-element-as-key-event-target
+        fireEvent.keyDown(document.activeElement!, { key });
 
         // Based on column header, screen reader should pronounce <Day Number> <Week Day>
         // But `toHaveAccessibleName` does not do the link between column header and cell value, so we only get <day number> in test
@@ -33,7 +35,7 @@ describe('<DateCalendar /> keyboard interactions', () => {
     });
 
     it('should manage a sequence of keyboard interactions', async () => {
-      const { user } = render(<DateCalendar defaultValue={adapterToUse.date('2020-08-13')} />);
+      render(<DateCalendar defaultValue={adapterToUse.date('2020-08-13')} />);
 
       await act(async () => screen.getByText('13').focus());
       const interactions = [
@@ -43,14 +45,15 @@ describe('<DateCalendar /> keyboard interactions', () => {
         { key: 'Home', expectFocusedDay: '2' },
         { key: 'ArrowDown', expectFocusedDay: '9' },
       ];
-      for (const { key, expectFocusedDay } of interactions) {
-        // eslint-disable-next-line no-await-in-loop
-        await user.keyboard(`{${key}}`);
+      interactions.forEach(({ key, expectFocusedDay }) => {
+        // Don't care about what's focused.
+        // eslint-disable-next-line mui/disallow-active-element-as-key-event-target
+        fireEvent.keyDown(document.activeElement!, { key });
 
         // Based on column header, screen reader should pronounce <Day Number> <Week Day>
         // But `toHaveAccessibleName` does not do the link between column header and cell value, so we only get <day number> in test
         expect(document.activeElement).toHaveAccessibleName(expectFocusedDay);
-      }
+      });
     });
 
     [
@@ -64,12 +67,12 @@ describe('<DateCalendar /> keyboard interactions', () => {
       { initialDay: '09', key: 'ArrowRight', expectFocusedDay: '10' },
     ].forEach(({ initialDay, key, expectFocusedDay }) => {
       it(`${key}`, async () => {
-        const { user } = render(
-          <DateCalendar defaultValue={adapterToUse.date(`2020-08-${initialDay}`)} />,
-        );
+        render(<DateCalendar defaultValue={adapterToUse.date(`2020-08-${initialDay}`)} />);
 
         await act(async () => screen.getByText(`${Number(initialDay)}`).focus());
-        await user.keyboard(`{${key}}`);
+        // Don't care about what's focused.
+        // eslint-disable-next-line mui/disallow-active-element-as-key-event-target
+        fireEvent.keyDown(document.activeElement!, { key });
 
         // Based on column header, screen reader should pronounce <Day Number> <Week Day>
         // But `toHaveAccessibleName` does not do the link between column header and cell value, so we only get <day number> in test
@@ -95,7 +98,7 @@ describe('<DateCalendar /> keyboard interactions', () => {
         { initialDay: '30', key: 'ArrowRight', expectFocusedDay: '2' },
       ].forEach(({ initialDay, key, expectFocusedDay }) => {
         it(`${key}`, async () => {
-          const { user } = render(
+          render(
             <DateCalendar
               defaultValue={adapterToUse.date(`2020-01-${initialDay}`)}
               shouldDisableDate={(date) =>
@@ -105,7 +108,9 @@ describe('<DateCalendar /> keyboard interactions', () => {
           );
 
           await act(async () => screen.getByText(`${Number(initialDay)}`).focus());
-          await user.keyboard(`{${key}}`);
+          // Don't care about what's focused.
+          // eslint-disable-next-line mui/disallow-active-element-as-key-event-target
+          fireEvent.keyDown(document.activeElement!, { key });
 
           // Based on column header, screen reader should pronounce <Day Number> <Week Day>
           // But `toHaveAccessibleName` does not do the link between column header and cell value, so we only get <day number> in test
@@ -116,11 +121,13 @@ describe('<DateCalendar /> keyboard interactions', () => {
 
     describe('navigate months', () => {
       it('should keep focus on arrow when switching month', async () => {
-        const { user } = render(<DateCalendar />);
+        render(<DateCalendar />);
 
         const nextMonthButton = screen.getByRole('button', { name: 'Next month' });
         await act(async () => nextMonthButton.focus());
-        await user.keyboard('{Enter}');
+        // Don't care about what's focused.
+        // eslint-disable-next-line mui/disallow-active-element-as-key-event-target
+        fireEvent.keyDown(document.activeElement!, { key: 'Enter' });
 
         expect(document.activeElement).toHaveAccessibleName('Next month');
       });

--- a/packages/x-date-pickers/src/DateCalendar/tests/timezone.DateCalendar.test.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/tests/timezone.DateCalendar.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { spy } from 'sinon';
-import { screen } from '@mui/internal-test-utils';
+import { fireEvent, screen } from '@mui/internal-test-utils';
 import { describeAdapters } from 'test/utils/pickers';
 import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
 
@@ -9,11 +9,11 @@ const TIMEZONE_TO_TEST = ['UTC', 'system', 'America/New_York'];
 describe('<DateCalendar /> - Timezone', () => {
   describeAdapters('Timezone prop', DateCalendar, ({ adapter, render }) => {
     describe.skipIf(!adapter.isTimezoneCompatible)('timezoneCompatible', () => {
-      it('should use default timezone for rendering and onChange when no value and no timezone prop are provided', async () => {
+      it('should use default timezone for rendering and onChange when no value and no timezone prop are provided', () => {
         const onChange = spy();
-        const { user } = render(<DateCalendar onChange={onChange} />);
+        render(<DateCalendar onChange={onChange} />);
 
-        await user.click(screen.getByRole('gridcell', { name: '25' }));
+        fireEvent.click(screen.getByRole('gridcell', { name: '25' }));
         const expectedDate = adapter.setDate(adapter.date(undefined, 'default'), 25);
 
         // Check the `onChange` value (uses default timezone, for example: UTC, see TZ env variable)
@@ -27,15 +27,13 @@ describe('<DateCalendar /> - Timezone', () => {
         expect(actualDate).toEqualDateTime(expectedDate);
       });
 
-      it('should use "default" timezone for onChange when provided', async () => {
+      it('should use "default" timezone for onChange when provided', () => {
         const onChange = spy();
         const value = adapter.date('2022-04-25T15:30');
 
-        const { user } = render(
-          <DateCalendar value={value} onChange={onChange} timezone="default" />,
-        );
+        render(<DateCalendar value={value} onChange={onChange} timezone="default" />);
 
-        await user.click(screen.getByRole('gridcell', { name: '25' }));
+        fireEvent.click(screen.getByRole('gridcell', { name: '25' }));
         const expectedDate = adapter.setDate(value, 25);
 
         // Check the `onChange` value (uses timezone prop)
@@ -46,7 +44,7 @@ describe('<DateCalendar /> - Timezone', () => {
         expect(actualDate).toEqualDateTime(expectedDate);
       });
 
-      it('should correctly render month days when timezone changes', async () => {
+      it('should correctly render month days when timezone changes', () => {
         function DateCalendarWithControlledTimezone() {
           const [timezone, setTimezone] = React.useState('Europe/Paris');
           return (
@@ -56,7 +54,7 @@ describe('<DateCalendar /> - Timezone', () => {
             </React.Fragment>
           );
         }
-        const { user } = render(<DateCalendarWithControlledTimezone />);
+        render(<DateCalendarWithControlledTimezone />);
 
         expect(
           screen.getAllByRole('gridcell', {
@@ -64,7 +62,7 @@ describe('<DateCalendar /> - Timezone', () => {
           }).length,
         ).to.equal(30);
 
-        await user.click(screen.getByRole('button', { name: 'Switch timezone' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Switch timezone' }));
 
         // the amount of rendered days should remain the same after changing timezone
         expect(
@@ -82,10 +80,10 @@ describe('<DateCalendar /> - Timezone', () => {
 
       TIMEZONE_TO_TEST.forEach((timezone) => {
         describe(`Timezone: ${timezone}`, () => {
-          it('should use timezone prop for onChange when no value is provided', async () => {
+          it('should use timezone prop for onChange when no value is provided', () => {
             const onChange = spy();
-            const { user } = render(<DateCalendar onChange={onChange} timezone={timezone} />);
-            await user.click(screen.getByRole('gridcell', { name: '25' }));
+            render(<DateCalendar onChange={onChange} timezone={timezone} />);
+            fireEvent.click(screen.getByRole('gridcell', { name: '25' }));
             const expectedDate = adapter.setDate(
               adapter.startOfDay(adapter.date(undefined, timezone)),
               25,
@@ -97,15 +95,13 @@ describe('<DateCalendar /> - Timezone', () => {
             expect(actualDate).toEqualDateTime(expectedDate);
           });
 
-          it('should use value timezone for onChange when a value is provided', async () => {
+          it('should use value timezone for onChange when a value is provided', () => {
             const onChange = spy();
             const value = adapter.date('2022-04-25T15:30', timezone);
 
-            const { user } = render(
-              <DateCalendar value={value} onChange={onChange} timezone="America/Chicago" />,
-            );
+            render(<DateCalendar value={value} onChange={onChange} timezone="America/Chicago" />);
 
-            await user.click(screen.getByRole('gridcell', { name: '25' }));
+            fireEvent.click(screen.getByRole('gridcell', { name: '25' }));
             const expectedDate = adapter.setDate(value, 25);
 
             // Check the `onChange` value (uses timezone prop)

--- a/packages/x-date-pickers/src/DateField/tests/blurPartialFilling.DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/blurPartialFilling.DateField.test.tsx
@@ -11,7 +11,7 @@ describeAdapters(
     it('marks field invalid on blur when only some sections are filled', async () => {
       const view = renderWithProps({});
 
-      await view.selectSection('month');
+      await view.selectSectionAsync('month');
       await view.user.keyboard('0');
       await view.user.keyboard('1');
 
@@ -30,7 +30,7 @@ describeAdapters(
       const view = renderWithProps({});
 
       // Focus a section then blur without typing
-      await view.selectSection('month');
+      await view.selectSectionAsync('month');
       await view.user.tab();
 
       expect(getFieldInputRoot()).to.have.attribute('aria-invalid', 'false');
@@ -42,7 +42,7 @@ describeAdapters(
       });
 
       // Focus and blur
-      await view.selectSection('month');
+      await view.selectSectionAsync('month');
       await view.user.tab();
 
       expect(getFieldInputRoot()).to.have.attribute('aria-invalid', 'false');

--- a/packages/x-date-pickers/src/DateField/tests/describeValue.DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/describeValue.DateField.test.tsx
@@ -25,10 +25,10 @@ describe('<DateField /> - Describe Value', () => {
 
       expectFieldValue(fieldRoot, expectedValueStr);
     },
-    setNewValue: async (value, { selectSection, pressKey }) => {
+    setNewValue: (value, { selectSection, pressKey }) => {
       const newValue = adapterToUse.addDays(value!, 1);
-      await selectSection('day');
-      await pressKey('ArrowUp');
+      selectSection('day');
+      pressKey(undefined, 'ArrowUp');
 
       return newValue;
     },

--- a/packages/x-date-pickers/src/DateField/tests/editing.DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/editing.DateField.test.tsx
@@ -2,6 +2,7 @@ import { spy } from 'sinon';
 import { DateField } from '@mui/x-date-pickers/DateField';
 import { act, fireEvent, waitFor } from '@mui/internal-test-utils';
 import { expectFieldValue, describeAdapters, getCleanedSelectedContent } from 'test/utils/pickers';
+import { fireUserEvent } from 'test/utils/fireUserEvent';
 
 describe('<DateField /> - Editing', () => {
   describeAdapters(
@@ -15,9 +16,9 @@ describe('<DateField /> - Editing', () => {
           onChange,
         });
 
-        await view.selectSection('year');
+        await view.selectSectionAsync('year');
 
-        await view.pressKey('ArrowUp');
+        view.pressKey(2, 'ArrowUp');
         expectFieldValue(view.getSectionsContainer(), '06/04/2022');
 
         expect(onChange.callCount).to.equal(1);
@@ -31,9 +32,9 @@ describe('<DateField /> - Editing', () => {
           onChange,
         });
 
-        await view.selectSection('year');
+        await view.selectSectionAsync('year');
 
-        await view.pressKey('ArrowUp');
+        view.pressKey(2, 'ArrowUp');
         expectFieldValue(view.getSectionsContainer(), '06/04/2023');
 
         expect(onChange.callCount).to.equal(1);
@@ -48,13 +49,13 @@ describe('<DateField /> - Editing', () => {
           format: `${adapter.formats.dayOfMonth} ${adapter.formats.monthShort}`,
         });
 
-        await view.selectSection('day');
+        await view.selectSectionAsync('day');
 
-        await view.pressKey('4');
+        view.pressKey(0, '4');
         expect(onChange.callCount).to.equal(0);
         expectFieldValue(view.getSectionsContainer(), '04 MMMM');
 
-        await view.pressKey('S');
+        view.pressKey(1, 'S');
         // // We reset the value displayed because the `onChange` callback did not update the controlled value.
         expect(onChange.callCount).to.equal(1);
         expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2022, 8, 4));
@@ -85,31 +86,30 @@ describe('<DateField /> - Editing', () => {
         'ArrowRight',
       ];
 
-      await view.selectSection('month');
+      await view.selectSectionAsync('month');
 
-      for (const key of keys) {
-        // eslint-disable-next-line no-await-in-loop
-        await view.pressKey(key);
+      keys.forEach((key) => {
+        view.pressKey(0, key);
         expectFieldValue(view.getSectionsContainer(), 'MM/DD/YYYY');
         expect(onChange.callCount).to.equal(0);
-      }
+      });
 
       // digit key press
-      await view.user.keyboard('2');
+      fireUserEvent.keyPress(view.getActiveSection(0), { key: '2' });
       expectFieldValue(view.getSectionsContainer(), 'MM/DD/YYYY');
     });
   });
 
   describeAdapters('Digit editing', DateField, ({ adapter, testFieldChange, renderWithProps }) => {
-    it('should set the day to the digit pressed when no digit no value is provided', async () => {
-      await testFieldChange({
+    it('should set the day to the digit pressed when no digit no value is provided', () => {
+      testFieldChange({
         format: adapter.formats.dayOfMonth,
         keyStrokes: [{ value: '1', expected: '01' }],
       });
     });
 
-    it('should concatenate the digit pressed to the current section value if the output is valid (digit format)', async () => {
-      await testFieldChange({
+    it('should concatenate the digit pressed to the current section value if the output is valid (digit format)', () => {
+      testFieldChange({
         format: adapter.formats.dayOfMonth,
         defaultValue: adapter.date('2022-06-01'),
         keyStrokes: [
@@ -119,16 +119,16 @@ describe('<DateField /> - Editing', () => {
       });
     });
 
-    it('should set the day to the digit pressed if the concatenated value exceeds the maximum value for the section when a value is provided (digit format)', async () => {
-      await testFieldChange({
+    it('should set the day to the digit pressed if the concatenated value exceeds the maximum value for the section when a value is provided (digit format)', () => {
+      testFieldChange({
         format: adapter.formats.dayOfMonth,
         defaultValue: adapter.date('2022-06-04'),
         keyStrokes: [{ value: '1', expected: '01' }],
       });
     });
 
-    it('should concatenate the digit pressed to the current section value if the output is valid (letter format)', async () => {
-      await testFieldChange({
+    it('should concatenate the digit pressed to the current section value if the output is valid (letter format)', () => {
+      testFieldChange({
         format: adapter.formats.month,
         defaultValue: adapter.date('2022-02-01'),
         keyStrokes: [
@@ -138,16 +138,16 @@ describe('<DateField /> - Editing', () => {
       });
     });
 
-    it('should set the day to the digit pressed if the concatenated value exceeds the maximum value for the section when a value is provided (letter format)', async () => {
-      await testFieldChange({
+    it('should set the day to the digit pressed if the concatenated value exceeds the maximum value for the section when a value is provided (letter format)', () => {
+      testFieldChange({
         format: adapter.formats.month,
         defaultValue: adapter.date('2022-06-01'),
         keyStrokes: [{ value: '1', expected: 'January' }],
       });
     });
 
-    it('should support 2-digits year format', async () => {
-      await testFieldChange({
+    it('should support 2-digits year format', () => {
+      testFieldChange({
         // This format is not present in any of the adapter formats
         format: adapter.lib.includes('moment') || adapter.lib.includes('dayjs') ? 'YY' : 'yy',
         keyStrokes: [
@@ -163,8 +163,8 @@ describe('<DateField /> - Editing', () => {
       });
     });
 
-    it('should support 2-digits year format when a value is provided', async () => {
-      await testFieldChange({
+    it('should support 2-digits year format when a value is provided', () => {
+      testFieldChange({
         // This format is not present in any of the adapter formats
         format: adapter.lib.includes('moment') || adapter.lib.includes('dayjs') ? 'YY' : 'yy',
         defaultValue: adapter.date('2022-06-04'),
@@ -176,8 +176,8 @@ describe('<DateField /> - Editing', () => {
       });
     });
 
-    it('should support 4-digits year format', async () => {
-      await testFieldChange({
+    it('should support 4-digits year format', () => {
+      testFieldChange({
         format: adapter.formats.year,
         keyStrokes: [
           { value: '2', expected: '0002' },
@@ -192,8 +192,8 @@ describe('<DateField /> - Editing', () => {
       });
     });
 
-    it('should support 4-digits year format when a value is provided', async () => {
-      await testFieldChange({
+    it('should support 4-digits year format when a value is provided', () => {
+      testFieldChange({
         format: adapter.formats.year,
         defaultValue: adapter.date('2022-06-04'),
         keyStrokes: [
@@ -209,8 +209,8 @@ describe('<DateField /> - Editing', () => {
       });
     });
 
-    it('should support month without trailing zeros format', async () => {
-      await testFieldChange({
+    it('should support month without trailing zeros format', () => {
+      testFieldChange({
         format: 'M', // This format is not present in any of the adapter formats
         keyStrokes: [
           { value: '1', expected: '1' },
@@ -222,8 +222,8 @@ describe('<DateField /> - Editing', () => {
     });
 
     // Luxon doesn't have any day format with a letter suffix
-    it.skipIf(adapter.lib === 'luxon')('should support day with letter suffix', async () => {
-      await testFieldChange({
+    it.skipIf(adapter.lib === 'luxon')('should support day with letter suffix', () => {
+      testFieldChange({
         format: adapter.lib === 'date-fns' ? 'do' : 'Do',
         keyStrokes: [
           { value: '1', expected: '1st' },
@@ -233,8 +233,8 @@ describe('<DateField /> - Editing', () => {
       });
     });
 
-    it('should respect leading zeros when shouldRespectLeadingZeros = true', async () => {
-      await testFieldChange({
+    it('should respect leading zeros when shouldRespectLeadingZeros = true', () => {
+      testFieldChange({
         format: ['luxon', 'date-fns'].includes(adapter.lib) ? 'd' : 'D',
         shouldRespectLeadingZeros: true,
         keyStrokes: [
@@ -245,8 +245,8 @@ describe('<DateField /> - Editing', () => {
       });
     });
 
-    it('should not respect leading zeros when shouldRespectLeadingZeros = false', async () => {
-      await testFieldChange({
+    it('should not respect leading zeros when shouldRespectLeadingZeros = false', () => {
+      testFieldChange({
         format: ['luxon', 'date-fns'].includes(adapter.lib) ? 'd' : 'D',
         shouldRespectLeadingZeros: false,
         keyStrokes: [
@@ -262,7 +262,7 @@ describe('<DateField /> - Editing', () => {
         format: adapter.formats.keyboardDate,
       });
 
-      await view.selectSection('month');
+      await view.selectSectionAsync('month');
 
       await view.user.keyboard('2');
       expectFieldValue(view.getSectionsContainer(), '02/DD/YYYY');
@@ -286,16 +286,16 @@ describe('<DateField /> - Editing', () => {
       expectFieldValue(view.getSectionsContainer(), '02/29/1988');
     });
 
-    it('should not edit when props.readOnly = true and no value is provided', async () => {
-      await testFieldChange({
+    it('should not edit when props.readOnly = true and no value is provided', () => {
+      testFieldChange({
         format: adapter.formats.year,
         readOnly: true,
         keyStrokes: [{ value: '1', expected: 'YYYY' }],
       });
     });
 
-    it('should not edit value when props.readOnly = true and a value is provided', async () => {
-      await testFieldChange({
+    it('should not edit value when props.readOnly = true and a value is provided', () => {
+      testFieldChange({
         format: adapter.formats.year,
         defaultValue: adapter.date(),
         readOnly: true,
@@ -306,12 +306,16 @@ describe('<DateField /> - Editing', () => {
     it('should reset the select "all" state when typing a digit', async () => {
       const view = renderWithProps({});
 
-      await view.selectSection('month');
+      await view.selectSectionAsync('month');
       // select all sections
-      await view.user.keyboard('{Control>}a{/Control}');
+      fireEvent.keyDown(view.getActiveSection(0), {
+        key: 'a',
+        keyCode: 65,
+        ctrlKey: true,
+      });
       expect(getCleanedSelectedContent()).to.equal('MM/DD/YYYY');
 
-      await view.user.keyboard('1');
+      view.pressKey(null, '1');
       expect(getCleanedSelectedContent()).to.equal('01');
     });
 
@@ -328,7 +332,7 @@ describe('<DateField /> - Editing', () => {
         view.getSection(2).focus();
       });
 
-      await view.user.keyboard('2');
+      view.pressKey(undefined, '2');
       expectFieldValue(view.getSectionsContainer(), 'MM/DD/0002');
     });
   });
@@ -337,23 +341,23 @@ describe('<DateField /> - Editing', () => {
     'Letter editing',
     DateField,
     ({ adapter, testFieldChange, testFieldKeyPress, renderWithProps }) => {
-      it('should select the first matching month with no previous query and no value is provided (letter format)', async () => {
-        await testFieldChange({
+      it('should select the first matching month with no previous query and no value is provided (letter format)', () => {
+        testFieldChange({
           format: adapter.formats.month,
           keyStrokes: [{ value: 'm', expected: 'March' }],
         });
       });
 
-      it('should select the first matching month with no previous query and a value is provided (letter format)', async () => {
-        await testFieldChange({
+      it('should select the first matching month with no previous query and a value is provided (letter format)', () => {
+        testFieldChange({
           format: adapter.formats.month,
           defaultValue: adapter.date(),
           keyStrokes: [{ value: 'm', expected: 'March' }],
         });
       });
 
-      it('should use the previously typed letters as long as it matches at least one month (letter format)', async () => {
-        await testFieldChange({
+      it('should use the previously typed letters as long as it matches at least one month (letter format)', () => {
+        testFieldChange({
           format: adapter.formats.month,
           keyStrokes: [
             // Current query: "J" => 3 matches
@@ -368,23 +372,23 @@ describe('<DateField /> - Editing', () => {
         });
       });
 
-      it('should select the first matching month with no previous query and no value is provided (digit format)', async () => {
-        await testFieldChange({
+      it('should select the first matching month with no previous query and no value is provided (digit format)', () => {
+        testFieldChange({
           format: 'MM', // This format is not present in any of the adapter formats
           keyStrokes: [{ value: 'm', expected: '03' }],
         });
       });
 
-      it('should select the first matching month with no previous query and a value is provided (digit format)', async () => {
-        await testFieldChange({
+      it('should select the first matching month with no previous query and a value is provided (digit format)', () => {
+        testFieldChange({
           format: 'MM', // This format is not present in any of the adapter formats
           defaultValue: adapter.date(),
           keyStrokes: [{ value: 'm', expected: '03' }],
         });
       });
 
-      it('should use the previously typed letters as long as it matches at least one month (digit format)', async () => {
-        await testFieldChange({
+      it('should use the previously typed letters as long as it matches at least one month (digit format)', () => {
+        testFieldChange({
           format: 'MM', // This format is not present in any of the adapter formats
           keyStrokes: [
             // Current query: "J" => 3 matches
@@ -399,8 +403,8 @@ describe('<DateField /> - Editing', () => {
         });
       });
 
-      it('should not edit when props.readOnly = true and no value is provided (letter)', async () => {
-        await testFieldKeyPress({
+      it('should not edit when props.readOnly = true and no value is provided (letter)', () => {
+        testFieldKeyPress({
           format: adapter.formats.month,
           readOnly: true,
           key: '1',
@@ -408,8 +412,8 @@ describe('<DateField /> - Editing', () => {
         });
       });
 
-      it('should not edit value when props.readOnly = true and a value is provided (letter)', async () => {
-        await testFieldKeyPress({
+      it('should not edit value when props.readOnly = true and a value is provided (letter)', () => {
+        testFieldKeyPress({
           format: adapter.formats.month,
           defaultValue: adapter.date(),
           readOnly: true,
@@ -421,12 +425,16 @@ describe('<DateField /> - Editing', () => {
       it('should reset the select "all" state when typing a letter', async () => {
         const view = renderWithProps({});
 
-        await view.selectSection('month');
+        await view.selectSectionAsync('month');
         // select all sections
-        await view.user.keyboard('{Control>}a{/Control}');
+        fireEvent.keyDown(view.getActiveSection(0), {
+          key: 'a',
+          keyCode: 65,
+          ctrlKey: true,
+        });
         expect(getCleanedSelectedContent()).to.equal('MM/DD/YYYY');
 
-        await view.user.keyboard('j');
+        view.pressKey(null, 'j');
         expect(getCleanedSelectedContent()).to.equal(adapter.lib === 'luxon' ? '1' : '01');
       });
     },
@@ -441,7 +449,7 @@ describe('<DateField /> - Editing', () => {
           format: `${adapter.formats.month} ${adapter.formats.year}`,
         });
 
-        await view.selectSection('month');
+        await view.selectSectionAsync('month');
         await view.user.keyboard('j');
         expectFieldValue(view.getSectionsContainer(), 'January YYYY');
 
@@ -455,7 +463,7 @@ describe('<DateField /> - Editing', () => {
           defaultValue: adapter.date(),
         });
 
-        await view.selectSection('month');
+        await view.selectSectionAsync('month');
 
         await view.user.keyboard('[Backspace]');
         expectFieldValue(view.getSectionsContainer(), 'MMMM 2022');
@@ -467,12 +475,16 @@ describe('<DateField /> - Editing', () => {
           defaultValue: adapter.date(),
         });
 
-        await view.selectSection('month');
+        await view.selectSectionAsync('month');
 
         // Select all sections
-        await view.user.keyboard('{Control>}a{/Control}');
+        fireEvent.keyDown(view.getActiveSection(0), {
+          key: 'a',
+          keyCode: 65,
+          ctrlKey: true,
+        });
 
-        await view.user.keyboard('{Backspace}');
+        view.pressKey(null, '');
         expectFieldValue(view.getSectionsContainer(), 'MMMM YYYY');
       });
 
@@ -481,19 +493,23 @@ describe('<DateField /> - Editing', () => {
           format: `${adapter.formats.month} ${adapter.formats.year}`,
         });
 
-        await view.selectSection('month');
+        await view.selectSectionAsync('month');
         await view.user.keyboard('j');
         expectFieldValue(view.getSectionsContainer(), 'January YYYY');
 
         // Select all sections
-        await view.user.keyboard('{Control>}a{/Control}');
+        fireEvent.keyDown(view.getActiveSection(0), {
+          key: 'a',
+          keyCode: 65,
+          ctrlKey: true,
+        });
 
         await view.user.keyboard('[Backspace]');
         expectFieldValue(view.getSectionsContainer(), 'MMMM YYYY');
       });
 
-      it('should not keep query after typing again on a cleared section (Backspace)', async () => {
-        await testFieldChange({
+      it('should not keep query after typing again on a cleared section (Backspace)', () => {
+        testFieldChange({
           format: adapter.formats.year,
           keyStrokes: [
             { value: '2', expected: '0002' },
@@ -503,8 +519,8 @@ describe('<DateField /> - Editing', () => {
         });
       });
 
-      it('should not clear the sections when props.readOnly = true (Backspace)', async () => {
-        await testFieldChange({
+      it('should not clear the sections when props.readOnly = true (Backspace)', () => {
+        testFieldChange({
           format: adapter.formats.year,
           defaultValue: adapter.date(),
           readOnly: true,
@@ -512,10 +528,10 @@ describe('<DateField /> - Editing', () => {
         });
       });
 
-      it('should not call `onChange` when clearing all sections and both dates are already empty (Backspace)', async () => {
+      it('should not call `onChange` when clearing all sections and both dates are already empty (Backspace)', () => {
         const onChange = spy();
 
-        await testFieldChange({
+        testFieldChange({
           format: adapter.formats.year,
           onChange,
           keyStrokes: [{ value: '', expected: 'YYYY' }],
@@ -533,20 +549,20 @@ describe('<DateField /> - Editing', () => {
           onChange,
         });
 
-        await view.selectSection('month');
-        await view.pressKey('');
+        await view.selectSectionAsync('month');
+        view.pressKey(0, '');
         expect(onChange.callCount).to.equal(1);
         expect(onChange.lastCall.firstArg).to.equal(null);
 
-        await view.selectSection('year');
-        await view.pressKey('');
+        await view.selectSectionAsync('year');
+        view.pressKey(1, '');
         expect(onChange.callCount).to.equal(1);
       });
 
-      it('should not call `onChange` if the section is already empty (Backspace)', async () => {
+      it('should not call `onChange` if the section is already empty (Backspace)', () => {
         const onChange = spy();
 
-        await testFieldChange({
+        testFieldChange({
           format: adapter.formats.year,
           defaultValue: adapter.date(),
           keyStrokes: [
@@ -591,10 +607,14 @@ describe('<DateField /> - Editing', () => {
         defaultValue: adapter.date(),
         onChange,
       });
-      await view.selectSection('month');
+      await view.selectSectionAsync('month');
 
       // Select all sections
-      await view.user.keyboard('{Control>}a{/Control}');
+      fireEvent.keyDown(view.getActiveSection(0), {
+        key: 'a',
+        keyCode: 65,
+        ctrlKey: true,
+      });
 
       await firePasteEvent(view.getSectionsContainer(), '09/16/2022');
 
@@ -607,10 +627,14 @@ describe('<DateField /> - Editing', () => {
       const view = renderWithProps({
         onChange,
       });
-      await view.selectSection('month');
+      await view.selectSectionAsync('month');
 
       // Select all sections
-      await view.user.keyboard('{Control>}a{/Control}');
+      fireEvent.keyDown(view.getActiveSection(0), {
+        key: 'a',
+        keyCode: 65,
+        ctrlKey: true,
+      });
 
       await firePasteEvent(view.getSectionsContainer(), '09/16/2022');
 
@@ -623,10 +647,14 @@ describe('<DateField /> - Editing', () => {
       const view = renderWithProps({
         onChange,
       });
-      await view.selectSection('month');
+      await view.selectSectionAsync('month');
 
       // Select all sections
-      await view.user.keyboard('{Control>}a{/Control}');
+      fireEvent.keyDown(view.getActiveSection(0), {
+        key: 'a',
+        keyCode: 65,
+        ctrlKey: true,
+      });
 
       await firePasteEvent(view.getSectionsContainer(), 'Some invalid content');
       expectFieldValue(view.getSectionsContainer(), 'MM/DD/YYYY');
@@ -641,10 +669,14 @@ describe('<DateField /> - Editing', () => {
         format: `${startChar}Escaped${endChar} ${adapter.formats.year}`,
       });
 
-      await view.selectSection('year');
+      await view.selectSectionAsync('year');
 
       // Select all sections
-      await view.user.keyboard('{Control>}a{/Control}');
+      fireEvent.keyDown(view.getActiveSection(0), {
+        key: 'a',
+        keyCode: 65,
+        ctrlKey: true,
+      });
 
       await firePasteEvent(view.getSectionsContainer(), `Escaped 2014`);
       expect(onChange.callCount).to.equal(1);
@@ -659,10 +691,14 @@ describe('<DateField /> - Editing', () => {
         readOnly: true,
       });
 
-      await view.selectSection('month');
+      await view.selectSectionAsync('month');
 
       // Select all sections
-      await view.user.keyboard('{Control>}a{/Control}');
+      fireEvent.keyDown(view.getActiveSection(0), {
+        key: 'a',
+        keyCode: 65,
+        ctrlKey: true,
+      });
 
       await firePasteEvent(view.getSectionsContainer(), '09/16/2022');
       expect(onChange.callCount).to.equal(0);
@@ -675,7 +711,7 @@ describe('<DateField /> - Editing', () => {
         onChange,
       });
 
-      await view.selectSection('month');
+      await view.selectSectionAsync('month');
 
       expectFieldValue(view.getSectionsContainer(), 'MM/DD/YYYY');
       await firePasteEvent(view.getActiveSection(0), '12');
@@ -692,7 +728,7 @@ describe('<DateField /> - Editing', () => {
         onChange,
       });
 
-      await view.selectSection('month');
+      await view.selectSectionAsync('month');
 
       expectFieldValue(view.getSectionsContainer(), '01/13/2018');
       await firePasteEvent(view.getActiveSection(0), '12');
@@ -709,7 +745,7 @@ describe('<DateField /> - Editing', () => {
         onChange,
       });
 
-      await view.selectSection('month');
+      await view.selectSectionAsync('month');
 
       expectFieldValue(view.getSectionsContainer(), '01/13/2018');
       await firePasteEvent(view.getActiveSection(0), 'Jun');
@@ -722,20 +758,20 @@ describe('<DateField /> - Editing', () => {
         defaultValue: adapter.date('2018-12-05'),
       });
 
-      await view.selectSection('day');
+      await view.selectSectionAsync('day');
 
-      await view.pressKey('2');
+      view.pressKey(1, '2');
       expectFieldValue(view.getSectionsContainer(), '12/02/2018');
 
       // Select all sections
-      await view.user.keyboard('{Control>}a{/Control}');
+      fireEvent.keyDown(view.getActiveSection(1), { key: 'a', keyCode: 65, ctrlKey: true });
 
       await firePasteEvent(view.getSectionsContainer(), '09/16/2022');
       expectFieldValue(view.getSectionsContainer(), '09/16/2022');
 
-      await view.selectSection('day');
+      await view.selectSectionAsync('day');
 
-      await view.pressKey('2'); // Press 2
+      view.pressKey(1, '2'); // Press 2
       expectFieldValue(view.getSectionsContainer(), '09/02/2022'); // If internal state is not reset it would be 22 instead of 02
     });
 
@@ -744,16 +780,16 @@ describe('<DateField /> - Editing', () => {
         defaultValue: adapter.date('2018-12-05'),
       });
 
-      await view.selectSection('month');
+      await view.selectSectionAsync('month');
 
-      await view.pressKey('1'); // Press 1
+      view.pressKey(0, '1'); // Press 1
       expectFieldValue(view.getSectionsContainer(), '01/05/2018');
 
       await firePasteEvent(view.getActiveSection(0), '05');
       expectFieldValue(view.getSectionsContainer(), '05/05/2018');
 
-      await view.selectSection('month'); // move back to month section
-      await view.pressKey('2'); // check that the search query has been cleared after pasting
+      await view.selectSectionAsync('month'); // move back to month section
+      view.pressKey(0, '2'); // check that the search query has been cleared after pasting
       expectFieldValue(view.getSectionsContainer(), '02/05/2018'); // If internal state is not reset it would be 12 instead of 02
     });
 
@@ -764,10 +800,14 @@ describe('<DateField /> - Editing', () => {
         disabled: true,
       });
 
-      await view.selectSection('month');
+      await view.selectSectionAsync('month');
 
       // Select all sections
-      await view.user.keyboard('{Control>}a{/Control}');
+      fireEvent.keyDown(view.getActiveSection(0), {
+        key: 'a',
+        keyCode: 65,
+        ctrlKey: true,
+      });
 
       await firePasteEvent(view.getSectionsContainer(), '09/16/2022');
       expect(onChange.callCount).to.equal(0);
@@ -785,7 +825,7 @@ describe('<DateField /> - Editing', () => {
           defaultValue: adapter.date('2010-04-03T03:03:03'),
           onChange,
         });
-        await view.selectSection('year');
+        await view.selectSectionAsync('year');
         await view.user.keyboard('{ArrowDown}');
         expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2009, 3, 3, 3, 3, 3));
       });
@@ -798,11 +838,15 @@ describe('<DateField /> - Editing', () => {
           onChange,
         });
 
-        await view.selectSection('month');
-        await view.user.keyboard('{Control>}a{/Control}');
+        await view.selectSectionAsync('month');
+        fireEvent.keyDown(view.getActiveSection(0), {
+          key: 'a',
+          keyCode: 65,
+          ctrlKey: true,
+        });
         await view.user.keyboard('[Backspace]');
         expectFieldValue(view.getSectionsContainer(), 'MM/DD/YYYY');
-        await view.selectSection('month');
+        await view.selectSectionAsync('month');
 
         await view.user.keyboard('1');
         expectFieldValue(view.getSectionsContainer(), '01/DD/YYYY');
@@ -827,7 +871,7 @@ describe('<DateField /> - Editing', () => {
           onChange,
         });
 
-        await view.selectSection('year');
+        await view.selectSectionAsync('year');
         await view.user.keyboard('{ArrowDown}');
 
         expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2009, 3, 3, 3, 3, 3));
@@ -842,7 +886,7 @@ describe('<DateField /> - Editing', () => {
           onChange,
         });
 
-        await view.selectSection('month');
+        await view.selectSectionAsync('month');
         await view.user.keyboard('{ArrowDown}');
         expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2010, 2, 3, 3, 3, 3));
       });
@@ -889,7 +933,7 @@ describe('<DateField /> - Editing', () => {
 
       view.setProps({ value: null });
 
-      await view.selectSection('month');
+      await view.selectSectionAsync('month');
       expectFieldValue(view.getSectionsContainer(), 'MM/DD/YYYY');
     });
 
@@ -898,7 +942,7 @@ describe('<DateField /> - Editing', () => {
       async () => {
         const view = renderWithProps({ value: null });
 
-        await view.selectSection('month');
+        await view.selectSectionAsync('month');
 
         await view.user.keyboard('1');
         expectFieldValue(view.getSectionsContainer(), '01/DD/YYYY');
@@ -916,7 +960,7 @@ describe('<DateField /> - Editing', () => {
         view.setProps({ value: adapter.date('2022-11-23') });
         view.setProps({ value: null });
 
-        await view.selectSection('month');
+        await view.selectSectionAsync('month');
 
         await view.user.keyboard('1');
         expectFieldValue(view.getSectionsContainer(), '01/DD/YYYY');
@@ -933,13 +977,17 @@ describe('<DateField /> - Editing', () => {
   describeAdapters('Select all', DateField, ({ renderWithProps }) => {
     it('should edit the 1st section when all sections are selected', async () => {
       const view = renderWithProps({});
-      await view.selectSection('month');
+      await view.selectSectionAsync('month');
 
       // Select all sections
-      await view.user.keyboard('{Control>}a{/Control}');
+      fireEvent.keyDown(view.getActiveSection(0), {
+        key: 'a',
+        keyCode: 65,
+        ctrlKey: true,
+      });
 
       // When all sections are selected, the value only contains the key pressed
-      await view.user.keyboard('9');
+      view.pressKey(null, '9');
 
       expectFieldValue(view.getSectionsContainer(), '09/DD/YYYY');
     });

--- a/packages/x-date-pickers/src/DateField/tests/editingKeyboard.DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/editingKeyboard.DateField.test.tsx
@@ -1,19 +1,21 @@
 import { spy } from 'sinon';
 import { DateField } from '@mui/x-date-pickers/DateField';
+import { fireEvent } from '@mui/internal-test-utils';
 import { expectFieldValue, describeAdapters } from 'test/utils/pickers';
+import { fireUserEvent } from 'test/utils/fireUserEvent';
 
 describe('<DateField /> - Editing Keyboard', () => {
   describeAdapters('key: ArrowDown', DateField, ({ adapter, testFieldKeyPress }) => {
-    it("should set the year to today's value when no value is provided (ArrowDown)", async () => {
-      await testFieldKeyPress({
+    it("should set the year to today's value when no value is provided (ArrowDown)", () => {
+      testFieldKeyPress({
         format: adapter.formats.year,
         key: 'ArrowDown',
         expectedValue: '2022',
       });
     });
 
-    it('should decrement the year when a value is provided', async () => {
-      await testFieldKeyPress({
+    it('should decrement the year when a value is provided', () => {
+      testFieldKeyPress({
         format: adapter.formats.year,
         defaultValue: adapter.date(),
         key: 'ArrowDown',
@@ -21,16 +23,16 @@ describe('<DateField /> - Editing Keyboard', () => {
       });
     });
 
-    it('should set the month to December when no value is provided', async () => {
-      await testFieldKeyPress({
+    it('should set the month to December when no value is provided', () => {
+      testFieldKeyPress({
         format: adapter.formats.month,
         key: 'ArrowDown',
         expectedValue: 'December',
       });
     });
 
-    it('should decrement the month when a value is provided', async () => {
-      await testFieldKeyPress({
+    it('should decrement the month when a value is provided', () => {
+      testFieldKeyPress({
         format: adapter.formats.month,
         defaultValue: adapter.date(),
         key: 'ArrowDown',
@@ -38,8 +40,8 @@ describe('<DateField /> - Editing Keyboard', () => {
       });
     });
 
-    it('should go to the last month of the current year when a value in January is provided', async () => {
-      await testFieldKeyPress({
+    it('should go to the last month of the current year when a value in January is provided', () => {
+      testFieldKeyPress({
         format: `${adapter.formats.month} ${adapter.formats.year}`,
         defaultValue: adapter.date('2022-01-15'),
         key: 'ArrowDown',
@@ -47,16 +49,16 @@ describe('<DateField /> - Editing Keyboard', () => {
       });
     });
 
-    it('should set the day to 31 when no value is provided', async () => {
-      await testFieldKeyPress({
+    it('should set the day to 31 when no value is provided', () => {
+      testFieldKeyPress({
         format: adapter.formats.dayOfMonth,
         key: 'ArrowDown',
         expectedValue: '31',
       });
     });
 
-    it('should decrement the day when a value is provided', async () => {
-      await testFieldKeyPress({
+    it('should decrement the day when a value is provided', () => {
+      testFieldKeyPress({
         format: adapter.formats.dayOfMonth,
         defaultValue: adapter.date(),
         key: 'ArrowDown',
@@ -64,8 +66,8 @@ describe('<DateField /> - Editing Keyboard', () => {
       });
     });
 
-    it('should decrement the month and keep the day when the new month has fewer days', async () => {
-      await testFieldKeyPress({
+    it('should decrement the month and keep the day when the new month has fewer days', () => {
+      testFieldKeyPress({
         format: `${adapter.formats.month} ${adapter.formats.dayOfMonth}`,
         defaultValue: adapter.date('2022-05-31'),
         key: 'ArrowDown',
@@ -73,8 +75,8 @@ describe('<DateField /> - Editing Keyboard', () => {
       });
     });
 
-    it('should go to the last day of the current month when a value in the first day of the month is provided', async () => {
-      await testFieldKeyPress({
+    it('should go to the last day of the current month when a value in the first day of the month is provided', () => {
+      testFieldKeyPress({
         format: `${adapter.formats.month} ${adapter.formats.dayOfMonth}`,
         defaultValue: adapter.date('2022-06-01'),
         key: 'ArrowDown',
@@ -83,8 +85,8 @@ describe('<DateField /> - Editing Keyboard', () => {
       });
     });
 
-    it('should not edit the value when props.readOnly = true and no value is provided (ArrowDown)', async () => {
-      await testFieldKeyPress({
+    it('should not edit the value when props.readOnly = true and no value is provided (ArrowDown)', () => {
+      testFieldKeyPress({
         format: adapter.formats.year,
         readOnly: true,
         key: 'ArrowDown',
@@ -92,8 +94,8 @@ describe('<DateField /> - Editing Keyboard', () => {
       });
     });
 
-    it('should not edit the value when props.readOnly = true and a value is provided (ArrowDown)', async () => {
-      await testFieldKeyPress({
+    it('should not edit the value when props.readOnly = true and a value is provided (ArrowDown)', () => {
+      testFieldKeyPress({
         format: adapter.formats.year,
         defaultValue: adapter.date(),
         readOnly: true,
@@ -104,16 +106,16 @@ describe('<DateField /> - Editing Keyboard', () => {
   });
 
   describeAdapters('key: ArrowUp', DateField, ({ adapter, testFieldKeyPress }) => {
-    it("should set the year to today's value when no value is provided (ArrowUp)", async () => {
-      await testFieldKeyPress({
+    it("should set the year to today's value when no value is provided (ArrowUp)", () => {
+      testFieldKeyPress({
         format: adapter.formats.year,
         key: 'ArrowUp',
         expectedValue: '2022',
       });
     });
 
-    it('should increment the year when a value is provided', async () => {
-      await testFieldKeyPress({
+    it('should increment the year when a value is provided', () => {
+      testFieldKeyPress({
         format: adapter.formats.year,
         defaultValue: adapter.date(),
         key: 'ArrowUp',
@@ -121,16 +123,16 @@ describe('<DateField /> - Editing Keyboard', () => {
       });
     });
 
-    it('should set the month to January when no value is provided', async () => {
-      await testFieldKeyPress({
+    it('should set the month to January when no value is provided', () => {
+      testFieldKeyPress({
         format: adapter.formats.month,
         key: 'ArrowUp',
         expectedValue: 'January',
       });
     });
 
-    it('should increment the month when a value is provided', async () => {
-      await testFieldKeyPress({
+    it('should increment the month when a value is provided', () => {
+      testFieldKeyPress({
         format: adapter.formats.month,
         defaultValue: adapter.date(),
         key: 'ArrowUp',
@@ -138,8 +140,8 @@ describe('<DateField /> - Editing Keyboard', () => {
       });
     });
 
-    it('should go to the first month of the current year when a value in December is provided', async () => {
-      await testFieldKeyPress({
+    it('should go to the first month of the current year when a value in December is provided', () => {
+      testFieldKeyPress({
         format: `${adapter.formats.month} ${adapter.formats.year}`,
         defaultValue: adapter.date('2022-12-15'),
         key: 'ArrowUp',
@@ -147,16 +149,16 @@ describe('<DateField /> - Editing Keyboard', () => {
       });
     });
 
-    it('should set the day 1 when no value is provided', async () => {
-      await testFieldKeyPress({
+    it('should set the day 1 when no value is provided', () => {
+      testFieldKeyPress({
         format: adapter.formats.dayOfMonth,
         key: 'ArrowUp',
         expectedValue: '01',
       });
     });
 
-    it('should increment the day when a value is provided', async () => {
-      await testFieldKeyPress({
+    it('should increment the day when a value is provided', () => {
+      testFieldKeyPress({
         format: adapter.formats.dayOfMonth,
         defaultValue: adapter.date(),
         key: 'ArrowUp',
@@ -164,8 +166,8 @@ describe('<DateField /> - Editing Keyboard', () => {
       });
     });
 
-    it('should increment the month and keep the day when the new month has fewer days', async () => {
-      await testFieldKeyPress({
+    it('should increment the month and keep the day when the new month has fewer days', () => {
+      testFieldKeyPress({
         format: `${adapter.formats.month} ${adapter.formats.dayOfMonth}`,
         defaultValue: adapter.date('2022-05-31'),
         key: 'ArrowUp',
@@ -173,8 +175,8 @@ describe('<DateField /> - Editing Keyboard', () => {
       });
     });
 
-    it('should go to the first day of the current month when a value in the last day of the month is provided', async () => {
-      await testFieldKeyPress({
+    it('should go to the first day of the current month when a value in the last day of the month is provided', () => {
+      testFieldKeyPress({
         format: `${adapter.formats.month} ${adapter.formats.dayOfMonth}`,
         defaultValue: adapter.date('2022-06-30'),
         key: 'ArrowUp',
@@ -183,8 +185,8 @@ describe('<DateField /> - Editing Keyboard', () => {
       });
     });
 
-    it('should not edit the value when props.readOnly = true and no value is provided (ArrowUp)', async () => {
-      await testFieldKeyPress({
+    it('should not edit the value when props.readOnly = true and no value is provided (ArrowUp)', () => {
+      testFieldKeyPress({
         format: adapter.formats.year,
         readOnly: true,
         key: 'ArrowUp',
@@ -192,8 +194,8 @@ describe('<DateField /> - Editing Keyboard', () => {
       });
     });
 
-    it('should not edit the value when props.readOnly = true and a value is provided (ArrowUp)', async () => {
-      await testFieldKeyPress({
+    it('should not edit the value when props.readOnly = true and a value is provided (ArrowUp)', () => {
+      testFieldKeyPress({
         format: adapter.formats.year,
         defaultValue: adapter.date(),
         readOnly: true,
@@ -209,18 +211,18 @@ describe('<DateField /> - Editing Keyboard', () => {
         format: `${adapter.formats.month} ${adapter.formats.year}`,
       });
 
-      await view.selectSection('month');
+      await view.selectSectionAsync('month');
 
       // Set a value for the "month" section
-      await view.pressKey('j');
+      view.pressKey(0, 'j');
       expectFieldValue(view.getSectionsContainer(), 'January YYYY');
 
-      await view.user.keyboard('{Delete}');
+      fireUserEvent.keyPress(view.getActiveSection(0), { key: 'Delete' });
       expectFieldValue(view.getSectionsContainer(), 'MMMM YYYY');
     });
 
-    it('should clear the selected section when all sections are completed', async () => {
-      await testFieldKeyPress({
+    it('should clear the selected section when all sections are completed', () => {
+      testFieldKeyPress({
         format: `${adapter.formats.month} ${adapter.formats.year}`,
         defaultValue: adapter.date(),
         key: 'Delete',
@@ -234,12 +236,16 @@ describe('<DateField /> - Editing Keyboard', () => {
         defaultValue: adapter.date(),
       });
 
-      await view.selectSection('month');
+      await view.selectSectionAsync('month');
 
       // Select all sections
-      await view.user.keyboard('{Control>}a{/Control}');
+      fireEvent.keyDown(view.getActiveSection(0), {
+        key: 'a',
+        keyCode: 65,
+        ctrlKey: true,
+      });
 
-      await view.user.keyboard('{Delete}');
+      fireUserEvent.keyPress(view.getSectionsContainer(), { key: 'Delete' });
       expectFieldValue(view.getSectionsContainer(), 'MMMM YYYY');
     });
 
@@ -248,16 +254,20 @@ describe('<DateField /> - Editing Keyboard', () => {
         format: `${adapter.formats.month} ${adapter.formats.year}`,
       });
 
-      await view.selectSection('month');
+      await view.selectSectionAsync('month');
 
       // Set a value for the "month" section
-      await view.pressKey('j');
+      view.pressKey(0, 'j');
       expectFieldValue(view.getSectionsContainer(), 'January YYYY');
 
       // Select all sections
-      await view.user.keyboard('{Control>}a{/Control}');
+      fireEvent.keyDown(view.getActiveSection(0), {
+        key: 'a',
+        keyCode: 65,
+        ctrlKey: true,
+      });
 
-      await view.user.keyboard('{Delete}');
+      fireUserEvent.keyPress(view.getSectionsContainer(), { key: 'Delete' });
       expectFieldValue(view.getSectionsContainer(), 'MMMM YYYY');
     });
 
@@ -266,20 +276,20 @@ describe('<DateField /> - Editing Keyboard', () => {
         format: adapter.formats.year,
       });
 
-      await view.selectSection('year');
+      await view.selectSectionAsync('year');
 
-      await view.pressKey('2');
+      view.pressKey(0, '2');
       expectFieldValue(view.getSectionsContainer(), '0002');
 
       await view.user.keyboard('[Delete]');
       expectFieldValue(view.getSectionsContainer(), 'YYYY');
 
-      await view.pressKey('2');
+      view.pressKey(0, '2');
       expectFieldValue(view.getSectionsContainer(), '0002');
     });
 
-    it('should not clear the sections when props.readOnly = true', async () => {
-      await testFieldKeyPress({
+    it('should not clear the sections when props.readOnly = true', () => {
+      testFieldKeyPress({
         format: adapter.formats.year,
         defaultValue: adapter.date(),
         readOnly: true,
@@ -296,12 +306,16 @@ describe('<DateField /> - Editing Keyboard', () => {
         onChange,
       });
 
-      await view.selectSection('month');
+      await view.selectSectionAsync('month');
 
       // Select all sections
-      await view.user.keyboard('{Control>}a{/Control}');
+      fireEvent.keyDown(view.getActiveSection(0), {
+        key: 'a',
+        keyCode: 65,
+        ctrlKey: true,
+      });
 
-      await view.user.keyboard('{Delete}');
+      fireUserEvent.keyPress(view.getSectionsContainer(), { key: 'Delete' });
       expect(onChange.callCount).to.equal(0);
     });
 
@@ -314,7 +328,7 @@ describe('<DateField /> - Editing Keyboard', () => {
         onChange,
       });
 
-      await view.selectSection('month');
+      await view.selectSectionAsync('month');
 
       await view.user.keyboard('[Delete]');
       expect(onChange.callCount).to.equal(1);
@@ -334,7 +348,7 @@ describe('<DateField /> - Editing Keyboard', () => {
         onChange,
       });
 
-      await view.selectSection('month');
+      await view.selectSectionAsync('month');
 
       await view.user.keyboard('[Delete]');
       expect(onChange.callCount).to.equal(1);
@@ -346,16 +360,16 @@ describe('<DateField /> - Editing Keyboard', () => {
 
   describeAdapters('key: PageUp', DateField, ({ adapter, testFieldKeyPress }) => {
     describe('day section (PageUp)', () => {
-      it('should set day to minimal when no value is provided', async () => {
-        await testFieldKeyPress({
+      it('should set day to minimal when no value is provided', () => {
+        testFieldKeyPress({
           format: adapter.formats.dayOfMonth,
           key: 'PageUp',
           expectedValue: '01',
         });
       });
 
-      it('should increment day by 5 when value is provided', async () => {
-        await testFieldKeyPress({
+      it('should increment day by 5 when value is provided', () => {
+        testFieldKeyPress({
           format: adapter.formats.dayOfMonth,
           defaultValue: adapter.date('2022-01-15'),
           key: 'PageUp',
@@ -363,8 +377,8 @@ describe('<DateField /> - Editing Keyboard', () => {
         });
       });
 
-      it('should flip day field when value is higher than 27', async () => {
-        await testFieldKeyPress({
+      it('should flip day field when value is higher than 27', () => {
+        testFieldKeyPress({
           format: adapter.formats.dayOfMonth,
           defaultValue: adapter.date('2022-01-28'),
           key: 'PageUp',
@@ -374,16 +388,16 @@ describe('<DateField /> - Editing Keyboard', () => {
     });
 
     describe('weekday section (PageUp)', () => {
-      it('should set weekday to Sunday when no value is provided', async () => {
-        await testFieldKeyPress({
+      it('should set weekday to Sunday when no value is provided', () => {
+        testFieldKeyPress({
           format: adapter.formats.weekday,
           key: 'PageUp',
           expectedValue: 'Sunday',
         });
       });
 
-      it('should increment weekday by 5 when value is provided', async () => {
-        await testFieldKeyPress({
+      it('should increment weekday by 5 when value is provided', () => {
+        testFieldKeyPress({
           format: adapter.formats.weekday,
           defaultValue: adapter.date('2024-06-03'),
           key: 'PageUp',
@@ -391,8 +405,8 @@ describe('<DateField /> - Editing Keyboard', () => {
         });
       });
 
-      it('should flip weekday field when value is higher than 3', async () => {
-        await testFieldKeyPress({
+      it('should flip weekday field when value is higher than 3', () => {
+        testFieldKeyPress({
           format: adapter.formats.weekday,
           defaultValue: adapter.date('2024-06-07'),
           key: 'PageUp',
@@ -402,16 +416,16 @@ describe('<DateField /> - Editing Keyboard', () => {
     });
 
     describe('month section (PageUp)', () => {
-      it('should set month to January when no value is provided', async () => {
-        await testFieldKeyPress({
+      it('should set month to January when no value is provided', () => {
+        testFieldKeyPress({
           format: adapter.formats.month,
           key: 'PageUp',
           expectedValue: 'January',
         });
       });
 
-      it('should increment month by 5 when value is provided', async () => {
-        await testFieldKeyPress({
+      it('should increment month by 5 when value is provided', () => {
+        testFieldKeyPress({
           format: adapter.formats.month,
           defaultValue: adapter.date('2022-01-15'),
           key: 'PageUp',
@@ -419,8 +433,8 @@ describe('<DateField /> - Editing Keyboard', () => {
         });
       });
 
-      it('should flip month field when value is higher than 7', async () => {
-        await testFieldKeyPress({
+      it('should flip month field when value is higher than 7', () => {
+        testFieldKeyPress({
           format: adapter.formats.month,
           defaultValue: adapter.date('2022-08-15'),
           key: 'PageUp',
@@ -430,16 +444,16 @@ describe('<DateField /> - Editing Keyboard', () => {
     });
 
     describe('year section (PageUp)', () => {
-      it('should set year to current year when no value is provided', async () => {
-        await testFieldKeyPress({
+      it('should set year to current year when no value is provided', () => {
+        testFieldKeyPress({
           format: adapter.formats.year,
           key: 'PageUp',
           expectedValue: new Date().getFullYear().toString(),
         });
       });
 
-      it('should increment year by 5 when value is provided', async () => {
-        await testFieldKeyPress({
+      it('should increment year by 5 when value is provided', () => {
+        testFieldKeyPress({
           format: adapter.formats.year,
           defaultValue: adapter.date('2022-01-15'),
           key: 'PageUp',
@@ -447,8 +461,8 @@ describe('<DateField /> - Editing Keyboard', () => {
         });
       });
 
-      it('should flip year field when value is higher than 9995', async () => {
-        await testFieldKeyPress({
+      it('should flip year field when value is higher than 9995', () => {
+        testFieldKeyPress({
           format: adapter.formats.year,
           defaultValue: adapter.date('9996-01-15'),
           key: 'PageUp',
@@ -460,16 +474,16 @@ describe('<DateField /> - Editing Keyboard', () => {
 
   describeAdapters('key: PageDown', DateField, ({ adapter, testFieldKeyPress }) => {
     describe('day section (PageDown)', () => {
-      it('should set day to maximal when no value is provided', async () => {
-        await testFieldKeyPress({
+      it('should set day to maximal when no value is provided', () => {
+        testFieldKeyPress({
           format: adapter.formats.dayOfMonth,
           key: 'PageDown',
           expectedValue: '31',
         });
       });
 
-      it('should decrement day by 5 when value is provided', async () => {
-        await testFieldKeyPress({
+      it('should decrement day by 5 when value is provided', () => {
+        testFieldKeyPress({
           format: adapter.formats.dayOfMonth,
           defaultValue: adapter.date('2022-01-15'),
           key: 'PageDown',
@@ -477,8 +491,8 @@ describe('<DateField /> - Editing Keyboard', () => {
         });
       });
 
-      it('should flip day field when value is lower than 5', async () => {
-        await testFieldKeyPress({
+      it('should flip day field when value is lower than 5', () => {
+        testFieldKeyPress({
           format: adapter.formats.dayOfMonth,
           defaultValue: adapter.date('2022-01-04'),
           key: 'PageDown',
@@ -488,16 +502,16 @@ describe('<DateField /> - Editing Keyboard', () => {
     });
 
     describe('weekday section (PageDown)', () => {
-      it('should set weekday to Saturday when no value is provided', async () => {
-        await testFieldKeyPress({
+      it('should set weekday to Saturday when no value is provided', () => {
+        testFieldKeyPress({
           format: adapter.formats.weekday,
           key: 'PageDown',
           expectedValue: 'Saturday',
         });
       });
 
-      it('should decrement weekday by 5 when value is provided', async () => {
-        await testFieldKeyPress({
+      it('should decrement weekday by 5 when value is provided', () => {
+        testFieldKeyPress({
           format: adapter.formats.weekday,
           defaultValue: adapter.date('2024-06-22'),
           key: 'PageDown',
@@ -505,8 +519,8 @@ describe('<DateField /> - Editing Keyboard', () => {
         });
       });
 
-      it('should flip weekday field when value is lower than 5', async () => {
-        await testFieldKeyPress({
+      it('should flip weekday field when value is lower than 5', () => {
+        testFieldKeyPress({
           format: adapter.formats.weekday,
           defaultValue: adapter.date('2024-06-23'),
           key: 'PageDown',
@@ -516,16 +530,16 @@ describe('<DateField /> - Editing Keyboard', () => {
     });
 
     describe('month section (PageDown)', () => {
-      it('should set month to December when no value is provided', async () => {
-        await testFieldKeyPress({
+      it('should set month to December when no value is provided', () => {
+        testFieldKeyPress({
           format: adapter.formats.month,
           key: 'PageDown',
           expectedValue: 'December',
         });
       });
 
-      it('should decrement month by 5 when value is provided', async () => {
-        await testFieldKeyPress({
+      it('should decrement month by 5 when value is provided', () => {
+        testFieldKeyPress({
           format: adapter.formats.month,
           defaultValue: adapter.date('2022-10-15'),
           key: 'PageDown',
@@ -533,8 +547,8 @@ describe('<DateField /> - Editing Keyboard', () => {
         });
       });
 
-      it('should flip month field when value is lower than 5', async () => {
-        await testFieldKeyPress({
+      it('should flip month field when value is lower than 5', () => {
+        testFieldKeyPress({
           format: adapter.formats.month,
           defaultValue: adapter.date('2022-04-15'),
           key: 'PageDown',
@@ -544,16 +558,16 @@ describe('<DateField /> - Editing Keyboard', () => {
     });
 
     describe('year section (PageDown)', () => {
-      it('should set year to current year when no value is provided', async () => {
-        await testFieldKeyPress({
+      it('should set year to current year when no value is provided', () => {
+        testFieldKeyPress({
           format: adapter.formats.year,
           key: 'PageDown',
           expectedValue: new Date().getFullYear().toString(),
         });
       });
 
-      it('should decrement year by 5 when value is provided', async () => {
-        await testFieldKeyPress({
+      it('should decrement year by 5 when value is provided', () => {
+        testFieldKeyPress({
           format: adapter.formats.year,
           defaultValue: adapter.date('2022-01-15'),
           key: 'PageDown',
@@ -561,8 +575,8 @@ describe('<DateField /> - Editing Keyboard', () => {
         });
       });
 
-      it('should flip year field when value is lower than 5', async () => {
-        await testFieldKeyPress({
+      it('should flip year field when value is lower than 5', () => {
+        testFieldKeyPress({
           format: adapter.formats.year,
           defaultValue: adapter.date('0003-01-15'),
           key: 'PageDown',

--- a/packages/x-date-pickers/src/DateField/tests/invalidStateKeyboard.DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/invalidStateKeyboard.DateField.test.tsx
@@ -16,7 +16,7 @@ describeAdapters(
       const view = renderWithProps({}); // default format is numeric, e.g. MM/DD/YYYY
 
       // Make month invalid by typing "00"
-      await view.selectSection('month');
+      await view.selectSectionAsync('month');
       await view.user.keyboard('00');
       await view.user.tab();
 
@@ -25,13 +25,13 @@ describeAdapters(
       // Should be invalid now
       expect(inputRoot).to.have.attribute('aria-invalid', 'true');
 
-      await view.selectSection('day');
+      await view.selectSectionAsync('day');
 
       // Returns to valid after refocusing (incomplete date)
       expect(inputRoot).to.have.attribute('aria-invalid', 'false');
       await view.user.keyboard('05');
 
-      await view.selectSection('year');
+      await view.selectSectionAsync('year');
       await view.user.keyboard('2025');
 
       // Should now be invalid

--- a/packages/x-date-pickers/src/DateField/tests/selection.DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/selection.DateField.test.tsx
@@ -45,20 +45,20 @@ describe('<DateField /> - Selection', () => {
     it('should select the clicked selection when the input is already focused', async () => {
       const view = renderWithProps({});
 
-      await view.selectSection('day');
+      await view.selectSectionAsync('day');
       expect(getCleanedSelectedContent()).to.equal('DD');
 
-      await view.selectSection('month');
+      await view.selectSectionAsync('month');
       expect(getCleanedSelectedContent()).to.equal('MM');
     });
 
     it('should not change the selection when clicking on the only already selected section', async () => {
       const view = renderWithProps({});
 
-      await view.selectSection('day');
+      await view.selectSectionAsync('day');
       expect(getCleanedSelectedContent()).to.equal('DD');
 
-      await view.selectSection('day');
+      await view.selectSectionAsync('day');
       expect(getCleanedSelectedContent()).to.equal('DD');
     });
 
@@ -67,7 +67,7 @@ describe('<DateField /> - Selection', () => {
         disabled: true,
       });
 
-      await view.selectSection('day');
+      await view.selectSectionAsync('day');
       expect(getCleanedSelectedContent()).to.equal('');
     });
   });
@@ -75,8 +75,12 @@ describe('<DateField /> - Selection', () => {
   describe('key: Ctrl + A', () => {
     it('should select all sections', async () => {
       const view = renderWithProps({});
-      await view.selectSection('month');
-      await view.user.keyboard('{Control>}a{/Control}');
+      await view.selectSectionAsync('month');
+      fireEvent.keyDown(view.getActiveSection(0), {
+        key: 'a',
+        keyCode: 65,
+        ctrlKey: true,
+      });
       expect(getCleanedSelectedContent()).to.equal('MM/DD/YYYY');
     });
 
@@ -84,8 +88,12 @@ describe('<DateField /> - Selection', () => {
       const view = renderWithProps({
         format: `- ${adapterToUse.formats.year}`,
       });
-      await view.selectSection('year');
-      await view.user.keyboard('{Control>}a{/Control}');
+      await view.selectSectionAsync('year');
+      fireEvent.keyDown(view.getActiveSection(0), {
+        key: 'a',
+        keyCode: 65,
+        ctrlKey: true,
+      });
       expect(getCleanedSelectedContent()).to.equal('- YYYY');
     });
   });
@@ -93,44 +101,52 @@ describe('<DateField /> - Selection', () => {
   describe('key: ArrowRight', () => {
     it('should move selection to the next section when one section is selected', async () => {
       const view = renderWithProps({});
-      await view.selectSection('day');
+      await view.selectSectionAsync('day');
       expect(getCleanedSelectedContent()).to.equal('DD');
-      await view.user.keyboard('{ArrowRight}');
+      fireEvent.keyDown(view.getActiveSection(1), { key: 'ArrowRight' });
       expect(getCleanedSelectedContent()).to.equal('YYYY');
     });
 
     it('should stay on the current section when the last section is selected', async () => {
       const view = renderWithProps({});
-      await view.selectSection('year');
+      await view.selectSectionAsync('year');
       expect(getCleanedSelectedContent()).to.equal('YYYY');
-      await view.user.keyboard('{ArrowRight}');
+      fireEvent.keyDown(view.getActiveSection(2), { key: 'ArrowRight' });
       expect(getCleanedSelectedContent()).to.equal('YYYY');
     });
 
     it('should select the last section when all the sections are selected', async () => {
       const view = renderWithProps({});
-      await view.selectSection('month');
+      await view.selectSectionAsync('month');
 
       // Select all sections
-      await view.user.keyboard('{Control>}a{/Control}');
+      fireEvent.keyDown(view.getActiveSection(0), {
+        key: 'a',
+        keyCode: 65,
+        ctrlKey: true,
+      });
       expect(getCleanedSelectedContent()).to.equal('MM/DD/YYYY');
 
-      await view.user.keyboard('{ArrowRight}');
+      fireEvent.keyDown(view.getSectionsContainer(), { key: 'ArrowRight' });
       expect(getCleanedSelectedContent()).to.equal('YYYY');
     });
 
     it('should select the next section when editing after all the sections were selected', async () => {
       const view = renderWithProps({});
-      await view.selectSection('month');
+      await view.selectSectionAsync('month');
 
       // Select all sections
-      await view.user.keyboard('{Control>}a{/Control}');
+      fireEvent.keyDown(view.getActiveSection(0), {
+        key: 'a',
+        keyCode: 65,
+        ctrlKey: true,
+      });
       expect(getCleanedSelectedContent()).to.equal('MM/DD/YYYY');
 
-      await view.user.keyboard('{ArrowDown}');
+      fireEvent.keyDown(view.getSectionsContainer(), { key: 'ArrowDown' });
       expect(getCleanedSelectedContent()).to.equal('12');
 
-      await view.user.keyboard('{ArrowRight}');
+      fireEvent.keyDown(view.getActiveSection(0), { key: 'ArrowRight' });
       expect(getCleanedSelectedContent()).to.equal('DD');
     });
   });
@@ -138,29 +154,33 @@ describe('<DateField /> - Selection', () => {
   describe('key: ArrowLeft', () => {
     it('should move selection to the previous section when one section is selected', async () => {
       const view = renderWithProps({});
-      await view.selectSection('day');
+      await view.selectSectionAsync('day');
       expect(getCleanedSelectedContent()).to.equal('DD');
-      await view.user.keyboard('{ArrowLeft}');
+      fireEvent.keyDown(view.getActiveSection(1), { key: 'ArrowLeft' });
       expect(getCleanedSelectedContent()).to.equal('MM');
     });
 
     it('should stay on the current section when the first section is selected', async () => {
       const view = renderWithProps({});
-      await view.selectSection('month');
+      await view.selectSectionAsync('month');
       expect(getCleanedSelectedContent()).to.equal('MM');
-      await view.user.keyboard('{ArrowLeft}');
+      fireEvent.keyDown(view.getActiveSection(0), { key: 'ArrowLeft' });
       expect(getCleanedSelectedContent()).to.equal('MM');
     });
 
     it('should select the first section when all the sections are selected', async () => {
       const view = renderWithProps({});
-      await view.selectSection('month');
+      await view.selectSectionAsync('month');
 
       // Select all sections
-      await view.user.keyboard('{Control>}a{/Control}');
+      fireEvent.keyDown(view.getActiveSection(0), {
+        key: 'a',
+        keyCode: 65,
+        ctrlKey: true,
+      });
       expect(getCleanedSelectedContent()).to.equal('MM/DD/YYYY');
 
-      await view.user.keyboard('{ArrowLeft}');
+      fireEvent.keyDown(view.getSectionsContainer(), { key: 'ArrowLeft' });
       expect(getCleanedSelectedContent()).to.equal('MM');
     });
 

--- a/packages/x-date-pickers/src/DateTimeField/tests/describeValue.DateTimeField.test.tsx
+++ b/packages/x-date-pickers/src/DateTimeField/tests/describeValue.DateTimeField.test.tsx
@@ -32,10 +32,10 @@ describe('<DateTimeField /> - Describe Value', () => {
 
       expectFieldValue(fieldRoot, expectedValueStr);
     },
-    setNewValue: async (value, { selectSection, pressKey }) => {
+    setNewValue: (value, { selectSection, pressKey }) => {
       const newValue = adapterToUse.addDays(value!, 1);
-      await selectSection('day');
-      await pressKey('ArrowUp');
+      selectSection('day');
+      pressKey(undefined, 'ArrowUp');
 
       return newValue;
     },

--- a/packages/x-date-pickers/src/DateTimeField/tests/editing.DateTimeField.test.tsx
+++ b/packages/x-date-pickers/src/DateTimeField/tests/editing.DateTimeField.test.tsx
@@ -1,4 +1,5 @@
 import { spy } from 'sinon';
+import { fireEvent } from '@mui/internal-test-utils';
 import { DateTimeField } from '@mui/x-date-pickers/DateTimeField';
 import {
   adapterToUse,
@@ -18,7 +19,7 @@ describe('<DateTimeField /> - Editing', () => {
   });
 
   describe('Reference value', () => {
-    it('should use the referenceDate prop when defined', async () => {
+    it('should use the referenceDate prop when defined', () => {
       const onChange = spy();
       const referenceDate = adapterToUse.date('2012-05-03T14:30:00');
 
@@ -28,14 +29,14 @@ describe('<DateTimeField /> - Editing', () => {
         format: adapterToUse.formats.month,
       });
 
-      await view.selectSection('month');
-      await view.user.keyboard('{ArrowUp}');
+      view.selectSection('month');
+      fireEvent.keyDown(view.getActiveSection(0), { key: 'ArrowUp' });
 
       // All sections not present should equal the one from the referenceDate, and the month should equal January (because it's an ArrowUp on an empty month).
       expect(onChange.lastCall.firstArg).toEqualDateTime(adapterToUse.setMonth(referenceDate, 0));
     });
 
-    it('should not use the referenceDate prop when a value is defined', async () => {
+    it('should not use the referenceDate prop when a value is defined', () => {
       const onChange = spy();
       const value = adapterToUse.date('2018-11-03T22:15:00');
       const referenceDate = adapterToUse.date('2012-05-03T14:30:00');
@@ -47,14 +48,14 @@ describe('<DateTimeField /> - Editing', () => {
         format: adapterToUse.formats.month,
       });
 
-      await view.selectSection('month');
-      await view.user.keyboard('{ArrowUp}');
+      view.selectSection('month');
+      fireEvent.keyDown(view.getActiveSection(0), { key: 'ArrowUp' });
 
       // Should equal the initial `value` prop with one less month.
       expect(onChange.lastCall.firstArg).toEqualDateTime(adapterToUse.setMonth(value, 11));
     });
 
-    it('should not use the referenceDate prop when a defaultValue is defined', async () => {
+    it('should not use the referenceDate prop when a defaultValue is defined', () => {
       const onChange = spy();
       const defaultValue = adapterToUse.date('2018-11-03T22:15:00');
       const referenceDate = adapterToUse.date('2012-05-03T14:30:00');
@@ -66,15 +67,15 @@ describe('<DateTimeField /> - Editing', () => {
         format: adapterToUse.formats.month,
       });
 
-      await view.selectSection('month');
-      await view.user.keyboard('{ArrowUp}');
+      view.selectSection('month');
+      fireEvent.keyDown(view.getActiveSection(0), { key: 'ArrowUp' });
 
       // Should equal the initial `defaultValue` prop with one less month.
       expect(onChange.lastCall.firstArg).toEqualDateTime(adapterToUse.setMonth(defaultValue, 11));
     });
 
     describe('Reference value based on section granularity', () => {
-      it('should only keep year when granularity = month', async () => {
+      it('should only keep year when granularity = month', () => {
         const onChange = spy();
 
         const view = renderWithProps({
@@ -82,13 +83,13 @@ describe('<DateTimeField /> - Editing', () => {
           format: adapterToUse.formats.month,
         });
 
-        await view.selectSection('month');
-        await view.user.keyboard('{ArrowUp}');
+        view.selectSection('month');
+        fireEvent.keyDown(view.getActiveSection(0), { key: 'ArrowUp' });
 
         expect(onChange.lastCall.firstArg).toEqualDateTime('2012-01-01');
       });
 
-      it('should only keep year and month when granularity = day', async () => {
+      it('should only keep year and month when granularity = day', () => {
         const onChange = spy();
 
         const view = renderWithProps({
@@ -96,13 +97,13 @@ describe('<DateTimeField /> - Editing', () => {
           format: adapterToUse.formats.dayOfMonth,
         });
 
-        await view.selectSection('day');
-        await view.user.keyboard('{ArrowUp}');
+        view.selectSection('day');
+        fireEvent.keyDown(view.getActiveSection(0), { key: 'ArrowUp' });
 
         expect(onChange.lastCall.firstArg).toEqualDateTime('2012-05-01');
       });
 
-      it('should only keep up to the hours when granularity = minutes', async () => {
+      it('should only keep up to the hours when granularity = minutes', () => {
         const onChange = spy();
 
         const view = renderWithProps({
@@ -110,21 +111,21 @@ describe('<DateTimeField /> - Editing', () => {
           format: adapterToUse.formats.fullTime24h,
         });
 
-        await view.selectSection('hours');
+        view.selectSection('hours');
 
         // Set hours
-        await view.user.keyboard('{ArrowUp}');
+        fireEvent.keyDown(view.getActiveSection(0), { key: 'ArrowUp' });
 
         // Set minutes
-        await view.user.keyboard('{ArrowRight}');
-        await view.user.keyboard('{ArrowUp}');
+        fireEvent.keyDown(view.getActiveSection(0), { key: 'ArrowRight' });
+        fireEvent.keyDown(view.getActiveSection(1), { key: 'ArrowUp' });
 
         expect(onChange.lastCall.firstArg).toEqualDateTime('2012-05-03T00:00:00.000Z');
       });
     });
 
     describe('Reference value based on validation props', () => {
-      it("should create a reference date just after the `minDate` if it's after the current date", async () => {
+      it("should create a reference date just after the `minDate` if it's after the current date", () => {
         const onChange = spy();
         const minDate = adapterToUse.date('2030-05-05T18:30:00');
 
@@ -134,14 +135,14 @@ describe('<DateTimeField /> - Editing', () => {
           format: adapterToUse.formats.month,
         });
 
-        await view.selectSection('month');
-        await view.user.keyboard('{ArrowUp}');
+        view.selectSection('month');
+        fireEvent.keyDown(view.getActiveSection(0), { key: 'ArrowUp' });
 
         // Respect the granularity and the minDate
         expect(onChange.lastCall.firstArg).toEqualDateTime('2030-01-01T00:00');
       });
 
-      it("should ignore the `minDate` if  it's before the current date", async () => {
+      it("should ignore the `minDate` if  it's before the current date", () => {
         const onChange = spy();
         const minDate = adapterToUse.date('2007-05-05T18:30:00');
 
@@ -151,14 +152,14 @@ describe('<DateTimeField /> - Editing', () => {
           format: adapterToUse.formats.month,
         });
 
-        await view.selectSection('month');
-        await view.user.keyboard('{ArrowUp}');
+        view.selectSection('month');
+        fireEvent.keyDown(view.getActiveSection(0), { key: 'ArrowUp' });
 
         // Respect the granularity but not the minDate
         expect(onChange.lastCall.firstArg).toEqualDateTime('2012-01-01T00:00');
       });
 
-      it("should create a reference date just before the `maxDate` if it's before the current date", async () => {
+      it("should create a reference date just before the `maxDate` if it's before the current date", () => {
         const onChange = spy();
         const maxDate = adapterToUse.date('2007-05-05T18:30:00');
 
@@ -168,14 +169,14 @@ describe('<DateTimeField /> - Editing', () => {
           format: adapterToUse.formats.month,
         });
 
-        await view.selectSection('month');
-        await view.user.keyboard('{ArrowUp}');
+        view.selectSection('month');
+        fireEvent.keyDown(view.getActiveSection(0), { key: 'ArrowUp' });
 
         // Respect the granularity and the minDate
         expect(onChange.lastCall.firstArg).toEqualDateTime('2007-01-01T00:00');
       });
 
-      it("should ignore the `maxDate` if  it's after the current date", async () => {
+      it("should ignore the `maxDate` if  it's after the current date", () => {
         const onChange = spy();
         const maxDate = adapterToUse.date('2030-05-05T18:30:00');
 
@@ -185,8 +186,8 @@ describe('<DateTimeField /> - Editing', () => {
           format: adapterToUse.formats.month,
         });
 
-        await view.selectSection('month');
-        await view.user.keyboard('{ArrowUp}');
+        view.selectSection('month');
+        fireEvent.keyDown(view.getActiveSection(0), { key: 'ArrowUp' });
 
         // Respect the granularity but not the maxDate
         expect(onChange.lastCall.firstArg).toEqualDateTime('2012-01-01T00:00');

--- a/packages/x-date-pickers/src/DateTimeField/tests/timezone.DateTimeField.test.tsx
+++ b/packages/x-date-pickers/src/DateTimeField/tests/timezone.DateTimeField.test.tsx
@@ -1,5 +1,6 @@
 import { spy } from 'sinon';
 import { DateTime } from 'luxon';
+import { fireEvent } from '@mui/internal-test-utils';
 import { DateTimeField } from '@mui/x-date-pickers/DateTimeField';
 import {
   createPickerRenderer,
@@ -15,27 +16,24 @@ describe('<DateTimeField /> - Timezone', () => {
     describe.skipIf(!adapter.isTimezoneCompatible)('timezoneCompatible', () => {
       const format = `${adapter.formats.keyboardDate} ${adapter.formats.hours24h}`;
 
-      const fillEmptyValue = async (
-        response: ReturnType<typeof renderWithProps>,
-        timezone: string,
-      ) => {
-        await response.selectSection('month');
+      const fillEmptyValue = (response: ReturnType<typeof renderWithProps>, timezone: string) => {
+        response.selectSection('month');
 
         // Set month
-        await response.user.keyboard('{ArrowDown}');
-        await response.user.keyboard('{ArrowRight}');
+        fireEvent.keyDown(response.getActiveSection(0), { key: 'ArrowDown' });
+        fireEvent.keyDown(response.getActiveSection(0), { key: 'ArrowRight' });
 
         // Set day
-        await response.user.keyboard('{ArrowDown}');
-        await response.user.keyboard('{ArrowRight}');
+        fireEvent.keyDown(response.getActiveSection(1), { key: 'ArrowDown' });
+        fireEvent.keyDown(response.getActiveSection(1), { key: 'ArrowRight' });
 
         // Set year
-        await response.user.keyboard('{ArrowDown}');
-        await response.user.keyboard('{ArrowRight}');
+        fireEvent.keyDown(response.getActiveSection(2), { key: 'ArrowDown' });
+        fireEvent.keyDown(response.getActiveSection(2), { key: 'ArrowRight' });
 
         // Set hours
-        await response.user.keyboard('{ArrowDown}');
-        await response.user.keyboard('{ArrowRight}');
+        fireEvent.keyDown(response.getActiveSection(3), { key: 'ArrowDown' });
+        fireEvent.keyDown(response.getActiveSection(3), { key: 'ArrowRight' });
 
         return adapter.setHours(
           adapter.setDate(adapter.setMonth(adapter.date(undefined, timezone), 11), 31),
@@ -43,14 +41,14 @@ describe('<DateTimeField /> - Timezone', () => {
         );
       };
 
-      it('should use default timezone for rendering and onChange when no value and no timezone prop are provided', async () => {
+      it('should use default timezone for rendering and onChange when no value and no timezone prop are provided', () => {
         const onChange = spy();
         const view = renderWithProps({
           onChange,
           format,
         });
 
-        const expectedDate = await fillEmptyValue(view, 'default');
+        const expectedDate = fillEmptyValue(view, 'default');
 
         // Check the rendered value (uses default timezone, for example: UTC, see TZ env variable)
         expectFieldValue(view.getSectionsContainer(), '12/31/2022 23');
@@ -68,14 +66,14 @@ describe('<DateTimeField /> - Timezone', () => {
 
       TIMEZONE_TO_TEST.forEach((timezone) => {
         describe(`Timezone: ${timezone}`, () => {
-          it('should use timezone prop for onChange and rendering when no value is provided', async () => {
+          it('should use timezone prop for onChange and rendering when no value is provided', () => {
             const onChange = spy();
             const view = renderWithProps({
               onChange,
               format,
               timezone,
             });
-            const expectedDate = await fillEmptyValue(view, timezone);
+            const expectedDate = fillEmptyValue(view, timezone);
 
             // Check the rendered value (uses timezone prop)
             expectFieldValue(view.getSectionsContainer(), '12/31/2022 23');
@@ -86,7 +84,7 @@ describe('<DateTimeField /> - Timezone', () => {
             expect(actualDate).toEqualDateTime(expectedDate);
           });
 
-          it('should use timezone prop for rendering and value timezone for onChange when a value is provided', async () => {
+          it('should use timezone prop for rendering and value timezone for onChange when a value is provided', () => {
             const onChange = spy();
             const view = renderWithProps({
               defaultValue: adapter.date(undefined, timezone),
@@ -95,8 +93,8 @@ describe('<DateTimeField /> - Timezone', () => {
               timezone: 'America/Chicago',
             });
 
-            await view.selectSection('month');
-            await view.user.keyboard('{ArrowDown}');
+            view.selectSection('month');
+            fireEvent.keyDown(view.getActiveSection(0), { key: 'ArrowDown' });
 
             // Check the rendered value (uses America/Chicago timezone)
             expectFieldValue(view.getSectionsContainer(), '05/14/2022 19');

--- a/packages/x-date-pickers/src/DesktopDatePicker/tests/DesktopDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/tests/DesktopDatePicker.test.tsx
@@ -4,7 +4,7 @@ import { TransitionProps } from '@mui/material/transitions';
 import { inputBaseClasses } from '@mui/material/InputBase';
 import { act, screen, waitFor } from '@mui/internal-test-utils';
 import { DesktopDatePicker, DesktopDatePickerProps } from '@mui/x-date-pickers/DesktopDatePicker';
-import { createPickerRenderer, adapterToUse, openPicker } from 'test/utils/pickers';
+import { createPickerRenderer, adapterToUse, openPickerAsync } from 'test/utils/pickers';
 import { isJSDOM } from 'test/utils/skipIf';
 import { PickersActionBar, PickersActionBarAction } from '@mui/x-date-pickers/PickersActionBar';
 import { PickerValidDate } from '@mui/x-date-pickers/models';
@@ -42,7 +42,7 @@ describe('<DesktopDatePicker />', () => {
         />,
       );
 
-      await openPicker(user, { type: 'date' });
+      await openPickerAsync(user, { type: 'date' });
 
       await user.click(screen.getByLabelText(/switch to year view/i));
       expect(handleViewChange.callCount).to.equal(1);
@@ -50,7 +50,7 @@ describe('<DesktopDatePicker />', () => {
       // Dismiss the picker
       await user.keyboard('[Escape]');
 
-      await openPicker(user, { type: 'date' });
+      await openPickerAsync(user, { type: 'date' });
       expect(handleViewChange.callCount).to.equal(2);
       expect(handleViewChange.lastCall.firstArg).to.equal('day');
     });
@@ -67,7 +67,7 @@ describe('<DesktopDatePicker />', () => {
         />,
       );
 
-      await openPicker(user, { type: 'date' });
+      await openPickerAsync(user, { type: 'date' });
 
       await user.click(screen.getByLabelText(/switch to year view/i));
       expect(handleViewChange.callCount).to.equal(1);
@@ -75,7 +75,7 @@ describe('<DesktopDatePicker />', () => {
       // Dismiss the picker
       await user.keyboard('[Escape]');
 
-      await openPicker(user, { type: 'date' });
+      await openPickerAsync(user, { type: 'date' });
       expect(handleViewChange.callCount).to.equal(2);
       expect(handleViewChange.lastCall.firstArg).to.equal('month');
     });
@@ -85,14 +85,14 @@ describe('<DesktopDatePicker />', () => {
         <DesktopDatePicker defaultValue={adapterToUse.date('2018-01-01')} views={['year']} />,
       );
 
-      await openPicker(user, { type: 'date' });
+      await openPickerAsync(user, { type: 'date' });
 
       expect(screen.getByRole('radio', { checked: true, name: '2018' })).not.to.equal(null);
 
       // Dismiss the picker
       await user.keyboard('[Escape]');
       setProps({ views: ['month', 'year'] });
-      await openPicker(user, { type: 'date' });
+      await openPickerAsync(user, { type: 'date' });
       // should have changed the open view
       expect(screen.getByRole('radio', { checked: true, name: 'January' })).not.to.equal(null);
     });
@@ -102,7 +102,7 @@ describe('<DesktopDatePicker />', () => {
         <DesktopDatePicker defaultValue={new Date(2019, 5, 5)} openTo="year" />,
       );
 
-      await openPicker(user, { type: 'date' });
+      await openPickerAsync(user, { type: 'date' });
       expect(document.activeElement).to.have.text('2019');
 
       await user.click(screen.getByText('2020'));
@@ -136,14 +136,14 @@ describe('<DesktopDatePicker />', () => {
         />,
       );
 
-      await openPicker(user, { type: 'date' });
+      await openPickerAsync(user, { type: 'date' });
 
       expect(screen.getByRole('radio', { checked: true, name: 'January' })).not.to.equal(null);
 
       // Dismiss the picker
       await user.keyboard('[Escape]');
       setProps({ view: 'year' });
-      await openPicker(user, { type: 'date' });
+      await openPickerAsync(user, { type: 'date' });
       // should have changed the open view
       expect(screen.getByRole('radio', { checked: true, name: '2018' })).not.to.equal(null);
     });
@@ -252,7 +252,7 @@ describe('<DesktopDatePicker />', () => {
         />,
       );
 
-      await openPicker(user, { type: 'date' });
+      await openPickerAsync(user, { type: 'date' });
 
       // Select year
       await user.click(screen.getByRole('radio', { name: '2025' }));
@@ -296,7 +296,7 @@ describe('<DesktopDatePicker />', () => {
         <TestCase onChange={onChange} onAccept={onAccept} onClose={onClose} />,
       );
 
-      await openPicker(user, { type: 'date' });
+      await openPickerAsync(user, { type: 'date' });
 
       // Change the day
       await user.click(screen.getByRole('gridcell', { name: '2' }));
@@ -304,7 +304,7 @@ describe('<DesktopDatePicker />', () => {
       expect(onAccept.callCount).to.equal(1);
       expect(onAccept.lastCall.args[0]).toEqualDateTime(new Date(2018, 0, 2));
       expect(onClose.callCount).to.equal(1);
-      await openPicker(user, { type: 'date' });
+      await openPickerAsync(user, { type: 'date' });
 
       // Change to the initial day
       await user.click(screen.getByRole('gridcell', { name: '1' }));
@@ -324,7 +324,7 @@ describe('<DesktopDatePicker />', () => {
         />,
       );
 
-      await openPicker(user, { type: 'date' });
+      await openPickerAsync(user, { type: 'date' });
 
       expect(screen.getByLabelText('Previous month')).to.have.attribute('disabled');
     });
@@ -337,7 +337,7 @@ describe('<DesktopDatePicker />', () => {
         />,
       );
 
-      await openPicker(user, { type: 'date' });
+      await openPickerAsync(user, { type: 'date' });
 
       expect(screen.getByLabelText('Previous month')).not.to.have.attribute('disabled');
     });
@@ -350,7 +350,7 @@ describe('<DesktopDatePicker />', () => {
         />,
       );
 
-      await openPicker(user, { type: 'date' });
+      await openPickerAsync(user, { type: 'date' });
 
       expect(screen.getByLabelText('Next month')).to.have.attribute('disabled');
     });
@@ -363,7 +363,7 @@ describe('<DesktopDatePicker />', () => {
         />,
       );
 
-      await openPicker(user, { type: 'date' });
+      await openPickerAsync(user, { type: 'date' });
 
       expect(screen.getByLabelText('Next month')).not.to.have.attribute('disabled');
     });
@@ -408,7 +408,7 @@ describe('<DesktopDatePicker />', () => {
     await expect(async () => {
       const { user } = render(<DesktopDatePicker defaultValue={null} openTo="month" />);
 
-      await openPicker(user, { type: 'date' });
+      await openPickerAsync(user, { type: 'date' });
     }).toWarnDev('MUI X: `openTo="month"` is not a valid prop.');
   });
 

--- a/packages/x-date-pickers/src/DesktopDatePicker/tests/describeValue.DesktopDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/tests/describeValue.DesktopDatePicker.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@mui/internal-test-utils';
+import { fireEvent, screen } from '@mui/internal-test-utils';
 import {
   createPickerRenderer,
   adapterToUse,
@@ -28,16 +28,16 @@ describe('<DesktopDatePicker /> - Describe Value', () => {
 
       expectFieldValue(fieldRoot, expectedValueStr);
     },
-    setNewValue: async (value, { isOpened, applySameValue, selectSection, pressKey, user }) => {
+    setNewValue: (value, { isOpened, applySameValue, selectSection, pressKey }) => {
       const newValue = applySameValue ? value! : adapterToUse.addDays(value!, 1);
 
       if (isOpened) {
-        await user.click(
+        fireEvent.click(
           screen.getByRole('gridcell', { name: adapterToUse.getDate(newValue).toString() }),
         );
       } else {
-        await selectSection('day');
-        await pressKey('ArrowUp');
+        selectSection('day');
+        pressKey(undefined, 'ArrowUp');
       }
 
       return newValue;

--- a/packages/x-date-pickers/src/DesktopDatePicker/tests/field.DesktopDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/tests/field.DesktopDatePicker.test.tsx
@@ -25,7 +25,7 @@ describe('<DesktopDatePicker /> - Field', () => {
         { componentFamily: 'picker' },
       );
 
-      await view.selectSection('month');
+      view.selectSection('month');
       expectFieldValue(view.getSectionsContainer(), 'MMMM DD');
 
       await view.user.keyboard('N');
@@ -56,7 +56,7 @@ describe('<DesktopDatePicker /> - Field', () => {
   });
 
   describeAdapters('Timezone', DesktopDatePicker, ({ adapter, renderWithProps }) => {
-    it('should clear the selected section when all sections are completed when using timezones', async () => {
+    it('should clear the selected section when all sections are completed when using timezones', () => {
       const view = renderWithProps(
         {
           defaultValue: adapter.date()!,
@@ -67,9 +67,9 @@ describe('<DesktopDatePicker /> - Field', () => {
       );
 
       expectFieldValue(view.getSectionsContainer(), 'June 2022');
-      await view.selectSection('month');
+      view.selectSection('month');
 
-      await view.pressKey('');
+      view.pressKey(0, '');
       expectFieldValue(view.getSectionsContainer(), 'MMMM 2022');
     });
   });

--- a/packages/x-date-pickers/src/DesktopDatePicker/tests/keepOpenDuringFieldFocus.clickFieldDoesNotClose.DesktopDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/tests/keepOpenDuringFieldFocus.clickFieldDoesNotClose.DesktopDatePicker.test.tsx
@@ -1,6 +1,10 @@
 import { screen } from '@mui/internal-test-utils';
 import { DesktopDatePicker } from '@mui/x-date-pickers/DesktopDatePicker';
-import { createPickerRenderer, getFieldSectionsContainer, openPicker } from 'test/utils/pickers';
+import {
+  createPickerRenderer,
+  getFieldSectionsContainer,
+  openPickerAsync,
+} from 'test/utils/pickers';
 
 describe('DesktopDatePicker keepOpenDuringFieldFocus - clicking field should not close', () => {
   const { render } = createPickerRenderer();
@@ -8,7 +12,7 @@ describe('DesktopDatePicker keepOpenDuringFieldFocus - clicking field should not
   it('keeps popper open when clicking back into the field while open', async () => {
     const { user } = render(<DesktopDatePicker keepOpenDuringFieldFocus />);
 
-    await openPicker(user, { type: 'date' });
+    await openPickerAsync(user, { type: 'date' });
 
     // Click the textbox (field input)
     const textbox = getFieldSectionsContainer();

--- a/packages/x-date-pickers/src/DesktopDateTimePicker/tests/DesktopDateTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDateTimePicker/tests/DesktopDateTimePicker.test.tsx
@@ -5,6 +5,7 @@ import {
   adapterToUse,
   createPickerRenderer,
   openPicker,
+  openPickerAsync,
   getFieldSectionsContainer,
   expectFieldValue,
 } from 'test/utils/pickers';
@@ -39,7 +40,7 @@ describe('<DesktopDateTimePicker />', () => {
         />,
       );
 
-      await openPicker(user, { type: 'date-time' });
+      openPicker({ type: 'date-time' });
 
       // Select year
       await user.click(screen.getByRole('radio', { name: '2025' }));
@@ -85,7 +86,7 @@ describe('<DesktopDateTimePicker />', () => {
       />,
     );
 
-    await openPicker(user, { type: 'date-time' });
+    openPicker({ type: 'date-time' });
 
     // Change the date multiple times to check that Picker doesn't close after cycling through all views internally
     await user.click(screen.getByRole('gridcell', { name: '2' }));
@@ -124,7 +125,7 @@ describe('<DesktopDateTimePicker />', () => {
       <DesktopDateTimePicker referenceDate={adapterToUse.date('2018-01-10')} />,
     );
 
-    await openPicker(user, { type: 'date-time' });
+    await openPickerAsync(user, { type: 'date-time' });
 
     const day = screen.getByRole('gridcell', { name: '10' });
     expect(day).toHaveFocus();

--- a/packages/x-date-pickers/src/DesktopDateTimePicker/tests/describeValue.DesktopDateTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDateTimePicker/tests/describeValue.DesktopDateTimePicker.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@mui/internal-test-utils';
+import { fireEvent, screen } from '@mui/internal-test-utils';
 import {
   createPickerRenderer,
   adapterToUse,
@@ -35,43 +35,43 @@ describe('<DesktopDateTimePicker /> - Describe Value', () => {
 
       expectFieldValue(fieldRoot, expectedValueStr);
     },
-    setNewValue: async (value, { isOpened, applySameValue, selectSection, pressKey, user }) => {
+    setNewValue: (value, { isOpened, applySameValue, selectSection, pressKey }) => {
       const newValue = applySameValue
         ? value!
         : adapterToUse.addMinutes(adapterToUse.addHours(adapterToUse.addDays(value!, 1), 1), 5);
 
       if (isOpened) {
-        await user.click(
+        fireEvent.click(
           screen.getByRole('gridcell', { name: adapterToUse.getDate(newValue).toString() }),
         );
         const hasMeridiem = adapterToUse.is12HourCycleInCurrentLocale();
         const hours = adapterToUse.format(newValue, hasMeridiem ? 'hours12h' : 'hours24h');
         const hoursNumber = adapterToUse.getHours(newValue);
-        await user.click(screen.getByRole('option', { name: `${parseInt(hours, 10)} hours` }));
-        await user.click(
+        fireEvent.click(screen.getByRole('option', { name: `${parseInt(hours, 10)} hours` }));
+        fireEvent.click(
           screen.getByRole('option', { name: `${adapterToUse.getMinutes(newValue)} minutes` }),
         );
         if (hasMeridiem) {
-          await user.click(screen.getByRole('option', { name: hoursNumber >= 12 ? 'PM' : 'AM' }));
+          fireEvent.click(screen.getByRole('option', { name: hoursNumber >= 12 ? 'PM' : 'AM' }));
         }
       } else {
-        await selectSection('day');
-        await pressKey('ArrowUp');
+        selectSection('day');
+        pressKey(undefined, 'ArrowUp');
 
-        await selectSection('hours');
-        await pressKey('ArrowUp');
+        selectSection('hours');
+        pressKey(undefined, 'ArrowUp');
 
-        await selectSection('minutes');
-        await pressKey('PageUp'); // increment by 5 minutes
+        selectSection('minutes');
+        pressKey(undefined, 'PageUp'); // increment by 5 minutes
 
         const hasMeridiem = adapterToUse.is12HourCycleInCurrentLocale();
         if (hasMeridiem) {
-          await selectSection('meridiem');
+          selectSection('meridiem');
           const previousHours = adapterToUse.getHours(value!);
           const newHours = adapterToUse.getHours(newValue);
           // update meridiem section if it changed
           if ((previousHours < 12 && newHours >= 12) || (previousHours >= 12 && newHours < 12)) {
-            await pressKey('ArrowUp');
+            pressKey(undefined, 'ArrowUp');
           }
         }
       }

--- a/packages/x-date-pickers/src/DesktopTimePicker/tests/DesktopTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopTimePicker/tests/DesktopTimePicker.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { spy } from 'sinon';
 import { screen, waitFor } from '@mui/internal-test-utils';
 import { DesktopTimePicker } from '@mui/x-date-pickers/DesktopTimePicker';
-import { adapterToUse, createPickerRenderer, openPicker } from 'test/utils/pickers';
+import { adapterToUse, createPickerRenderer, openPickerAsync } from 'test/utils/pickers';
 
 describe('<DesktopTimePicker />', () => {
   const { render } = createPickerRenderer();
@@ -71,7 +71,7 @@ describe('<DesktopTimePicker />', () => {
         />,
       );
 
-      await openPicker(user, { type: 'time' });
+      await openPickerAsync(user, { type: 'time' });
 
       await user.click(screen.getByRole('option', { name: '09:00 AM' }));
       expect(onChange.callCount).to.equal(1);
@@ -100,7 +100,7 @@ describe('<DesktopTimePicker />', () => {
         />,
       );
 
-      await openPicker(user, { type: 'time' });
+      await openPickerAsync(user, { type: 'time' });
 
       await user.click(screen.getByRole('option', { name: '2 hours' }));
       expect(onChange.callCount).to.equal(1);
@@ -138,7 +138,7 @@ describe('<DesktopTimePicker />', () => {
         />,
       );
 
-      await openPicker(user, { type: 'time' });
+      await openPickerAsync(user, { type: 'time' });
 
       await user.click(screen.getByRole('option', { name: '15 minutes' }));
       expect(onChange.callCount).to.equal(1);
@@ -181,7 +181,7 @@ describe('<DesktopTimePicker />', () => {
         />,
       );
 
-      await openPicker(user, { type: 'time' });
+      await openPickerAsync(user, { type: 'time' });
 
       await user.click(screen.getByRole('option', { name: 'PM' }));
       expect(onChange.callCount).to.equal(1);

--- a/packages/x-date-pickers/src/DesktopTimePicker/tests/describeValue.DesktopTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopTimePicker/tests/describeValue.DesktopTimePicker.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@mui/internal-test-utils';
+import { fireEvent, screen } from '@mui/internal-test-utils';
 import {
   createPickerRenderer,
   adapterToUse,
@@ -33,7 +33,7 @@ describe('<DesktopTimePicker /> - Describe Value', () => {
 
       expectFieldValue(fieldRoot, expectedValueStr);
     },
-    setNewValue: async (value, { isOpened, applySameValue, selectSection, pressKey, user }) => {
+    setNewValue: (value, { isOpened, applySameValue, selectSection, pressKey }) => {
       const newValue = applySameValue
         ? value!
         : adapterToUse.addMinutes(adapterToUse.addHours(value!, 1), 5);
@@ -42,28 +42,28 @@ describe('<DesktopTimePicker /> - Describe Value', () => {
         const hasMeridiem = adapterToUse.is12HourCycleInCurrentLocale();
         const hours = adapterToUse.format(newValue, hasMeridiem ? 'hours12h' : 'hours24h');
         const hoursNumber = adapterToUse.getHours(newValue);
-        await user.click(screen.getByRole('option', { name: `${parseInt(hours, 10)} hours` }));
-        await user.click(
+        fireEvent.click(screen.getByRole('option', { name: `${parseInt(hours, 10)} hours` }));
+        fireEvent.click(
           screen.getByRole('option', { name: `${adapterToUse.getMinutes(newValue)} minutes` }),
         );
         if (hasMeridiem) {
-          await user.click(screen.getByRole('option', { name: hoursNumber >= 12 ? 'PM' : 'AM' }));
+          fireEvent.click(screen.getByRole('option', { name: hoursNumber >= 12 ? 'PM' : 'AM' }));
         }
       } else {
-        await selectSection('hours');
-        await pressKey('ArrowUp');
+        selectSection('hours');
+        pressKey(undefined, 'ArrowUp');
 
-        await selectSection('minutes');
-        await pressKey('PageUp'); // increment by 5 minutes
+        selectSection('minutes');
+        pressKey(undefined, 'PageUp'); // increment by 5 minutes
 
         const hasMeridiem = adapterToUse.is12HourCycleInCurrentLocale();
         if (hasMeridiem) {
-          await selectSection('meridiem');
+          selectSection('meridiem');
           const previousHours = adapterToUse.getHours(value!);
           const newHours = adapterToUse.getHours(newValue);
           // update meridiem section if it changed
           if ((previousHours < 12 && newHours >= 12) || (previousHours >= 12 && newHours < 12)) {
-            await pressKey('ArrowUp');
+            pressKey(undefined, 'ArrowUp');
           }
         }
       }

--- a/packages/x-date-pickers/src/DigitalClock/tests/DigitalClock.test.tsx
+++ b/packages/x-date-pickers/src/DigitalClock/tests/DigitalClock.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable mui/disallow-active-element-as-key-event-target */
 import { spy } from 'sinon';
 import { DigitalClock } from '@mui/x-date-pickers/DigitalClock';
 import {
@@ -6,19 +7,17 @@ import {
   digitalClockHandler,
   formatFullTimeValue,
 } from 'test/utils/pickers';
-import { screen } from '@mui/internal-test-utils';
+import { fireEvent, screen } from '@mui/internal-test-utils';
 
 describe('<DigitalClock />', () => {
   const { render } = createPickerRenderer();
 
   describe('Reference date', () => {
-    it('should use `referenceDate` when no value defined', async () => {
+    it('should use `referenceDate` when no value defined', () => {
       const onChange = spy();
       const referenceDate = '2018-01-01T12:30:00';
 
-      const { user } = render(
-        <DigitalClock onChange={onChange} referenceDate={adapterToUse.date(referenceDate)} />,
-      );
+      render(<DigitalClock onChange={onChange} referenceDate={adapterToUse.date(referenceDate)} />);
 
       // the first item should not be initially focusable when `referenceDate` is defined
       expect(
@@ -33,8 +32,7 @@ describe('<DigitalClock />', () => {
         }),
       ).to.have.attribute('tabindex', '0');
 
-      await digitalClockHandler.setViewValue(
-        user,
+      digitalClockHandler.setViewValue(
         adapterToUse,
         adapterToUse.setMinutes(adapterToUse.setHours(adapterToUse.date(), 15), 30),
       );
@@ -54,10 +52,10 @@ describe('<DigitalClock />', () => {
       ).to.have.attribute('tabindex', '0');
     });
 
-    it('should not use `referenceDate` when a value is defined', async () => {
+    it('should not use `referenceDate` when a value is defined', () => {
       const onChange = spy();
 
-      const { user } = render(
+      render(
         <DigitalClock
           onChange={onChange}
           value={adapterToUse.date('2019-01-01T12:30:00')}
@@ -65,8 +63,7 @@ describe('<DigitalClock />', () => {
         />,
       );
 
-      await digitalClockHandler.setViewValue(
-        user,
+      digitalClockHandler.setViewValue(
         adapterToUse,
         adapterToUse.setMinutes(adapterToUse.setHours(adapterToUse.date(), 15), 30),
       );
@@ -74,10 +71,10 @@ describe('<DigitalClock />', () => {
       expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2019, 0, 1, 15, 30));
     });
 
-    it('should not use `referenceDate` when a defaultValue is defined', async () => {
+    it('should not use `referenceDate` when a defaultValue is defined', () => {
       const onChange = spy();
 
-      const { user } = render(
+      render(
         <DigitalClock
           onChange={onChange}
           defaultValue={adapterToUse.date('2019-01-01T12:30:00')}
@@ -85,8 +82,7 @@ describe('<DigitalClock />', () => {
         />,
       );
 
-      await digitalClockHandler.setViewValue(
-        user,
+      digitalClockHandler.setViewValue(
         adapterToUse,
         adapterToUse.setMinutes(adapterToUse.setHours(adapterToUse.date(), 15), 30),
       );
@@ -96,64 +92,68 @@ describe('<DigitalClock />', () => {
   });
 
   describe('Keyboard support', () => {
-    it('should move focus up by 5 on PageUp press', async () => {
+    it('should move focus up by 5 on PageUp press', () => {
       const handleChange = spy();
-      const { user } = render(<DigitalClock autoFocus onChange={handleChange} />);
+      render(<DigitalClock autoFocus onChange={handleChange} />);
       const options = screen.getAllByRole('option');
       const lastOptionIndex = options.length - 1;
 
-      await user.keyboard('{End}'); // moves focus to last element
-      await user.keyboard('{PageUp}');
+      fireEvent.keyDown(document.activeElement!, { key: 'End' }); // moves focus to last element
+      fireEvent.keyDown(document.activeElement!, { key: 'PageUp' });
 
       expect(handleChange.callCount).to.equal(0);
       expect(document.activeElement).to.equal(options[lastOptionIndex - 5]);
 
-      await user.keyboard('{PageUp}');
+      fireEvent.keyDown(options[lastOptionIndex - 5], { key: 'PageUp' });
       expect(handleChange.callCount).to.equal(0);
       expect(document.activeElement).to.equal(options[lastOptionIndex - 10]);
     });
 
-    it('should move focus to first item on PageUp press when current focused item index is among the first 5 items', async () => {
+    it('should move focus to first item on PageUp press when current focused item index is among the first 5 items', () => {
       const handleChange = spy();
-      const { user } = render(<DigitalClock autoFocus onChange={handleChange} />);
+      render(<DigitalClock autoFocus onChange={handleChange} />);
       const options = screen.getAllByRole('option');
 
       // moves focus to 4th element using arrow down
-      await user.keyboard('{ArrowDown}{ArrowDown}{ArrowDown}');
+      [0, 1, 2].forEach((index) => {
+        fireEvent.keyDown(options[index], { key: 'ArrowDown' });
+      });
 
-      await user.keyboard('{PageUp}');
+      fireEvent.keyDown(options[3], { key: 'PageUp' });
       expect(handleChange.callCount).to.equal(0);
       expect(document.activeElement).to.equal(options[0]);
     });
 
-    it('should move focus down by 5 on PageDown press', async () => {
+    it('should move focus down by 5 on PageDown press', () => {
       const handleChange = spy();
-      const { user } = render(<DigitalClock autoFocus onChange={handleChange} />);
+      render(<DigitalClock autoFocus onChange={handleChange} />);
       const options = screen.getAllByRole('option');
 
-      await user.keyboard('{PageDown}');
+      fireEvent.keyDown(options[0], { key: 'PageDown' });
 
       expect(handleChange.callCount).to.equal(0);
       expect(document.activeElement).to.equal(options[5]);
 
-      await user.keyboard('{PageDown}');
+      fireEvent.keyDown(options[5], { key: 'PageDown' });
 
       expect(handleChange.callCount).to.equal(0);
       expect(document.activeElement).to.equal(options[10]);
     });
 
-    it('should move focus to last item on PageDown press when current focused item index is among the last 5 items', async () => {
+    it('should move focus to last item on PageDown press when current focused item index is among the last 5 items', () => {
       const handleChange = spy();
-      const { user } = render(<DigitalClock autoFocus onChange={handleChange} />);
+      render(<DigitalClock autoFocus onChange={handleChange} />);
       const options = screen.getAllByRole('option');
       const lastOptionIndex = options.length - 1;
 
       const lastElement = options[lastOptionIndex];
 
-      await user.keyboard('{End}'); // moves focus to last element
+      fireEvent.keyDown(document.activeElement!, { key: 'End' }); // moves focus to last element
       // moves focus 4 steps above last item using arrow up
-      await user.keyboard('{ArrowUp}{ArrowUp}{ArrowUp}');
-      await user.keyboard('{PageDown}');
+      [0, 1, 2].forEach((index) => {
+        fireEvent.keyDown(options[lastOptionIndex - index], { key: 'ArrowUp' });
+      });
+      fireEvent.keyDown(options[lastOptionIndex - 3], { key: 'PageDown' });
 
       expect(handleChange.callCount).to.equal(0);
       expect(document.activeElement).to.equal(lastElement);

--- a/packages/x-date-pickers/src/DigitalClock/tests/describeValue.DigitalClock.test.tsx
+++ b/packages/x-date-pickers/src/DigitalClock/tests/describeValue.DigitalClock.test.tsx
@@ -29,9 +29,9 @@ describe('<DigitalClock /> - Describe Value', () => {
         expect(selectedItem).to.have.text(formatFullTimeValue(adapterToUse, expectedValue));
       }
     },
-    setNewValue: async (value, { user }) => {
+    setNewValue: (value) => {
       const newValue = adapterToUse.addMinutes(adapterToUse.addHours(value!, 1), 30);
-      await digitalClockHandler.setViewValue(user, adapterToUse, newValue);
+      digitalClockHandler.setViewValue(adapterToUse, newValue);
 
       return newValue;
     },

--- a/packages/x-date-pickers/src/DigitalClock/tests/timezone.DigitalClock.test.tsx
+++ b/packages/x-date-pickers/src/DigitalClock/tests/timezone.DigitalClock.test.tsx
@@ -1,5 +1,5 @@
 import { spy } from 'sinon';
-import { screen } from '@mui/internal-test-utils';
+import { fireEvent, screen } from '@mui/internal-test-utils';
 import { DigitalClock } from '@mui/x-date-pickers/DigitalClock';
 import { getDateOffset, describeAdapters } from 'test/utils/pickers';
 
@@ -16,11 +16,11 @@ const get24HourFromDigitalClock = () => {
 describe('<DigitalClock /> - Timezone', () => {
   describeAdapters('Timezone prop', DigitalClock, ({ adapter, render }) => {
     describe.skipIf(!adapter.isTimezoneCompatible)('timezoneCompatible', () => {
-      it('should use default timezone for rendering and onChange when no value and no timezone prop are provided', async () => {
+      it('should use default timezone for rendering and onChange when no value and no timezone prop are provided', () => {
         const onChange = spy();
-        const { user } = render(<DigitalClock onChange={onChange} />);
+        render(<DigitalClock onChange={onChange} />);
 
-        await user.click(screen.getByRole('option', { name: '08:00 AM' }));
+        fireEvent.click(screen.getByRole('option', { name: '08:00 AM' }));
 
         const expectedDate = adapter.setHours(adapter.date(), 8);
 
@@ -105,11 +105,11 @@ describe('<DigitalClock /> - Timezone', () => {
 
       TIMEZONE_TO_TEST.forEach((timezone) => {
         describe(`Timezone: ${timezone}`, () => {
-          it('should use timezone prop for onChange when no value is provided', async () => {
+          it('should use timezone prop for onChange when no value is provided', () => {
             const onChange = spy();
-            const { user } = render(<DigitalClock onChange={onChange} timezone={timezone} />);
+            render(<DigitalClock onChange={onChange} timezone={timezone} />);
 
-            await user.click(screen.getByRole('option', { name: '08:00 AM' }));
+            fireEvent.click(screen.getByRole('option', { name: '08:00 AM' }));
 
             const expectedDate = adapter.setHours(
               adapter.startOfDay(adapter.date(undefined, timezone)),
@@ -122,11 +122,11 @@ describe('<DigitalClock /> - Timezone', () => {
             expect(actualDate).toEqualDateTime(expectedDate);
           });
 
-          it('should use timezone prop for rendering and value timezone for onChange when a value is provided', async () => {
+          it('should use timezone prop for rendering and value timezone for onChange when a value is provided', () => {
             const onChange = spy();
             const value = adapter.date('2022-04-17T04:30', timezone);
 
-            const { user } = render(
+            render(
               <DigitalClock defaultValue={value} onChange={onChange} timezone="America/Chicago" />,
             );
 
@@ -140,7 +140,7 @@ describe('<DigitalClock /> - Timezone', () => {
               (adapter.getHours(value) + offsetDiff / 60 + 24) % 24,
             );
 
-            await user.click(screen.getByRole('option', { name: '08:30 PM' }));
+            fireEvent.click(screen.getByRole('option', { name: '08:30 PM' }));
 
             const actualDate = onChange.lastCall.firstArg;
 

--- a/packages/x-date-pickers/src/MobileDatePicker/tests/MobileDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileDatePicker/tests/MobileDatePicker.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { spy } from 'sinon';
-import { screen } from '@mui/internal-test-utils';
+import { fireEvent, screen } from '@mui/internal-test-utils';
 import { PickerDay } from '@mui/x-date-pickers/PickerDay';
 import { DayCalendarSkeleton } from '@mui/x-date-pickers/DayCalendarSkeleton';
 import { MobileDatePicker } from '@mui/x-date-pickers/MobileDatePicker';
@@ -19,21 +19,21 @@ describe('<MobileDatePicker />', () => {
     Component: MobileDatePicker,
   });
 
-  it('allows to change only year', async () => {
+  it('allows to change only year', () => {
     const onChangeMock = spy();
-    const { user } = render(
+    render(
       <MobileDatePicker open value={adapterToUse.date('2019-01-01')} onChange={onChangeMock} />,
     );
 
-    await user.click(screen.getByLabelText(/switch to year view/i));
-    await user.click(screen.getByText('2010', { selector: 'button' }));
+    fireEvent.click(screen.getByLabelText(/switch to year view/i));
+    fireEvent.click(screen.getByText('2010', { selector: 'button' }));
 
     expect(screen.getAllByTestId('calendar-month-and-year-text')[0]).to.have.text('January 2010');
     expect(onChangeMock.callCount).to.equal(1);
   });
 
-  it('allows to select edge years from list', async () => {
-    const { user } = render(
+  it('allows to select edge years from list', () => {
+    render(
       <MobileDatePicker
         open
         reduceAnimations
@@ -43,15 +43,15 @@ describe('<MobileDatePicker />', () => {
       />,
     );
 
-    await user.click(screen.getByText('2010', { selector: 'button' }));
+    fireEvent.click(screen.getByText('2010', { selector: 'button' }));
     expect(screen.getByTestId('datepicker-toolbar-date')).to.have.text('Fri, Jan 1');
   });
 
-  it('prop `onMonthChange` – dispatches callback when months switching', async () => {
+  it('prop `onMonthChange` – dispatches callback when months switching', () => {
     const onMonthChangeMock = spy();
-    const { user } = render(<MobileDatePicker open onMonthChange={onMonthChangeMock} />);
+    render(<MobileDatePicker open onMonthChange={onMonthChangeMock} />);
 
-    await user.click(screen.getByLabelText('Next month'));
+    fireEvent.click(screen.getByLabelText('Next month'));
     expect(onMonthChangeMock.callCount).to.equal(1);
   });
 
@@ -129,7 +129,7 @@ describe('<MobileDatePicker />', () => {
   });
 
   describe('picker state', () => {
-    it('should call `onAccept` even if controlled', async () => {
+    it('should call `onAccept` even if controlled', () => {
       const onAccept = spy();
 
       function ControlledMobileDatePicker(props) {
@@ -138,12 +138,12 @@ describe('<MobileDatePicker />', () => {
         return <MobileDatePicker {...props} value={value} onChange={setValue} />;
       }
 
-      const { user } = render(<ControlledMobileDatePicker onAccept={onAccept} />);
+      render(<ControlledMobileDatePicker onAccept={onAccept} />);
 
-      await openPicker(user, { type: 'date' });
+      openPicker({ type: 'date' });
 
-      await user.click(screen.getByText('15', { selector: 'button' }));
-      await user.click(screen.getByText('OK', { selector: 'button' }));
+      fireEvent.click(screen.getByText('15', { selector: 'button' }));
+      fireEvent.click(screen.getByText('OK', { selector: 'button' }));
 
       expect(onAccept.callCount).to.equal(1);
     });
@@ -161,7 +161,7 @@ describe('<MobileDatePicker />', () => {
       expectFieldValue(view.getSectionsContainer(), 'MM/DD/YYYY');
 
       // Open and Dismiss the picker
-      await openPicker(view.user, { type: 'date' });
+      openPicker({ type: 'date' });
       await view.user.keyboard('[Escape]');
 
       // Verify it's still a clean value

--- a/packages/x-date-pickers/src/MobileDatePicker/tests/describeValue.MobileDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileDatePicker/tests/describeValue.MobileDatePicker.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@mui/internal-test-utils';
+import { screen, fireEvent } from '@mui/internal-test-utils';
 import {
   createPickerRenderer,
   adapterToUse,
@@ -29,19 +29,20 @@ describe('<MobileDatePicker /> - Describe Value', () => {
 
       expectFieldValue(fieldRoot, expectedValueStr);
     },
-    setNewValue: async (value, { isOpened, applySameValue, user }) => {
+    setNewValue: (value, { isOpened, applySameValue }) => {
       if (!isOpened) {
-        await openPicker(user, { type: 'date' });
+        openPicker({ type: 'date' });
       }
 
       const newValue = applySameValue ? value! : adapterToUse.addDays(value!, 1);
-      await user.click(
+      fireEvent.click(
         screen.getByRole('gridcell', { name: adapterToUse.getDate(newValue).toString() }),
       );
 
       // Close the Picker to return to the initial state
       if (!isOpened) {
-        await user.keyboard('{Escape}');
+        // eslint-disable-next-line mui/disallow-active-element-as-key-event-target
+        fireEvent.keyDown(document.activeElement!, { key: 'Escape' });
       }
 
       return newValue;

--- a/packages/x-date-pickers/src/MobileDateTimePicker/tests/MobileDateTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileDateTimePicker/tests/MobileDateTimePicker.test.tsx
@@ -1,5 +1,5 @@
 import { spy } from 'sinon';
-import { screen } from '@mui/internal-test-utils';
+import { fireEvent, screen } from '@mui/internal-test-utils';
 import { MobileDateTimePicker } from '@mui/x-date-pickers/MobileDateTimePicker';
 import { adapterToUse, createPickerRenderer, openPicker } from 'test/utils/pickers';
 import { hasTouchSupport } from 'test/utils/skipIf';
@@ -92,7 +92,7 @@ describe('<MobileDateTimePicker />', () => {
         />,
       );
 
-      await openPicker(user, { type: 'date-time' });
+      openPicker({ type: 'date-time' });
       expect(onChange.callCount).to.equal(0);
       expect(onAccept.callCount).to.equal(0);
       expect(onClose.callCount).to.equal(0);
@@ -110,13 +110,13 @@ describe('<MobileDateTimePicker />', () => {
       expect(onChange.lastCall.args[0]).toEqualDateTime(new Date(2010, 0, 15));
 
       // Change the hours
-      await user.click(screen.getByRole('button', { name: 'Next' }));
-      await user.click(screen.getByRole('option', { name: '11 hours' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+      fireEvent.click(screen.getByRole('option', { name: '11 hours' }));
       expect(onChange.callCount).to.equal(3);
       expect(onChange.lastCall.args[0]).toEqualDateTime(adapterToUse.date('2010-01-15T11:00:00'));
 
       // Change the minutes
-      await user.click(screen.getByRole('option', { name: '55 minutes' }));
+      fireEvent.click(screen.getByRole('option', { name: '55 minutes' }));
       expect(onChange.callCount).to.equal(4);
       expect(onChange.lastCall.args[0]).toEqualDateTime(adapterToUse.date('2010-01-15T11:55:00'));
       expect(onAccept.callCount).to.equal(0);

--- a/packages/x-date-pickers/src/MobileDateTimePicker/tests/describeValue.MobileDateTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileDateTimePicker/tests/describeValue.MobileDateTimePicker.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@mui/internal-test-utils';
+import { screen, fireEvent } from '@mui/internal-test-utils';
 import {
   createPickerRenderer,
   adapterToUse,
@@ -36,35 +36,36 @@ describe('<MobileDateTimePicker /> - Describe Value', () => {
 
       expectFieldValue(fieldRoot, expectedValueStr);
     },
-    setNewValue: async (value, { isOpened, applySameValue, user }) => {
+    setNewValue: (value, { isOpened, applySameValue }) => {
       if (!isOpened) {
-        await openPicker(user, { type: 'date-time' });
+        openPicker({ type: 'date-time' });
       }
 
       const newValue = applySameValue
         ? value!
         : adapterToUse.addMinutes(adapterToUse.addHours(adapterToUse.addDays(value!, 1), 1), 5);
-      await user.click(
+      fireEvent.click(
         screen.getByRole('gridcell', { name: adapterToUse.getDate(newValue).toString() }),
       );
-      await user.click(screen.getByRole('button', { name: 'Next' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Next' }));
       const hasMeridiem = adapterToUse.is12HourCycleInCurrentLocale();
       const hours = adapterToUse.format(newValue, hasMeridiem ? 'hours12h' : 'hours24h');
       const hoursNumber = adapterToUse.getHours(newValue);
-      await user.click(screen.getByRole('option', { name: `${parseInt(hours, 10)} hours` }));
-      await user.click(
+      fireEvent.click(screen.getByRole('option', { name: `${parseInt(hours, 10)} hours` }));
+      fireEvent.click(
         screen.getByRole('option', { name: `${adapterToUse.getMinutes(newValue)} minutes` }),
       );
       if (hasMeridiem) {
-        await user.click(screen.getByRole('option', { name: hoursNumber >= 12 ? 'PM' : 'AM' }));
+        fireEvent.click(screen.getByRole('option', { name: hoursNumber >= 12 ? 'PM' : 'AM' }));
       }
 
       // Close the picker
       if (!isOpened) {
-        await user.keyboard('{Escape}');
+        // eslint-disable-next-line mui/disallow-active-element-as-key-event-target
+        fireEvent.keyDown(document.activeElement!, { key: 'Escape' });
       } else {
         // return to the date view in case we'd like to repeat the selection process
-        await user.click(screen.getByRole('tab', { name: 'pick date' }));
+        fireEvent.click(screen.getByRole('tab', { name: 'pick date' }));
       }
 
       return newValue;

--- a/packages/x-date-pickers/src/MobileTimePicker/tests/MobileTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileTimePicker/tests/MobileTimePicker.test.tsx
@@ -1,5 +1,5 @@
 import { spy } from 'sinon';
-import { screen } from '@mui/internal-test-utils';
+import { fireEvent, screen } from '@mui/internal-test-utils';
 import { MobileTimePicker } from '@mui/x-date-pickers/MobileTimePicker';
 import {
   createPickerRenderer,
@@ -13,9 +13,9 @@ describe('<MobileTimePicker />', () => {
   const { render } = createPickerRenderer();
 
   describe('picker state', () => {
-    it('should fire a change event when meridiem changes', async () => {
+    it('should fire a change event when meridiem changes', () => {
       const handleChange = spy();
-      const { user } = render(
+      render(
         <MobileTimePicker
           ampm
           onChange={handleChange}
@@ -26,7 +26,7 @@ describe('<MobileTimePicker />', () => {
       );
       const buttonPM = screen.getByRole('button', { name: 'PM' });
 
-      await user.click(buttonPM);
+      fireEvent.click(buttonPM);
 
       expect(handleChange.callCount).to.equal(1);
       expect(handleChange.firstCall.args[0]).toEqualDateTime(new Date(2019, 0, 1, 16, 20));
@@ -47,7 +47,7 @@ describe('<MobileTimePicker />', () => {
         />,
       );
 
-      await openPicker(user, { type: 'time' });
+      openPicker({ type: 'time' });
 
       // Change the hours
       const hourClockEvent = getClockTouchEvent(11, '12hours');

--- a/packages/x-date-pickers/src/MobileTimePicker/tests/describeValue.MobileTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileTimePicker/tests/describeValue.MobileTimePicker.test.tsx
@@ -1,4 +1,4 @@
-import { screen, fireTouchChangedEvent, waitFor } from '@mui/internal-test-utils';
+import { screen, fireEvent, fireTouchChangedEvent } from '@mui/internal-test-utils';
 import {
   createPickerRenderer,
   adapterToUse,
@@ -11,7 +11,6 @@ import {
 } from 'test/utils/pickers';
 import { MobileTimePicker } from '@mui/x-date-pickers/MobileTimePicker';
 import { PickerValue } from '@mui/x-date-pickers/internals';
-import { isJSDOM } from 'test/utils/skipIf';
 
 describe('<MobileTimePicker /> - Describe Value', () => {
   const { render } = createPickerRenderer();
@@ -36,9 +35,9 @@ describe('<MobileTimePicker /> - Describe Value', () => {
 
       expectFieldValue(fieldRoot, expectedValueStr);
     },
-    setNewValue: async (value, { isOpened, applySameValue, user }) => {
+    setNewValue: (value, { isOpened, applySameValue }) => {
       if (!isOpened) {
-        await openPicker(user, { type: 'time' });
+        openPicker({ type: 'time' });
       }
 
       const newValue = applySameValue
@@ -60,31 +59,16 @@ describe('<MobileTimePicker /> - Describe Value', () => {
       if (hasMeridiem) {
         const newHours = adapterToUse.getHours(newValue);
         // select appropriate meridiem
-        await user.click(screen.getByRole('button', { name: newHours >= 12 ? 'PM' : 'AM' }));
+        fireEvent.click(screen.getByRole('button', { name: newHours >= 12 ? 'PM' : 'AM' }));
       }
 
       // Close the picker
       if (!isOpened) {
-        await user.keyboard('{Escape}');
+        // eslint-disable-next-line mui/disallow-active-element-as-key-event-target
+        fireEvent.keyDown(document.activeElement!, { key: 'Escape' });
       } else {
-        // Return to the hours view in case we'd like to repeat the selection process.
-        const openPreviousViewButton = screen.getByRole('button', { name: 'Open previous view' });
-        await user.click(openPreviousViewButton);
-        await waitFor(() => {
-          expect(openPreviousViewButton).to.have.attribute('disabled');
-        });
-        // The "Open previous view" button becomes disabled after we
-        // land back on the first view, which traps focus on a disabled
-        // element in jsdom and swallows follow-up keyboard events.
-        // Click the dialog body to move focus to a live element
-        // so callers can press Escape to dismiss the picker.
-        if (isJSDOM) {
-          await user.click(screen.getByRole('dialog'));
-        } else {
-          await waitFor(() => {
-            expect(document.activeElement).toBe(screen.getByRole('dialog').parentElement);
-          });
-        }
+        // return to the hours view in case we'd like to repeat the selection process
+        fireEvent.click(screen.getByRole('button', { name: 'Open previous view' }));
       }
 
       return newValue;

--- a/packages/x-date-pickers/src/MonthCalendar/tests/MonthCalendar.test.tsx
+++ b/packages/x-date-pickers/src/MonthCalendar/tests/MonthCalendar.test.tsx
@@ -1,5 +1,5 @@
 import { spy } from 'sinon';
-import { screen } from '@mui/internal-test-utils';
+import { fireEvent, screen } from '@mui/internal-test-utils';
 import { MonthCalendar } from '@mui/x-date-pickers/MonthCalendar';
 import { createPickerRenderer, adapterToUse } from 'test/utils/pickers';
 import { vi } from 'vitest';
@@ -7,11 +7,9 @@ import { vi } from 'vitest';
 describe('<MonthCalendar />', () => {
   const { render } = createPickerRenderer();
 
-  it('should allow to pick month standalone by click, `Enter` and `Space`', async () => {
+  it('should allow to pick month standalone by click, `Enter` and `Space`', () => {
     const onChange = spy();
-    const { user } = render(
-      <MonthCalendar value={adapterToUse.date('2019-02-02')} onChange={onChange} />,
-    );
+    render(<MonthCalendar value={adapterToUse.date('2019-02-02')} onChange={onChange} />);
     const targetMonth = screen.getByRole('radio', { name: 'February' });
 
     // A native button implies Enter and Space keydown behavior
@@ -21,7 +19,7 @@ describe('<MonthCalendar />', () => {
     // - fireEvent.keyUp(targetDay, { key: 'Space' })
     expect(targetMonth.tagName).to.equal('BUTTON');
 
-    await user.click(targetMonth);
+    fireEvent.click(targetMonth);
 
     expect(onChange.callCount).to.equal(1);
     expect(onChange.args[0][0]).toEqualDateTime(new Date(2019, 1, 2));
@@ -36,11 +34,11 @@ describe('<MonthCalendar />', () => {
       vi.useRealTimers();
     });
 
-    it('should select start of month without time when no initial value is present', async () => {
+    it('should select start of month without time when no initial value is present', () => {
       const onChange = spy();
-      const { user } = render(<MonthCalendar onChange={onChange} />);
+      render(<MonthCalendar onChange={onChange} />);
 
-      await user.click(screen.getByRole('radio', { name: 'February' }));
+      fireEvent.click(screen.getByRole('radio', { name: 'February' }));
 
       expect(onChange.callCount).to.equal(1);
       expect(onChange.args[0][0]).toEqualDateTime(new Date(2019, 1, 1, 0, 0, 0));
@@ -81,57 +79,51 @@ describe('<MonthCalendar />', () => {
     expect(screen.getByRole('radio', { name: 'February', checked: false })).not.to.equal(null);
   });
 
-  it('does not allow to pick months if readOnly prop is passed', async () => {
+  it('does not allow to pick months if readOnly prop is passed', () => {
     const onChangeMock = spy();
-    const { user } = render(
+    render(
       <MonthCalendar value={adapterToUse.date('2019-02-02')} onChange={onChangeMock} readOnly />,
     );
 
-    await user.click(screen.getByText('Mar', { selector: 'button' }));
+    fireEvent.click(screen.getByText('Mar', { selector: 'button' }));
     expect(onChangeMock.callCount).to.equal(0);
 
-    await user.click(screen.getByText('Apr', { selector: 'button' }));
+    fireEvent.click(screen.getByText('Apr', { selector: 'button' }));
     expect(onChangeMock.callCount).to.equal(0);
 
-    await user.click(screen.getByText('Jul', { selector: 'button' }));
+    fireEvent.click(screen.getByText('Jul', { selector: 'button' }));
     expect(onChangeMock.callCount).to.equal(0);
   });
 
-  it('clicking on a month button should not trigger the form submit', async () => {
+  it('clicking on a month button should not trigger the form submit', () => {
     const onSubmitMock = spy();
-    const { user } = render(
+    render(
       <form onSubmit={onSubmitMock}>
         <MonthCalendar defaultValue={adapterToUse.date('2018-02-02')} />
       </form>,
     );
 
-    await user.click(screen.getByText('Mar', { selector: 'button' }));
+    fireEvent.click(screen.getByText('Mar', { selector: 'button' }));
     expect(onSubmitMock.callCount).to.equal(0);
   });
 
   describe('Disabled', () => {
-    it('should disable all months if props.disabled = true', async () => {
+    it('should disable all months if props.disabled = true', () => {
       const onChange = spy();
-      const { user } = render(
+      render(
         <MonthCalendar value={adapterToUse.date('2019-02-15')} onChange={onChange} disabled />,
       );
 
-      // Hoist the user-event instance so we don't recreate it on every
-      // iteration; all we need is to bypass the pointer-events check on
-      // disabled buttons.
-      const userWithoutPointerEventsCheck = user.setup({ pointerEventsCheck: 0 });
-      const monthButtons = screen.getAllByRole('radio');
-      for (const monthButton of monthButtons) {
+      screen.getAllByRole('radio').forEach((monthButton) => {
         expect(monthButton).to.have.attribute('disabled');
-        // eslint-disable-next-line no-await-in-loop
-        await userWithoutPointerEventsCheck.click(monthButton);
+        fireEvent.click(monthButton);
         expect(onChange.callCount).to.equal(0);
-      }
+      });
     });
 
-    it('should disable months before props.minDate but not the month in which props.minDate is', async () => {
+    it('should disable months before props.minDate but not the month in which props.minDate is', () => {
       const onChange = spy();
-      const { user } = render(
+      render(
         <MonthCalendar
           value={adapterToUse.date('2019-02-15')}
           onChange={onChange}
@@ -145,16 +137,16 @@ describe('<MonthCalendar />', () => {
       expect(january).to.have.attribute('disabled');
       expect(february).not.to.have.attribute('disabled');
 
-      await user.setup({ pointerEventsCheck: 0 }).click(january);
+      fireEvent.click(january);
       expect(onChange.callCount).to.equal(0);
 
-      await user.click(february);
+      fireEvent.click(february);
       expect(onChange.callCount).to.equal(1);
     });
 
-    it('should disable months after props.maxDate but not the month in which props.maxDate is', async () => {
+    it('should disable months after props.maxDate but not the month in which props.maxDate is', () => {
       const onChange = spy();
-      const { user } = render(
+      render(
         <MonthCalendar
           value={adapterToUse.date('2019-02-15')}
           onChange={onChange}
@@ -168,16 +160,16 @@ describe('<MonthCalendar />', () => {
       expect(may).to.have.attribute('disabled');
       expect(april).not.to.have.attribute('disabled');
 
-      await user.setup({ pointerEventsCheck: 0 }).click(may);
+      fireEvent.click(may);
       expect(onChange.callCount).to.equal(0);
 
-      await user.click(april);
+      fireEvent.click(april);
       expect(onChange.callCount).to.equal(1);
     });
 
-    it('should disable months if props.shouldDisableMonth returns true', async () => {
+    it('should disable months if props.shouldDisableMonth returns true', () => {
       const onChange = spy();
-      const { user } = render(
+      render(
         <MonthCalendar
           value={adapterToUse.date('2019-02-02')}
           onChange={onChange}
@@ -191,10 +183,10 @@ describe('<MonthCalendar />', () => {
       expect(april).to.have.attribute('disabled');
       expect(jun).not.to.have.attribute('disabled');
 
-      await user.setup({ pointerEventsCheck: 0 }).click(april);
+      fireEvent.click(april);
       expect(onChange.callCount).to.equal(0);
 
-      await user.click(jun);
+      fireEvent.click(jun);
       expect(onChange.callCount).to.equal(1);
     });
 

--- a/packages/x-date-pickers/src/MonthCalendar/tests/describeValue.MonthCalendar.test.tsx
+++ b/packages/x-date-pickers/src/MonthCalendar/tests/describeValue.MonthCalendar.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@mui/internal-test-utils';
+import { fireEvent, screen } from '@mui/internal-test-utils';
 import { createPickerRenderer, adapterToUse, describeValue } from 'test/utils/pickers';
 import { MonthCalendar } from '@mui/x-date-pickers/MonthCalendar';
 import { PickerValue } from '@mui/x-date-pickers/internals';
@@ -25,10 +25,10 @@ describe('<MonthCalendar /> - Describe Value', () => {
         expect(activeMonth).to.have.attribute('aria-checked', 'true');
       }
     },
-    setNewValue: async (value, { user }) => {
+    setNewValue: (value) => {
       const newValue = adapterToUse.addMonths(value!, 1);
 
-      await user.click(screen.getByRole('radio', { name: adapterToUse.format(newValue, 'month') }));
+      fireEvent.click(screen.getByRole('radio', { name: adapterToUse.format(newValue, 'month') }));
 
       return newValue;
     },

--- a/packages/x-date-pickers/src/MultiSectionDigitalClock/tests/MultiSectionDigitalClock.test.tsx
+++ b/packages/x-date-pickers/src/MultiSectionDigitalClock/tests/MultiSectionDigitalClock.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable mui/disallow-active-element-as-key-event-target */
 import * as React from 'react';
 import { spy } from 'sinon';
 import {
@@ -9,17 +10,17 @@ import {
   adapterToUse,
   multiSectionDigitalClockHandler,
 } from 'test/utils/pickers';
-import { screen, within } from '@mui/internal-test-utils';
+import { fireEvent, screen, within } from '@mui/internal-test-utils';
 
 describe('<MultiSectionDigitalClock />', () => {
   const { render } = createPickerRenderer();
 
   describe('Reference date', () => {
-    it('should use `referenceDate` when no value defined', async () => {
+    it('should use `referenceDate` when no value defined', () => {
       const onChange = spy();
       const referenceDate = '2018-01-01T13:30:00';
 
-      const { user } = render(
+      render(
         <MultiSectionDigitalClock
           onChange={onChange}
           referenceDate={adapterToUse.date(referenceDate)}
@@ -35,8 +36,7 @@ describe('<MultiSectionDigitalClock />', () => {
       expect(screen.getByRole('option', { name: '30 minutes' })).to.have.attribute('tabindex', '0');
       expect(screen.getByRole('option', { name: 'PM' })).to.have.attribute('tabindex', '0');
 
-      await multiSectionDigitalClockHandler.setViewValue(
-        user,
+      multiSectionDigitalClockHandler.setViewValue(
         adapterToUse,
         adapterToUse.setMinutes(adapterToUse.setHours(adapterToUse.date(), 15), 30),
       );
@@ -52,7 +52,7 @@ describe('<MultiSectionDigitalClock />', () => {
       expect(screen.getByRole('option', { name: '0 minutes' })).to.have.attribute('tabindex', '0');
     });
 
-    it('should not use `referenceDate` when a value is defined', async () => {
+    it('should not use `referenceDate` when a value is defined', () => {
       const onChange = spy();
 
       function ControlledMultiSectionDigitalClock(props: MultiSectionDigitalClockProps) {
@@ -70,7 +70,7 @@ describe('<MultiSectionDigitalClock />', () => {
         );
       }
 
-      const { user } = render(
+      render(
         <ControlledMultiSectionDigitalClock
           onChange={onChange}
           value={adapterToUse.date('2019-01-01T12:30:00')}
@@ -78,8 +78,7 @@ describe('<MultiSectionDigitalClock />', () => {
         />,
       );
 
-      await multiSectionDigitalClockHandler.setViewValue(
-        user,
+      multiSectionDigitalClockHandler.setViewValue(
         adapterToUse,
         adapterToUse.setMinutes(adapterToUse.setHours(adapterToUse.date(), 15), 30),
       );
@@ -87,10 +86,10 @@ describe('<MultiSectionDigitalClock />', () => {
       expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2019, 0, 1, 15, 30));
     });
 
-    it('should not use `referenceDate` when a defaultValue is defined', async () => {
+    it('should not use `referenceDate` when a defaultValue is defined', () => {
       const onChange = spy();
 
-      const { user } = render(
+      render(
         <MultiSectionDigitalClock
           onChange={onChange}
           defaultValue={adapterToUse.date('2019-01-01T12:30:00')}
@@ -98,8 +97,7 @@ describe('<MultiSectionDigitalClock />', () => {
         />,
       );
 
-      await multiSectionDigitalClockHandler.setViewValue(
-        user,
+      multiSectionDigitalClockHandler.setViewValue(
         adapterToUse,
         adapterToUse.setMinutes(adapterToUse.setHours(adapterToUse.date(), 15), 30),
       );
@@ -109,70 +107,74 @@ describe('<MultiSectionDigitalClock />', () => {
   });
 
   describe('Keyboard support', () => {
-    it('should move item focus up by 5 on PageUp press', async () => {
+    it('should move item focus up by 5 on PageUp press', () => {
       const handleChange = spy();
-      const { user } = render(<MultiSectionDigitalClock autoFocus onChange={handleChange} />);
+      render(<MultiSectionDigitalClock autoFocus onChange={handleChange} />);
       const hoursSectionListbox = screen.getAllByRole('listbox')[0]; // get only hour section
       const hoursOptions = within(hoursSectionListbox).getAllByRole('option');
       const lastOptionIndex = hoursOptions.length - 1;
 
-      await user.keyboard('{End}'); // moves focus to last element
-      await user.keyboard('{PageUp}');
+      fireEvent.keyDown(document.activeElement!, { key: 'End' }); // moves focus to last element
+      fireEvent.keyDown(document.activeElement!, { key: 'PageUp' });
 
       expect(handleChange.callCount).to.equal(0);
       expect(document.activeElement).to.equal(hoursOptions[lastOptionIndex - 5]);
 
-      await user.keyboard('{PageUp}');
+      fireEvent.keyDown(hoursOptions[lastOptionIndex - 5], { key: 'PageUp' });
 
       expect(handleChange.callCount).to.equal(0);
       expect(document.activeElement).to.equal(hoursOptions[lastOptionIndex - 10]);
     });
 
-    it('should move focus to first item on PageUp press when current focused item index is among the first 5 items', async () => {
+    it('should move focus to first item on PageUp press when current focused item index is among the first 5 items', () => {
       const handleChange = spy();
-      const { user } = render(<MultiSectionDigitalClock autoFocus onChange={handleChange} />);
+      render(<MultiSectionDigitalClock autoFocus onChange={handleChange} />);
       const hoursSectionListbox = screen.getAllByRole('listbox')[0]; // get only hour section
       const hoursOptions = within(hoursSectionListbox).getAllByRole('option');
 
       // moves focus to 4th element using arrow down
-      await user.keyboard('{ArrowDown}{ArrowDown}{ArrowDown}');
+      [0, 1, 2].forEach((index) => {
+        fireEvent.keyDown(hoursOptions[index], { key: 'ArrowDown' });
+      });
 
-      await user.keyboard('{PageUp}');
+      fireEvent.keyDown(hoursOptions[3], { key: 'PageUp' });
       expect(handleChange.callCount).to.equal(0);
       expect(document.activeElement).to.equal(hoursOptions[0]);
     });
 
-    it('should move item focus down by 5 on PageDown press', async () => {
+    it('should move item focus down by 5 on PageDown press', () => {
       const handleChange = spy();
-      const { user } = render(<MultiSectionDigitalClock autoFocus onChange={handleChange} />);
+      render(<MultiSectionDigitalClock autoFocus onChange={handleChange} />);
       const hoursSectionListbox = screen.getAllByRole('listbox')[0]; // get only hour section
       const hoursOptions = within(hoursSectionListbox).getAllByRole('option');
 
-      await user.keyboard('{PageDown}');
+      fireEvent.keyDown(hoursOptions[0], { key: 'PageDown' });
 
       expect(handleChange.callCount).to.equal(0);
       expect(document.activeElement).to.equal(hoursOptions[5]);
 
-      await user.keyboard('{PageDown}');
+      fireEvent.keyDown(hoursOptions[5], { key: 'PageDown' });
 
       expect(handleChange.callCount).to.equal(0);
       expect(document.activeElement).to.equal(hoursOptions[10]);
     });
 
-    it('should move focus to last item on PageDown press when current focused item index is among the last 5 items', async () => {
+    it('should move focus to last item on PageDown press when current focused item index is among the last 5 items', () => {
       const handleChange = spy();
-      const { user } = render(<MultiSectionDigitalClock autoFocus onChange={handleChange} />);
+      render(<MultiSectionDigitalClock autoFocus onChange={handleChange} />);
       const hoursSectionListbox = screen.getAllByRole('listbox')[0]; // get only hour section
       const hoursOptions = within(hoursSectionListbox).getAllByRole('option');
       const lastOptionIndex = hoursOptions.length - 1;
 
       const lastElement = hoursOptions[lastOptionIndex];
 
-      await user.keyboard('{End}'); // moves focus to last element
+      fireEvent.keyDown(document.activeElement!, { key: 'End' }); // moves focus to last element
       // moves focus 4 steps above last item using arrow up
-      await user.keyboard('{ArrowUp}{ArrowUp}{ArrowUp}');
+      [0, 1, 2].forEach((index) => {
+        fireEvent.keyDown(hoursOptions[lastOptionIndex - index], { key: 'ArrowUp' });
+      });
 
-      await user.keyboard('{PageDown}');
+      fireEvent.keyDown(hoursOptions[lastOptionIndex - 3], { key: 'PageDown' });
       expect(handleChange.callCount).to.equal(0);
       expect(document.activeElement).to.equal(lastElement);
     });

--- a/packages/x-date-pickers/src/MultiSectionDigitalClock/tests/describeValue.MultiSectionDigitalClock.test.tsx
+++ b/packages/x-date-pickers/src/MultiSectionDigitalClock/tests/describeValue.MultiSectionDigitalClock.test.tsx
@@ -37,9 +37,9 @@ describe('<MultiSectionDigitalClock /> - Describe Value', () => {
         }
       }
     },
-    setNewValue: async (value, { user }) => {
+    setNewValue: (value) => {
       const newValue = adapterToUse.addMinutes(adapterToUse.addHours(value!, 1), 5);
-      await multiSectionDigitalClockHandler.setViewValue(user, adapterToUse, newValue);
+      multiSectionDigitalClockHandler.setViewValue(adapterToUse, newValue);
 
       return newValue;
     },

--- a/packages/x-date-pickers/src/PickerDay/PickerDay.test.tsx
+++ b/packages/x-date-pickers/src/PickerDay/PickerDay.test.tsx
@@ -1,5 +1,5 @@
 import { spy } from 'sinon';
-import { screen } from '@mui/internal-test-utils';
+import { fireEvent, screen } from '@mui/internal-test-utils';
 import ButtonBase from '@mui/material/ButtonBase';
 import { PickerDay, pickerDayClasses as classes } from '@mui/x-date-pickers/PickerDay';
 import { adapterToUse, createPickerRenderer } from 'test/utils/pickers';
@@ -28,10 +28,10 @@ describe('<PickerDay />', () => {
     }),
   );
 
-  it('selects the date on click, Enter and Space', async () => {
+  it('selects the date on click, Enter and Space', () => {
     const handleDaySelect = spy();
     const day = adapterToUse.date();
-    const { user } = render(
+    render(
       <PickerDay
         day={day}
         outsideCurrentMonth={false}
@@ -49,7 +49,7 @@ describe('<PickerDay />', () => {
     // - fireEvent.keyUp(targetDay, { key: 'Space' })
     expect(targetDay.tagName).to.equal('BUTTON');
 
-    await user.click(targetDay);
+    fireEvent.click(targetDay);
 
     expect(handleDaySelect.callCount).to.equal(1);
     expect(handleDaySelect.args[0][0]).toEqualDateTime(day);

--- a/packages/x-date-pickers/src/PickersActionBar/PickersActionBar.test.tsx
+++ b/packages/x-date-pickers/src/PickersActionBar/PickersActionBar.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { spy } from 'sinon';
-import { screen } from '@mui/internal-test-utils';
+import { fireEvent, screen } from '@mui/internal-test-utils';
 import { PickersActionBar } from '@mui/x-date-pickers/PickersActionBar';
 import { createPickerRenderer } from 'test/utils/pickers';
 import { PickerContext } from '../hooks/usePickerContext';
@@ -22,11 +22,9 @@ describe('<PickersActionBar />', () => {
       hasNextStep: false,
     } as any;
 
-    const { user } = render(
-      <PickerContext.Provider value={spys}>{element}</PickerContext.Provider>,
-    );
+    render(<PickerContext.Provider value={spys}>{element}</PickerContext.Provider>);
 
-    return { ...spys, user };
+    return spys;
   };
 
   it('should not render buttons if actions array is empty', () => {
@@ -35,35 +33,31 @@ describe('<PickersActionBar />', () => {
     expect(screen.queryByRole('button')).to.equal(null);
   });
 
-  it('should render button for "clear" action calling the associated callback', async () => {
-    const { clearValue, user } = renderWithContext(<PickersActionBar actions={['clear']} />);
+  it('should render button for "clear" action calling the associated callback', () => {
+    const { clearValue } = renderWithContext(<PickersActionBar actions={['clear']} />);
 
-    await user.click(screen.getByText(/clear/i));
+    fireEvent.click(screen.getByText(/clear/i));
     expect(clearValue.callCount).to.equal(1);
   });
 
-  it('should render button for "cancel" action calling the associated callback', async () => {
-    const { cancelValueChanges, user } = renderWithContext(
-      <PickersActionBar actions={['cancel']} />,
-    );
+  it('should render button for "cancel" action calling the associated callback', () => {
+    const { cancelValueChanges } = renderWithContext(<PickersActionBar actions={['cancel']} />);
 
-    await user.click(screen.getByText(/cancel/i));
+    fireEvent.click(screen.getByText(/cancel/i));
     expect(cancelValueChanges.callCount).to.equal(1);
   });
 
-  it('should render button for "accept" action calling the associated callback', async () => {
-    const { acceptValueChanges, user } = renderWithContext(
-      <PickersActionBar actions={['accept']} />,
-    );
+  it('should render button for "accept" action calling the associated callback', () => {
+    const { acceptValueChanges } = renderWithContext(<PickersActionBar actions={['accept']} />);
 
-    await user.click(screen.getByText(/ok/i));
+    fireEvent.click(screen.getByText(/ok/i));
     expect(acceptValueChanges.callCount).to.equal(1);
   });
 
-  it('should render button for "today" action calling the associated callback', async () => {
-    const { setValueToToday, user } = renderWithContext(<PickersActionBar actions={['today']} />);
+  it('should render button for "today" action calling the associated callback', () => {
+    const { setValueToToday } = renderWithContext(<PickersActionBar actions={['today']} />);
 
-    await user.click(screen.getByText(/today/i));
+    fireEvent.click(screen.getByText(/today/i));
     expect(setValueToToday.callCount).to.equal(1);
   });
 

--- a/packages/x-date-pickers/src/StaticDatePicker/tests/StaticDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/StaticDatePicker/tests/StaticDatePicker.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@mui/internal-test-utils';
+import { fireEvent, screen } from '@mui/internal-test-utils';
 import { StaticDatePicker } from '@mui/x-date-pickers/StaticDatePicker';
 import { createPickerRenderer, adapterToUse } from 'test/utils/pickers';
 
@@ -12,21 +12,19 @@ describe('<StaticDatePicker />', () => {
     expect(screen.getAllByTestId('day')).to.have.length(31);
   });
 
-  it('switches between months', async () => {
-    const { user } = render(
-      <StaticDatePicker reduceAnimations defaultValue={adapterToUse.date('2019-01-01')} />,
-    );
+  it('switches between months', () => {
+    render(<StaticDatePicker reduceAnimations defaultValue={adapterToUse.date('2019-01-01')} />);
 
     expect(screen.getByTestId('calendar-month-and-year-text')).to.have.text('January 2019');
 
     const nextMonth = screen.getByLabelText('Next month');
     const previousMonth = screen.getByLabelText('Previous month');
-    await user.click(nextMonth);
-    await user.click(nextMonth);
+    fireEvent.click(nextMonth);
+    fireEvent.click(nextMonth);
 
-    await user.click(previousMonth);
-    await user.click(previousMonth);
-    await user.click(previousMonth);
+    fireEvent.click(previousMonth);
+    fireEvent.click(previousMonth);
+    fireEvent.click(previousMonth);
 
     expect(screen.getByTestId('calendar-month-and-year-text')).to.have.text('December 2018');
   });

--- a/packages/x-date-pickers/src/StaticDatePicker/tests/StaticDatePickerKeyboard.test.tsx
+++ b/packages/x-date-pickers/src/StaticDatePicker/tests/StaticDatePickerKeyboard.test.tsx
@@ -1,4 +1,4 @@
-import { act, screen } from '@mui/internal-test-utils';
+import { act, fireEvent, screen } from '@mui/internal-test-utils';
 import { StaticDatePicker } from '@mui/x-date-pickers/StaticDatePicker';
 import { DateView } from '@mui/x-date-pickers/models';
 import { createPickerRenderer, adapterToUse } from 'test/utils/pickers';
@@ -27,8 +27,8 @@ describe('<StaticDatePicker /> - Keyboard interactions', () => {
       { key: 'ArrowRight', expectFocusedDay: '14' },
       { key: 'ArrowDown', expectFocusedDay: '20' },
     ].forEach(({ key, expectFocusedDay }) => {
-      it(`${key}`, async () => {
-        const { user } = render(
+      it(`${key}`, () => {
+        render(
           <StaticDatePicker
             autoFocus
             displayStaticWrapperAs="desktop"
@@ -36,7 +36,9 @@ describe('<StaticDatePicker /> - Keyboard interactions', () => {
           />,
         );
 
-        await user.keyboard(`{${key}}`);
+        // Don't care about what's focused.
+        // eslint-disable-next-line mui/disallow-active-element-as-key-event-target
+        fireEvent.keyDown(document.activeElement!, { key });
 
         // Based on column header, screen reader should pronounce <Day Number> <Week Day>
         // But `toHaveAccessibleName` does not do the link between column header and cell value, so we only get <day number> in test
@@ -54,8 +56,8 @@ describe('<StaticDatePicker /> - Keyboard interactions', () => {
       { initialDay: '10', key: 'ArrowLeft', expectFocusedDay: '9' },
       { initialDay: '09', key: 'ArrowRight', expectFocusedDay: '10' },
     ].forEach(({ initialDay, key, expectFocusedDay }) => {
-      it(`${key}`, async () => {
-        const { user } = render(
+      it(`${key}`, () => {
+        render(
           <StaticDatePicker
             autoFocus
             displayStaticWrapperAs="desktop"
@@ -63,7 +65,9 @@ describe('<StaticDatePicker /> - Keyboard interactions', () => {
           />,
         );
 
-        await user.keyboard(`{${key}}`);
+        // Don't care about what's focused.
+        // eslint-disable-next-line mui/disallow-active-element-as-key-event-target
+        fireEvent.keyDown(document.activeElement!, { key });
 
         // Based on column header, screen reader should pronounce <Day Number> <Week Day>
         // But `toHaveAccessibleName` does not do the link between column header and cell value, so we only get <day number> in test
@@ -73,7 +77,7 @@ describe('<StaticDatePicker /> - Keyboard interactions', () => {
   });
 
   it("doesn't allow to select disabled date from keyboard", async () => {
-    const { user } = render(
+    render(
       <StaticDatePicker
         autoFocus
         displayStaticWrapperAs="desktop"
@@ -84,7 +88,11 @@ describe('<StaticDatePicker /> - Keyboard interactions', () => {
 
     expect(document.activeElement).toHaveAccessibleName('13');
 
-    await user.keyboard('{ArrowLeft}{ArrowLeft}{ArrowLeft}');
+    for (let i = 0; i < 3; i += 1) {
+      // Don't care about what's focused.
+      // eslint-disable-next-line mui/disallow-active-element-as-key-event-target
+      fireEvent.keyDown(document.activeElement!, { key: 'ArrowLeft' });
+    }
 
     // leaves focus on the same date
     expect(document.activeElement).toHaveAccessibleName('13');
@@ -97,8 +105,8 @@ describe('<StaticDatePicker /> - Keyboard interactions', () => {
       { key: 'ArrowRight', expectFocusedYear: '2021' },
       { key: 'ArrowDown', expectFocusedYear: '2024' },
     ].forEach(({ key, expectFocusedYear }) => {
-      it(`${key}`, async () => {
-        const { user } = render(
+      it(`${key}`, () => {
+        render(
           <StaticDatePicker
             openTo="year"
             reduceAnimations
@@ -109,7 +117,7 @@ describe('<StaticDatePicker /> - Keyboard interactions', () => {
 
         const year = screen.getByText('2020', { selector: 'button' });
         act(() => year.focus());
-        await user.keyboard(`{${key}}`);
+        fireEvent.keyDown(year, { key });
 
         expect(document.activeElement).to.have.text(expectFocusedYear);
       });
@@ -123,8 +131,8 @@ describe('<StaticDatePicker /> - Keyboard interactions', () => {
       { key: 'ArrowRight', expectFocusedMonth: 'Sep' },
       { key: 'ArrowDown', expectFocusedMonth: 'Nov' },
     ].forEach(({ key, expectFocusedMonth }) => {
-      it(`${key}`, async () => {
-        const { user } = render(
+      it(`${key}`, () => {
+        render(
           <StaticDatePicker
             openTo="month"
             views={['month']}
@@ -136,7 +144,7 @@ describe('<StaticDatePicker /> - Keyboard interactions', () => {
 
         const aug = screen.getByText('Aug', { selector: 'button' });
         act(() => aug.focus());
-        await user.keyboard(`{${key}}`);
+        fireEvent.keyDown(aug, { key });
 
         expect(document.activeElement).to.have.text(expectFocusedMonth);
       });
@@ -150,8 +158,8 @@ describe('<StaticDatePicker /> - Keyboard interactions', () => {
       { key: 'ArrowRight', expectFocusedDay: '14' },
       { key: 'ArrowDown', expectFocusedDay: '20' },
     ].forEach(({ key, expectFocusedDay }) => {
-      it(`${key}`, async () => {
-        const { user } = render(
+      it(`${key}`, () => {
+        render(
           <StaticDatePicker
             openTo="day"
             reduceAnimations
@@ -162,7 +170,7 @@ describe('<StaticDatePicker /> - Keyboard interactions', () => {
 
         const startDay = screen.getByText('13', { selector: 'button' });
         act(() => startDay.focus());
-        await user.keyboard(`{${key}}`);
+        fireEvent.keyDown(startDay, { key });
 
         expect(document.activeElement).to.have.text(expectFocusedDay);
       });
@@ -191,8 +199,8 @@ describe('<StaticDatePicker /> - Keyboard interactions', () => {
     });
   });
 
-  it(`should have one element with tabIndex=0 for day view even if not in current month`, async () => {
-    const { user } = render(
+  it(`should have one element with tabIndex=0 for day view even if not in current month`, () => {
+    render(
       <StaticDatePicker
         openTo="day"
         reduceAnimations
@@ -201,7 +209,7 @@ describe('<StaticDatePicker /> - Keyboard interactions', () => {
       />,
     );
 
-    await user.click(screen.getByTitle('Next month'));
+    fireEvent.click(screen.getByTitle('Next month'));
     const day13 = screen.getByText('13', { selector: 'button' });
     const day1 = screen.getByText('1', { selector: 'button' });
     expect(day1).to.have.attribute('tabindex', '0');

--- a/packages/x-date-pickers/src/StaticDateTimePicker/tests/StaticDateTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/StaticDateTimePicker/tests/StaticDateTimePicker.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { spy } from 'sinon';
-import { screen } from '@mui/internal-test-utils';
+import { fireEvent, screen } from '@mui/internal-test-utils';
 import { StaticDateTimePicker } from '@mui/x-date-pickers/StaticDateTimePicker';
 import { createPickerRenderer, adapterToUse } from 'test/utils/pickers';
 import { DateTimePickerTabs, DateTimePickerTabsProps } from '../../DateTimePicker';
@@ -8,13 +8,13 @@ import { DateTimePickerTabs, DateTimePickerTabsProps } from '../../DateTimePicke
 describe('<StaticDateTimePicker />', () => {
   const { render } = createPickerRenderer();
 
-  it('should allow to select the same day', async () => {
+  it('should allow to select the same day', () => {
     const onChange = spy();
-    const { user } = render(
+    render(
       <StaticDateTimePicker onChange={onChange} defaultValue={adapterToUse.date('2018-01-01')} />,
     );
 
-    await user.click(screen.getByRole('gridcell', { name: '1' }));
+    fireEvent.click(screen.getByRole('gridcell', { name: '1' }));
     expect(onChange.callCount).to.equal(1);
   });
 

--- a/packages/x-date-pickers/src/StaticTimePicker/StaticTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/StaticTimePicker/StaticTimePicker.test.tsx
@@ -1,5 +1,5 @@
 import { spy } from 'sinon';
-import { fireTouchChangedEvent, screen, within } from '@mui/internal-test-utils';
+import { fireTouchChangedEvent, screen, within, fireEvent } from '@mui/internal-test-utils';
 import { adapterToUse, createPickerRenderer, describeValidation } from 'test/utils/pickers';
 import { StaticTimePicker } from '@mui/x-date-pickers/StaticTimePicker';
 import { describeConformance } from 'test/utils/describeConformance';
@@ -32,7 +32,7 @@ describe('<StaticTimePicker />', () => {
 
   it.skipIf(!hasTouchSupport)(
     'should allow view modification, but not update value when `readOnly` prop is passed',
-    async () => {
+    () => {
       const selectEvent = {
         changedTouches: [
           {
@@ -43,7 +43,7 @@ describe('<StaticTimePicker />', () => {
       };
       const onChange = spy();
       const onViewChange = spy();
-      const { user } = render(
+      render(
         <StaticTimePicker
           value={adapterToUse.date('2019-01-01')}
           onChange={onChange}
@@ -53,16 +53,16 @@ describe('<StaticTimePicker />', () => {
       );
 
       // Can switch between views
-      await user.click(screen.getByTestId('minutes'));
+      fireEvent.click(screen.getByTestId('minutes'));
       expect(onViewChange.callCount).to.equal(1);
 
-      await user.click(screen.getByTestId('hours'));
+      fireEvent.click(screen.getByTestId('hours'));
       expect(onViewChange.callCount).to.equal(2);
 
       // Can not switch between meridiem
-      await user.click(screen.getByRole('button', { name: /AM/i }));
+      fireEvent.click(screen.getByRole('button', { name: /AM/i }));
       expect(onChange.callCount).to.equal(0);
-      await user.click(screen.getByRole('button', { name: /PM/i }));
+      fireEvent.click(screen.getByRole('button', { name: /PM/i }));
       expect(onChange.callCount).to.equal(0);
 
       // Can not set value
@@ -81,7 +81,7 @@ describe('<StaticTimePicker />', () => {
 
   it.skipIf(!hasTouchSupport)(
     'should allow switching between views and display disabled options when `disabled` prop is passed',
-    async () => {
+    () => {
       const selectEvent = {
         changedTouches: [
           {
@@ -92,7 +92,7 @@ describe('<StaticTimePicker />', () => {
       };
       const onChange = spy();
       const onViewChange = spy();
-      const { user } = render(
+      render(
         <StaticTimePicker
           value={adapterToUse.date('2019-01-01')}
           onChange={onChange}
@@ -102,17 +102,16 @@ describe('<StaticTimePicker />', () => {
       );
 
       // Can switch between views
-      await user.click(screen.getByTestId('minutes'));
+      fireEvent.click(screen.getByTestId('minutes'));
       expect(onViewChange.callCount).to.equal(1);
 
-      await user.click(screen.getByTestId('hours'));
+      fireEvent.click(screen.getByTestId('hours'));
       expect(onViewChange.callCount).to.equal(2);
 
-      const userWithoutPointerEventsCheck = user.setup({ pointerEventsCheck: 0 });
       // Can not switch between meridiem
-      await userWithoutPointerEventsCheck.click(screen.getByRole('button', { name: /AM/i }));
+      fireEvent.click(screen.getByRole('button', { name: /AM/i }));
       expect(onChange.callCount).to.equal(0);
-      await userWithoutPointerEventsCheck.click(screen.getByRole('button', { name: /PM/i }));
+      fireEvent.click(screen.getByRole('button', { name: /PM/i }));
       expect(onChange.callCount).to.equal(0);
 
       // Can not set value

--- a/packages/x-date-pickers/src/TimeClock/tests/TimeClock.test.tsx
+++ b/packages/x-date-pickers/src/TimeClock/tests/TimeClock.test.tsx
@@ -1,5 +1,5 @@
 import { spy } from 'sinon';
-import { fireTouchChangedEvent, screen, within } from '@mui/internal-test-utils';
+import { fireEvent, fireTouchChangedEvent, screen, within } from '@mui/internal-test-utils';
 import { TimeClock } from '@mui/x-date-pickers/TimeClock';
 import { createPickerRenderer, adapterToUse, timeClockHandler } from 'test/utils/pickers';
 import { hasTouchSupport } from 'test/utils/skipIf';
@@ -55,17 +55,18 @@ describe('<TimeClock />', () => {
     expect(selectedOption).toHaveAccessibleName('4 hours');
   });
 
-  it('selects the first hour on Home press', async () => {
+  it('selects the first hour on Home press', () => {
     const handleChange = spy();
-    const { user } = render(
+    render(
       <TimeClock
         autoFocus
         value={adapterToUse.date('2019-01-01T04:20:00')}
         onChange={handleChange}
       />,
     );
+    const listbox = screen.getByRole('listbox');
 
-    await user.keyboard('{Home}');
+    fireEvent.keyDown(listbox, { key: 'Home' });
 
     expect(handleChange.callCount).to.equal(1);
     const [newDate, reason] = handleChange.firstCall.args;
@@ -77,17 +78,18 @@ describe('<TimeClock />', () => {
     expect(reason).to.equal('partial');
   });
 
-  it('selects the last hour on End press', async () => {
+  it('selects the last hour on End press', () => {
     const handleChange = spy();
-    const { user } = render(
+    render(
       <TimeClock
         autoFocus
         value={adapterToUse.date('2019-01-01T04:20:00')}
         onChange={handleChange}
       />,
     );
+    const listbox = screen.getByRole('listbox');
 
-    await user.keyboard('{End}');
+    fireEvent.keyDown(listbox, { key: 'End' });
 
     expect(handleChange.callCount).to.equal(1);
     const [newDate, reason] = handleChange.firstCall.args;
@@ -96,17 +98,18 @@ describe('<TimeClock />', () => {
     expect(reason).to.equal('partial');
   });
 
-  it('selects the next hour on ArrowUp press', async () => {
+  it('selects the next hour on ArrowUp press', () => {
     const handleChange = spy();
-    const { user } = render(
+    render(
       <TimeClock
         autoFocus
         value={adapterToUse.date('2019-01-01T04:20:00')}
         onChange={handleChange}
       />,
     );
+    const listbox = screen.getByRole('listbox');
 
-    await user.keyboard('{ArrowUp}');
+    fireEvent.keyDown(listbox, { key: 'ArrowUp' });
 
     expect(handleChange.callCount).to.equal(1);
     const [newDate, reason] = handleChange.firstCall.args;
@@ -115,17 +118,18 @@ describe('<TimeClock />', () => {
     expect(reason).to.equal('partial');
   });
 
-  it('selects the previous hour on ArrowDown press', async () => {
+  it('selects the previous hour on ArrowDown press', () => {
     const handleChange = spy();
-    const { user } = render(
+    render(
       <TimeClock
         autoFocus
         value={adapterToUse.date('2019-01-01T04:20:00')}
         onChange={handleChange}
       />,
     );
+    const listbox = screen.getByRole('listbox');
 
-    await user.keyboard('{ArrowDown}');
+    fireEvent.keyDown(listbox, { key: 'ArrowDown' });
 
     expect(handleChange.callCount).to.equal(1);
     const [newDate, reason] = handleChange.firstCall.args;
@@ -134,17 +138,18 @@ describe('<TimeClock />', () => {
     expect(reason).to.equal('partial');
   });
 
-  it('should increase hour selection by 5 on PageUp press', async () => {
+  it('should increase hour selection by 5 on PageUp press', () => {
     const handleChange = spy();
-    const { user } = render(
+    render(
       <TimeClock
         autoFocus
         value={adapterToUse.date('2019-01-01T22:20:00')}
         onChange={handleChange}
       />,
     );
+    const listbox = screen.getByRole('listbox');
 
-    await user.keyboard('{PageUp}');
+    fireEvent.keyDown(listbox, { key: 'PageUp' });
 
     expect(handleChange.callCount).to.equal(1);
     const [newDate, reason] = handleChange.firstCall.args;
@@ -153,17 +158,18 @@ describe('<TimeClock />', () => {
     expect(reason).to.equal('partial');
   });
 
-  it('should decrease hour selection by 5 on PageDown press', async () => {
+  it('should decrease hour selection by 5 on PageDown press', () => {
     const handleChange = spy();
-    const { user } = render(
+    render(
       <TimeClock
         autoFocus
         value={adapterToUse.date('2019-01-01T02:20:00')}
         onChange={handleChange}
       />,
     );
+    const listbox = screen.getByRole('listbox');
 
-    await user.keyboard('{PageDown}');
+    fireEvent.keyDown(listbox, { key: 'PageDown' });
 
     expect(handleChange.callCount).to.equal(1);
     const [newDate, reason] = handleChange.firstCall.args;
@@ -175,25 +181,26 @@ describe('<TimeClock />', () => {
   [
     {
       keyName: 'Enter',
-      keySequence: '{Enter}',
+      keyValue: 'Enter',
     },
     {
       keyName: 'Space',
-      keySequence: '[Space]',
+      keyValue: ' ',
     },
-  ].forEach(({ keyName, keySequence }) => {
-    it(`sets value on ${keyName} press`, async () => {
+  ].forEach(({ keyName, keyValue }) => {
+    it(`sets value on ${keyName} press`, () => {
       const handleChange = spy();
-      const { user } = render(
+      render(
         <TimeClock
           autoFocus
           defaultValue={adapterToUse.date('2019-01-01T04:20:00')}
           onChange={handleChange}
         />,
       );
+      const listbox = screen.getByRole('listbox');
 
-      await user.keyboard('{ArrowDown}');
-      await user.keyboard(keySequence);
+      fireEvent.keyDown(listbox, { key: 'ArrowDown' });
+      fireEvent.keyDown(listbox, { key: keyValue });
 
       expect(handleChange.callCount).to.equal(2);
       let [newDate, reason] = handleChange.lastCall.args;
@@ -201,8 +208,8 @@ describe('<TimeClock />', () => {
       expect(adapterToUse.getHours(newDate)).to.equal(3);
       expect(reason).to.equal('partial');
 
-      await user.keyboard('{ArrowUp}');
-      await user.keyboard(keySequence);
+      fireEvent.keyDown(listbox, { key: 'ArrowUp' });
+      fireEvent.keyDown(listbox, { key: keyValue });
 
       expect(handleChange.callCount).to.equal(4);
       [newDate, reason] = handleChange.lastCall.args;
@@ -546,17 +553,18 @@ describe('<TimeClock />', () => {
   });
 
   describe('default value', () => {
-    it('if value is provided, keeps minutes and seconds when changing hour', async () => {
+    it('if value is provided, keeps minutes and seconds when changing hour', () => {
       const handleChange = spy();
-      const { user } = render(
+      render(
         <TimeClock
           autoFocus
           value={adapterToUse.date('2019-01-01T04:19:47')}
           onChange={handleChange}
         />,
       );
+      const listbox = screen.getByRole('listbox');
 
-      await user.keyboard('{ArrowUp}');
+      fireEvent.keyDown(listbox, { key: 'ArrowUp' });
 
       expect(handleChange.callCount).to.equal(1);
       const [newDate] = handleChange.firstCall.args;
@@ -565,11 +573,12 @@ describe('<TimeClock />', () => {
       expect(adapterToUse.getSeconds(newDate)).to.equal(47);
     });
 
-    it('if value is not provided, uses zero as default for minutes and seconds when selecting hour', async () => {
+    it('if value is not provided, uses zero as default for minutes and seconds when selecting hour', () => {
       const handleChange = spy();
-      const { user } = render(<TimeClock autoFocus value={null} onChange={handleChange} />);
+      render(<TimeClock autoFocus value={null} onChange={handleChange} />);
+      const listbox = screen.getByRole('listbox');
 
-      await user.keyboard('{ArrowUp}');
+      fireEvent.keyDown(listbox, { key: 'ArrowUp' });
 
       expect(handleChange.callCount).to.equal(1);
       const [newDate] = handleChange.firstCall.args;
@@ -580,15 +589,14 @@ describe('<TimeClock />', () => {
   });
 
   describe('Reference date', () => {
-    it('should use `referenceDate` when no value defined', async () => {
+    it('should use `referenceDate` when no value defined', () => {
       const onChange = spy();
 
-      const { user } = render(
+      render(
         <TimeClock onChange={onChange} referenceDate={adapterToUse.date('2018-01-01T12:30:00')} />,
       );
 
-      await timeClockHandler.setViewValue(
-        user,
+      timeClockHandler.setViewValue(
         adapterToUse,
         adapterToUse.setHours(adapterToUse.date(), 3),
         'hours',
@@ -597,10 +605,10 @@ describe('<TimeClock />', () => {
       expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2018, 0, 1, 15, 30));
     });
 
-    it('should not use `referenceDate` when a value is defined', async () => {
+    it('should not use `referenceDate` when a value is defined', () => {
       const onChange = spy();
 
-      const { user } = render(
+      render(
         <TimeClock
           onChange={onChange}
           value={adapterToUse.date('2019-01-01T12:20:00')}
@@ -608,8 +616,7 @@ describe('<TimeClock />', () => {
         />,
       );
 
-      await timeClockHandler.setViewValue(
-        user,
+      timeClockHandler.setViewValue(
         adapterToUse,
         adapterToUse.setHours(adapterToUse.date(), 3),
         'hours',
@@ -618,10 +625,10 @@ describe('<TimeClock />', () => {
       expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2019, 0, 1, 15, 20));
     });
 
-    it('should not use `referenceDate` when a defaultValue is defined', async () => {
+    it('should not use `referenceDate` when a defaultValue is defined', () => {
       const onChange = spy();
 
-      const { user } = render(
+      render(
         <TimeClock
           onChange={onChange}
           defaultValue={adapterToUse.date('2019-01-01T12:20:00')}
@@ -629,8 +636,7 @@ describe('<TimeClock />', () => {
         />,
       );
 
-      await timeClockHandler.setViewValue(
-        user,
+      timeClockHandler.setViewValue(
         adapterToUse,
         adapterToUse.setHours(adapterToUse.date(), 3),
         'hours',

--- a/packages/x-date-pickers/src/TimeClock/tests/describeValue.TimeClock.test.tsx
+++ b/packages/x-date-pickers/src/TimeClock/tests/describeValue.TimeClock.test.tsx
@@ -34,11 +34,11 @@ describe('<TimeClock /> - Describe Value', () => {
         }
       }
     },
-    setNewValue: async (value, { user }) => {
+    setNewValue: (value) => {
       const newValue = adapterToUse.addMinutes(adapterToUse.addHours(value!, 1), 5);
 
-      await timeClockHandler.setViewValue(user, adapterToUse, newValue, 'hours');
-      await timeClockHandler.setViewValue(user, adapterToUse, newValue, 'minutes');
+      timeClockHandler.setViewValue(adapterToUse, newValue, 'hours');
+      timeClockHandler.setViewValue(adapterToUse, newValue, 'minutes');
 
       return newValue;
     },

--- a/packages/x-date-pickers/src/TimeField/tests/describeValue.TimeField.test.tsx
+++ b/packages/x-date-pickers/src/TimeField/tests/describeValue.TimeField.test.tsx
@@ -30,10 +30,10 @@ describe('<TimeField /> - Describe Value', () => {
 
       expectFieldValue(fieldRoot, expectedValueStr);
     },
-    setNewValue: async (value, { selectSection, pressKey }) => {
+    setNewValue: (value, { selectSection, pressKey }) => {
       const newValue = adapterToUse.addHours(value!, 1);
-      await selectSection('hours');
-      await pressKey('ArrowUp');
+      selectSection('hours');
+      pressKey(undefined, 'ArrowUp');
 
       return newValue;
     },

--- a/packages/x-date-pickers/src/TimeField/tests/editing.TimeField.test.tsx
+++ b/packages/x-date-pickers/src/TimeField/tests/editing.TimeField.test.tsx
@@ -1,5 +1,6 @@
 import { spy } from 'sinon';
 import { TimeField } from '@mui/x-date-pickers/TimeField';
+import { fireEvent } from '@mui/internal-test-utils';
 import {
   expectFieldValue,
   getCleanedSelectedContent,
@@ -11,16 +12,16 @@ import {
 describe('<TimeField /> - Editing', () => {
   describeAdapters('key: ArrowDown', TimeField, ({ adapter, testFieldKeyPress }) => {
     describe('24 hours format (ArrowDown)', () => {
-      it('should set the hour to 23 when no value is provided', async () => {
-        await testFieldKeyPress({
+      it('should set the hour to 23 when no value is provided', () => {
+        testFieldKeyPress({
           format: adapter.formats.hours24h,
           key: 'ArrowDown',
           expectedValue: '23',
         });
       });
 
-      it('should decrement the hour when a value is provided', async () => {
-        await testFieldKeyPress({
+      it('should decrement the hour when a value is provided', () => {
+        testFieldKeyPress({
           format: adapter.formats.hours24h,
           defaultValue: adapter.date('2022-06-15T14:12:25'),
           key: 'ArrowDown',
@@ -28,8 +29,8 @@ describe('<TimeField /> - Editing', () => {
         });
       });
 
-      it('should go to the last hour of the previous day when a value in the first hour is provided', async () => {
-        await testFieldKeyPress({
+      it('should go to the last hour of the previous day when a value in the first hour is provided', () => {
+        testFieldKeyPress({
           format: adapter.formats.fullTime24h,
           defaultValue: adapter.date('2022-06-15T00:12:25'),
           key: 'ArrowDown',
@@ -37,16 +38,16 @@ describe('<TimeField /> - Editing', () => {
         });
       });
 
-      it('should set the minutes to 59 when no value is provided', async () => {
-        await testFieldKeyPress({
+      it('should set the minutes to 59 when no value is provided', () => {
+        testFieldKeyPress({
           format: adapter.formats.minutes,
           key: 'ArrowDown',
           expectedValue: '59',
         });
       });
 
-      it('should decrement the minutes when a value is provided', async () => {
-        await testFieldKeyPress({
+      it('should decrement the minutes when a value is provided', () => {
+        testFieldKeyPress({
           format: adapter.formats.minutes,
           defaultValue: adapter.date('2022-06-15T14:12:25'),
           key: 'ArrowDown',
@@ -54,8 +55,8 @@ describe('<TimeField /> - Editing', () => {
         });
       });
 
-      it('should go to the last minute of the current hour when a value with 0 minutes is provided', async () => {
-        await testFieldKeyPress({
+      it('should go to the last minute of the current hour when a value with 0 minutes is provided', () => {
+        testFieldKeyPress({
           format: adapter.formats.fullTime24h,
           defaultValue: adapter.date('2022-06-15T14:00:25'),
           key: 'ArrowDown',
@@ -66,16 +67,16 @@ describe('<TimeField /> - Editing', () => {
     });
 
     describe('12 hours format (ArrowDown)', () => {
-      it('should set the hour to 11 when no value is provided', async () => {
-        await testFieldKeyPress({
+      it('should set the hour to 11 when no value is provided', () => {
+        testFieldKeyPress({
           format: adapter.formats.hours12h,
           key: 'ArrowDown',
           expectedValue: '12',
         });
       });
 
-      it('should go to the last hour of the current morning when a value in the first hour is provided', async () => {
-        await testFieldKeyPress({
+      it('should go to the last hour of the current morning when a value in the first hour is provided', () => {
+        testFieldKeyPress({
           format: adapter.formats.fullTime12h,
           defaultValue: adapter.date('2022-06-15T00:12:25'),
           key: 'ArrowDown',
@@ -83,8 +84,8 @@ describe('<TimeField /> - Editing', () => {
         });
       });
 
-      it('should set the meridiem to PM when no value is provided', async () => {
-        await testFieldKeyPress({
+      it('should set the meridiem to PM when no value is provided', () => {
+        testFieldKeyPress({
           format: adapter.formats.fullTime12h,
           key: 'ArrowDown',
           expectedValue: 'hh:mm PM',
@@ -92,8 +93,8 @@ describe('<TimeField /> - Editing', () => {
         });
       });
 
-      it('should set the meridiem to PM when a value in AM is provided', async () => {
-        await testFieldKeyPress({
+      it('should set the meridiem to PM when a value in AM is provided', () => {
+        testFieldKeyPress({
           format: adapter.formats.fullTime12h,
           defaultValue: adapter.date('2022-06-15T02:12:25'),
           key: 'ArrowDown',
@@ -102,8 +103,8 @@ describe('<TimeField /> - Editing', () => {
         });
       });
 
-      it('should set the meridiem to AM when a value in PM is provided', async () => {
-        await testFieldKeyPress({
+      it('should set the meridiem to AM when a value in PM is provided', () => {
+        testFieldKeyPress({
           format: adapter.formats.fullTime12h,
           defaultValue: adapter.date('2022-06-15T14:12:25'),
           key: 'ArrowDown',
@@ -116,16 +117,16 @@ describe('<TimeField /> - Editing', () => {
 
   describeAdapters('key: ArrowUp', TimeField, ({ adapter, testFieldKeyPress }) => {
     describe('24 hours format (ArrowUp)', () => {
-      it('should set the hour to 0 when no value is provided', async () => {
-        await testFieldKeyPress({
+      it('should set the hour to 0 when no value is provided', () => {
+        testFieldKeyPress({
           format: adapter.formats.hours24h,
           key: 'ArrowUp',
           expectedValue: '00',
         });
       });
 
-      it('should increment the hour when a value is provided', async () => {
-        await testFieldKeyPress({
+      it('should increment the hour when a value is provided', () => {
+        testFieldKeyPress({
           format: adapter.formats.hours24h,
           defaultValue: adapter.date('2022-06-15T14:12:25'),
           key: 'ArrowUp',
@@ -133,8 +134,8 @@ describe('<TimeField /> - Editing', () => {
         });
       });
 
-      it('should go to the first hour of the current day when a value in the last hour is provided', async () => {
-        await testFieldKeyPress({
+      it('should go to the first hour of the current day when a value in the last hour is provided', () => {
+        testFieldKeyPress({
           format: adapter.formats.fullTime24h,
           defaultValue: adapter.date('2022-06-15T23:12:25'),
           key: 'ArrowUp',
@@ -142,16 +143,16 @@ describe('<TimeField /> - Editing', () => {
         });
       });
 
-      it('should set the minutes to 00 when no value is provided', async () => {
-        await testFieldKeyPress({
+      it('should set the minutes to 00 when no value is provided', () => {
+        testFieldKeyPress({
           format: adapter.formats.minutes,
           key: 'ArrowUp',
           expectedValue: '00',
         });
       });
 
-      it('should increment the minutes when a value is provided', async () => {
-        await testFieldKeyPress({
+      it('should increment the minutes when a value is provided', () => {
+        testFieldKeyPress({
           format: adapter.formats.minutes,
           defaultValue: adapter.date('2022-06-15T14:12:25'),
           key: 'ArrowUp',
@@ -159,8 +160,8 @@ describe('<TimeField /> - Editing', () => {
         });
       });
 
-      it('should go to the first minute of the current hour when a value with 59 minutes is provided', async () => {
-        await testFieldKeyPress({
+      it('should go to the first minute of the current hour when a value with 59 minutes is provided', () => {
+        testFieldKeyPress({
           format: adapter.formats.fullTime24h,
           defaultValue: adapter.date('2022-06-15T14:59:25'),
           key: 'ArrowUp',
@@ -171,8 +172,8 @@ describe('<TimeField /> - Editing', () => {
     });
 
     describe('12 hours format (ArrowUp)', () => {
-      it('should set the meridiem to AM when no value is provided', async () => {
-        await testFieldKeyPress({
+      it('should set the meridiem to AM when no value is provided', () => {
+        testFieldKeyPress({
           format: adapter.formats.fullTime12h,
           key: 'ArrowUp',
           expectedValue: 'hh:mm AM',
@@ -180,8 +181,8 @@ describe('<TimeField /> - Editing', () => {
         });
       });
 
-      it('should set the meridiem to PM when a value in AM is provided', async () => {
-        await testFieldKeyPress({
+      it('should set the meridiem to PM when a value in AM is provided', () => {
+        testFieldKeyPress({
           format: adapter.formats.fullTime12h,
           defaultValue: adapter.date('2022-06-15T02:12:25'),
           key: 'ArrowUp',
@@ -190,8 +191,8 @@ describe('<TimeField /> - Editing', () => {
         });
       });
 
-      it('should set the meridiem to AM when a value in PM is provided', async () => {
-        await testFieldKeyPress({
+      it('should set the meridiem to AM when a value in PM is provided', () => {
+        testFieldKeyPress({
           format: adapter.formats.fullTime12h,
           defaultValue: adapter.date('2022-06-15T14:12:25'),
           key: 'ArrowUp',
@@ -205,8 +206,8 @@ describe('<TimeField /> - Editing', () => {
   describeAdapters('key: PageDown', TimeField, ({ adapter, testFieldKeyPress }) => {
     describe('24 hours format (PageDown)', () => {
       describe('Hours field', () => {
-        it('should set hours field to maximal when no default value is provided', async () => {
-          await testFieldKeyPress({
+        it('should set hours field to maximal when no default value is provided', () => {
+          testFieldKeyPress({
             format: adapter.formats.hours24h,
             key: 'PageDown',
             expectedValue: '23',
@@ -214,8 +215,8 @@ describe('<TimeField /> - Editing', () => {
           });
         });
 
-        it('should decrement hours field by 5 when default value is provided', async () => {
-          await testFieldKeyPress({
+        it('should decrement hours field by 5 when default value is provided', () => {
+          testFieldKeyPress({
             format: adapter.formats.hours24h,
             key: 'PageDown',
             defaultValue: adapter.date('2024-06-04T10:25:00'),
@@ -224,8 +225,8 @@ describe('<TimeField /> - Editing', () => {
           });
         });
 
-        it('should flip hours field when default value is lower than 5', async () => {
-          await testFieldKeyPress({
+        it('should flip hours field when default value is lower than 5', () => {
+          testFieldKeyPress({
             format: adapter.formats.hours24h,
             key: 'PageDown',
             defaultValue: adapter.date('2024-06-04T02:25:00'),
@@ -236,16 +237,16 @@ describe('<TimeField /> - Editing', () => {
       });
 
       describe('Minutes field', () => {
-        it('should set minutes field to maximal when no default value is provided', async () => {
-          await testFieldKeyPress({
+        it('should set minutes field to maximal when no default value is provided', () => {
+          testFieldKeyPress({
             format: adapter.formats.minutes,
             key: 'PageDown',
             expectedValue: '59',
           });
         });
 
-        it('should decrement minutes field by 5 when default value is provided', async () => {
-          await testFieldKeyPress({
+        it('should decrement minutes field by 5 when default value is provided', () => {
+          testFieldKeyPress({
             format: adapter.formats.minutes,
             key: 'PageDown',
             defaultValue: adapter.date('2024-06-04T10:59:00'),
@@ -253,8 +254,8 @@ describe('<TimeField /> - Editing', () => {
           });
         });
 
-        it('should flip minutes field when default value is lower than 5', async () => {
-          await testFieldKeyPress({
+        it('should flip minutes field when default value is lower than 5', () => {
+          testFieldKeyPress({
             format: adapter.formats.minutes,
             key: 'PageDown',
             defaultValue: adapter.date('2024-06-04T02:02:00'),
@@ -266,16 +267,16 @@ describe('<TimeField /> - Editing', () => {
 
     describe('12 hours format (PageDown)', () => {
       describe('Hours field', () => {
-        it('should set hours field to maximal when no default value is provided', async () => {
-          await testFieldKeyPress({
+        it('should set hours field to maximal when no default value is provided', () => {
+          testFieldKeyPress({
             format: adapter.formats.hours12h,
             key: 'PageDown',
             expectedValue: '12',
           });
         });
 
-        it('should decrement hours field by 5 when default value is provided', async () => {
-          await testFieldKeyPress({
+        it('should decrement hours field by 5 when default value is provided', () => {
+          testFieldKeyPress({
             format: adapter.formats.hours12h,
             key: 'PageDown',
             defaultValue: adapter.date('2024-06-04T10:25:00'),
@@ -283,8 +284,8 @@ describe('<TimeField /> - Editing', () => {
           });
         });
 
-        it('should flip hours field when default value is lower than 5', async () => {
-          await testFieldKeyPress({
+        it('should flip hours field when default value is lower than 5', () => {
+          testFieldKeyPress({
             format: adapter.formats.hours12h,
             key: 'PageDown',
             defaultValue: adapter.date('2024-06-04T02:25:00'),
@@ -294,8 +295,8 @@ describe('<TimeField /> - Editing', () => {
       });
 
       describe('Meridiem field', () => {
-        it('should set meridiem to PM when no default value is provided', async () => {
-          await testFieldKeyPress({
+        it('should set meridiem to PM when no default value is provided', () => {
+          testFieldKeyPress({
             format: adapter.formats.meridiem,
             key: 'PageDown',
             expectedValue: 'PM',
@@ -303,15 +304,15 @@ describe('<TimeField /> - Editing', () => {
           });
         });
 
-        it('should switch between AM and PM when meridiem value is not empty', async () => {
-          await testFieldKeyPress({
+        it('should switch between AM and PM when meridiem value is not empty', () => {
+          testFieldKeyPress({
             format: adapter.formats.meridiem,
             defaultValue: adapter.date('2024-05-30T02:12:25'),
             key: 'PageDown',
             expectedValue: 'PM',
             selectedSection: 'meridiem',
           });
-          await testFieldKeyPress({
+          testFieldKeyPress({
             format: adapter.formats.meridiem,
             defaultValue: adapter.date('2024-05-30T20:12:25'),
             key: 'PageDown',
@@ -326,8 +327,8 @@ describe('<TimeField /> - Editing', () => {
   describeAdapters('key: PageUp', TimeField, ({ adapter, testFieldKeyPress }) => {
     describe('24 hours format (PageUp)', () => {
       describe('Hours field', () => {
-        it('should set hours field to minimal when no default value is provided', async () => {
-          await testFieldKeyPress({
+        it('should set hours field to minimal when no default value is provided', () => {
+          testFieldKeyPress({
             format: adapter.formats.hours24h,
             key: 'PageUp',
             expectedValue: '00',
@@ -335,8 +336,8 @@ describe('<TimeField /> - Editing', () => {
           });
         });
 
-        it('should increment hours field by 5 when default value is provided', async () => {
-          await testFieldKeyPress({
+        it('should increment hours field by 5 when default value is provided', () => {
+          testFieldKeyPress({
             format: adapter.formats.hours24h,
             key: 'PageUp',
             defaultValue: adapter.date('2024-06-04T10:25:00'),
@@ -345,8 +346,8 @@ describe('<TimeField /> - Editing', () => {
           });
         });
 
-        it('should flip hours field when default value is higher than 19', async () => {
-          await testFieldKeyPress({
+        it('should flip hours field when default value is higher than 19', () => {
+          testFieldKeyPress({
             format: adapter.formats.hours24h,
             key: 'PageUp',
             defaultValue: adapter.date('2024-06-04T21:25:00'),
@@ -357,16 +358,16 @@ describe('<TimeField /> - Editing', () => {
       });
 
       describe('Minutes field', () => {
-        it('should set minutes field to minimal when no default value is provided', async () => {
-          await testFieldKeyPress({
+        it('should set minutes field to minimal when no default value is provided', () => {
+          testFieldKeyPress({
             format: adapter.formats.hours24h,
             key: 'PageUp',
             expectedValue: '00',
           });
         });
 
-        it('should increment minutes field by 5 when default value is provided', async () => {
-          await testFieldKeyPress({
+        it('should increment minutes field by 5 when default value is provided', () => {
+          testFieldKeyPress({
             format: adapter.formats.minutes,
             key: 'PageUp',
             defaultValue: adapter.date('2024-06-04T10:25:00'),
@@ -374,8 +375,8 @@ describe('<TimeField /> - Editing', () => {
           });
         });
 
-        it('should flip minutes field when default value is higher than 55', async () => {
-          await testFieldKeyPress({
+        it('should flip minutes field when default value is higher than 55', () => {
+          testFieldKeyPress({
             format: adapter.formats.minutes,
             key: 'PageUp',
             defaultValue: adapter.date('2024-06-04T21:56:00'),
@@ -386,8 +387,8 @@ describe('<TimeField /> - Editing', () => {
     });
     describe('12 hours format (PageUp)', () => {
       describe('Hours field', () => {
-        it('should set hours field to minimal when no default value is provided', async () => {
-          await testFieldKeyPress({
+        it('should set hours field to minimal when no default value is provided', () => {
+          testFieldKeyPress({
             format: adapter.formats.hours12h,
             key: 'PageUp',
             expectedValue: '01',
@@ -395,8 +396,8 @@ describe('<TimeField /> - Editing', () => {
           });
         });
 
-        it('should increment hours field by 5 when default value is provided', async () => {
-          await testFieldKeyPress({
+        it('should increment hours field by 5 when default value is provided', () => {
+          testFieldKeyPress({
             format: adapter.formats.hours12h,
             key: 'PageUp',
             defaultValue: adapter.date('2024-06-04T05:25:00'),
@@ -405,8 +406,8 @@ describe('<TimeField /> - Editing', () => {
           });
         });
 
-        it('should flip hours field when default value is higher than 07', async () => {
-          await testFieldKeyPress({
+        it('should flip hours field when default value is higher than 07', () => {
+          testFieldKeyPress({
             format: adapter.formats.hours12h,
             key: 'PageUp',
             defaultValue: adapter.date('2024-06-04T08:25:00'),
@@ -417,8 +418,8 @@ describe('<TimeField /> - Editing', () => {
       });
 
       describe('Meridiem field', () => {
-        it('should set meridiem to AM when no default value is provided', async () => {
-          await testFieldKeyPress({
+        it('should set meridiem to AM when no default value is provided', () => {
+          testFieldKeyPress({
             format: adapter.formats.meridiem,
             key: 'PageUp',
             expectedValue: 'AM',
@@ -426,15 +427,15 @@ describe('<TimeField /> - Editing', () => {
           });
         });
 
-        it('should switch between AM and PM when meridiem value is not empty', async () => {
-          await testFieldKeyPress({
+        it('should switch between AM and PM when meridiem value is not empty', () => {
+          testFieldKeyPress({
             format: adapter.formats.meridiem,
             defaultValue: adapter.date('2024-05-30T02:12:25'),
             key: 'PageUp',
             expectedValue: 'PM',
             selectedSection: 'meridiem',
           });
-          await testFieldKeyPress({
+          testFieldKeyPress({
             format: adapter.formats.meridiem,
             defaultValue: adapter.date('2024-05-30T20:12:25'),
             key: 'PageUp',
@@ -447,15 +448,15 @@ describe('<TimeField /> - Editing', () => {
   });
 
   describeAdapters('Digit editing', TimeField, ({ adapter, renderWithProps, testFieldChange }) => {
-    it('should set the minute to the digit pressed when no digit no value is provided', async () => {
-      await testFieldChange({
+    it('should set the minute to the digit pressed when no digit no value is provided', () => {
+      testFieldChange({
         format: adapter.formats.minutes,
         keyStrokes: [{ value: '1', expected: '01' }],
       });
     });
 
-    it('should concatenate the digit pressed to the current section value if the output is valid', async () => {
-      await testFieldChange({
+    it('should concatenate the digit pressed to the current section value if the output is valid', () => {
+      testFieldChange({
         format: adapter.formats.minutes,
         defaultValue: adapter.date('2022-06-15T14:12:25'),
         keyStrokes: [
@@ -465,8 +466,8 @@ describe('<TimeField /> - Editing', () => {
       });
     });
 
-    it('should set the minute to the digit pressed if the concatenate exceeds the maximum value for the section', async () => {
-      await testFieldChange({
+    it('should set the minute to the digit pressed if the concatenate exceeds the maximum value for the section', () => {
+      testFieldChange({
         format: adapter.formats.minutes,
         defaultValue: adapter.date('2022-06-15T14:12:25'),
         keyStrokes: [
@@ -476,16 +477,16 @@ describe('<TimeField /> - Editing', () => {
       });
     });
 
-    it('should not edit when props.readOnly = true and no value is provided (digit)', async () => {
-      await testFieldChange({
+    it('should not edit when props.readOnly = true and no value is provided (digit)', () => {
+      testFieldChange({
         format: adapter.formats.minutes,
         readOnly: true,
         keyStrokes: [{ value: '1', expected: 'mm' }],
       });
     });
 
-    it('should not edit value when props.readOnly = true and a value is provided (digit)', async () => {
-      await testFieldChange({
+    it('should not edit value when props.readOnly = true and a value is provided (digit)', () => {
+      testFieldChange({
         format: adapter.formats.minutes,
         defaultValue: adapter.date('2022-06-15T14:12:25'),
         readOnly: true,
@@ -498,9 +499,9 @@ describe('<TimeField /> - Editing', () => {
         format: adapter.formats.fullTime12h,
       });
 
-      await view.selectSection('hours');
+      await view.selectSectionAsync('hours');
 
-      await view.pressKey('2');
+      view.pressKey(0, '2');
       expectFieldValue(view.getSectionsContainer(), '02:mm aa');
       expect(getCleanedSelectedContent()).to.equal('mm');
     });
@@ -510,30 +511,30 @@ describe('<TimeField /> - Editing', () => {
         format: adapter.formats.fullTime12h,
       });
 
-      await view.selectSection('hours');
+      await view.selectSectionAsync('hours');
 
-      await view.pressKey('1');
+      view.pressKey(0, '1');
       expectFieldValue(view.getSectionsContainer(), '01:mm aa');
       expect(getCleanedSelectedContent()).to.equal('01');
 
       // Press "3"
-      await view.pressKey('3');
+      view.pressKey(0, '3');
       expectFieldValue(view.getSectionsContainer(), '03:mm aa');
       expect(getCleanedSelectedContent()).to.equal('mm');
     });
   });
 
   describeAdapters('Letter editing', TimeField, ({ adapter, testFieldChange }) => {
-    it('should not edit when props.readOnly = true and no value is provided (letter)', async () => {
-      await testFieldChange({
+    it('should not edit when props.readOnly = true and no value is provided (letter)', () => {
+      testFieldChange({
         format: adapter.formats.meridiem,
         readOnly: true,
         keyStrokes: [{ value: 'a', expected: 'aa' }],
       });
     });
 
-    it('should not edit value when props.readOnly = true and a value is provided (letter)', async () => {
-      await testFieldChange({
+    it('should not edit value when props.readOnly = true and a value is provided (letter)', () => {
+      testFieldChange({
         format: adapter.formats.meridiem,
         defaultValue: adapter.date('2022-06-15T14:12:25'),
         readOnly: true,
@@ -541,8 +542,8 @@ describe('<TimeField /> - Editing', () => {
       });
     });
 
-    it('should set meridiem to AM when pressing "a" and no value is provided', async () => {
-      await testFieldChange({
+    it('should set meridiem to AM when pressing "a" and no value is provided', () => {
+      testFieldChange({
         format: adapter.formats.meridiem,
         selectedSection: 'meridiem',
         // Press "a"
@@ -550,8 +551,8 @@ describe('<TimeField /> - Editing', () => {
       });
     });
 
-    it('should set meridiem to PM when pressing "p" and no value is provided', async () => {
-      await testFieldChange({
+    it('should set meridiem to PM when pressing "p" and no value is provided', () => {
+      testFieldChange({
         format: adapter.formats.meridiem,
         selectedSection: 'meridiem',
         // Press "p"
@@ -559,8 +560,8 @@ describe('<TimeField /> - Editing', () => {
       });
     });
 
-    it('should set meridiem to AM when pressing "a" and a value is provided', async () => {
-      await testFieldChange({
+    it('should set meridiem to AM when pressing "a" and a value is provided', () => {
+      testFieldChange({
         format: adapter.formats.meridiem,
         defaultValue: adapter.date('2022-06-15T14:12:25'),
         selectedSection: 'meridiem',
@@ -569,8 +570,8 @@ describe('<TimeField /> - Editing', () => {
       });
     });
 
-    it('should set meridiem to PM when pressing "p" and a value is provided', async () => {
-      await testFieldChange({
+    it('should set meridiem to PM when pressing "p" and a value is provided', () => {
+      testFieldChange({
         format: adapter.formats.meridiem,
         defaultValue: adapter.date('2022-06-15T14:12:25'),
         selectedSection: 'meridiem',
@@ -579,8 +580,8 @@ describe('<TimeField /> - Editing', () => {
       });
     });
 
-    it('should not edit when pressing the Space key', async () => {
-      await testFieldChange({
+    it('should not edit when pressing the Space key', () => {
+      testFieldChange({
         format: adapter.formats.hours24h,
         keyStrokes: [{ value: ' ', expected: 'hh' }],
       });
@@ -599,8 +600,8 @@ describe('<TimeField /> - Editing', () => {
           onChange,
         });
 
-        await view.selectSection('hours');
-        await view.user.keyboard('{ArrowDown}');
+        await view.selectSectionAsync('hours');
+        fireEvent.keyDown(view.getActiveSection(0), { key: 'ArrowDown' });
 
         expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2010, 3, 3, 2, 3, 3));
       });
@@ -614,15 +615,19 @@ describe('<TimeField /> - Editing', () => {
           format: adapter.formats.fullTime24h,
         });
 
-        await view.selectSection('hours');
-        await view.user.keyboard('{Control>}a{/Control}');
-        await view.user.keyboard('{Backspace}');
-        await view.user.keyboard('{ArrowLeft}');
+        await view.selectSectionAsync('hours');
+        fireEvent.keyDown(view.getActiveSection(0), {
+          key: 'a',
+          keyCode: 65,
+          ctrlKey: true,
+        });
+        view.pressKey(null, '');
+        fireEvent.keyDown(view.getSectionsContainer(), { key: 'ArrowLeft' });
 
-        await view.pressKey('3');
+        view.pressKey(0, '3');
         expectFieldValue(view.getSectionsContainer(), '03:mm');
 
-        await view.pressKey('4');
+        view.pressKey(1, '4');
         expectFieldValue(view.getSectionsContainer(), '03:04');
         expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2010, 3, 3, 3, 4, 3));
       });
@@ -636,8 +641,8 @@ describe('<TimeField /> - Editing', () => {
           format: adapter.formats.hours24h,
         });
 
-        await view.selectSection('hours');
-        await view.user.keyboard('{ArrowDown}');
+        await view.selectSectionAsync('hours');
+        fireEvent.keyDown(view.getActiveSection(0), { key: 'ArrowDown' });
 
         expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2010, 3, 3, 2, 3, 3));
       });
@@ -645,8 +650,8 @@ describe('<TimeField /> - Editing', () => {
   );
 
   describeAdapters('props: minutesStep', TimeField, ({ adapter, testFieldKeyPress }) => {
-    it('should use `minutesStep` to set initial minutes with ArrowUp', async () => {
-      await testFieldKeyPress({
+    it('should use `minutesStep` to set initial minutes with ArrowUp', () => {
+      testFieldKeyPress({
         format: adapter.formats.minutes,
         key: 'ArrowUp',
         minutesStep: 5,
@@ -654,8 +659,8 @@ describe('<TimeField /> - Editing', () => {
       });
     });
 
-    it('should use `minutesStep` to set initial minutes with ArrowDown', async () => {
-      await testFieldKeyPress({
+    it('should use `minutesStep` to set initial minutes with ArrowDown', () => {
+      testFieldKeyPress({
         format: adapter.formats.minutes,
         key: 'ArrowDown',
         minutesStep: 5,
@@ -663,8 +668,8 @@ describe('<TimeField /> - Editing', () => {
       });
     });
 
-    it('should use `minutesStep` to increase minutes', async () => {
-      await testFieldKeyPress({
+    it('should use `minutesStep` to increase minutes', () => {
+      testFieldKeyPress({
         format: adapter.formats.minutes,
         defaultValue: adapter.date('2022-06-15T14:00:25'),
         key: 'ArrowUp',
@@ -673,8 +678,8 @@ describe('<TimeField /> - Editing', () => {
       });
     });
 
-    it('should use `minutesStep` to decrease minutes', async () => {
-      await testFieldKeyPress({
+    it('should use `minutesStep` to decrease minutes', () => {
+      testFieldKeyPress({
         format: adapter.formats.minutes,
         defaultValue: adapter.date('2022-06-15T14:00:25'),
         key: 'ArrowDown',
@@ -683,8 +688,8 @@ describe('<TimeField /> - Editing', () => {
       });
     });
 
-    it('should go to the closest valid values according to `minutesStep` when pressing ArrowDown', async () => {
-      await testFieldKeyPress({
+    it('should go to the closest valid values according to `minutesStep` when pressing ArrowDown', () => {
+      testFieldKeyPress({
         format: adapter.formats.minutes,
         defaultValue: adapter.date('2022-06-15T14:02:25'),
         key: 'ArrowDown',
@@ -693,8 +698,8 @@ describe('<TimeField /> - Editing', () => {
       });
     });
 
-    it('should go to the closest valid values according to `minutesStep` when pressing ArrowUp', async () => {
-      await testFieldKeyPress({
+    it('should go to the closest valid values according to `minutesStep` when pressing ArrowUp', () => {
+      testFieldKeyPress({
         format: adapter.formats.minutes,
         defaultValue: adapter.date('2022-06-15T14:02:25'),
         key: 'ArrowUp',
@@ -728,8 +733,8 @@ describe('<TimeField /> - Editing', () => {
       expectFieldValue(view.getSectionsContainer(), '02:12 PM');
     });
 
-    it('should wrap from 11 to 0 when pressing ArrowUp at the maximum', async () => {
-      await testFieldKeyPress({
+    it('should wrap from 11 to 0 when pressing ArrowUp at the maximum', () => {
+      testFieldKeyPress({
         format: 'K:mm aa',
         defaultValue: adapter.date('2022-06-15T23:12:00'),
         key: 'ArrowUp',
@@ -746,15 +751,15 @@ describe('<TimeField /> - Editing', () => {
         onChange,
       });
 
-      await view.selectSection('hours');
-      await view.user.keyboard('{ArrowUp}');
+      await view.selectSectionAsync('hours');
+      fireEvent.keyDown(view.getActiveSection(0), { key: 'ArrowUp' });
 
       // K=0 + PM = noon (12:xx), not midnight (00:xx)
       expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2022, 5, 15, 12, 12, 0));
     });
 
-    it('should wrap from 0 to 11 when pressing ArrowDown at the minimum', async () => {
-      await testFieldKeyPress({
+    it('should wrap from 0 to 11 when pressing ArrowDown at the minimum', () => {
+      testFieldKeyPress({
         format: 'K:mm aa',
         defaultValue: adapter.date('2022-06-15T12:12:00'),
         key: 'ArrowDown',
@@ -762,8 +767,8 @@ describe('<TimeField /> - Editing', () => {
       });
     });
 
-    it('should accept typed digit input for K format', async () => {
-      await testFieldChange({
+    it('should accept typed digit input for K format', () => {
+      testFieldChange({
         format: 'K:mm aa',
         keyStrokes: [
           // "1" stays in the section because "10" and "11" are still valid
@@ -799,8 +804,8 @@ describe('<TimeField /> - Editing', () => {
         expectFieldValue(view.getSectionsContainer(), '14:12');
       });
 
-      it('should wrap from 24 to 1 when pressing ArrowUp at the maximum', async () => {
-        await testFieldKeyPress({
+      it('should wrap from 24 to 1 when pressing ArrowUp at the maximum', () => {
+        testFieldKeyPress({
           format: 'k:mm',
           defaultValue: adapter.date('2022-06-15T00:12:00'),
           key: 'ArrowUp',
@@ -808,8 +813,8 @@ describe('<TimeField /> - Editing', () => {
         });
       });
 
-      it('should wrap from 1 to 24 when pressing ArrowDown at the minimum', async () => {
-        await testFieldKeyPress({
+      it('should wrap from 1 to 24 when pressing ArrowDown at the minimum', () => {
+        testFieldKeyPress({
           format: 'k:mm',
           defaultValue: adapter.date('2022-06-15T01:12:00'),
           key: 'ArrowDown',
@@ -817,8 +822,8 @@ describe('<TimeField /> - Editing', () => {
         });
       });
 
-      it('should accept two-digit input for kk format', async () => {
-        await testFieldChange({
+      it('should accept two-digit input for kk format', () => {
+        testFieldChange({
           format: 'kk:mm',
           keyStrokes: [
             { value: '1', expected: '01:mm' },

--- a/packages/x-date-pickers/src/TimeField/tests/timezone.TimeField.test.tsx
+++ b/packages/x-date-pickers/src/TimeField/tests/timezone.TimeField.test.tsx
@@ -24,7 +24,7 @@ describe('<TimeField /> - Timezone', () => {
           onChange,
         });
 
-        await view.selectSection('meridiem');
+        await view.selectSectionAsync('meridiem');
         // Toggle PM → AM
         await view.user.keyboard('{ArrowDown}');
 
@@ -50,7 +50,7 @@ describe('<TimeField /> - Timezone', () => {
           onChange,
         });
 
-        await view.selectSection('meridiem');
+        await view.selectSectionAsync('meridiem');
         // Toggle AM → PM
         await view.user.keyboard('{ArrowUp}');
 

--- a/packages/x-date-pickers/src/YearCalendar/tests/YearCalendar.test.tsx
+++ b/packages/x-date-pickers/src/YearCalendar/tests/YearCalendar.test.tsx
@@ -1,5 +1,5 @@
 import { spy } from 'sinon';
-import { act, screen } from '@mui/internal-test-utils';
+import { act, fireEvent, screen } from '@mui/internal-test-utils';
 import { YearCalendar } from '@mui/x-date-pickers/YearCalendar';
 import { createPickerRenderer, adapterToUse } from 'test/utils/pickers';
 import { vi } from 'vitest';
@@ -7,11 +7,9 @@ import { vi } from 'vitest';
 describe('<YearCalendar />', () => {
   const { render } = createPickerRenderer();
 
-  it('allows to pick year standalone by click, `Enter` and `Space`', async () => {
+  it('allows to pick year standalone by click, `Enter` and `Space`', () => {
     const onChange = spy();
-    const { user } = render(
-      <YearCalendar value={adapterToUse.date('2019-02-02')} onChange={onChange} />,
-    );
+    render(<YearCalendar value={adapterToUse.date('2019-02-02')} onChange={onChange} />);
     const targetYear = screen.getByRole('radio', { name: '2025' });
 
     // A native button implies Enter and Space keydown behavior
@@ -21,31 +19,31 @@ describe('<YearCalendar />', () => {
     // - fireEvent.keyUp(targetDay, { key: 'Space' })
     expect(targetYear.tagName).to.equal('BUTTON');
 
-    await user.click(targetYear);
+    fireEvent.click(targetYear);
 
     expect(onChange.callCount).to.equal(1);
     expect(onChange.args[0][0]).toEqualDateTime(new Date(2025, 1, 2));
   });
 
-  it('should select start of year without time when no initial value is present', async () => {
+  it('should select start of year without time when no initial value is present', () => {
     const onChange = spy();
-    const { user } = render(<YearCalendar onChange={onChange} />);
+    render(<YearCalendar onChange={onChange} />);
 
-    await user.click(screen.getByRole('radio', { name: '2025' }));
+    fireEvent.click(screen.getByRole('radio', { name: '2025' }));
 
     expect(onChange.callCount).to.equal(1);
     expect(onChange.args[0][0]).toEqualDateTime(new Date(2025, 0, 1, 0, 0, 0, 0));
   });
 
-  it('does not allow to pick year if readOnly prop is passed', async () => {
+  it('does not allow to pick year if readOnly prop is passed', () => {
     const onChangeMock = spy();
-    const { user } = render(
+    render(
       <YearCalendar value={adapterToUse.date('2019-02-02')} onChange={onChangeMock} readOnly />,
     );
     const targetYear = screen.getByRole('radio', { name: '2025' });
     expect(targetYear.tagName).to.equal('BUTTON');
 
-    await user.click(targetYear);
+    fireEvent.click(targetYear);
 
     expect(onChangeMock.callCount).to.equal(0);
   });
@@ -76,28 +74,20 @@ describe('<YearCalendar />', () => {
   });
 
   describe('Disabled', () => {
-    it('should disable all years if props.disabled = true', async () => {
+    it('should disable all years if props.disabled = true', () => {
       const onChange = spy();
-      const { user } = render(
-        <YearCalendar value={adapterToUse.date('2017-02-15')} onChange={onChange} disabled />,
-      );
+      render(<YearCalendar value={adapterToUse.date('2017-02-15')} onChange={onChange} disabled />);
 
-      // Hoist the user-event instance so we don't recreate it on every
-      // iteration; all we need is to bypass the pointer-events check on
-      // disabled buttons.
-      const userWithoutPointerEventsCheck = user.setup({ pointerEventsCheck: 0 });
-      const yearButtons = screen.getAllByRole('radio');
-      for (const yearButton of yearButtons) {
+      screen.getAllByRole('radio').forEach((yearButton) => {
         expect(yearButton).to.have.attribute('disabled');
-        // eslint-disable-next-line no-await-in-loop
-        await userWithoutPointerEventsCheck.click(yearButton);
+        fireEvent.click(yearButton);
         expect(onChange.callCount).to.equal(0);
-      }
+      });
     });
 
-    it('should not render years before props.minDate but should render and not disable the year in which props.minDate is', async () => {
+    it('should not render years before props.minDate but should render and not disable the year in which props.minDate is', () => {
       const onChange = spy();
-      const { user } = render(
+      render(
         <YearCalendar
           value={adapterToUse.date('2017-02-15')}
           onChange={onChange}
@@ -111,13 +101,13 @@ describe('<YearCalendar />', () => {
       expect(year2017).to.equal(null);
       expect(year2018).not.to.have.attribute('disabled');
 
-      await user.click(year2018);
+      fireEvent.click(year2018);
       expect(onChange.callCount).to.equal(1);
     });
 
-    it('should not render years after props.maxDate but should render and not disable the year in which props.maxDate is', async () => {
+    it('should not render years after props.maxDate but should render and not disable the year in which props.maxDate is', () => {
       const onChange = spy();
-      const { user } = render(
+      render(
         <YearCalendar
           value={adapterToUse.date('2019-02-15')}
           onChange={onChange}
@@ -131,13 +121,13 @@ describe('<YearCalendar />', () => {
       expect(year2026).to.equal(null);
       expect(year2025).not.to.have.attribute('disabled');
 
-      await user.click(year2025);
+      fireEvent.click(year2025);
       expect(onChange.callCount).to.equal(1);
     });
 
-    it('should disable years if props.shouldDisableYear returns true', async () => {
+    it('should disable years if props.shouldDisableYear returns true', () => {
       const onChange = spy();
-      const { user } = render(
+      render(
         <YearCalendar
           value={adapterToUse.date('2019-01-02')}
           onChange={onChange}
@@ -151,16 +141,16 @@ describe('<YearCalendar />', () => {
       expect(year2024).to.have.attribute('disabled');
       expect(year2025).not.to.have.attribute('disabled');
 
-      await user.setup({ pointerEventsCheck: 0 }).click(year2024);
+      fireEvent.click(year2024);
       expect(onChange.callCount).to.equal(0);
 
-      await user.click(year2025);
+      fireEvent.click(year2025);
       expect(onChange.callCount).to.equal(1);
     });
   });
 
-  it('should allow to focus years when it contains valid date', async () => {
-    const { user } = render(
+  it('should allow to focus years when it contains valid date', () => {
+    render(
       <YearCalendar
         // date is chose such as replacing year by 2018 or 2020 makes it out of valid range
         defaultValue={adapterToUse.date('2019-08-01')}
@@ -171,11 +161,11 @@ describe('<YearCalendar />', () => {
     const button2019 = screen.getByRole('radio', { name: '2019' });
 
     act(() => button2019.focus());
-    await user.keyboard('{ArrowLeft}');
+    fireEvent.keyDown(button2019, { key: 'ArrowLeft' });
     expect(document.activeElement).to.have.text('2018');
 
     act(() => button2019.focus());
-    await user.keyboard('{ArrowRight}');
+    fireEvent.keyDown(button2019, { key: 'ArrowRight' });
     expect(document.activeElement).to.have.text('2020');
   });
 

--- a/packages/x-date-pickers/src/YearCalendar/tests/describeValue.YearCalendar.test.tsx
+++ b/packages/x-date-pickers/src/YearCalendar/tests/describeValue.YearCalendar.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@mui/internal-test-utils';
+import { fireEvent, screen } from '@mui/internal-test-utils';
 import { YearCalendar } from '@mui/x-date-pickers/YearCalendar';
 import { createPickerRenderer, adapterToUse, describeValue } from 'test/utils/pickers';
 import { PickerValue } from '@mui/x-date-pickers/internals';
@@ -23,9 +23,9 @@ describe('<YearCalendar /> - Describe Value', () => {
         expect(activeYear).to.have.text(adapterToUse.getYear(expectedValue).toString());
       }
     },
-    setNewValue: async (value, { user }) => {
+    setNewValue: (value) => {
       const newValue = adapterToUse.addYears(value!, 1);
-      await user.click(
+      fireEvent.click(
         screen.getByRole('radio', { name: adapterToUse.getYear(newValue).toString() }),
       );
 

--- a/packages/x-date-pickers/src/YearCalendar/tests/keyboard.YearCalendar.test.tsx
+++ b/packages/x-date-pickers/src/YearCalendar/tests/keyboard.YearCalendar.test.tsx
@@ -1,7 +1,9 @@
+import { fireEvent, screen } from '@mui/internal-test-utils';
 import { YearCalendar } from '@mui/x-date-pickers/YearCalendar';
 import { createPickerRenderer, adapterToUse } from 'test/utils/pickers';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 
+/* eslint-disable mui/disallow-active-element-as-key-event-target */
 describe('<YearCalendar /> - Keyboard', () => {
   const { render } = createPickerRenderer();
 
@@ -9,8 +11,8 @@ describe('<YearCalendar /> - Keyboard', () => {
     direction: 'rtl',
   });
 
-  async function changeYear(
-    userEventKey: string,
+  function changeYear(
+    keyPressed: string,
     expectedValue: string,
     yearsOrder: 'asc' | 'desc' = 'asc',
     direction: 'ltr' | 'rtl' = 'ltr',
@@ -31,42 +33,42 @@ describe('<YearCalendar /> - Keyboard', () => {
         yearCalendar
       );
 
-    const { user } = render(elementsToRender);
-    // Move focus to the current year
-    await user.keyboard('{Tab}');
-    await user.keyboard(userEventKey);
+    render(elementsToRender);
+    const startYear = screen.getByRole('radio', { checked: true });
+    fireEvent.focus(startYear);
+    fireEvent.keyDown(document.activeElement!, { key: keyPressed });
     expect(document.activeElement?.textContent).to.equal(expectedValue);
   }
 
-  it('should increase the year when pressing right and yearsOrder is asc (default)', async () => {
-    await changeYear('{ArrowRight}', '2001');
+  it('should increase the year when pressing right and yearsOrder is asc (default)', () => {
+    changeYear('ArrowRight', '2001');
   });
 
-  it('should decrease the year when pressing left and yearsOrder is asc (default)', async () => {
-    await changeYear('{ArrowLeft}', '1999');
+  it('should decrease the year when pressing left and yearsOrder is asc (default)', () => {
+    changeYear('ArrowLeft', '1999');
   });
 
-  it('should decrease the year when pressing right and yearsOrder is desc', async () => {
-    await changeYear('{ArrowRight}', '1999', 'desc');
+  it('should decrease the year when pressing right and yearsOrder is desc', () => {
+    changeYear('ArrowRight', '1999', 'desc');
   });
 
-  it('should increase the year when pressing left and yearsOrder is desc', async () => {
-    await changeYear('{ArrowLeft}', '2001', 'desc');
+  it('should increase the year when pressing left and yearsOrder is desc', () => {
+    changeYear('ArrowLeft', '2001', 'desc');
   });
 
-  it('should decrease the year when pressing right and yearsOrder is asc (default) and theme is RTL', async () => {
-    await changeYear('{ArrowRight}', '1999', 'asc', 'rtl');
+  it('should decrease the year when pressing right and yearsOrder is asc (default) and theme is RTL', () => {
+    changeYear('ArrowRight', '1999', 'asc', 'rtl');
   });
 
-  it('should increase the year when pressing left and yearsOrder is asc (default) and theme is RTL', async () => {
-    await changeYear('{ArrowLeft}', '2001', 'asc', 'rtl');
+  it('should increase the year when pressing left and yearsOrder is asc (default) and theme is RTL', () => {
+    changeYear('ArrowLeft', '2001', 'asc', 'rtl');
   });
 
-  it('should increase the year when pressing right and yearsOrder is desc and theme is RTL', async () => {
-    await changeYear('{ArrowRight}', '2001', 'desc', 'rtl');
+  it('should increase the year when pressing right and yearsOrder is desc and theme is RTL', () => {
+    changeYear('ArrowRight', '2001', 'desc', 'rtl');
   });
 
-  it('should decrease the year when pressing left and yearsOrder is desc and theme is RTL', async () => {
-    await changeYear('{ArrowLeft}', '1999', 'desc', 'rtl');
+  it('should decrease the year when pressing left and yearsOrder is desc and theme is RTL', () => {
+    changeYear('ArrowLeft', '1999', 'desc', 'rtl');
   });
 });

--- a/packages/x-date-pickers/src/internals/hooks/useField/useFieldRootProps.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useFieldRootProps.ts
@@ -72,7 +72,7 @@ export function useFieldRootProps(
     switch (true) {
       // Select all
       case (event.ctrlKey || event.metaKey) &&
-        (event.key?.toUpperCase() === 'A' || String.fromCharCode(event.keyCode) === 'A') &&
+        String.fromCharCode(event.keyCode) === 'A' &&
         !event.shiftKey &&
         !event.altKey: {
         // prevent default to make sure that the next line "select all" while updating

--- a/packages/x-date-pickers/src/tests/fieldKeyboardInteraction.test.tsx
+++ b/packages/x-date-pickers/src/tests/fieldKeyboardInteraction.test.tsx
@@ -1,5 +1,6 @@
 import moment from 'moment';
 import jMoment from 'moment-jalaali';
+import { fireEvent } from '@mui/internal-test-utils';
 import {
   buildFieldInteractions,
   getCleanedSelectedContent,
@@ -68,35 +69,33 @@ describe(`RTL - test arrows navigation`, () => {
 
   const { renderWithProps } = buildFieldInteractions({ render, Component: DateTimeField });
 
-  it('should move selected section to the next section respecting RTL order in empty field', async () => {
+  it('should move selected section to the next section respecting RTL order in empty field', () => {
     const expectedValues = ['hh', 'mm', 'YYYY', 'MM', 'DD', 'DD'];
 
     const view = renderWithProps({}, { direction: 'rtl' });
 
-    await view.selectSection('hours');
+    view.selectSection('hours');
 
-    for (const expectedValue of expectedValues) {
+    expectedValues.forEach((expectedValue) => {
       expect(getCleanedSelectedContent()).to.equal(expectedValue);
-      // eslint-disable-next-line no-await-in-loop
-      await view.user.keyboard('{ArrowRight}');
-    }
+      fireEvent.keyDown(view.getActiveSection(undefined), { key: 'ArrowRight' });
+    });
   });
 
-  it('should move selected section to the previous section respecting RTL order in empty field', async () => {
+  it('should move selected section to the previous section respecting RTL order in empty field', () => {
     const expectedValues = ['DD', 'MM', 'YYYY', 'mm', 'hh', 'hh'];
 
     const view = renderWithProps({}, { direction: 'rtl' });
 
-    await view.selectSection('day');
+    view.selectSection('day');
 
-    for (const expectedValue of expectedValues) {
+    expectedValues.forEach((expectedValue) => {
       expect(getCleanedSelectedContent()).to.equal(expectedValue);
-      // eslint-disable-next-line no-await-in-loop
-      await view.user.keyboard('{ArrowLeft}');
-    }
+      fireEvent.keyDown(view.getActiveSection(undefined), { key: 'ArrowLeft' });
+    });
   });
 
-  it('should move selected section to the next section respecting RTL order in non-empty field', async () => {
+  it('should move selected section to the next section respecting RTL order in non-empty field', () => {
     // 25/04/2018 => 1397/02/05
     const expectedValues = ['11', '54', '1397', '02', '05', '05'];
 
@@ -107,16 +106,15 @@ describe(`RTL - test arrows navigation`, () => {
       { direction: 'rtl' },
     );
 
-    await view.selectSection('hours');
+    view.selectSection('hours');
 
-    for (const expectedValue of expectedValues) {
+    expectedValues.forEach((expectedValue) => {
       expect(getCleanedSelectedContent()).to.equal(expectedValue);
-      // eslint-disable-next-line no-await-in-loop
-      await view.user.keyboard('{ArrowRight}');
-    }
+      fireEvent.keyDown(view.getActiveSection(undefined), { key: 'ArrowRight' });
+    });
   });
 
-  it('should move selected section to the previous section respecting RTL order in non-empty field', async () => {
+  it('should move selected section to the previous section respecting RTL order in non-empty field', () => {
     // 25/04/2018 => 1397/02/05
     const expectedValues = ['05', '02', '1397', '54', '11', '11'];
 
@@ -127,13 +125,12 @@ describe(`RTL - test arrows navigation`, () => {
       { direction: 'rtl' },
     );
 
-    await view.selectSection('day');
+    view.selectSection('day');
 
-    for (const expectedValue of expectedValues) {
+    expectedValues.forEach((expectedValue) => {
       expect(getCleanedSelectedContent()).to.equal(expectedValue);
-      // eslint-disable-next-line no-await-in-loop
-      await view.user.keyboard('{ArrowLeft}');
-    }
+      fireEvent.keyDown(view.getActiveSection(undefined), { key: 'ArrowLeft' });
+    });
   });
 });
 
@@ -170,7 +167,7 @@ adapterToTest.forEach((adapterName) => {
       return valueStr;
     };
 
-    const testKeyPress = async ({
+    const testKeyPress = ({
       key,
       format,
       initialValue,
@@ -187,8 +184,8 @@ adapterToTest.forEach((adapterName) => {
         defaultValue: initialValue,
         format,
       });
-      await view.selectSection(sectionConfig.type);
-      await view.user.keyboard(`{${key}}`);
+      view.selectSection(sectionConfig.type);
+      fireEvent.keyDown(view.getActiveSection(0), { key });
 
       expectFieldValue(
         view.getSectionsContainer(),
@@ -199,11 +196,11 @@ adapterToTest.forEach((adapterName) => {
     const testKeyboardInteraction = (formatToken) => {
       const sectionConfig = getDateSectionConfigFromFormatToken(adapter, formatToken);
 
-      it(`should increase "${sectionConfig.type}" when pressing ArrowUp on "${formatToken}" token`, async () => {
+      it(`should increase "${sectionConfig.type}" when pressing ArrowUp on "${formatToken}" token`, () => {
         const initialValue = adapter.date(testDate);
         const expectedValue = updateDate(initialValue, adapter, sectionConfig.type, 1);
 
-        await testKeyPress({
+        testKeyPress({
           key: 'ArrowUp',
           initialValue,
           expectedValue,
@@ -212,11 +209,11 @@ adapterToTest.forEach((adapterName) => {
         });
       });
 
-      it(`should decrease "${sectionConfig.type}" when pressing ArrowDown on "${formatToken}" token`, async () => {
+      it(`should decrease "${sectionConfig.type}" when pressing ArrowDown on "${formatToken}" token`, () => {
         const initialValue = adapter.date(testDate);
         const expectedValue = updateDate(initialValue, adapter, sectionConfig.type, -1);
 
-        await testKeyPress({
+        testKeyPress({
           key: 'ArrowDown',
           initialValue,
           expectedValue,

--- a/test/utils/pickers/assertions.ts
+++ b/test/utils/pickers/assertions.ts
@@ -1,3 +1,4 @@
+import { SinonSpy } from 'sinon';
 import {
   cleanText,
   isPickerRangeType,
@@ -14,22 +15,16 @@ export const expectFieldValue = (
   return expect(value).to.equal(expectedValue);
 };
 
-/**
- * Asserts that a picker change-handler value deep-equals the expected one.
- *
- * Pass the raw value (e.g. `onChange.lastCall.firstArg`) rather than the
- * spy, so the helper stays agnostic of the spy library.
- */
 export function expectPickerChangeHandlerValue(
   type: PickerComponentType | PickerRangeComponentType,
-  actualValue: any,
+  spyCallback: SinonSpy,
   expectedValue: any,
 ) {
   if (isPickerRangeType(type)) {
-    actualValue.forEach((value: any, index: number) => {
+    spyCallback.lastCall.firstArg.forEach((value: any, index: number) => {
       expect(value).to.deep.equal(expectedValue[index]);
     });
   } else {
-    expect(actualValue).to.deep.equal(expectedValue);
+    expect(spyCallback.lastCall.firstArg).to.deep.equal(expectedValue);
   }
 }

--- a/test/utils/pickers/describePicker/describePicker.tsx
+++ b/test/utils/pickers/describePicker/describePicker.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { spy } from 'sinon';
-import { fireEvent, screen, createDescribe } from '@mui/internal-test-utils';
+import { screen, fireEvent, createDescribe } from '@mui/internal-test-utils';
 import SvgIcon, { SvgIconProps } from '@mui/material/SvgIcon';
 import { DescribePickerOptions } from './describePicker.types';
 
@@ -49,67 +49,55 @@ function innerDescribePicker(ElementToTest: React.ElementType, options: Describe
   });
 
   describe('Component slot: DesktopPaper', () => {
-    it.skipIf(hasNoView || variant !== 'desktop')(
-      'should forward onClick and onTouchStart',
-      async () => {
-        const handleClick = spy();
-        const handleTouchStart = spy();
-        const { user } = render(
-          <ElementToTest
-            {...propsToOpen}
-            slotProps={{
-              desktopPaper: {
-                onClick: handleClick,
-                onTouchStart: handleTouchStart,
-                'data-testid': 'paper',
-              },
-            }}
-          />,
-        );
-        const paper = screen.getByTestId('paper');
+    it.skipIf(hasNoView || variant !== 'desktop')('should forward onClick and onTouchStart', () => {
+      const handleClick = spy();
+      const handleTouchStart = spy();
+      render(
+        <ElementToTest
+          {...propsToOpen}
+          slotProps={{
+            desktopPaper: {
+              onClick: handleClick,
+              onTouchStart: handleTouchStart,
+              'data-testid': 'paper',
+            },
+          }}
+        />,
+      );
+      const paper = screen.getByTestId('paper');
 
-        await user.click(paper);
-        // `userEvent.pointer({ keys: '[TouchA>]' })` doesn't fire a
-        // `touchstart` in jsdom (no native `TouchEvent` support), so use
-        // `fireEvent.touchStart` to cover the `onTouchStart` slot prop.
-        fireEvent.touchStart(paper);
+      fireEvent.click(paper);
+      fireEvent.touchStart(paper);
 
-        expect(handleClick.callCount).to.equal(1);
-        expect(handleTouchStart.callCount).to.equal(1);
-      },
-    );
+      expect(handleClick.callCount).to.equal(1);
+      expect(handleTouchStart.callCount).to.equal(1);
+    });
   });
 
   describe('Component slot: Popper', () => {
-    it.skipIf(hasNoView || variant !== 'desktop')(
-      'should forward onClick and onTouchStart',
-      async () => {
-        const handleClick = spy();
-        const handleTouchStart = spy();
-        const { user } = render(
-          <ElementToTest
-            {...propsToOpen}
-            slotProps={{
-              popper: {
-                onClick: handleClick,
-                onTouchStart: handleTouchStart,
-                'data-testid': 'popper',
-              },
-            }}
-          />,
-        );
-        const popper = screen.getByTestId('popper');
+    it.skipIf(hasNoView || variant !== 'desktop')('should forward onClick and onTouchStart', () => {
+      const handleClick = spy();
+      const handleTouchStart = spy();
+      render(
+        <ElementToTest
+          {...propsToOpen}
+          slotProps={{
+            popper: {
+              onClick: handleClick,
+              onTouchStart: handleTouchStart,
+              'data-testid': 'popper',
+            },
+          }}
+        />,
+      );
+      const popper = screen.getByTestId('popper');
 
-        await user.click(popper);
-        // `userEvent.pointer({ keys: '[TouchA>]' })` doesn't fire a
-        // `touchstart` in jsdom (no native `TouchEvent` support), so use
-        // `fireEvent.touchStart` to cover the `onTouchStart` slot prop.
-        fireEvent.touchStart(popper);
+      fireEvent.click(popper);
+      fireEvent.touchStart(popper);
 
-        expect(handleClick.callCount).to.equal(1);
-        expect(handleTouchStart.callCount).to.equal(1);
-      },
-    );
+      expect(handleClick.callCount).to.equal(1);
+      expect(handleTouchStart.callCount).to.equal(1);
+    });
   });
 
   describe('Component slot: Toolbar', () => {

--- a/test/utils/pickers/describeValue/describeValue.tsx
+++ b/test/utils/pickers/describeValue/describeValue.tsx
@@ -55,6 +55,11 @@ function innerDescribeValue<TValue extends PickerValidValue, C extends PickerCom
         selectSection: () => {
           throw new Error('You can only use `selectSection` on components that render a field');
         },
+        selectSectionAsync: () => {
+          throw new Error(
+            'You can only use `selectSectionAsync` on components that render a field',
+          );
+        },
         getHiddenInput: () => {
           throw new Error('You can only use `getHiddenInput` on components that render a field');
         },

--- a/test/utils/pickers/describeValue/describeValue.types.ts
+++ b/test/utils/pickers/describeValue/describeValue.types.ts
@@ -31,7 +31,6 @@ export type DescribeValueOptions<
         setNewValue: (
           value: InferNonNullablePickerValue<TValue>,
           options: {
-            user: MuiRenderResult['user'];
             selectSection: FieldSectionSelector;
             pressKey: FieldPressCharacter;
             isOpened?: boolean;
@@ -39,17 +38,13 @@ export type DescribeValueOptions<
             setEndDate?: boolean;
             closeMobilePicker?: boolean;
           },
-        ) => Promise<InferNonNullablePickerValue<TValue>>;
+        ) => InferNonNullablePickerValue<TValue>;
       }
     : {
         setNewValue: (
           value: TValue,
-          options: {
-            user: MuiRenderResult['user'];
-            selectSection: FieldSectionSelector;
-            pressKey: FieldPressCharacter;
-          },
-        ) => Promise<TValue>;
+          options: { selectSection: FieldSectionSelector; pressKey: FieldPressCharacter },
+        ) => TValue;
       });
 
 export type DescribeValueTestSuite<

--- a/test/utils/pickers/describeValue/testControlledUnControlled.tsx
+++ b/test/utils/pickers/describeValue/testControlledUnControlled.tsx
@@ -9,6 +9,7 @@ import {
   isPickerSingleInput,
 } from 'test/utils/pickers';
 import { DescribeValueOptions, DescribeValueTestSuite } from './describeValue.types';
+import { fireUserEvent } from '../../fireUserEvent';
 
 export const testControlledUnControlled: DescribeValueTestSuite<any, any> = (
   ElementToTest,
@@ -107,15 +108,14 @@ export const testControlledUnControlled: DescribeValueTestSuite<any, any> = (
         assertRenderedValue(values[0]);
       });
 
-      it('should call onChange when updating a value defined with `props.defaultValue` and update the rendered value', async () => {
+      it('should call onChange when updating a value defined with `props.defaultValue` and update the rendered value', () => {
         const onChange = spy();
 
         const response = renderWithProps({
           defaultValue: values[0],
           onChange,
         });
-        const newValue = await setNewValue(values[0], {
-          user: response.user,
+        const newValue = setNewValue(values[0], {
           selectSection: response.selectSection,
           pressKey: response.pressKey,
           closeMobilePicker: true,
@@ -133,7 +133,7 @@ export const testControlledUnControlled: DescribeValueTestSuite<any, any> = (
         // }
       });
 
-      it('should call onChange when updating a value defined with `props.value`', async () => {
+      it('should call onChange when updating a value defined with `props.value`', () => {
         const onChange = spy();
 
         const useControlledElement = (props: any) => {
@@ -152,8 +152,7 @@ export const testControlledUnControlled: DescribeValueTestSuite<any, any> = (
           { value: values[0], onChange },
           { hook: useControlledElement },
         );
-        const newValue = await setNewValue(values[0], {
-          user: response.user,
+        const newValue = setNewValue(values[0], {
           selectSection: response.selectSection,
           pressKey: response.pressKey,
           closeMobilePicker: true,
@@ -203,7 +202,7 @@ export const testControlledUnControlled: DescribeValueTestSuite<any, any> = (
     });
 
     describe('Accessibility and field editing', () => {
-      it('should allow editing in field on single input mobile pickers', async () => {
+      it('should allow editing in field on single input mobile pickers', () => {
         if (componentFamily !== 'picker' || params.variant !== 'mobile') {
           return;
         }
@@ -214,8 +213,8 @@ export const testControlledUnControlled: DescribeValueTestSuite<any, any> = (
           onChange: handleChange,
           defaultValue: values[0],
         });
-        await response.selectSection(undefined);
-        await response.pressKey('ArrowUp');
+        response.selectSection(undefined);
+        fireUserEvent.keyPress(response.getActiveSection(0), { key: 'ArrowUp' });
         expect(handleChange.callCount).to.equal(isPickerSingleInput(params) ? 1 : 0);
       });
 

--- a/test/utils/pickers/describeValue/testPickerActionBar.tsx
+++ b/test/utils/pickers/describeValue/testPickerActionBar.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { spy } from 'sinon';
-import { screen } from '@mui/internal-test-utils';
+import { fireEvent, screen } from '@mui/internal-test-utils';
 import { PickerRangeValue } from '@mui/x-date-pickers/internals';
 import {
   adapterToUse,
@@ -33,12 +33,12 @@ export const testPickerActionBar: DescribeValueTestSuite<any, 'picker'> = (
 
   describe('Picker action bar', () => {
     describe('clear action', () => {
-      it('should call onClose, onChange with empty value and onAccept with empty value', async () => {
+      it('should call onClose, onChange with empty value and onAccept with empty value', () => {
         const onChange = spy();
         const onAccept = spy();
         const onClose = spy();
 
-        const { user } = render(
+        render(
           <ElementToTest
             onChange={onChange}
             onAccept={onAccept}
@@ -50,20 +50,20 @@ export const testPickerActionBar: DescribeValueTestSuite<any, 'picker'> = (
         );
 
         // Clear the date
-        await user.click(screen.getByText(/clear/i));
+        fireEvent.click(screen.getByText(/clear/i));
         expect(onChange.callCount).to.equal(1);
-        expectPickerChangeHandlerValue(pickerParams.type, onChange.lastCall.firstArg, emptyValue);
+        expectPickerChangeHandlerValue(pickerParams.type, onChange, emptyValue);
         expect(onAccept.callCount).to.equal(1);
-        expectPickerChangeHandlerValue(pickerParams.type, onAccept.lastCall.firstArg, emptyValue);
+        expectPickerChangeHandlerValue(pickerParams.type, onAccept, emptyValue);
         expect(onClose.callCount).to.equal(1);
       });
 
-      it('should not call onChange or onAccept if the value is already empty value', async () => {
+      it('should not call onChange or onAccept if the value is already empty value', () => {
         const onChange = spy();
         const onAccept = spy();
         const onClose = spy();
 
-        const { user } = render(
+        render(
           <ElementToTest
             onChange={onChange}
             onAccept={onAccept}
@@ -75,7 +75,7 @@ export const testPickerActionBar: DescribeValueTestSuite<any, 'picker'> = (
         );
 
         // Clear the date
-        await user.click(screen.getByText(/clear/i));
+        fireEvent.click(screen.getByText(/clear/i));
         expect(onChange.callCount).to.equal(0);
         expect(onAccept.callCount).to.equal(0);
         expect(onClose.callCount).to.equal(1);
@@ -83,12 +83,12 @@ export const testPickerActionBar: DescribeValueTestSuite<any, 'picker'> = (
     });
 
     describe('cancel action', () => {
-      it('should call onClose and onChange with the initial value', async () => {
+      it('should call onClose and onChange with the initial value', () => {
         const onChange = spy();
         const onAccept = spy();
         const onClose = spy();
 
-        const { selectSection, pressKey, user } = renderWithProps({
+        const { selectSection, pressKey } = renderWithProps({
           onChange,
           onAccept,
           onClose,
@@ -99,15 +99,10 @@ export const testPickerActionBar: DescribeValueTestSuite<any, 'picker'> = (
         });
 
         // Change the value (already tested)
-        await setNewValue(values[0], {
-          user,
-          isOpened: true,
-          selectSection,
-          pressKey,
-        });
+        setNewValue(values[0], { isOpened: true, selectSection, pressKey });
 
         // Cancel the modifications
-        await user.click(screen.getByText(/cancel/i));
+        fireEvent.click(screen.getByText(/cancel/i));
         expect(onChange.callCount).to.equal(
           getExpectedOnChangeCount(componentFamily, pickerParams) + 1,
         );
@@ -122,12 +117,12 @@ export const testPickerActionBar: DescribeValueTestSuite<any, 'picker'> = (
         expect(onClose.callCount).to.equal(1);
       });
 
-      it('should not call onChange if no prior value modification', async () => {
+      it('should not call onChange if no prior value modification', () => {
         const onChange = spy();
         const onAccept = spy();
         const onClose = spy();
 
-        const { user } = render(
+        render(
           <ElementToTest
             onChange={onChange}
             onAccept={onAccept}
@@ -140,7 +135,7 @@ export const testPickerActionBar: DescribeValueTestSuite<any, 'picker'> = (
         );
 
         // Cancel the modifications
-        await user.click(screen.getByText(/cancel/i));
+        fireEvent.click(screen.getByText(/cancel/i));
         expect(onChange.callCount).to.equal(0);
         expect(onAccept.callCount).to.equal(0);
         expect(onClose.callCount).to.equal(1);
@@ -148,12 +143,12 @@ export const testPickerActionBar: DescribeValueTestSuite<any, 'picker'> = (
     });
 
     describe('confirm action', () => {
-      it('should call onClose and onAccept with the live value', async () => {
+      it('should call onClose and onAccept with the live value', () => {
         const onChange = spy();
         const onAccept = spy();
         const onClose = spy();
 
-        const { selectSection, pressKey, user } = renderWithProps({
+        const { selectSection, pressKey } = renderWithProps({
           onChange,
           onAccept,
           onClose,
@@ -164,15 +159,10 @@ export const testPickerActionBar: DescribeValueTestSuite<any, 'picker'> = (
         });
 
         // Change the value (already tested)
-        await setNewValue(values[0], {
-          user,
-          isOpened: true,
-          selectSection,
-          pressKey,
-        });
+        setNewValue(values[0], { isOpened: true, selectSection, pressKey });
 
         // Accept the modifications
-        await user.click(screen.getAllByRole('button', { name: 'OK' })[0]);
+        fireEvent.click(screen.getAllByRole('button', { name: 'OK' })[0]);
         expect(onChange.callCount).to.equal(
           getExpectedOnChangeCount(componentFamily, pickerParams),
         ); // The accepted value as already been committed, don't call onChange again
@@ -180,12 +170,12 @@ export const testPickerActionBar: DescribeValueTestSuite<any, 'picker'> = (
         expect(onClose.callCount).to.equal(1);
       });
 
-      it('should call onChange, onClose and onAccept when validating the default value', async () => {
+      it('should call onChange, onClose and onAccept when validating the default value', () => {
         const onChange = spy();
         const onAccept = spy();
         const onClose = spy();
 
-        const { user } = render(
+        render(
           <ElementToTest
             onChange={onChange}
             onAccept={onAccept}
@@ -198,18 +188,18 @@ export const testPickerActionBar: DescribeValueTestSuite<any, 'picker'> = (
         );
 
         // Accept the modifications
-        await user.click(screen.getByText(/ok/i));
+        fireEvent.click(screen.getByText(/ok/i));
         expect(onChange.callCount).to.equal(1);
         expect(onAccept.callCount).to.equal(1);
         expect(onClose.callCount).to.equal(1);
       });
 
-      it('should call onClose but not onAccept when validating an already validated value', async () => {
+      it('should call onClose but not onAccept when validating an already validated value', () => {
         const onChange = spy();
         const onAccept = spy();
         const onClose = spy();
 
-        const { user } = render(
+        render(
           <ElementToTest
             onChange={onChange}
             onAccept={onAccept}
@@ -222,7 +212,7 @@ export const testPickerActionBar: DescribeValueTestSuite<any, 'picker'> = (
         );
 
         // Accept the modifications
-        await user.click(screen.getByText(/ok/i));
+        fireEvent.click(screen.getByText(/ok/i));
         expect(onChange.callCount).to.equal(0);
         expect(onAccept.callCount).to.equal(0);
         expect(onClose.callCount).to.equal(1);
@@ -238,12 +228,12 @@ export const testPickerActionBar: DescribeValueTestSuite<any, 'picker'> = (
         vi.useRealTimers();
       });
 
-      it("should call onClose, onChange with today's value and onAccept with today's value", async () => {
+      it("should call onClose, onChange with today's value and onAccept with today's value", () => {
         const onChange = spy();
         const onAccept = spy();
         const onClose = spy();
 
-        const { user } = render(
+        render(
           <ElementToTest
             onChange={onChange}
             onAccept={onAccept}
@@ -254,7 +244,7 @@ export const testPickerActionBar: DescribeValueTestSuite<any, 'picker'> = (
           />,
         );
 
-        await user.click(screen.getByText(/today/i));
+        fireEvent.click(screen.getByText(/today/i));
 
         let startOfToday: any;
         if (pickerParams.type === 'date') {
@@ -266,9 +256,9 @@ export const testPickerActionBar: DescribeValueTestSuite<any, 'picker'> = (
         }
 
         expect(onChange.callCount).to.equal(1);
-        expectPickerChangeHandlerValue(pickerParams.type, onChange.lastCall.firstArg, startOfToday);
+        expectPickerChangeHandlerValue(pickerParams.type, onChange, startOfToday);
         expect(onAccept.callCount).to.equal(1);
-        expectPickerChangeHandlerValue(pickerParams.type, onAccept.lastCall.firstArg, startOfToday);
+        expectPickerChangeHandlerValue(pickerParams.type, onAccept, startOfToday);
         expect(onClose.callCount).to.equal(1);
       });
     });

--- a/test/utils/pickers/describeValue/testPickerOpenCloseLifeCycle.tsx
+++ b/test/utils/pickers/describeValue/testPickerOpenCloseLifeCycle.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { spy } from 'sinon';
 import { config } from 'react-transition-group';
-import { screen, waitFor } from '@mui/internal-test-utils';
+import { fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import { PickerRangeValue, PickerValidValue } from '@mui/x-date-pickers/internals';
 import {
   getExpectedOnChangeCount,
@@ -9,9 +9,11 @@ import {
   isPickerRangeType,
   isPickerSingleInput,
   openPicker,
+  openPickerAsync,
   PickerRangeComponentType,
 } from 'test/utils/pickers';
 import { DescribeValueTestSuite } from './describeValue.types';
+import { fireUserEvent } from '../../fireUserEvent';
 
 export const testPickerOpenCloseLifeCycle: DescribeValueTestSuite<PickerValidValue, 'picker'> = (
   ElementToTest,
@@ -38,28 +40,28 @@ export const testPickerOpenCloseLifeCycle: DescribeValueTestSuite<PickerValidVal
       expect(screen.queryByRole(viewWrapperRole)).toBeVisible();
     });
 
-    it('should not open when `prop.disabled` is true ', async () => {
+    it('should not open when `prop.disabled` is true ', () => {
       const onOpen = spy();
-      const { user } = render(<ElementToTest disabled onOpen={onOpen} />);
+      render(<ElementToTest disabled onOpen={onOpen} />);
 
-      await openPicker(user, pickerParams);
+      openPicker(pickerParams);
       expect(onOpen.callCount).to.equal(0);
     });
 
-    it('should not open when `prop.readOnly` is true ', async () => {
+    it('should not open when `prop.readOnly` is true ', () => {
       const onOpen = spy();
-      const { user } = render(<ElementToTest readOnly onOpen={onOpen} />);
+      render(<ElementToTest readOnly onOpen={onOpen} />);
 
-      await openPicker(user, pickerParams);
+      openPicker(pickerParams);
       expect(onOpen.callCount).to.equal(0);
     });
 
-    it('should call onChange, onClose and onAccept (if Desktop Date Picker or Desktop Date Range Picker) when selecting a value', async () => {
+    it('should call onChange, onClose and onAccept (if Desktop Date Picker or Desktop Date Range Picker) when selecting a value', () => {
       const onChange = spy();
       const onAccept = spy();
       const onClose = spy();
 
-      const { selectSection, pressKey, user } = renderWithProps(
+      const { selectSection, pressKey } = renderWithProps(
         {
           onChange,
           onAccept,
@@ -75,18 +77,12 @@ export const testPickerOpenCloseLifeCycle: DescribeValueTestSuite<PickerValidVal
       expect(onClose.callCount).to.equal(0);
 
       // Change the value
-      let newValue = await setNewValue(values[0], {
-        isOpened: true,
-        user,
-        selectSection,
-        pressKey,
-      });
+      let newValue = setNewValue(values[0], { isOpened: true, selectSection, pressKey });
       expect(onChange.callCount).to.equal(getExpectedOnChangeCount(componentFamily, pickerParams));
       if (isRangeType) {
-        newValue = await setNewValue(newValue, {
+        newValue = setNewValue(newValue, {
           isOpened: true,
           setEndDate: true,
-          user,
           selectSection,
           pressKey,
         });
@@ -103,30 +99,25 @@ export const testPickerOpenCloseLifeCycle: DescribeValueTestSuite<PickerValidVal
 
     it.skipIf(pickerParams.variant !== 'mobile')(
       'should not select input content after closing on mobile',
-      async () => {
-        const { selectSection, pressKey, user } = renderWithProps(
+      () => {
+        const { selectSection, pressKey } = renderWithProps(
           { defaultValue: values[0] },
           { componentFamily },
         );
 
         // Change the value
-        await setNewValue(values[0], {
-          user,
-          selectSection,
-          pressKey,
-          closeMobilePicker: true,
-        });
+        setNewValue(values[0], { selectSection, pressKey, closeMobilePicker: true });
         const fieldRoot = getFieldInputRoot();
         expect(fieldRoot.scrollLeft).to.be.equal(0);
       },
     );
 
-    it('should call onChange, onClose and onAccept when selecting a value and `props.closeOnSelect` is true', async () => {
+    it('should call onChange, onClose and onAccept when selecting a value and `props.closeOnSelect` is true', () => {
       const onChange = spy();
       const onAccept = spy();
       const onClose = spy();
 
-      const { selectSection, pressKey, user } = renderWithProps(
+      const { selectSection, pressKey } = renderWithProps(
         {
           onChange,
           onAccept,
@@ -143,18 +134,12 @@ export const testPickerOpenCloseLifeCycle: DescribeValueTestSuite<PickerValidVal
       expect(onClose.callCount).to.equal(0);
 
       // Change the value
-      let newValue = await setNewValue(values[0], {
-        isOpened: true,
-        user,
-        selectSection,
-        pressKey,
-      });
+      let newValue = setNewValue(values[0], { isOpened: true, selectSection, pressKey });
       expect(onChange.callCount).to.equal(getExpectedOnChangeCount(componentFamily, pickerParams));
       if (isRangeType) {
-        newValue = await setNewValue(newValue, {
+        newValue = setNewValue(newValue, {
           isOpened: true,
           setEndDate: true,
-          user,
           selectSection,
           pressKey,
         });
@@ -168,12 +153,12 @@ export const testPickerOpenCloseLifeCycle: DescribeValueTestSuite<PickerValidVal
       expect(onClose.callCount).to.equal(1);
     });
 
-    it('should not call onChange or onAccept when selecting the same value', async () => {
+    it('should not call onChange or onAccept when selecting the same value', () => {
       const onChange = spy();
       const onAccept = spy();
       const onClose = spy();
 
-      const { selectSection, pressKey, user } = renderWithProps(
+      const { selectSection, pressKey } = renderWithProps(
         {
           onChange,
           onAccept,
@@ -186,19 +171,12 @@ export const testPickerOpenCloseLifeCycle: DescribeValueTestSuite<PickerValidVal
       );
 
       // Change the value (same value)
-      await setNewValue(values[0], {
-        isOpened: true,
-        applySameValue: true,
-        user,
-        selectSection,
-        pressKey,
-      });
+      setNewValue(values[0], { isOpened: true, applySameValue: true, selectSection, pressKey });
       if (isRangeType) {
-        await setNewValue(values[0], {
+        setNewValue(values[0], {
           isOpened: true,
           applySameValue: true,
           setEndDate: true,
-          user,
           selectSection,
           pressKey,
         });
@@ -209,12 +187,12 @@ export const testPickerOpenCloseLifeCycle: DescribeValueTestSuite<PickerValidVal
       expect(onClose.callCount).to.equal(1);
     });
 
-    it('should not call onClose or onAccept when selecting a date and `props.closeOnSelect` is false', async () => {
+    it('should not call onClose or onAccept when selecting a date and `props.closeOnSelect` is false', () => {
       const onChange = spy();
       const onAccept = spy();
       const onClose = spy();
 
-      const { selectSection, pressKey, user } = renderWithProps(
+      const { selectSection, pressKey } = renderWithProps(
         {
           onChange,
           onAccept,
@@ -227,19 +205,13 @@ export const testPickerOpenCloseLifeCycle: DescribeValueTestSuite<PickerValidVal
       );
 
       // Change the value
-      let newValue = await setNewValue(values[0], {
-        isOpened: true,
-        user,
-        selectSection,
-        pressKey,
-      });
+      let newValue = setNewValue(values[0], { isOpened: true, selectSection, pressKey });
       const initialChangeCount = getExpectedOnChangeCount(componentFamily, pickerParams);
       expect(onChange.callCount).to.equal(initialChangeCount);
       if (isRangeType) {
-        newValue = await setNewValue(newValue, {
+        newValue = setNewValue(newValue, {
           isOpened: true,
           setEndDate: true,
-          user,
           selectSection,
           pressKey,
         });
@@ -253,22 +225,16 @@ export const testPickerOpenCloseLifeCycle: DescribeValueTestSuite<PickerValidVal
       expect(onClose.callCount).to.equal(0);
 
       // Change the value
-      let newValueBis = await setNewValue(newValue, {
-        isOpened: true,
-        user,
-        selectSection,
-        pressKey,
-      });
+      let newValueBis = setNewValue(newValue, { isOpened: true, selectSection, pressKey });
       if (isRangeType) {
         expect(onChange.callCount).to.equal(
           initialChangeCount +
             getExpectedOnChangeCount(componentFamily, pickerParams) * 2 -
             (pickerParams.type === 'date-time-range' || pickerParams.type === 'time-range' ? 1 : 0),
         );
-        newValueBis = await setNewValue(newValueBis, {
+        newValueBis = setNewValue(newValueBis, {
           isOpened: true,
           setEndDate: true,
-          user,
           selectSection,
           pressKey,
         });
@@ -306,12 +272,7 @@ export const testPickerOpenCloseLifeCycle: DescribeValueTestSuite<PickerValidVal
       );
 
       // Change the value (already tested)
-      const newValue = await setNewValue(values[0], {
-        isOpened: true,
-        user,
-        selectSection,
-        pressKey,
-      });
+      const newValue = setNewValue(values[0], { isOpened: true, selectSection, pressKey });
 
       // Dismiss the picker
       await user.keyboard('[Escape]');
@@ -330,12 +291,12 @@ export const testPickerOpenCloseLifeCycle: DescribeValueTestSuite<PickerValidVal
     // TODO: Fix this test and enable it on mobile and date-range
     it.skipIf(pickerParams.variant === 'mobile' || isRangeType)(
       'should call onClose when clicking outside of the picker without prior change',
-      async () => {
+      () => {
         const onChange = spy();
         const onAccept = spy();
         const onClose = spy();
 
-        const { user } = render(
+        render(
           <ElementToTest
             onChange={onChange}
             onAccept={onAccept}
@@ -347,7 +308,7 @@ export const testPickerOpenCloseLifeCycle: DescribeValueTestSuite<PickerValidVal
         );
 
         // Dismiss the picker
-        await user.click(document.body);
+        fireUserEvent.mousePress(document.body);
         expect(onChange.callCount).to.equal(0);
         expect(onAccept.callCount).to.equal(0);
         expect(onClose.callCount).to.equal(1);
@@ -357,12 +318,12 @@ export const testPickerOpenCloseLifeCycle: DescribeValueTestSuite<PickerValidVal
     // TODO: Fix this test and enable it on mobile and date-range
     it.skipIf(pickerParams.variant === 'mobile' || isRangeType)(
       'should call onClose and onAccept with the live value when clicking outside of the picker',
-      async () => {
+      () => {
         const onChange = spy();
         const onAccept = spy();
         const onClose = spy();
 
-        const { selectSection, pressKey, user } = renderWithProps(
+        const { selectSection, pressKey } = renderWithProps(
           {
             onChange,
             onAccept,
@@ -375,15 +336,10 @@ export const testPickerOpenCloseLifeCycle: DescribeValueTestSuite<PickerValidVal
         );
 
         // Change the value (already tested)
-        const newValue = await setNewValue(values[0], {
-          isOpened: true,
-          user,
-          selectSection,
-          pressKey,
-        });
+        const newValue = setNewValue(values[0], { isOpened: true, selectSection, pressKey });
 
         // Dismiss the picker
-        await user.keyboard('{Escape}');
+        fireUserEvent.keyPress(document.activeElement!, { key: 'Escape' });
         expect(onChange.callCount).to.equal(
           getExpectedOnChangeCount(componentFamily, pickerParams),
         );
@@ -393,12 +349,12 @@ export const testPickerOpenCloseLifeCycle: DescribeValueTestSuite<PickerValidVal
       },
     );
 
-    it('should not call onClose or onAccept when clicking outside of the picker if not opened', async () => {
+    it('should not call onClose or onAccept when clicking outside of the picker if not opened', () => {
       const onChange = spy();
       const onAccept = spy();
       const onClose = spy();
 
-      const { user } = render(
+      render(
         <ElementToTest
           onChange={onChange}
           onAccept={onAccept}
@@ -408,23 +364,21 @@ export const testPickerOpenCloseLifeCycle: DescribeValueTestSuite<PickerValidVal
       );
 
       // Dismiss the picker
-      await user.click(document.body);
+      fireEvent.click(document.body);
       expect(onChange.callCount).to.equal(0);
       expect(onAccept.callCount).to.equal(0);
       expect(onClose.callCount).to.equal(0);
     });
 
-    it('should not call onClose or onAccept when pressing escape when picker is not opened', async () => {
+    it('should not call onClose or onAccept when pressing escape when picker is not opened', () => {
       const onChange = spy();
       const onAccept = spy();
       const onClose = spy();
 
-      const { user } = render(
-        <ElementToTest onChange={onChange} onAccept={onAccept} onClose={onClose} />,
-      );
+      render(<ElementToTest onChange={onChange} onAccept={onAccept} onClose={onClose} />);
 
       // Dismiss the picker
-      await user.keyboard('{Escape}');
+      fireEvent.keyDown(document.body, { key: 'Escape' });
       expect(onChange.callCount).to.equal(0);
       expect(onAccept.callCount).to.equal(0);
       expect(onClose.callCount).to.equal(0);
@@ -440,7 +394,7 @@ export const testPickerOpenCloseLifeCycle: DescribeValueTestSuite<PickerValidVal
     config.disabled = false;
     const { user } = render(<ElementToTest slotProps={{ toolbar: { hidden: false } }} />);
 
-    await openPicker(user, {
+    await openPickerAsync(user, {
       type: pickerType,
       fieldType: 'single-input',
       initialFocus: 'start',
@@ -461,7 +415,7 @@ export const testPickerOpenCloseLifeCycle: DescribeValueTestSuite<PickerValidVal
     await waitFor(() => expect(screen.queryByRole(viewWrapperRole)).to.equal(null));
 
     // open the picker again
-    await openPicker(user, {
+    await openPickerAsync(user, {
       type: pickerType,
       fieldType: 'single-input',
       initialFocus: 'start',
@@ -497,7 +451,7 @@ export const testPickerOpenCloseLifeCycle: DescribeValueTestSuite<PickerValidVal
         { componentFamily },
       );
 
-      await openPicker(user, pickerParams);
+      await openPickerAsync(user, pickerParams);
 
       await user.keyboard('{Enter}');
 

--- a/test/utils/pickers/describeValue/testShortcuts.tsx
+++ b/test/utils/pickers/describeValue/testShortcuts.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { spy } from 'sinon';
 import { expectPickerChangeHandlerValue } from 'test/utils/pickers';
-import { screen } from '@mui/internal-test-utils';
+import { fireEvent, screen } from '@mui/internal-test-utils';
 import { DescribeValueTestSuite } from './describeValue.types';
 
 export const testShortcuts: DescribeValueTestSuite<any, 'picker'> = (ElementToTest, options) => {
@@ -21,7 +21,7 @@ export const testShortcuts: DescribeValueTestSuite<any, 'picker'> = (ElementToTe
       const onAccept = spy();
       const onClose = spy();
 
-      const { user } = render(
+      render(
         <ElementToTest
           onChange={onChange}
           onAccept={onAccept}
@@ -44,21 +44,21 @@ export const testShortcuts: DescribeValueTestSuite<any, 'picker'> = (ElementToTe
 
       const shortcut = await screen.findByRole('button', { name: 'Test shortcut' });
 
-      await user.click(shortcut);
+      fireEvent.click(shortcut);
 
       expect(onChange.callCount).to.equal(1);
-      expectPickerChangeHandlerValue(pickerParams.type, onChange.lastCall.firstArg, values[1]);
+      expectPickerChangeHandlerValue(pickerParams.type, onChange, values[1]);
       expect(onAccept.callCount).to.equal(1);
-      expectPickerChangeHandlerValue(pickerParams.type, onAccept.lastCall.firstArg, values[1]);
+      expectPickerChangeHandlerValue(pickerParams.type, onAccept, values[1]);
       expect(onClose.callCount).to.equal(1);
     });
 
-    it('should call onClose and onChange when picking a shortcut with changeImportance="accept"', async () => {
+    it('should call onClose and onChange when picking a shortcut with changeImportance="accept"', () => {
       const onChange = spy();
       const onAccept = spy();
       const onClose = spy();
 
-      const { user } = render(
+      render(
         <ElementToTest
           onChange={onChange}
           onAccept={onAccept}
@@ -81,21 +81,21 @@ export const testShortcuts: DescribeValueTestSuite<any, 'picker'> = (ElementToTe
       );
 
       const shortcut = screen.getByRole('button', { name: 'Test shortcut' });
-      await user.click(shortcut);
+      fireEvent.click(shortcut);
 
       expect(onChange.callCount).to.equal(1);
-      expectPickerChangeHandlerValue(pickerParams.type, onChange.lastCall.firstArg, values[1]);
+      expectPickerChangeHandlerValue(pickerParams.type, onChange, values[1]);
       expect(onAccept.callCount).to.equal(1);
-      expectPickerChangeHandlerValue(pickerParams.type, onAccept.lastCall.firstArg, values[1]);
+      expectPickerChangeHandlerValue(pickerParams.type, onAccept, values[1]);
       expect(onClose.callCount).to.equal(1);
     });
 
-    it('should call onClose and onChange when picking a shortcut with changeImportance="set"', async () => {
+    it('should call onClose and onChange when picking a shortcut with changeImportance="set"', () => {
       const onChange = spy();
       const onAccept = spy();
       const onClose = spy();
 
-      const { user } = render(
+      render(
         <ElementToTest
           onChange={onChange}
           onAccept={onAccept}
@@ -118,10 +118,10 @@ export const testShortcuts: DescribeValueTestSuite<any, 'picker'> = (ElementToTe
       );
 
       const shortcut = screen.getByRole('button', { name: 'Test shortcut' });
-      await user.click(shortcut);
+      fireEvent.click(shortcut);
 
       expect(onChange.callCount).to.equal(1);
-      expectPickerChangeHandlerValue(pickerParams.type, onChange.lastCall.firstArg, values[1]);
+      expectPickerChangeHandlerValue(pickerParams.type, onChange, values[1]);
       expect(onAccept.callCount).to.equal(0);
       expect(onClose.callCount).to.equal(0);
     });

--- a/test/utils/pickers/fields.tsx
+++ b/test/utils/pickers/fields.tsx
@@ -5,6 +5,7 @@ import { FieldRef, FieldSectionType } from '@mui/x-date-pickers/models';
 import { pickersSectionListClasses } from '@mui/x-date-pickers/PickersSectionList';
 import { pickersInputBaseClasses } from '@mui/x-date-pickers/PickersTextField';
 import { PickerValue } from '@mui/x-date-pickers/internals';
+import { fireUserEvent } from '../fireUserEvent';
 import { expectFieldValue } from './assertions';
 
 interface BuildFieldInteractionsParams<P extends {}> {
@@ -15,9 +16,17 @@ interface BuildFieldInteractionsParams<P extends {}> {
 export type FieldSectionSelector = (
   selectedSection: FieldSectionType | undefined,
   index?: 'first' | 'last',
+) => void;
+
+export type FieldSectionSelectorAsync = (
+  selectedSection: FieldSectionType | undefined,
+  index?: 'first' | 'last',
 ) => Promise<void>;
 
-export type FieldPressCharacter = (character: string) => Promise<void>;
+export type FieldPressCharacter = (
+  sectionIndex: number | undefined | null,
+  character: string,
+) => void;
 
 export interface BuildFieldInteractionsResponse<P extends {}> {
   renderWithProps: (
@@ -29,11 +38,15 @@ export interface BuildFieldInteractionsResponse<P extends {}> {
     },
   ) => ReturnType<ReturnType<typeof createRenderer>['render']> & {
     /**
+     * @deprecated use `selectSectionAsync` instead.
+     */
+    selectSection: FieldSectionSelector;
+    /**
      * Helper that simplifies selecting a section of the date field.
      * @param {FieldSectionType | undefined} selectedSection The requested section to select.
      * @param {'first' | 'last'} index The index of the section to select.
      */
-    selectSection: FieldSectionSelector;
+    selectSectionAsync: FieldSectionSelectorAsync;
     getSectionsContainer: () => HTMLDivElement;
     /**
      * Returns the contentEditable DOM node of the requested section.
@@ -48,11 +61,9 @@ export interface BuildFieldInteractionsResponse<P extends {}> {
      */
     getActiveSection: (sectionIndex: number | undefined) => HTMLSpanElement;
     /**
-     * Press a character on the currently focused section using user-event.
-     * The section must be focused first via `selectSection`.
-     * @param {string} character The character to press. Navigation keys like
-     *   `ArrowUp`, `Backspace`, `Delete` are mapped to their user-event
-     *   curly-brace form (`{ArrowUp}`); other strings are typed as text.
+     * Press a character on the active section.
+     * @param {number | undefined | null} sectionIndex If null presses on the fieldContainer, otherwise if defined asserts that the active section is the expected one
+     * @param {string} character The character to press.
      */
     pressKey: FieldPressCharacter;
     getHiddenInput: () => HTMLInputElement;
@@ -63,13 +74,13 @@ export interface BuildFieldInteractionsResponse<P extends {}> {
       expectedValue: string;
       selectedSection?: FieldSectionType;
     },
-  ) => Promise<void>;
+  ) => void;
   testFieldChange: (
     params: P & {
       keyStrokes: { value: string; expected: string }[];
       selectedSection?: FieldSectionType;
     },
-  ) => Promise<void>;
+  ) => void;
 }
 
 const RTL_THEME = createTheme({
@@ -143,7 +154,30 @@ export const buildFieldInteractions = <P extends {}>({
         `.${pickersSectionListClasses.section}[data-sectionindex="${sectionIndex}"] .${pickersSectionListClasses.sectionContent}`,
       )!;
 
-    const selectSection: FieldSectionSelector = async (selectedSection, index = 'first') => {
+    const selectSection: FieldSectionSelector = (selectedSection, index = 'first') => {
+      let sectionIndexToSelect: number;
+      if (selectedSection === undefined) {
+        sectionIndexToSelect = 0;
+      } else {
+        const sections = fieldRef.current!.getSections();
+        sectionIndexToSelect = sections[index === 'first' ? 'findIndex' : 'findLastIndex'](
+          (section) => section.type === selectedSection,
+        );
+      }
+
+      act(() => {
+        fieldRef.current!.setSelectedSections(sectionIndexToSelect);
+      });
+
+      act(() => {
+        getSection(sectionIndexToSelect).focus();
+      });
+    };
+
+    const selectSectionAsync: FieldSectionSelectorAsync = async (
+      selectedSection,
+      index = 'first',
+    ) => {
       let sectionIndexToSelect: number;
       if (selectedSection === undefined) {
         sectionIndexToSelect = 0;
@@ -177,7 +211,10 @@ export const buildFieldInteractions = <P extends {}>({
       return activeElement;
     };
 
-    const pressKey: FieldPressCharacter = async (key) => {
+    const pressKey: FieldPressCharacter = (sectionIndex, key) => {
+      const target =
+        sectionIndex === null ? getSectionsContainer() : getActiveSection(sectionIndex);
+
       if (
         [
           'ArrowUp',
@@ -187,26 +224,19 @@ export const buildFieldInteractions = <P extends {}>({
           'Home',
           'End',
           'Delete',
-          'Backspace',
           'ArrowLeft',
           'ArrowRight',
         ].includes(key)
       ) {
-        await result.user.keyboard(`{${key}}`);
-      } else if (key === ' ') {
-        await result.user.keyboard('{Space}');
-      } else if (key === '') {
-        // The legacy sync helper passed an empty string to fire
-        // `input({ textContent: '' })`, which cleared the section. The
-        // equivalent user-event gesture is pressing Backspace.
-        await result.user.keyboard('{Backspace}');
+        fireUserEvent.keyPress(target, { key });
       } else {
-        await result.user.keyboard(key);
+        fireEvent.input(target, { target: { textContent: key } });
       }
     };
 
     return {
       selectSection,
+      selectSectionAsync,
       getActiveSection,
       getSection,
       pressKey,
@@ -216,7 +246,7 @@ export const buildFieldInteractions = <P extends {}>({
     };
   };
 
-  const testFieldKeyPress: BuildFieldInteractionsResponse<P>['testFieldKeyPress'] = async ({
+  const testFieldKeyPress: BuildFieldInteractionsResponse<P>['testFieldKeyPress'] = ({
     key,
     expectedValue,
     selectedSection,
@@ -225,12 +255,12 @@ export const buildFieldInteractions = <P extends {}>({
     const response = renderWithProps({
       ...props,
     } as any);
-    await response.selectSection(selectedSection);
-    await response.pressKey(key);
+    response.selectSection(selectedSection);
+    response.pressKey(undefined, key);
     expectFieldValue(response.getSectionsContainer(), expectedValue);
   };
 
-  const testFieldChange: BuildFieldInteractionsResponse<P>['testFieldChange'] = async ({
+  const testFieldChange: BuildFieldInteractionsResponse<P>['testFieldChange'] = ({
     keyStrokes,
     selectedSection,
     ...props
@@ -238,23 +268,18 @@ export const buildFieldInteractions = <P extends {}>({
     const response = renderWithProps({
       ...props,
     } as any);
-    await response.selectSection(selectedSection);
-    for (const keyStroke of keyStrokes) {
-      // eslint-disable-next-line no-await-in-loop
-      await response.pressKey(keyStroke.value);
+    response.selectSection(selectedSection);
+    keyStrokes.forEach((keyStroke) => {
+      response.pressKey(undefined, keyStroke.value);
       expectFieldValue(
         response.getSectionsContainer(),
         keyStroke.expected,
         (props as any).shouldRespectLeadingZeros ? 'singleDigit' : undefined,
       );
-    }
+    });
   };
 
-  return {
-    testFieldKeyPress,
-    testFieldChange,
-    renderWithProps,
-  };
+  return { testFieldKeyPress, testFieldChange, renderWithProps };
 };
 
 export const cleanText = (text: string, specialCase?: 'singleDigit' | 'RTL') => {

--- a/test/utils/pickers/openPicker.ts
+++ b/test/utils/pickers/openPicker.ts
@@ -15,38 +15,39 @@ export type OpenPickerParams =
       fieldType: 'single-input' | 'multi-input';
     };
 
-// user-event refuses to click elements with `pointer-events: none` (e.g.
-// disabled/readOnly pickers). Tests that intentionally try to open such
-// pickers — to verify the `onOpen` callback is not called — need the click
-// to dispatch anyway. Let user-event throw first (happy path stays a single
-// call) and only fall back to `fireEvent.click` when `getComputedStyle`
-// confirms the reason. That avoids matching on user-event's error wording
-// and avoids paying the style-computation cost on every click.
-const clickTarget = async (user: MuiRenderResult['user'], target: Element) => {
-  try {
-    await user.click(target);
-  } catch (error) {
-    if (window.getComputedStyle(target).pointerEvents === 'none') {
-      fireEvent.click(target);
-      return;
-    }
-    throw error;
-  }
-};
-
-export const openPicker = async (user: MuiRenderResult['user'], params: OpenPickerParams) => {
+/**
+ * @deprecated use `openPickerAsync` instead
+ */
+export const openPicker = (params: OpenPickerParams) => {
   const isRangeType =
     params.type === 'date-range' ||
     params.type === 'date-time-range' ||
     params.type === 'time-range';
   if (isRangeType && params.fieldType === 'multi-input') {
     const fieldSectionsContainer = getFieldSectionsContainer(params.initialFocus === 'end' ? 1 : 0);
-    await clickTarget(user, fieldSectionsContainer);
+    fireEvent.click(fieldSectionsContainer);
     return true;
   }
 
   const target = screen.getByLabelText(/(choose date)|(choose time)|(choose range)/i);
 
-  await clickTarget(user, target);
+  fireEvent.click(target);
+  return true;
+};
+
+export const openPickerAsync = async (user: MuiRenderResult['user'], params: OpenPickerParams) => {
+  const isRangeType =
+    params.type === 'date-range' ||
+    params.type === 'date-time-range' ||
+    params.type === 'time-range';
+  if (isRangeType && params.fieldType === 'multi-input') {
+    const fieldSectionsContainer = getFieldSectionsContainer(params.initialFocus === 'end' ? 1 : 0);
+    await user.click(fieldSectionsContainer);
+    return true;
+  }
+
+  const target = screen.getByLabelText(/(choose date)|(choose time)|(choose range)/i);
+
+  await user.click(target);
   return true;
 };

--- a/test/utils/pickers/viewHandlers.ts
+++ b/test/utils/pickers/viewHandlers.ts
@@ -1,19 +1,14 @@
-import { act, fireTouchChangedEvent, screen, MuiRenderResult } from '@mui/internal-test-utils';
+import { fireEvent, fireTouchChangedEvent, screen } from '@mui/internal-test-utils';
 import { getClockTouchEvent, formatFullTimeValue } from 'test/utils/pickers';
 import { MuiPickersAdapter, PickerValidDate, TimeView } from '@mui/x-date-pickers/models';
 import { formatMeridiem } from '@mui/x-date-pickers/internals';
 
 interface ViewHandler<TView> {
-  setViewValue: (
-    user: MuiRenderResult['user'],
-    adapter: MuiPickersAdapter,
-    viewValue: PickerValidDate,
-    view?: TView,
-  ) => Promise<void>;
+  setViewValue: (adapter: MuiPickersAdapter, viewValue: PickerValidDate, view?: TView) => void;
 }
 
 export const timeClockHandler: ViewHandler<TimeView> = {
-  setViewValue: async (_, adapter, value, view) => {
+  setViewValue: (adapter, value, view) => {
     const hasMeridiem = adapter.is12HourCycleInCurrentLocale();
 
     let valueInt;
@@ -31,30 +26,26 @@ export const timeClockHandler: ViewHandler<TimeView> = {
 
     const hourClockEvent = getClockTouchEvent(valueInt, clockView);
 
-    await act(async () => {
-      fireTouchChangedEvent(screen.getByTestId('clock'), 'touchmove', hourClockEvent);
-    });
-    await act(async () => {
-      fireTouchChangedEvent(screen.getByTestId('clock'), 'touchend', hourClockEvent);
-    });
+    fireTouchChangedEvent(screen.getByTestId('clock'), 'touchmove', hourClockEvent);
+    fireTouchChangedEvent(screen.getByTestId('clock'), 'touchend', hourClockEvent);
   },
 };
 
 export const digitalClockHandler: ViewHandler<TimeView> = {
-  setViewValue: async (user, adapter, value) => {
-    await user.click(screen.getByRole('option', { name: formatFullTimeValue(adapter, value) }));
+  setViewValue: (adapter, value) => {
+    fireEvent.click(screen.getByRole('option', { name: formatFullTimeValue(adapter, value) }));
   },
 };
 
 export const multiSectionDigitalClockHandler: ViewHandler<TimeView> = {
-  setViewValue: async (user, adapter, value) => {
+  setViewValue: (adapter, value) => {
     const hasMeridiem = adapter.is12HourCycleInCurrentLocale();
     const hoursLabel = parseInt(adapter.format(value, hasMeridiem ? 'hours12h' : 'hours24h'), 10);
     const minutesLabel = adapter.getMinutes(value).toString();
-    await user.click(screen.getByRole('option', { name: `${hoursLabel} hours` }));
-    await user.click(screen.getByRole('option', { name: `${minutesLabel} minutes` }));
+    fireEvent.click(screen.getByRole('option', { name: `${hoursLabel} hours` }));
+    fireEvent.click(screen.getByRole('option', { name: `${minutesLabel} minutes` }));
     if (hasMeridiem) {
-      await user.click(
+      fireEvent.click(
         screen.getByRole('option', {
           name: formatMeridiem(adapter, adapter.getHours(value) >= 12 ? 'pm' : 'am'),
         }),


### PR DESCRIPTION
Reverts [#22043](https://github.com/mui/mui-x/pull/22043).

## Summary

The browser-mode test CI for `@mui/x-date-pickers` and `@mui/x-date-pickers-pro` has become noticeably flaky since [#22043](https://github.com/mui/mui-x/pull/22043) migrated Pickers tests from sync `fireEvent` / `fireUserEvent` to async `@testing-library/user-event`. The working hypothesis is that user-event v14's fuller pointer/keyboard sequence (`pointerover` -> `pointerdown` -> `pointerup` -> `click`, plus focus events, with `setTimeout(0)` between steps) compounds across the ~4200 Pickers tests and is the root of the regression.

This PR rolls back #22043 wholesale via `git revert cc5032f53b9` and returns Pickers tests to the pre-PR sync-fireEvent style. Provisional pending CI measurement — if user-event turns out not to be the culprit, this revert can itself be reverted.

The `fireUserEvent` test util (`test/utils/fireUserEvent/`) is untouched — it's still in active use in DataGrid tests, this revert just brings it back into use in Pickers tests too.

## Test plan

- [x] `pnpm --filter "@mui/x-date-pickers*" run typescript`
- [x] `pnpm test:unit --project "x-date-pickers" --run` -- 3310 passed / 816 skipped
- [x] `pnpm test:unit --project "x-date-pickers-pro" --run` -- 998 passed / 299 skipped / 2 todo
- [x] `pnpm test:browser --project "x-date-pickers" --run` -- 3320 passed / 805 skipped (31s)
- [x] `pnpm test:browser --project "x-date-pickers-pro" --run` -- 1000 passed / 296 skipped / 2 todo (15s)
- [x] `pnpm eslint`
- [x] `pnpm prettier`
- [ ] Watch the next ~3-5 browser-CI runs after merge for median runtime / flake rate vs the last week pre-revert