### PR TITLE
[charts] POC: LTTB sub-sampling on LineChart

### DIFF
--- a/packages/x-charts/src/LineChart/sampling/lttb.ts
+++ b/packages/x-charts/src/LineChart/sampling/lttb.ts
@@ -1,0 +1,69 @@
+/**
+ * Largest-Triangle-Three-Buckets (LTTB) downsampling.
+ *
+ * Reference: Sveinn Steinarsson, "Downsampling Time Series for Visual Representation",
+ * MSc thesis, University of Iceland, 2013.
+ *
+ * Returns the indices of the points kept after downsampling, in order.
+ * The first and last points are always preserved.
+ */
+export function lttbIndices(
+  xs: ArrayLike<number>,
+  ys: ArrayLike<number>,
+  threshold: number,
+): number[] {
+  const dataLen = xs.length;
+  if (threshold >= dataLen || threshold <= 2) {
+    const all = new Array(dataLen);
+    for (let i = 0; i < dataLen; i += 1) {
+      all[i] = i;
+    }
+    return all;
+  }
+
+  const sampled: number[] = new Array(threshold);
+  const every = (dataLen - 2) / (threshold - 2);
+
+  let a = 0;
+  sampled[0] = 0;
+
+  for (let i = 0; i < threshold - 2; i += 1) {
+    let avgX = 0;
+    let avgY = 0;
+    const avgRangeStart = Math.floor((i + 1) * every) + 1;
+    let avgRangeEnd = Math.floor((i + 2) * every) + 1;
+    avgRangeEnd = avgRangeEnd < dataLen ? avgRangeEnd : dataLen;
+    const avgRangeLen = avgRangeEnd - avgRangeStart;
+
+    for (let j = avgRangeStart; j < avgRangeEnd; j += 1) {
+      avgX += xs[j];
+      avgY += ys[j];
+    }
+    avgX /= avgRangeLen;
+    avgY /= avgRangeLen;
+
+    const rangeOffs = Math.floor(i * every) + 1;
+    const rangeTo = Math.floor((i + 1) * every) + 1;
+
+    const pointAX = xs[a];
+    const pointAY = ys[a];
+
+    let maxArea = -1;
+    let maxAreaPoint = rangeOffs;
+
+    for (let j = rangeOffs; j < rangeTo; j += 1) {
+      const area =
+        Math.abs((pointAX - avgX) * (ys[j] - pointAY) - (pointAX - xs[j]) * (avgY - pointAY)) * 0.5;
+      if (area > maxArea) {
+        maxArea = area;
+        maxAreaPoint = j;
+      }
+    }
+
+    sampled[i + 1] = maxAreaPoint;
+    a = maxAreaPoint;
+  }
+
+  sampled[threshold - 1] = dataLen - 1;
+  return sampled;
+}

--- a/packages/x-charts/src/LineChart/useLinePlotData.ts
+++ b/packages/x-charts/src/LineChart/useLinePlotData.ts
@@ -9,6 +9,8 @@ import { type ChartsXAxisProps, type ChartsYAxisProps } from '../models';
 import { getValueToPositionMapper, useLineSeriesContext, useXAxes, useYAxes } from '../hooks';
 import { DEFAULT_X_AXIS_KEY } from '../constants';
 import { type SeriesId } from '../models/seriesType/common';
+import { useDrawingArea } from '../hooks/useDrawingArea';
+import { lttbIndices } from './sampling/lttb';
 
 interface LinePlotDataPoint {
   d: string;
@@ -26,6 +28,7 @@ export function useLinePlotData(
   const defaultXAxisId = useXAxes().xAxisIds[0];
   const defaultYAxisId = useYAxes().yAxisIds[0];
   const getGradientId = useChartGradientIdBuilder();
+  const drawingArea = useDrawingArea();
 
   // This memo prevents odd line chart behavior when hydrating.
   const allData = React.useMemo(() => {
@@ -121,8 +124,36 @@ export function useLinePlotData(
             return { x, y: visibleStackedData[index], nullData };
           }) ?? [];
 
-        const d3Data = connectNulls ? formattedData.filter((d) => !d.nullData) : formattedData;
+        const d3DataFull = connectNulls ? formattedData.filter((d) => !d.nullData) : formattedData;
         const hidden = series[seriesId].hidden;
+
+        const sampling = series[seriesId].sampling;
+        let d3Data = d3DataFull;
+        if (sampling && d3DataFull.length > 2) {
+          const samplingConfig = typeof sampling === 'string' ? { type: sampling } : sampling;
+          if (samplingConfig.type === 'lttb') {
+            const target = samplingConfig.target ?? Math.max(2, Math.floor(drawingArea.width));
+            const threshold = samplingConfig.threshold ?? target;
+            if (d3DataFull.length > threshold) {
+              const hasNulls = d3DataFull.some((d) => d.nullData && !d.isExtension);
+              if (!hasNulls) {
+                const len = d3DataFull.length;
+                const xs = new Float64Array(len);
+                const ys = new Float64Array(len);
+                for (let i = 0; i < len; i += 1) {
+                  const point = d3DataFull[i];
+                  xs[i] = point.isExtension ? point.x : (xPosition(point.x) ?? 0);
+                  ys[i] = yScale(hidden ? point.y[0] : point.y[1]) ?? 0;
+                }
+                const indices = lttbIndices(xs, ys, target);
+                d3Data = new Array(indices.length);
+                for (let i = 0; i < indices.length; i += 1) {
+                  d3Data[i] = d3DataFull[indices[i]];
+                }
+              }
+            }
+          }
+        }
 
         const linePath = d3Line<{
           x: any;
@@ -152,7 +183,7 @@ export function useLinePlotData(
     }
 
     return linePlotData;
-  }, [seriesData, defaultXAxisId, defaultYAxisId, xAxes, yAxes, getGradientId]);
+  }, [seriesData, defaultXAxisId, defaultYAxisId, xAxes, yAxes, getGradientId, drawingArea]);
 
   return allData;
 }

