### PR TITLE
[internal-gestures] Improve passive event listener handling

### DIFF
--- a/packages/x-internal-gestures/src/core/PointerManager.ts
+++ b/packages/x-internal-gestures/src/core/PointerManager.ts
@@ -77,9 +77,21 @@ export type PointerManagerOptions = {
 
   /**
    * Whether to use passive event listeners for better scrolling performance.
-   * When true, listeners cannot call preventDefault() on events.
    *
-   * @default true
+   * Tradeoff:
+   * - `true`: Listeners cannot call `preventDefault()`. Browsers can scroll
+   *   without waiting for handlers, which keeps the page responsive but
+   *   means gestures cannot suppress native scrolling/zooming.
+   * - `false`: Listeners can call `preventDefault()`. Required for gestures
+   *   that need to override native behaviour (e.g. preventing page scroll
+   *   while panning), at the cost of blocking the scroll thread until the
+   *   handler returns.
+   *
+   * Most gesture-driven UIs need `preventDefault()`, so the default is
+   * `false`. Set to `true` when the gestures only observe input and never
+   * need to suppress browser defaults.
+   *
+   * @default false
    */
   passive?: boolean;
 

--- a/packages/x-internal-gestures/src/core/gestures/TurnWheelGesture.ts
+++ b/packages/x-internal-gestures/src/core/gestures/TurnWheelGesture.ts
@@ -210,13 +210,19 @@ export class TurnWheelGesture<GestureName extends string> extends Gesture<Gestur
   ): void {
     super.init(element, pointerManager, gestureRegistry, keyboardManager);
 
-    // Add event listener directly to the element
+    // Wheel listeners must be explicitly non-passive when the gesture needs
+    // to call preventDefault(); otherwise the browser ignores the call and
+    // logs a warning. When preventDefault is disabled, mark the listener as
+    // passive so the browser can optimise scroll responsiveness.
     // @ts-expect-error, WheelEvent is correct.
-    this.element.addEventListener('wheel', this.handleWheelEvent);
+    this.element.addEventListener('wheel', this.handleWheelEvent, {
+      passive: !this.preventDefault,
+    });
   }
 
   public destroy(): void {
-    // Remove the element-specific event listener
+    // Remove the element-specific event listener. Only `capture` is
+    // significant for matching; the `passive` flag is ignored on remove.
     // @ts-expect-error, WheelEvent is correct.
     this.element.removeEventListener('wheel', this.handleWheelEvent);
     this.resetState();

--- a/packages/x-internal-gestures/src/core/gestures/TurnWheelGesture.ts
+++ b/packages/x-internal-gestures/src/core/gestures/TurnWheelGesture.ts
@@ -210,12 +210,11 @@ export class TurnWheelGesture<GestureName extends string> extends Gesture<Gestur
   ): void {
     super.init(element, pointerManager, gestureRegistry, keyboardManager);
 
-    // Wheel listeners must be explicitly non-passive when the gesture needs
-    // to call preventDefault(); otherwise the browser ignores the call and
-    // logs a warning. When preventDefault is disabled, mark the listener as
-    // passive so the browser can optimise scroll responsiveness.
+    // Add event listener directly to the element
     // @ts-expect-error, WheelEvent is correct.
     this.element.addEventListener('wheel', this.handleWheelEvent, {
+      // Provide the `passive` value to prevent inconsistencies between chrome and safari
+      // See https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#passive
       passive: !this.preventDefault,
     });
   }

--- a/packages/x-internal-gestures/src/core/gestures/TurnWheelGesture.ts
+++ b/packages/x-internal-gestures/src/core/gestures/TurnWheelGesture.ts
@@ -221,8 +221,7 @@ export class TurnWheelGesture<GestureName extends string> extends Gesture<Gestur
   }
 
   public destroy(): void {
-    // Remove the element-specific event listener. Only `capture` is
-    // significant for matching; the `passive` flag is ignored on remove.
+    // Remove the element-specific event listener.
     // @ts-expect-error, WheelEvent is correct.
     this.element.removeEventListener('wheel', this.handleWheelEvent);
     this.resetState();


### PR DESCRIPTION
## Summary

Combines two related fixes around passive event listener handling.

**1. Make `TurnWheelGesture` wheel listener explicitly non-passive.**
The wheel listener was added without explicit listener options, so its passive state was browser-dependent. When configured with `preventDefault: true`, browsers that defaulted the listener to passive silently ignored the `preventDefault()` call. Pass an explicit `{ passive: !this.preventDefault }` so the listener is always active when `preventDefault` is needed and passive otherwise.

**2. Document `PointerManager.passive` default and tradeoff.**
The option defaulted to `false` in code but the JSDoc claimed `@default true`, with no explanation of the tradeoff between scroll responsiveness and `preventDefault()` capability. Update the JSDoc to match the implementation and describe when each value is appropriate.