### PR TITLE
[x-license] Move test keys to a dedicated /test-keys subpath

### DIFF
--- a/packages/x-data-grid-premium/src/tests/license.DataGridPremium.test.tsx
+++ b/packages/x-data-grid-premium/src/tests/license.DataGridPremium.test.tsx
@@ -1,7 +1,8 @@
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import { DataGridPremium } from '@mui/x-data-grid-premium';
 import { LicenseInfo } from '@mui/x-license';
-import { TEST_LICENSE_KEY_PRO, clearLicenseStatusCache } from '@mui/x-license/internals';
+import { clearLicenseStatusCache } from '@mui/x-license/internals';
+import { TEST_LICENSE_KEY_PRO } from '@mui/x-license/test-keys';
 
 describe('<DataGridPremium /> - License', () => {
   const { render } = createRenderer();

--- a/packages/x-license/package.json
+++ b/packages/x-license/package.json
@@ -46,7 +46,8 @@
   },
   "exports": {
     ".": "./src/index.ts",
-    "./internals": "./src/internals/index.ts"
+    "./internals": "./src/internals/index.ts",
+    "./test-keys": "./src/test-keys.ts"
   },
   "imports": {
     "#formatErrorMessage": "@mui/x-internals/formatErrorMessage"

--- a/packages/x-license/src/internals/index.ts
+++ b/packages/x-license/src/internals/index.ts
@@ -13,4 +13,3 @@ export {
   clearLicenseStatusCache,
 } from '../useLicenseVerifier/useLicenseVerifier';
 export * from '../verifyLicense/verifyLicense';
-export * from '../test-keys';

--- a/packages/x-scheduler-premium/src/event-calendar-premium/tests/license.EventCalendarPremium.test.tsx
+++ b/packages/x-scheduler-premium/src/event-calendar-premium/tests/license.EventCalendarPremium.test.tsx
@@ -1,7 +1,8 @@
 import { screen } from '@mui/internal-test-utils';
 import { EventCalendarPremium } from '@mui/x-scheduler-premium/event-calendar-premium';
 import { LicenseInfo } from '@mui/x-license';
-import { TEST_LICENSE_KEY_PRO, clearLicenseStatusCache } from '@mui/x-license/internals';
+import { clearLicenseStatusCache } from '@mui/x-license/internals';
+import { TEST_LICENSE_KEY_PRO } from '@mui/x-license/test-keys';
 import {
   createSchedulerRenderer,
   DEFAULT_TESTING_VISIBLE_DATE,

--- a/packages/x-scheduler-premium/src/event-timeline-premium/tests/license.EventTimelinePremium.test.tsx
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/tests/license.EventTimelinePremium.test.tsx
@@ -1,7 +1,8 @@
 import { screen } from '@mui/internal-test-utils';
 import { EventTimelinePremium } from '@mui/x-scheduler-premium/event-timeline-premium';
 import { LicenseInfo } from '@mui/x-license';
-import { TEST_LICENSE_KEY_PRO, clearLicenseStatusCache } from '@mui/x-license/internals';
+import { clearLicenseStatusCache } from '@mui/x-license/internals';
+import { TEST_LICENSE_KEY_PRO } from '@mui/x-license/test-keys';
 import {
   createSchedulerRenderer,
   DEFAULT_TESTING_VISIBLE_DATE,

--- a/test/e2e/index.tsx
+++ b/test/e2e/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom/client';
 import { BrowserRouter as Router, Routes, Route, Link } from 'react-router';
 import { LicenseInfo } from '@mui/x-license';
-import { TEST_LICENSE_KEY_PREMIUM } from '@mui/x-license/internals';
+import { TEST_LICENSE_KEY_PREMIUM } from '@mui/x-license/test-keys';
 import TestViewer from './TestViewer';
 
 LicenseInfo.setLicenseKey(TEST_LICENSE_KEY_PREMIUM);

--- a/test/performance-charts/setup.ts
+++ b/test/performance-charts/setup.ts
@@ -1,6 +1,6 @@
 import { beforeAll } from 'vitest';
 import { LicenseInfo } from '@mui/x-license';
-import { TEST_LICENSE_KEY_PRO } from '@mui/x-license/internals';
+import { TEST_LICENSE_KEY_PRO } from '@mui/x-license/test-keys';
 
 beforeAll(() => {
   LicenseInfo.setLicenseKey(TEST_LICENSE_KEY_PRO);

--- a/test/regressions/index.tsx
+++ b/test/regressions/index.tsx
@@ -5,7 +5,7 @@ import { Globals } from '@react-spring/web';
 // eslint-disable-next-line import/no-relative-packages
 import '../utils/setupFakeClock';
 import { LicenseInfo } from '@mui/x-license';
-import { TEST_LICENSE_KEY_PREMIUM } from '@mui/x-license/internals';
+import { TEST_LICENSE_KEY_PREMIUM } from '@mui/x-license/test-keys';
 import TestViewer from './TestViewer';
 import { type Test, testsBySuite } from './testsBySuite';
 

--- a/test/setupVitest.ts
+++ b/test/setupVitest.ts
@@ -9,7 +9,7 @@ import { clearWarningsCache } from '@mui/x-internals/warning';
 import setupVitest from '@mui/internal-test-utils/setupVitest';
 import { configure, isJsdom } from '@mui/internal-test-utils';
 import { LicenseInfo } from '@mui/x-license';
-import { TEST_LICENSE_KEY_PREMIUM } from '@mui/x-license/internals';
+import { TEST_LICENSE_KEY_PREMIUM } from '@mui/x-license/test-keys';
 
 (globalThis as any).MUI_TEST_ENV = true;
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).


## Summary

`@mui/x-license/internals` is the runtime entrypoint imported by every commercial package (data-grid-pro/premium, charts-pro/premium, date-pickers-pro, tree-view-pro, scheduler-premium) to wire up `useLicenseVerifier` and `Watermark`. It was also re-exporting every entry of `test-keys.ts`, 17 base64+md5 strings used only by tests, which leaked them into the public TypeScript surface and inflated CI bundle-size measurements.

This PR is a refactor with no behavior change.

## Motivation

- **API hygiene:** test-only fixtures shouldn't ship as part of `internals`' public type surface. Removing them avoids accidental adoption and frees us from supporting them as stable API.
- **Accurate CI measurement:** the bundle-size-checker measured `internals` with `import *`, which forced test-keys into the count. The number it reports, and uses to gate regressions, will now reflect what real consumers actually pull.
- **Tree-shaking guarantee:** modern bundlers strip these already, but `export *` barrel chains are a known weak spot in older esbuild/SSR/edge runtimes. After this change, test-keys aren't reachable from `internals` at all.

No production consumer was importing these symbols, so no runtime behavior changes.