### PR TITLE
[charts] POC: async scatter pipeline with skeleton

### DIFF
--- a/test/performance-charts/tests/AsyncScatter.bench.tsx
+++ b/test/performance-charts/tests/AsyncScatter.bench.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import { benchmark } from '@mui/internal-benchmark';
+import { ScatterChart } from '@mui/x-charts/ScatterChart';
+import { AsyncScatter } from './asyncPipeline/AsyncScatter';
+
+function generateFlat(n: number) {
+  const data = new Float64Array(2 * n);
+  let s = 1;
+  for (let i = 0; i < 2 * n; i += 1) {
+    s = (s * 9301 + 49297) % 233280;
+    data[i] = s / 233280;
+  }
+  return data;
+}
+
+function generateObjects(n: number) {
+  const data = new Array<{ id: number; x: number; y: number }>(n);
+  let s = 1;
+  for (let i = 0; i < n; i += 1) {
+    s = (s * 9301 + 49297) % 233280;
+    const x = s / 233280;
+    s = (s * 9301 + 49297) % 233280;
+    const y = s / 233280;
+    data[i] = { id: i, x, y };
+  }
+  return data;
+}
+
+const SIZES = [100_000, 1_000_000] as const;
+const WIDTH = 800;
+const HEIGHT = 400;
+
+// Pre-generate object datasets for the sync baseline (kept for the lifetime of the run).
+const objectDatasets = new Map<number, ReturnType<typeof generateObjects>>();
+for (const n of SIZES) {
+  objectDatasets.set(n, generateObjects(n));
+}
+
+for (const n of SIZES) {
+  // Async path transfers the buffer, so each iteration needs its own copy.
+  benchmark(
+    `AsyncScatter ${n.toLocaleString()} pts — async (worker)`,
+    () => <AsyncScatter data={generateFlat(n)} width={WIDTH} height={HEIGHT} markerSize={2} />,
+    async ({ waitForElementTiming }) => {
+      await waitForElementTiming('async-done', 60_000);
+    },
+    { warmupRuns: 1, runs: 3 },
+  );
+
+  const syncData = objectDatasets.get(n)!;
+  const syncOpts = n >= 1_000_000 ? { warmupRuns: 1, runs: 3 } : undefined;
+  benchmark(
+    `AsyncScatter ${n.toLocaleString()} pts — sync baseline (ScatterChart)`,
+    () => (
+      <ScatterChart series={[{ data: syncData, markerSize: 2 }]} width={WIDTH} height={HEIGHT} />
+    ),
+    syncOpts,
+  );
+}

--- a/test/performance-charts/tests/asyncPipeline/AsyncScatter.tsx
+++ b/test/performance-charts/tests/asyncPipeline/AsyncScatter.tsx
@@ -1,0 +1,97 @@
+import * as React from 'react';
+
+interface AsyncScatterProps {
+  /**
+   * Flat Float64 buffer of (x, y) pairs. Length = 2 * pointCount.
+   */
+  data: Float64Array;
+  width: number;
+  height: number;
+  markerSize?: number;
+  padding?: number;
+}
+
+interface WorkerResult {
+  paths: string[];
+  processingMs: number;
+  pointCount: number;
+}
+
+/**
+ * POC scatter renderer that offloads scale computation + path generation to a Web Worker.
+ * Renders a skeleton (border + "loading" label) while the worker computes, then swaps in the
+ * full path elements when the worker returns.
+ *
+ * Intentionally bypasses the lib's ChartProvider pipeline — this is an architecture spike, not
+ * a production-shape integration.
+ */
+export function AsyncScatter(props: AsyncScatterProps) {
+  const { data, width, height, markerSize = 2, padding = 20 } = props;
+  const [result, setResult] = React.useState<WorkerResult | null>(null);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    const worker = new Worker(new URL('./scatterWorker.ts', import.meta.url), {
+      type: 'module',
+    });
+
+    worker.onmessage = (event: MessageEvent<WorkerResult>) => {
+      if (cancelled) {
+        return;
+      }
+      setResult(event.data);
+    };
+
+    // Transfer the buffer (zero-copy out). Caller must not reuse `data` after this.
+    worker.postMessage({ data, width, height, padding, markerSize }, [data.buffer]);
+
+    return () => {
+      cancelled = true;
+      worker.terminate();
+    };
+  }, [data, width, height, padding, markerSize]);
+
+  return (
+    <React.Fragment>
+      <svg width={width} height={height} style={{ border: '1px solid #ddd' }}>
+        {result === null ? (
+          <React.Fragment>
+            <rect
+              x={padding}
+              y={padding}
+              width={width - 2 * padding}
+              height={height - 2 * padding}
+              fill="#f5f5f5"
+            />
+            <text
+              x={width / 2}
+              y={height / 2}
+              textAnchor="middle"
+              dominantBaseline="middle"
+              fontSize={14}
+            >
+              loading…
+            </text>
+          </React.Fragment>
+        ) : (
+          result.paths.map((d, i) => <path key={i} fill="#1976d2" d={d} />)
+        )}
+      </svg>
+      {result !== null && (
+        <span
+          elementtiming="async-done"
+          style={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            opacity: 0.01,
+            pointerEvents: 'none',
+            fontSize: 1,
+          }}
+        >
+          {'\xA0'}
+        </span>
+      )}
+    </React.Fragment>
+  );
+}