--- a/packages/x-charts/src/models/seriesType/line.ts
+++ b/packages/x-charts/src/models/seriesType/line.ts
@@ -101,6 +101,31 @@ export interface CommonLineSeriesType {
    * @default 0
    */
   baseline?: number | 'min' | 'max';
+  /**
+   * Downsample the series before rendering.
+   *
+   * - `'lttb'` enables Largest-Triangle-Three-Buckets sampling with default `target` equal to the chart width in pixels.
+   * - Object form lets you override the algorithm, the threshold above which sampling kicks in, and the target number of points to keep.
+   *
+   * Sampling is skipped when the series contains `null` values.
+   *
+   * @default undefined
+   */
+  sampling?:
+    | 'lttb'
+    | {
+        type: 'lttb';
+        /**
+         * Sampling kicks in only when the series has more points than this threshold.
+         * @default chart width in pixels
+         */
+        threshold?: number;
+        /**
+         * Target number of points to keep after sampling.
+         * @default chart width in pixels
+         */
+        target?: number;
+      };
 }
 
 export interface LineSeriesType

--- a/test/performance-charts/tests/LineChartSubsampling.bench.tsx
+++ b/test/performance-charts/tests/LineChartSubsampling.bench.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import { benchmark } from '@mui/internal-benchmark';
+import { LineChart } from '@mui/x-charts/LineChart';
+
+function generateSeries(n: number) {
+  const xs = new Array<number>(n);
+  const ys = new Array<number>(n);
+  for (let i = 0; i < n; i += 1) {
+    xs[i] = i;
+    ys[i] = 50 + Math.sin(i / 5) * 25 + Math.cos(i / 137) * 10 + (Math.random() - 0.5) * 5;
+  }
+  return { xs, ys };
+}
+
+const SIZES = [10_000, 100_000, 1_000_000] as const;
+const datasets = new Map<number, { xs: number[]; ys: number[] }>();
+for (const n of SIZES) {
+  datasets.set(n, generateSeries(n));
+}
+
+const WIDTH = 800;
+const HEIGHT = 400;
+
+for (const n of SIZES) {
+  const { xs, ys } = datasets.get(n)!;
+  const opts = n >= 1_000_000 ? { warmupRuns: 1, runs: 3 } : undefined;
+
+  benchmark(
+    `LineChart ${n.toLocaleString()} pts — baseline (no sampling)`,
+    () => (
+      <LineChart
+        xAxis={[{ data: xs }]}
+        series={[{ data: ys, showMark: false }]}
+        width={WIDTH}
+        height={HEIGHT}
+      />
+    ),
+    opts,
+  );
+
+  benchmark(
+    `LineChart ${n.toLocaleString()} pts — LTTB sampling`,
+    () => (
+      <LineChart
+        xAxis={[{ data: xs }]}
+        series={[{ data: ys, showMark: false, sampling: 'lttb' }]}
+        width={WIDTH}
+        height={HEIGHT}
+      />
+    ),
+    opts,
+  );
+}


### PR DESCRIPTION
## Summary

POC for the **Charts Performance — Data processing** objective. Adds opt-in LTTB downsampling to `LineChart`. Sample is run on screen-space coords inside `useLinePlotData`, before the d3-shape line path is generated. Default target equals the chart width in pixels.

\`\`\`tsx
<LineChart
  series={[{ data: ys, sampling: 'lttb' }]}
  ...
/>
\`\`\`

## Bench (chromium, 800x400)

| Pts  | Baseline mount | LTTB mount | Speedup | Paint baseline / LTTB |
| ---- | -------------- | ---------- | ------- | --------------------- |
| 10k  | 16.6 ms        | 10.6 ms    | 1.57x   | —                     |
| 100k | 148 ms         | 80 ms      | 1.85x   | —                     |
| 1M   | 1504 ms        | 640 ms     | 2.35x   | **3034 ms / 645 ms**  |

## Constraints

- Skipped when the series contains \`null\` values (segmentation-free POC).
- See \`charts-perf-data-processing.md\` for the full study.

This POC stays as a reference point. The proposal goes through the async pipeline (Option B) which absorbs sampling into the worker.