### PR TITLE
[charts] POC: MapReduce-style multi-worker fan-out (SAB)

### DIFF
--- a/charts-perf-data-processing.md
+++ b/charts-perf-data-processing.md
@@ -1,0 +1,171 @@
+# Decision
+
+<aside>
+
+✅ **Option: B — Async pipeline + skeleton, layered on top of cache + LTTB**
+
+**Why?** POC 5b shows the only structural lift large enough to hit the marketing target ("smooth at 1M, responsive at 100k"). At 1M scatter, current `ScatterChart` blocks the main thread for ~12.6 s before first paint; the async-pipeline POC pulls first paint down to **22 ms** and full paint to ~1.3 s. Sampling and caching alone (Option A) cap out at ~2x mount time and don't address the freeze-before-first-paint UX.
+
+</aside>
+
+# Context
+
+We want to be able to render line/bar/scatter charts at 100k–1M points without freezing the browser, and to be perceived as a "fast" charts library next to ECharts/AG Charts/Highcharts. WebGL rendering (the previous objective) lifted the "too many elements on screen" ceiling for some chart types. This effort is about the other half: data prep, sampling, and main-thread responsiveness during processing.
+
+Six small POCs were built on dedicated branches to evaluate concrete approaches against the existing codebase. None of the branches are pushed; PR links below will be filled once we agree on the path forward.
+
+# Problems
+
+1. **Frozen browser during initial mount at 1M points.** `ScatterChart` mount + first paint blocks the main thread for ~12.6 s at 1M. Hover, click, scroll — all unresponsive.
+2. **Sampling alone caps below 1M.** LTTB on a line series brings 100k from laggy to smooth, but at 1M the upstream pipeline (d3-stack, `flatMap` over `xData`) still walks the full array and dominates.
+3. **No mechanism to keep the main thread free while processing.** Selectors run synchronously inside React render. There is no async/worker entry point in the current pipeline.
+4. **Progressive rendering at the leaf component level does not help.** The dominant cost is upstream of the leaf, so chunking just the path-string emission saves ~5 % of mount time.
+5. **Pan/zoom re-runs sampling from scratch each render.** No memoization of the sampled output.
+6. **Branding cost of `SharedArrayBuffer`.** SAB is the cheapest worker transfer mode but requires app-level COOP+COEP server config.
+
+# Options
+
+## A. Incremental wins (sampling + cache + transfer-mode worker for sampling)
+
+Ship LTTB sub-sampling on line/bar (POC 1), viewport-keyed memoization cache (POC 6), and optionally move the LTTB call itself into a worker (POC 5 transfer findings). Keep the existing synchronous selector pipeline. No skeleton state; mount is still synchronous, just cheaper.
+
+**What lands**
+
+- Line series gets a `sampling: 'lttb'` opt-in (POC 1).
+- Bar series gets a min/max bucketing equivalent (not built — projected from POC 1).
+- Sampler output is memoized per `(data ref, target, viewport)` (POC 6).
+- Optionally the LTTB pass moves to a worker.
+
+**What it buys**
+
+- 100k line series goes from 148 ms mount to 80 ms (POC 1).
+- 1M line series mount drops from 1.5 s to 0.6 s (POC 1).
+- Re-renders with stable data prop hit the cache for free (POC 6, ~50x).
+
+**What it doesn't buy**
+
+- 1M scatter still freezes the browser before first paint. The pipeline is synchronous and must process the full dataset before React can commit.
+- The "responsive while loading" claim is not honestly defensible.
+
+## B. Async pipeline with skeleton chart (this objective's main bet)
+
+Refactor the chart so a worker computes the heavy parts of the pipeline (extremums, scale, path-string generation) off the main thread. The component renders a skeleton (axes + placeholder) immediately, then swaps in the full data when the worker returns. POC 5b validated this end-to-end for scatter; bench numbers are dramatic.
+
+**What lands**
+
+- A worker entry shipped with the lib that takes raw data + viewport metrics and returns ready-to-paint SVG path strings (or WebGL draw lists, where applicable).
+- New chart-level prop (likely `processInWorker` or auto-trigger above a threshold) wiring the chart through the worker.
+- Skeleton render (axes + empty plot area) while the worker is busy.
+- Cancellation when the data prop changes mid-flight.
+- Layered over A: LTTB sampling and the cache run inside the worker, so the main thread never sees them.
+
+**What it buys**
+
+- 1M scatter first paint at **22 ms** (vs 12.6 s today). 570x.
+- 1M scatter full paint at **1.3 s** (vs 12.6 s today). 10x.
+- Main thread stays responsive — hover, click, pan all work during processing.
+- Marketing claim becomes defensible against ECharts numbers.
+
+**What it costs**
+
+- Architectural refactor of the chart pipeline (selectors → state-driven processed series).
+- Worker bundling that survives downstream consumer bundlers (Vite/Webpack/Next).
+- Open design questions: per-chart vs shared worker pool, cancellation semantics, data-shape (Float64 zero-copy vs `{x,y}[]` clone).
+
+## Comparison
+
+[Comparison](https://www.notion.so/350cbfe7b660800fa32af2be73e9d5d1?pvs=21)
+
+| Lever                              | A: incremental           | B: async pipeline                         |
+| ---------------------------------- | ------------------------ | ----------------------------------------- |
+| Engineering size                   | small / medium           | large                                     |
+| 100k line mount                    | 80 ms                    | 80 ms (same; A's sampling runs in worker) |
+| 1M scatter first paint             | ~6 s (still synchronous) | **22 ms**                                 |
+| 1M scatter full paint              | ~6 s                     | **1.3 s**                                 |
+| Main thread free during processing | no                       | yes                                       |
+| Marketing claim "responsive at 1M" | no                       | yes                                       |
+| Risk surface                       | low (opt-in props)       | medium (pipeline rewrite)                 |
+| Composes with WebGL renderer work  | yes                      | yes                                       |
+
+# Proposal
+
+**Option: B — async pipeline + skeleton, with A's pieces (LTTB + cache) running inside the worker.**
+
+**Why?**
+
+- POC 5b numbers leave little room for argument on the user-perceived metric: 22 ms vs 12.6 s to first paint at 1M. No combination of sampling and caching closes that gap, because the freeze happens _before_ sampling can run.
+- The architecture extends naturally to line and bar (worker is the right home for d3-stack and `flatMap`-over-`xData` at scale) and composes with the existing WebGL renderer (worker can produce WebGL draw lists instead of SVG path strings).
+- POC 1 (sampling) and POC 6 (cache) become implementation details inside the worker rather than separate features. Their measured wins still apply; they just stop blocking the main thread.
+- POC 4 (progressive at leaf level) showed conclusively that defer-and-batch at the rendering layer doesn't address the upstream cost. Don't pursue it.
+- POC 5 (transfer cost) tells us to default to `Transferable` and treat `SharedArrayBuffer` as an opt-in for hosts that can configure COOP+COEP. No need to take that branding cost as a default.
+
+**Sequence of work**
+
+1. Land POC 1 (LTTB on line) as the first user-visible deliverable. Cheap, opt-in, real win at 100k. (~1 sprint)
+2. Design the async-pipeline API and worker boundary. Resolve open questions on shape, cancellation, bundling. (~1 sprint)
+3. Build the worker for scatter first (smallest pipeline). Ship behind an experimental prop. (~2 sprints)
+4. Roll the same pattern to line and bar, with LTTB + cache running inside the worker. (~2 sprints)
+5. Document `SharedArrayBuffer` as an advanced opt-in for hosts that can enable cross-origin isolation. (~0.5 sprint)
+6. _(Optional, follow-up)_ MapReduce-style multi-worker fan-out for the path-generation stage. POC 7 measured ~3x on top of the single-worker baseline at 1M, gated on cross-origin isolation being enabled. Worth doing if customer demand justifies; otherwise can wait. (~1 sprint)
+
+# Benchmarks
+
+All numbers measured on a single machine (chromium via vitest browser, predictable JS flags, software rendering). 800x400 chart unless noted. Higher-is-worse for milliseconds.
+
+- **POC 1 — LTTB sub-sampling on `LineChart`** (branch `perf-poc/subsampling-line-lttb`, commit `716b783b2c`)
+  - 10k pts: mount 16.6 ms → 10.6 ms (1.57x)
+  - 100k pts: mount 148 ms → 80 ms (1.85x)
+  - 1M pts: mount 1504 ms → 640 ms; paint **3034 ms → 645 ms** (4.7x paint)
+  - Skipped when series contains nulls (segmentation-free POC).
+
+- **POC 4 — Progressive `ScatterChart` render at leaf level** (branch `perf-poc/progressive-scatter`, commit `a40467831f`)
+  - 50k: mount 242 ms → 224 ms; paint 463 ms → 463 ms.
+  - 200k: mount 1122 ms → 1118 ms; paint 1874 ms → 1880 ms.
+  - 1M: hangs (cumulative O(N²/batchSize) re-walk in naive impl).
+  - **Conclusion: ineffective** — upstream pipeline dominates, leaf-level chunking saves ~5 % of mount.
+
+- **POC 5 — Web Worker transfer cost spike** (branch `perf-poc/worker-series-processor`, commit `82a37b0af4`)
+  - 1M Float64 (16 MB), wallclock to round-trip:
+    - main (sync): 5.5 ms
+    - worker via clone: 16.9 ms (send 1.8 + worker 5.6 + recv 9.5)
+    - worker via transfer: 8.9 ms (send 0.06 + worker 5.0 + recv 3.9)
+    - worker via SAB: **unsupported** (vitest browser does not set COOP/COEP)
+  - **Default to `Transferable`.** SAB only as opt-in.
+
+- **POC 5b — Async scatter pipeline with skeleton** (branch `perf-poc/worker-async-pipeline`, commit `aa6611ad7d`)
+  - 100k: async first paint **6 ms** vs sync `ScatterChart` 1076 ms (180x); async full paint 115 ms vs 1076 ms (9x).
+  - 1M: async first paint **22 ms** vs sync 12 599 ms (**570x**); async full paint 1258 ms vs 12 599 ms (**10x**).
+  - Caveat: experimental component bypasses the lib `ChartProvider` pipeline. Production integration will re-add some of that overhead. Conservative estimate: 3–5x full-paint win after re-integration; first-paint win stays intact regardless.
+
+- **POC 6 — Viewport-keyed sample cache** (branch `perf-poc/memo-sampled-cache`, commit `425689a805`)
+  - 1M, 60 calls, per-call cost:
+    - Uncached LTTB: 5.25 ms
+    - Cached, full-range repeats (98 % hits): **0.10 ms** (~50x)
+    - Cached, continuous pan, no quantize (0 % hits): 26.7 ms (worse — slice cost)
+    - Cached, pan with 5 % quantize (48 % hits): 13.7 ms
+    - Cached, zoom cycle through 5 levels (97 % hits): **0.61 ms**
+  - **Free win for re-renders** (Scenario B). **Strong fit for zoom-snap UX** (Scenario E). **Continuous pan needs worker offload, not cache.**
+
+- **POC 7 — MapReduce-style multi-worker fan-out with `SharedArrayBuffer`** (branch `perf-poc/mapreduce-sab`, commit `3dc9979901`)
+  - 1M scatter, path generation only, hardwareConcurrency=11, mean of 5 runs:
+    - 1 worker: 228.8 ms (baseline)
+    - 2 workers: 127.5 ms (1.79x)
+    - 4 workers: 88.3 ms (2.59x)
+    - 8 workers: **77.0 ms (2.97x)**
+  - Speedup ceiling ~3x, not Nx. Bottleneck above 4 workers is output cloning — path strings posted back via structured clone (~10 MB / N per worker). To break through, paths would need to be written into a shared output buffer (UTF-8 bytes) and read back as one string.
+  - Required enabling `Cross-Origin-Opener-Policy: same-origin` + `Cross-Origin-Embedder-Policy: require-corp` in the test/perf vitest config. App-level config in production.
+  - Browser paint of 1M paths still happens after worker processing — MapReduce only speeds up JS work, not rasterization.
+  - **Recommended as a follow-up to Option B**, gated on customer demand for cross-origin isolation. Meaningful at 1M+ but not transformative.
+
+## Branches and PRs
+
+| POC                                 | Branch                             | Commit       | PR                                 |
+| ----------------------------------- | ---------------------------------- | ------------ | ---------------------------------- |
+| 1. LTTB sub-sampling (line)         | `perf-poc/subsampling-line-lttb`   | `716b783b2c` | _(not opened)_                     |
+| 4. Progressive scatter (leaf level) | `perf-poc/progressive-scatter`     | `a40467831f` | _(not opened — negative result)_   |
+| 5. Worker transfer cost spike       | `perf-poc/worker-series-processor` | `82a37b0af4` | _(not opened)_                     |
+| 5b. Async pipeline + skeleton       | `perf-poc/worker-async-pipeline`   | `aa6611ad7d` | _(not opened — proposed approach)_ |
+| 6. Viewport-keyed sample cache      | `perf-poc/memo-sampled-cache`      | `425689a805` | _(not opened)_                     |
+| 7. MapReduce SAB fan-out            | `perf-poc/mapreduce-sab`           | `3dc9979901` | _(not opened — follow-up)_         |
+
+POC 2 (bar bucket sub-sampling) and POC 3 (progressive line render) were scoped but not built. Bar bucket is a small port of POC 1; progressive line was deprioritised after POC 4's negative result.

--- a/test/performance-charts/tests/MapReduceSAB.bench.tsx
+++ b/test/performance-charts/tests/MapReduceSAB.bench.tsx
@@ -1,0 +1,178 @@
+import { it, expect } from 'vitest';
+
+interface PartitionResult {
+  paths: string[];
+  processingMs: number;
+  start: number;
+  end: number;
+}
+
+interface RunStats {
+  workerCount: number;
+  pointCount: number;
+  total: number;
+  extremumsMs: number;
+  spawnMs: number;
+  workerMaxMs: number;
+  joinMs: number;
+  pathsLen: number;
+  note?: string;
+}
+
+function generate(n: number): Float64Array {
+  const data = new Float64Array(2 * n);
+  let s = 1;
+  for (let i = 0; i < 2 * n; i += 1) {
+    s = (s * 9301 + 49297) % 233280;
+    data[i] = s / 233280;
+  }
+  return data;
+}
+
+function computeExtremums(data: Float64Array) {
+  let xMin = Infinity;
+  let xMax = -Infinity;
+  let yMin = Infinity;
+  let yMax = -Infinity;
+  for (let i = 0; i < data.length; i += 2) {
+    const x = data[i];
+    const y = data[i + 1];
+    if (x < xMin) {
+      xMin = x;
+    }
+    if (x > xMax) {
+      xMax = x;
+    }
+    if (y < yMin) {
+      yMin = y;
+    }
+    if (y > yMax) {
+      yMax = y;
+    }
+  }
+  return { xMin, xMax, yMin, yMax };
+}
+
+async function runWithWorkers(workerCount: number, n: number): Promise<RunStats> {
+  if (typeof SharedArrayBuffer === 'undefined') {
+    return {
+      workerCount,
+      pointCount: n,
+      total: 0,
+      extremumsMs: 0,
+      spawnMs: 0,
+      workerMaxMs: 0,
+      joinMs: 0,
+      pathsLen: 0,
+      note: 'SharedArrayBuffer unavailable (cross-origin isolation not enabled)',
+    };
+  }
+  const start = performance.now();
+  const seed = generate(n);
+  const sab = new SharedArrayBuffer(seed.byteLength);
+  new Float64Array(sab).set(seed);
+
+  const tExtremums = performance.now();
+  const { xMin, xMax, yMin, yMax } = computeExtremums(new Float64Array(sab));
+  const extremumsMs = performance.now() - tExtremums;
+
+  const tSpawn = performance.now();
+  const workers: Worker[] = [];
+  for (let w = 0; w < workerCount; w += 1) {
+    workers.push(new Worker(new URL('./mapReduce/worker.ts', import.meta.url), { type: 'module' }));
+  }
+  const spawnMs = performance.now() - tSpawn;
+
+  const partitionSize = Math.ceil(n / workerCount);
+  const promises: Promise<PartitionResult>[] = workers.map((worker, i) => {
+    return new Promise<PartitionResult>((resolve) => {
+      worker.onmessage = (event: MessageEvent<PartitionResult>) => resolve(event.data);
+      worker.postMessage({
+        sab,
+        start: i * partitionSize,
+        end: Math.min((i + 1) * partitionSize, n),
+        width: 800,
+        height: 400,
+        padding: 20,
+        markerSize: 2,
+        xMin,
+        xMax,
+        yMin,
+        yMax,
+      });
+    });
+  });
+
+  const results = await Promise.all(promises);
+  const tJoin = performance.now();
+  // Concatenate paths in original order. Each result.paths is already in slice order.
+  const allPaths: string[] = [];
+  for (const r of results) {
+    for (const p of r.paths) {
+      allPaths.push(p);
+    }
+  }
+  const joinMs = performance.now() - tJoin;
+  const total = performance.now() - start;
+  const workerMaxMs = Math.max(...results.map((r) => r.processingMs));
+
+  for (const w of workers) {
+    w.terminate();
+  }
+
+  return {
+    workerCount,
+    pointCount: n,
+    total,
+    extremumsMs,
+    spawnMs,
+    workerMaxMs,
+    joinMs,
+    pathsLen: allPaths.length,
+  };
+}
+
+function logStats(label: string, samples: RunStats[]) {
+  const note = samples[0].note;
+  const mean = (xs: number[]) => xs.reduce((p, c) => p + c, 0) / xs.length;
+  const totals = samples.map((s) => s.total);
+  const workerMaxes = samples.map((s) => s.workerMaxMs);
+  const spawns = samples.map((s) => s.spawnMs);
+  const extremums = samples.map((s) => s.extremumsMs);
+  const joins = samples.map((s) => s.joinMs);
+  // eslint-disable-next-line no-console
+  console.log(
+    `[mapreduce] ${label.padEnd(28)} ` +
+      (note ? `note="${note}"` : '') +
+      `total_mean=${mean(totals).toFixed(2).padStart(8)}ms ` +
+      `extr=${mean(extremums).toFixed(2).padStart(6)}ms ` +
+      `spawn=${mean(spawns).toFixed(2).padStart(6)}ms ` +
+      `worker_max=${mean(workerMaxes).toFixed(2).padStart(7)}ms ` +
+      `join=${mean(joins).toFixed(2).padStart(6)}ms ` +
+      `paths=${samples[0].pathsLen}`,
+  );
+}
+
+const SIZES = [1_000_000] as const;
+const WORKER_COUNTS = [1, 2, 4, 8] as const;
+const RUNS = 5;
+
+for (const n of SIZES) {
+  it(`mapreduce ${n.toLocaleString()} pts — hardware concurrency = ${navigator.hardwareConcurrency}`, async () => {
+    // eslint-disable-next-line no-console
+    console.log(
+      `[mapreduce] crossOriginIsolated=${(globalThis as unknown as { crossOriginIsolated: boolean }).crossOriginIsolated} ` +
+        `SAB=${typeof SharedArrayBuffer !== 'undefined'} ` +
+        `hardwareConcurrency=${navigator.hardwareConcurrency}`,
+    );
+    for (const wc of WORKER_COUNTS) {
+      const samples: RunStats[] = [];
+      for (let i = 0; i < RUNS; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        samples.push(await runWithWorkers(wc, n));
+      }
+      logStats(`workers=${wc}`, samples);
+    }
+    expect(true).toBe(true);
+  }, 180_000);
+}

--- a/test/performance-charts/tests/mapReduce/worker.ts
+++ b/test/performance-charts/tests/mapReduce/worker.ts
@@ -1,0 +1,61 @@
+// Partition worker: receives a SharedArrayBuffer + an index range and computes
+// SVG path strings for that slice using pre-computed global extremums.
+
+interface PartitionMsg {
+  sab: SharedArrayBuffer;
+  start: number; // inclusive (point index, not Float64 index)
+  end: number; // exclusive
+  width: number;
+  height: number;
+  padding: number;
+  markerSize: number;
+  xMin: number;
+  xMax: number;
+  yMin: number;
+  yMax: number;
+}
+
+interface PartitionResult {
+  paths: string[];
+  processingMs: number;
+  start: number;
+  end: number;
+}
+
+const ALMOST_ZERO = 0.01;
+const MAX_POINTS_PER_PATH = 1000;
+
+self.addEventListener('message', (event: MessageEvent<PartitionMsg>) => {
+  const { sab, start, end, width, height, padding, markerSize, xMin, xMax, yMin, yMax } =
+    event.data;
+  const data = new Float64Array(sab);
+  const t0 = performance.now();
+
+  const innerW = width - 2 * padding;
+  const innerH = height - 2 * padding;
+  const xRange = xMax - xMin || 1;
+  const yRange = yMax - yMin || 1;
+
+  const paths: string[] = [];
+  const buf: string[] = [];
+  let inBuf = 0;
+  for (let i = start; i < end; i += 1) {
+    const xi = i * 2;
+    const sx = padding + ((data[xi] - xMin) / xRange) * innerW;
+    const sy = height - padding - ((data[xi + 1] - yMin) / yRange) * innerH;
+    buf.push(`M${sx - markerSize} ${sy} a${markerSize} ${markerSize} 0 1 1 0 ${ALMOST_ZERO}`);
+    inBuf += 1;
+    if (inBuf >= MAX_POINTS_PER_PATH) {
+      paths.push(buf.join(''));
+      buf.length = 0;
+      inBuf = 0;
+    }
+  }
+  if (buf.length) {
+    paths.push(buf.join(''));
+  }
+
+  const processingMs = performance.now() - t0;
+  const result: PartitionResult = { paths, processingMs, start, end };
+  (self as unknown as Worker).postMessage(result);
+});

--- a/test/performance-charts/vitest.config.ts
+++ b/test/performance-charts/vitest.config.ts
@@ -1,9 +1,20 @@
 import { mergeConfig, defineConfig } from 'vitest/config';
 import { createBenchmarkVitestConfig } from '@mui/internal-benchmark/vitest';
 
+const crossOriginIsolationHeaders = {
+  'Cross-Origin-Opener-Policy': 'same-origin',
+  'Cross-Origin-Embedder-Policy': 'require-corp',
+};
+
 export default mergeConfig(
   createBenchmarkVitestConfig(),
   defineConfig({
+    server: {
+      headers: crossOriginIsolationHeaders,
+    },
+    preview: {
+      headers: crossOriginIsolationHeaders,
+    },
     test: {
       setupFiles: ['./setup.ts'],
     },


### PR DESCRIPTION
## Summary

POC for the **Charts Performance — Data processing** objective. Multi-worker fan-out for the scatter path-generation stage. All workers read the same input via \`SharedArrayBuffer\` (zero-copy, no per-worker clone). Each owns an index range and emits its slice's path strings.

Required cross-origin isolation, enabled in the test-perf vitest config:

\`\`\`
Cross-Origin-Opener-Policy: same-origin
Cross-Origin-Embedder-Policy: require-corp
\`\`\`

## Bench (chromium, 1M scatter, hardwareConcurrency=11, mean of 5)

| Workers | Total       | Worker max | Speedup |
| ------- | ----------- | ---------- | ------- |
| 1       | 228.8 ms    | 169.6 ms   | baseline|
| 2       | 127.5 ms    | 83.8 ms    | 1.79x   |
| 4       | 88.3 ms     | 42.2 ms    | 2.59x   |
| 8       | **77.0 ms** | 34.7 ms    | **2.97x** |

## Findings

1. Speedup ceiling ~3x, not Nx. Diminishing returns past 4 workers.
2. Bottleneck above 4 workers is **output cloning** — path strings posted back via structured clone (~10 MB / N per worker). To break through, paths would need to be written into a shared output buffer (UTF-8 bytes) and read back as one string.
3. SAB requires app-level COOP+COEP. Document as opt-in for hosts that can configure cross-origin isolation.
4. Browser paint of 1M paths still happens after worker processing — MapReduce only speeds up JS work, not rasterization.

Recommended as a follow-up to Option B for users who can opt into cross-origin isolation. See \`charts-perf-data-processing.md\`.

**Not for merge** — POC reference, scoped as a follow-up.