### PR TITLE
[charts-pro] Revert #22329 to fix the zoom with wheel

### DIFF
--- a/packages/x-internal-gestures/src/core/PointerManager.ts
+++ b/packages/x-internal-gestures/src/core/PointerManager.ts
@@ -77,21 +77,9 @@ export type PointerManagerOptions = {
 
   /**
    * Whether to use passive event listeners for better scrolling performance.
+   * When true, listeners cannot call preventDefault() on events.
    *
-   * Tradeoff:
-   * - `true`: Listeners cannot call `preventDefault()`. Browsers can scroll
-   *   without waiting for handlers, which keeps the page responsive but
-   *   means gestures cannot suppress native scrolling/zooming.
-   * - `false`: Listeners can call `preventDefault()`. Required for gestures
-   *   that need to override native behaviour (e.g. preventing page scroll
-   *   while panning), at the cost of blocking the scroll thread until the
-   *   handler returns.
-   *
-   * Most gesture-driven UIs need `preventDefault()`, so the default is
-   * `false`. Set to `true` when the gestures only observe input and never
-   * need to suppress browser defaults.
-   *
-   * @default false
+   * @default true
    */
   passive?: boolean;
 

--- a/packages/x-internal-gestures/src/core/gestures/TurnWheelGesture.ts
+++ b/packages/x-internal-gestures/src/core/gestures/TurnWheelGesture.ts
@@ -212,15 +212,11 @@ export class TurnWheelGesture<GestureName extends string> extends Gesture<Gestur
 
     // Add event listener directly to the element
     // @ts-expect-error, WheelEvent is correct.
-    this.element.addEventListener('wheel', this.handleWheelEvent, {
-      // Provide the `passive` value to prevent inconsistencies between chrome and safari
-      // See https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#passive
-      passive: !this.preventDefault,
-    });
+    this.element.addEventListener('wheel', this.handleWheelEvent);
   }
 
   public destroy(): void {
-    // Remove the element-specific event listener.
+    // Remove the element-specific event listener
     // @ts-expect-error, WheelEvent is correct.
     this.element.removeEventListener('wheel', this.handleWheelEvent);
     this.resetState();


### PR DESCRIPTION
Revert #22329

The #22329 introduce a breaking change

Go to https://deploy-preview-22329--material-ui-x.netlify.app/x/react-charts/zoom-and-pan/

You will see the console full of this message error when using the wheel

> Unable to preventDefault inside passive event listener invocation.
(anonymous) @ useZoomOnWheel.ts:77
