### PR TITLE
[DataGrid] Position overlays below top pinned rows

### DIFF
--- a/packages/x-data-grid/src/components/base/GridOverlays.tsx
+++ b/packages/x-data-grid/src/components/base/GridOverlays.tsx
@@ -33,7 +33,7 @@ const GridOverlayWrapperRoot = styled('div', {
   loadingOverlayVariant !== 'skeleton'
     ? {
         position: 'sticky', // To stay in place while scrolling
-        top: 'var(--DataGrid-headersTotalHeight)', // TODO: take pinned rows into account
+        top: 'var(--DataGrid-topContainerHeight)',
         left: 0,
         right: `${right}px`,
         width: 0, // To stay above the content instead of shifting it down


### PR DESCRIPTION
Use the full top container height for sticky overlays so loading overlays account for top pinned rows instead of only the column headers.

Fixes #22337
- Before: https://stackblitz.com/edit/xchqp3rd?file=src%2FDemo.tsx
- After: https://stackblitz.com/edit/xchqp3rd-4prbvghi?file=src%2FDemo.tsx