### PR TITLE
[internal-gestures] Add passive option to TurnWheelGesture

### DIFF
--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartInteractionListener/useChartInteractionListener.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartInteractionListener/useChartInteractionListener.ts
@@ -86,10 +86,12 @@ export const useChartInteractionListener: ChartPlugin<UseChartInteractionListene
             name: 'zoomTurnWheel',
             sensitivity: 0.01,
             initialDelta: 1,
+            passive: false,
           }),
           new TurnWheelGesture({
             name: 'panTurnWheel',
             sensitivity: 0.5,
+            passive: false,
           }),
           new TapAndDragGesture({
             name: 'zoomTapAndDrag',

--- a/packages/x-internal-gestures/src/core/gestures/TurnWheelGesture.test.ts
+++ b/packages/x-internal-gestures/src/core/gestures/TurnWheelGesture.test.ts
@@ -162,4 +162,89 @@ describe('TurnWheel Gesture', () => {
       min: -1000,
     });
   });
+
+  describe('passive option', () => {
+    function getWheelPassive(addEventListenerSpy: ReturnType<typeof vi.spyOn>): boolean {
+      const wheelCall = addEventListenerSpy.mock.calls.find((call: any) => call[0] === 'wheel');
+      expect(wheelCall).toBeDefined();
+      const options = wheelCall![2];
+      expect(typeof options).toBe('object');
+      return (options as AddEventListenerOptions).passive!;
+    }
+
+    function setupWithOptions(options: { preventDefault?: boolean; passive?: boolean }) {
+      const localTarget = document.createElement('div');
+      container.appendChild(localTarget);
+      const spy = vi.spyOn(localTarget, 'addEventListener');
+
+      const manager = new GestureManager({
+        gestures: [
+          new TurnWheelGesture({
+            name: 'turnWheel',
+            ...options,
+          }),
+        ],
+      });
+      manager.registerElement('turnWheel', localTarget);
+
+      return { manager, passive: getWheelPassive(spy) };
+    }
+
+    it('should default passive to false when preventDefault is false', () => {
+      const { manager, passive } = setupWithOptions({ preventDefault: false });
+      expect(passive).toBe(false);
+      manager.destroy();
+    });
+
+    it('should default passive to false when preventDefault is true', () => {
+      const { manager, passive } = setupWithOptions({ preventDefault: true });
+      expect(passive).toBe(false);
+      manager.destroy();
+    });
+
+    it('should respect explicit passive=true when preventDefault is false', () => {
+      const { manager, passive } = setupWithOptions({
+        preventDefault: false,
+        passive: true,
+      });
+      expect(passive).toBe(true);
+      manager.destroy();
+    });
+
+    it('should respect explicit passive=false when preventDefault is false', () => {
+      const { manager, passive } = setupWithOptions({
+        preventDefault: false,
+        passive: false,
+      });
+      expect(passive).toBe(false);
+      manager.destroy();
+    });
+
+    it('should force passive to false when preventDefault is true even if passive=true is passed', () => {
+      const { manager, passive } = setupWithOptions({
+        preventDefault: true,
+        passive: true,
+      });
+      expect(passive).toBe(false);
+      manager.destroy();
+    });
+
+    it('should preserve passive option when cloning', () => {
+      const original = new TurnWheelGesture({
+        name: 'turnWheel',
+        preventDefault: false,
+        passive: true,
+      });
+
+      const localTarget = document.createElement('div');
+      container.appendChild(localTarget);
+      const spy = vi.spyOn(localTarget, 'addEventListener');
+
+      const manager = new GestureManager({ gestures: [original] });
+      manager.registerElement('turnWheel', localTarget);
+
+      expect(getWheelPassive(spy)).toBe(true);
+      manager.destroy();
+    });
+  });
 });

