### PR TITLE
[internal-gestures] Document passive default and tradeoff

### DIFF
--- a/packages/x-internal-gestures/src/core/PointerManager.ts
+++ b/packages/x-internal-gestures/src/core/PointerManager.ts
@@ -77,9 +77,21 @@ export type PointerManagerOptions = {
 
   /**
    * Whether to use passive event listeners for better scrolling performance.
-   * When true, listeners cannot call preventDefault() on events.
    *
-   * @default true
+   * Tradeoff:
+   * - `true`: Listeners cannot call `preventDefault()`. Browsers can scroll
+   *   without waiting for handlers, which keeps the page responsive but
+   *   means gestures cannot suppress native scrolling/zooming.
+   * - `false`: Listeners can call `preventDefault()`. Required for gestures
+   *   that need to override native behaviour (e.g. preventing page scroll
+   *   while panning), at the cost of blocking the scroll thread until the
+   *   handler returns.
+   *
+   * Most gesture-driven UIs need `preventDefault()`, so the default is
+   * `false`. Set to `true` when the gestures only observe input and never
+   * need to suppress browser defaults.
+   *
+   * @default false
    */
   passive?: boolean;
 


### PR DESCRIPTION
## Summary

The `PointerManager.passive` option defaulted to `false` in code but the JSDoc claimed `@default true`, with no explanation of the tradeoff between scroll responsiveness and `preventDefault()` capability.

Update the JSDoc to match the implementation and describe when each value is appropriate.