--- a/test/performance-charts/tests/asyncPipeline/scatterWorker.ts
+++ b/test/performance-charts/tests/asyncPipeline/scatterWorker.ts
@@ -1,0 +1,73 @@
+// Async-pipeline POC: worker computes scatter paths end-to-end.
+// Input: Float64Array of (x, y) pairs + viewport metrics.
+// Output: SVG <path d=...> strings (one per 1000-point chunk).
+
+interface Msg {
+  data: Float64Array;
+  width: number;
+  height: number;
+  padding: number;
+  markerSize: number;
+}
+
+interface Result {
+  paths: string[];
+  processingMs: number;
+  pointCount: number;
+}
+
+const ALMOST_ZERO = 0.01;
+const MAX_POINTS_PER_PATH = 1000;
+
+self.addEventListener('message', (event: MessageEvent<Msg>) => {
+  const { data, width, height, padding, markerSize } = event.data;
+  const t0 = performance.now();
+
+  let xMin = Infinity;
+  let xMax = -Infinity;
+  let yMin = Infinity;
+  let yMax = -Infinity;
+  for (let i = 0; i < data.length; i += 2) {
+    const x = data[i];
+    const y = data[i + 1];
+    if (x < xMin) {
+      xMin = x;
+    }
+    if (x > xMax) {
+      xMax = x;
+    }
+    if (y < yMin) {
+      yMin = y;
+    }
+    if (y > yMax) {
+      yMax = y;
+    }
+  }
+
+  const innerW = width - 2 * padding;
+  const innerH = height - 2 * padding;
+  const xRange = xMax - xMin || 1;
+  const yRange = yMax - yMin || 1;
+
+  const paths: string[] = [];
+  const buf: string[] = [];
+  let inBuf = 0;
+  for (let i = 0; i < data.length; i += 2) {
+    const sx = padding + ((data[i] - xMin) / xRange) * innerW;
+    const sy = height - padding - ((data[i + 1] - yMin) / yRange) * innerH;
+    buf.push(`M${sx - markerSize} ${sy} a${markerSize} ${markerSize} 0 1 1 0 ${ALMOST_ZERO}`);
+    inBuf += 1;
+    if (inBuf >= MAX_POINTS_PER_PATH) {
+      paths.push(buf.join(''));
+      buf.length = 0;
+      inBuf = 0;
+    }
+  }
+  if (buf.length) {
+    paths.push(buf.join(''));
+  }
+
+  const processingMs = performance.now() - t0;
+  const result: Result = { paths, processingMs, pointCount: data.length / 2 };
+  (self as unknown as Worker).postMessage(result);
+});


### PR DESCRIPTION
## Summary

POC for the **Charts Performance — Data processing** objective. Architecture spike for the async-pipeline approach (Option B in the findings doc).

Three pieces:
- `scatterWorker.ts` — receives a Float64 (x, y) buffer + viewport metrics, computes the linear scale, and returns SVG path strings.
- `AsyncScatter.tsx` — experimental React component that renders a skeleton until the worker returns, then swaps in `<path>` elements.
- `AsyncScatter.bench.tsx` — pits the spike against `ScatterChart` at 100k and 1M.

## Bench (chromium, 800x400)

| Pts  | Async first paint (skeleton) | Async full paint | Sync `ScatterChart` paint |
| ---- | ---------------------------- | ---------------- | ------------------------- |
| 100k | 6 ms                         | 115 ms           | 1076 ms                   |
| 1M   | **22 ms**                    | 1258 ms          | **12 599 ms** (570x first)|

## Caveat

The component bypasses the lib's `ChartProvider` pipeline; the 10× full-paint speedup conflates worker offload AND no-pipeline. Production integration re-adds the pipeline tax. First-paint win (skeleton) survives regardless.

This POC validated the architecture; the proposed implementation is on `feat/async-chart-pipeline` (#22370). See `charts-perf-data-processing.md`.

**Not for merge** — POC reference, superseded by the async-pipeline plugin PR.