--- a/packages/x-internal-gestures/src/core/gestures/TurnWheelGesture.test.ts
+++ b/packages/x-internal-gestures/src/core/gestures/TurnWheelGesture.test.ts
@@ -190,9 +190,9 @@ describe('TurnWheel Gesture', () => {
       return { manager, passive: getWheelPassive(spy) };
     }
 
-    it('should default passive to false when preventDefault is false', () => {
+    it('should default passive to true when preventDefault is false', () => {
       const { manager, passive } = setupWithOptions({ preventDefault: false });
-      expect(passive).toBe(false);
+      expect(passive).toBe(true);
       manager.destroy();
     });
 

--- a/packages/x-internal-gestures/src/core/gestures/TurnWheelGesture.ts
+++ b/packages/x-internal-gestures/src/core/gestures/TurnWheelGesture.ts
@@ -64,7 +64,8 @@ export type TurnWheelGestureOptions<GestureName extends string> = GestureOptions
    * `event.preventDefault()` on the source wheel event.
    * Set to `false` if you need to call `preventDefault()` on the
    * `srcEvent` from the emitted gesture event yourself.
-   * @default !preventDefault
+   * Forced to `false` when `preventDefault` is `true`.
+   * @default true
    */
   passive?: boolean;
 
@@ -184,8 +185,7 @@ export class TurnWheelGesture<GestureName extends string> extends Gesture<Gestur
 
   /**
    * Whether the underlying wheel listener is registered as passive.
-   * Defaults to the opposite of `preventDefault` so consumers calling
-   * `preventDefault()` on the source event keep working.
+   * Defaults to `true`; forced to `false` when `preventDefault` is `true`.
    */
   private passive: boolean;
 
@@ -197,8 +197,8 @@ export class TurnWheelGesture<GestureName extends string> extends Gesture<Gestur
     this.initialDelta = options.initialDelta ?? 0;
     this.invert = options.invert ?? false;
     // If `preventDefault` is true, we must set `passive` to false to allow calling `preventDefault()` on the source event.
-    // If `preventDefault` is false, we can set `passive` to whatever the user specified
-    this.passive = !this.preventDefault && options.passive !== undefined ? options.passive : false;
+    // Otherwise, default to `true` (passive) and let consumers opt out to call `preventDefault()` themselves.
+    this.passive = this.preventDefault ? false : (options.passive ?? true);
 
     this.state.totalDeltaX = this.initialDelta;
     this.state.totalDeltaY = this.initialDelta;

--- a/packages/x-internal-gestures/src/core/gestures/TurnWheelGesture.ts
+++ b/packages/x-internal-gestures/src/core/gestures/TurnWheelGesture.ts
@@ -59,6 +59,16 @@ export type TurnWheelGestureOptions<GestureName extends string> = GestureOptions
   invert?: boolean;
 
   /**
+   * Whether the underlying `wheel` event listener is registered as passive.
+   * When `true`, neither the gesture nor any consumer can call
+   * `event.preventDefault()` on the source wheel event.
+   * Set to `false` if you need to call `preventDefault()` on the
+   * `srcEvent` from the emitted gesture event yourself.
+   * @default !preventDefault
+   */
+  passive?: boolean;
+
+  /**
    * Wheel events happen on mouse mode only.
    */
   pointerMode?: never;
@@ -137,7 +147,7 @@ export class TurnWheelGesture<GestureName extends string> extends Gesture<Gestur
 
   protected readonly mutableOptionsType!: Omit<
     typeof this.optionsType,
-    'name' | 'pointerMode' | 'pointerOptions'
+    'name' | 'pointerMode' | 'pointerOptions' | 'passive'
   >;
 
   protected readonly mutableStateType!: Partial<typeof this.state>;
@@ -172,6 +182,13 @@ export class TurnWheelGesture<GestureName extends string> extends Gesture<Gestur
    */
   private invert: boolean;
 
+  /**
+   * Whether the underlying wheel listener is registered as passive.
+   * Defaults to the opposite of `preventDefault` so consumers calling
+   * `preventDefault()` on the source event keep working.
+   */
+  private passive: boolean;
+
   constructor(options: TurnWheelGestureOptions<GestureName>) {
     super(options);
     this.sensitivity = options.sensitivity ?? 1;
@@ -179,6 +196,9 @@ export class TurnWheelGesture<GestureName extends string> extends Gesture<Gestur
     this.min = options.min ?? Number.MIN_SAFE_INTEGER;
     this.initialDelta = options.initialDelta ?? 0;
     this.invert = options.invert ?? false;
+    // If `preventDefault` is true, we must set `passive` to false to allow calling `preventDefault()` on the source event.
+    // If `preventDefault` is false, we can set `passive` to whatever the user specified
+    this.passive = !this.preventDefault && options.passive !== undefined ? options.passive : false;
 
     this.state.totalDeltaX = this.initialDelta;
     this.state.totalDeltaY = this.initialDelta;
@@ -195,6 +215,7 @@ export class TurnWheelGesture<GestureName extends string> extends Gesture<Gestur
       min: this.min,
       initialDelta: this.initialDelta,
       invert: this.invert,
+      passive: this.passive,
       requiredKeys: [...this.requiredKeys],
       preventIf: [...this.preventIf],
       // Apply any overrides passed to the method
@@ -215,7 +236,7 @@ export class TurnWheelGesture<GestureName extends string> extends Gesture<Gestur
     this.element.addEventListener('wheel', this.handleWheelEvent, {
       // Provide the `passive` value to prevent inconsistencies between chrome and safari
       // See https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#passive
-      passive: !this.preventDefault,
+      passive: this.passive,
     });
   }
 


### PR DESCRIPTION
## Summary

- Adds a `passive` option to `TurnWheelGestureOptions`, controlling the `passive` flag of the underlying `wheel` event listener.
- Lets consumers call `event.detail.srcEvent.preventDefault()` themselves on the gesture event when `preventDefault: false` is set on the gesture.
- When `preventDefault: true`, `passive` is forced to `false` so the gesture itself can call `preventDefault()`.