### PR TITLE
[internal-gestures] Enforce pointer-type filter in ShadowRoot branch

### DIFF
--- a/packages/x-internal-gestures/src/core/PointerGesture.ts
+++ b/packages/x-internal-gestures/src/core/PointerGesture.ts
@@ -169,18 +169,21 @@ export abstract class PointerGesture<GestureName extends string> extends Gesture
     pointers: PointerData[],
     calculatedTarget: TargetElement,
   ): PointerData[] {
-    return pointers.filter(
-      (pointer) =>
-        (this.isPointerTypeAllowed(pointer.pointerType) &&
-          (calculatedTarget === pointer.target ||
-            pointer.target === this.originalTarget ||
-            calculatedTarget === this.originalTarget ||
-            ('contains' in calculatedTarget &&
-              calculatedTarget.contains(pointer.target as Node)))) ||
-        ('getRootNode' in calculatedTarget &&
-          calculatedTarget.getRootNode() instanceof ShadowRoot &&
-          pointer.srcEvent.composedPath().includes(calculatedTarget)),
-    );
+    return pointers.filter((pointer) => {
+      if (!this.isPointerTypeAllowed(pointer.pointerType)) {
+        return false;
+      }
+      const targetMatches =
+        calculatedTarget === pointer.target ||
+        pointer.target === this.originalTarget ||
+        calculatedTarget === this.originalTarget ||
+        ('contains' in calculatedTarget && calculatedTarget.contains(pointer.target as Node));
+      const shadowRootMatches =
+        'getRootNode' in calculatedTarget &&
+        calculatedTarget.getRootNode() instanceof ShadowRoot &&
+        pointer.srcEvent.composedPath().includes(calculatedTarget);
+      return targetMatches || shadowRootMatches;
+    });
   }
 
   public destroy(): void {


### PR DESCRIPTION
## Summary

`getRelevantPointers` had the shape `(typeAllowed && targetMatch) || (shadowRoot && composedPath)`, so the ShadowRoot fallback branch bypassed `isPointerTypeAllowed`. A pointer of a disallowed type whose target's root was a ShadowRoot would still be returned to the gesture.

Hoist the type check so it gates both branches.