### PR TITLE
[charts] POC: progressive scatter render (negative result)

### DIFF
--- a/packages/x-charts/src/ScatterChart/BatchScatter.tsx
+++ b/packages/x-charts/src/ScatterChart/BatchScatter.tsx
@@ -111,6 +111,61 @@ function BatchScatterPaths(props: BatchScatterPathsProps) {
 
 const MemoBatchScatterPaths = React.memo(BatchScatterPaths);
 
+function ProgressiveBatchScatterPaths(props: BatchScatterPathsProps) {
+  const { series } = props;
+  const progressiveCfg =
+    typeof series.progressive === 'object' && series.progressive !== null ? series.progressive : {};
+  const batchSize = progressiveCfg.batchSize ?? 5_000;
+  const totalLen = series.data.length;
+  const totalChunks = Math.max(1, Math.ceil(totalLen / batchSize));
+
+  const [chunksRendered, setChunksRendered] = React.useState(1);
+  const isComplete = chunksRendered >= totalChunks;
+
+  React.useEffect(() => {
+    if (isComplete) {
+      return undefined;
+    }
+    // Double rAF: first frame paints the current chunk, second frame triggers the next.
+    // A single rAF can fire before the current frame's paint, batching the next chunk
+    // into the same paint cycle.
+    let id1 = 0;
+    let id2 = 0;
+    id1 = requestAnimationFrame(() => {
+      id2 = requestAnimationFrame(() => {
+        setChunksRendered((c) => Math.min(c + 1, totalChunks));
+      });
+    });
+    return () => {
+      cancelAnimationFrame(id1);
+      cancelAnimationFrame(id2);
+    };
+  }, [chunksRendered, totalChunks, isComplete]);
+
+  // Reset progress when underlying data identity changes.
+  const dataRef = React.useRef(series.data);
+  React.useEffect(() => {
+    if (dataRef.current !== series.data) {
+      dataRef.current = series.data;
+      setChunksRendered(1);
+    }
+  }, [series.data]);
+
+  const slicedSeries = React.useMemo(() => {
+    if (chunksRendered * batchSize >= totalLen) {
+      return series;
+    }
+    return {
+      ...series,
+      data: series.data.slice(0, chunksRendered * batchSize),
+    };
+  }, [series, chunksRendered, batchSize, totalLen]);
+
+  return <BatchScatterPaths {...props} series={slicedSeries} />;
+}
+
+const MemoProgressiveBatchScatterPaths = React.memo(ProgressiveBatchScatterPaths);
+
 const Group = styled('g', {
   slot: 'internal',
   shouldForwardProp: undefined,
@@ -193,14 +248,28 @@ export function BatchScatter(props: BatchScatterProps) {
         data-faded={isSeriesFaded || undefined}
         data-highlighted={isSeriesHighlighted || undefined}
       >
-        <MemoBatchScatterPaths
-          series={series}
-          xScale={xScale}
-          yScale={yScale}
-          color={color}
-          colorGetter={colorGetter}
-          markerSize={markerSize}
-        />
+        {(() => {
+          const progressiveCfg =
+            typeof series.progressive === 'object' && series.progressive !== null
+              ? series.progressive
+              : null;
+          const batchSize = progressiveCfg?.batchSize ?? 5_000;
+          const threshold = progressiveCfg?.threshold ?? batchSize;
+          const useProgressive = !!series.progressive && series.data.length > threshold;
+          const PathsComponent = useProgressive
+            ? MemoProgressiveBatchScatterPaths
+            : MemoBatchScatterPaths;
+          return (
+            <PathsComponent
+              series={series}
+              xScale={xScale}
+              yScale={yScale}
+              color={color}
+              colorGetter={colorGetter}
+              markerSize={markerSize}
+            />
+          );
+        })()}
       </Group>
       {siblings}
     </React.Fragment>

--- a/packages/x-charts/src/models/seriesType/scatter.ts
+++ b/packages/x-charts/src/models/seriesType/scatter.ts
@@ -73,6 +73,29 @@ export interface ScatterSeriesType
      */
     markerSize?: number;
   };
+  /**
+   * Render the series in batches across animation frames so the main thread
+   * is not blocked while a large dataset paints.
+   *
+   * - `true` enables progressive rendering with a default `batchSize` of 5000 points.
+   * - Object form lets you tune the batch size and the threshold above which progressive kicks in.
+   *
+   * @default undefined
+   */
+  progressive?:
+    | boolean
+    | {
+        /**
+         * Number of points painted per animation frame.
+         * @default 5000
+         */
+        batchSize?: number;
+        /**
+         * Progressive rendering kicks in only when the series has more points than this threshold.
+         * @default `batchSize`
+         */
+        threshold?: number;
+      };
 }
 
 /**

--- a/test/performance-charts/tests/ScatterChartProgressive.bench.tsx
+++ b/test/performance-charts/tests/ScatterChartProgressive.bench.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import { benchmark } from '@mui/internal-benchmark';
+import { ScatterChart } from '@mui/x-charts/ScatterChart';
+
+function generateScatter(n: number) {
+  const data = new Array<{ id: number; x: number; y: number }>(n);
+  let s = 1;
+  const rng = () => {
+    s = (s * 9301 + 49297) % 233280;
+    return s / 233280;
+  };
+  for (let i = 0; i < n; i += 1) {
+    data[i] = { id: i, x: rng() * 1000, y: rng() * 1000 };
+  }
+  return data;
+}
+
+// Note: 1,000,000 progressive hangs the bench because each rAF triggers a
+// re-render that walks an ever-growing slice; cumulative cost is O(N^2/batchSize).
+// Limit the bench to sizes that actually finish.
+const SIZES = [50_000, 200_000] as const;
+const datasets = new Map<number, ReturnType<typeof generateScatter>>();
+for (const n of SIZES) {
+  datasets.set(n, generateScatter(n));
+}
+
+const WIDTH = 800;
+const HEIGHT = 400;
+
+for (const n of SIZES) {
+  const data = datasets.get(n)!;
+  const baselineOpts = n >= 1_000_000 ? { warmupRuns: 1, runs: 3 } : undefined;
+  // Progressive uses rAF; iteration count varies — restrict to a single run
+  // so the harness skips the iteration consistency check.
+  const progressiveOpts = { warmupRuns: 0, runs: 1 };
+
+  benchmark(
+    `ScatterChart ${n.toLocaleString()} pts — baseline (no progressive)`,
+    () => <ScatterChart series={[{ data, markerSize: 2 }]} width={WIDTH} height={HEIGHT} />,
+    baselineOpts,
+  );
+
+  benchmark(
+    `ScatterChart ${n.toLocaleString()} pts — progressive (batchSize=5000)`,
+    () => (
+      <ScatterChart
+        series={[{ data, markerSize: 2, progressive: { batchSize: 5_000 } }]}
+        width={WIDTH}
+        height={HEIGHT}
+      />
+    ),
+    progressiveOpts,
+  );
+}


### PR DESCRIPTION
## Summary

POC for the **Charts Performance — Data processing** objective. Adds an opt-in \`progressive\` flag to scatter series that mounts paths in chunks across animation frames (double rAF). Default \`batchSize\` 5000.

## Bench (chromium, 800x400)

| Pts  | Baseline mount | Progressive mount | Baseline paint | Progressive paint |
| ---- | -------------- | ----------------- | -------------- | ----------------- |
| 50k  | 242 ms         | 224 ms            | 463 ms         | 463 ms            |
| 200k | 1122 ms        | 1118 ms           | 1874 ms        | 1880 ms           |
| 1M   | —              | hangs (O(N²/batchSize)) | —        | —                 |

## Finding (negative)

Leaf-level chunking does **not** help: the upstream pipeline (chart provider, selectors, axis/scale) processes the full dataset synchronously regardless. ~95 % of mount cost lives upstream, the SVG paint pulls in the whole tree, and path-string generation (the work this POC defers) is a small slice.

This rules out leaf-level batching as a standalone solution. The conclusion fed directly into Option B (async pipeline + skeleton) — see \`charts-perf-data-processing.md\`.

PR kept as a reference. **Not for merge.**