### PR TITLE
[charts] POC: Web Worker transfer cost spike

### DIFF
--- a/test/performance-charts/tests/WorkerTransferSpike.bench.tsx
+++ b/test/performance-charts/tests/WorkerTransferSpike.bench.tsx
@@ -1,0 +1,122 @@
+// Standalone perf spike for Web Worker data transfer modes.
+// Runs as a vitest browser test (not via @mui/internal-benchmark) because we
+// want raw transfer timings, not React render timings.
+
+import { it, expect } from 'vitest';
+
+type Mode = 'main' | 'clone' | 'transfer' | 'sab';
+
+interface Stats {
+  mode: Mode;
+  total: number;
+  send: number;
+  workerProcessing: number;
+  receive: number;
+  note?: string;
+}
+
+function generate(n: number) {
+  const data = new Float64Array(2 * n);
+  let s = 1;
+  for (let i = 0; i < 2 * n; i += 1) {
+    s = (s * 9301 + 49297) % 233280;
+    data[i] = s / 233280;
+  }
+  return data;
+}
+
+function processSync(buffer: Float64Array) {
+  for (let i = 0; i < buffer.length; i += 2) {
+    buffer[i] = buffer[i] * 0.001;
+    buffer[i + 1] = buffer[i + 1] * 0.001;
+  }
+}
+
+async function runOnce(mode: Mode, n: number): Promise<Stats> {
+  const data = generate(n);
+  const start = performance.now();
+
+  if (mode === 'main') {
+    processSync(data);
+    const total = performance.now() - start;
+    return { mode, total, send: 0, workerProcessing: total, receive: 0 };
+  }
+
+  const worker = new Worker(new URL('./workerSpike/worker.ts', import.meta.url), {
+    type: 'module',
+  });
+
+  const messageReceived = new Promise<{ processingMs: number }>((resolve) => {
+    worker.onmessage = (e) => resolve(e.data as { processingMs: number });
+  });
+
+  const tBeforeSend = performance.now();
+
+  try {
+    if (mode === 'sab') {
+      const sab = new SharedArrayBuffer(data.byteLength);
+      new Float64Array(sab).set(data);
+      worker.postMessage({ mode, sab });
+    } else if (mode === 'transfer') {
+      worker.postMessage({ mode, data }, [data.buffer]);
+    } else {
+      worker.postMessage({ mode, data });
+    }
+  } catch (err) {
+    worker.terminate();
+    return {
+      mode,
+      total: 0,
+      send: 0,
+      workerProcessing: 0,
+      receive: 0,
+      note: `unsupported: ${(err as Error).message}`,
+    };
+  }
+
+  const send = performance.now() - tBeforeSend;
+  const result = await messageReceived;
+  const total = performance.now() - start;
+  const workerProcessing = result.processingMs;
+  const receive = total - send - workerProcessing;
+  worker.terminate();
+
+  return { mode, total, send, workerProcessing, receive };
+}
+
+const SIZES = [100_000, 1_000_000] as const;
+const MODES: Mode[] = ['main', 'clone', 'transfer', 'sab'];
+const RUNS = 5;
+
+const results: Stats[][] = [];
+
+for (const n of SIZES) {
+  for (const mode of MODES) {
+    it(`worker transfer ${n.toLocaleString()} pts — ${mode}`, async () => {
+      const samples: Stats[] = [];
+      for (let i = 0; i < RUNS; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        samples.push(await runOnce(mode, n));
+      }
+      const note = samples[0].note;
+      const totals = samples.map((s) => s.total);
+      const sends = samples.map((s) => s.send);
+      const workers = samples.map((s) => s.workerProcessing);
+      const receives = samples.map((s) => s.receive);
+      const mean = (a: number[]) => a.reduce((p, c) => p + c, 0) / a.length;
+
+      // eslint-disable-next-line no-console
+      console.log(
+        `[spike] n=${n} mode=${mode}` +
+          (note ? ` note="${note}"` : '') +
+          ` total_mean=${mean(totals).toFixed(2)}` +
+          ` send_mean=${mean(sends).toFixed(2)}` +
+          ` worker_mean=${mean(workers).toFixed(2)}` +
+          ` recv_mean=${mean(receives).toFixed(2)}` +
+          ` runs=${RUNS}`,
+      );
+      results.push(samples);
+      expect(samples.length).toBe(RUNS);
+    }, 60_000);
+  }
+}

--- a/test/performance-charts/tests/workerSpike/worker.ts
+++ b/test/performance-charts/tests/workerSpike/worker.ts
@@ -1,0 +1,39 @@
+// Simulated scatter "seriesProcessor" workload: scale each (x, y) pair.
+// Representative of pure CPU work that the real seriesProcessor does
+// (mapping dataset -> tuples + applying defaults).
+
+type WorkerMessage =
+  | { mode: 'clone' | 'transfer'; data: Float64Array }
+  | { mode: 'sab'; sab: SharedArrayBuffer };
+
+self.addEventListener('message', (e: MessageEvent<WorkerMessage>) => {
+  const msg = e.data;
+  let buffer: Float64Array;
+
+  if (msg.mode === 'sab') {
+    buffer = new Float64Array(msg.sab);
+  } else {
+    buffer = msg.data;
+  }
+
+  const t0 = performance.now();
+
+  // Simulated work: scale each (x, y) pair.
+  for (let i = 0; i < buffer.length; i += 2) {
+    buffer[i] = buffer[i] * 0.001;
+    buffer[i + 1] = buffer[i + 1] * 0.001;
+  }
+
+  const processingMs = performance.now() - t0;
+
+  if (msg.mode === 'sab') {
+    (self as unknown as Worker).postMessage({ mode: 'sab', processingMs });
+  } else if (msg.mode === 'transfer') {
+    (self as unknown as Worker).postMessage(
+      { mode: 'transfer', processingMs, data: buffer },
+      { transfer: [buffer.buffer] },
+    );
+  } else {
+    (self as unknown as Worker).postMessage({ mode: 'clone', processingMs, data: buffer });
+  }
+});


### PR DESCRIPTION
## Summary

POC for the **Charts Performance — Data processing** objective. Standalone vitest browser test that measures wallclock cost of moving a Float64 buffer through three Web Worker transfer mechanisms vs the synchronous main-thread baseline.

## Bench (chromium, 1M points = 16 MB Float64)

| Mode               | Total       | Send | Worker | Receive |
| ------------------ | ----------- | ---- | ------ | ------- |
| main (sync)        | 5.5 ms      | —    | 5.5    | —       |
| worker via clone   | 16.9 ms     | 1.8  | 5.6    | 9.5     |
| worker via transfer| 8.9 ms      | 0.06 | 5.0    | 3.9     |
| worker via SAB     | unsupported | —    | —      | —       |

## Findings

1. \`Transferable\` beats clone ~2x — should be the default.
2. Worker round-trip overhead (~10 ms at 1M with transfer) often exceeds the saved compute for trivial workloads. Worker is justified only when the processing cost ≥ ~50–100 ms.
3. \`SharedArrayBuffer\` requires app-level COOP+COEP server config. Document as opt-in for hosts that can configure cross-origin isolation.

Inputs to the architecture decision in Option B. See \`charts-perf-data-processing.md\`.

**Not for merge** — POC reference.