### PR TITLE
[charts] Add experimental AsyncScatterPlot (superseded)

### DIFF
--- a/packages/x-charts/src/AsyncScatterPlot/AsyncScatterPlot.test.tsx
+++ b/packages/x-charts/src/AsyncScatterPlot/AsyncScatterPlot.test.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import { spy } from 'sinon';
+import { createRenderer, screen, waitFor } from '@mui/internal-test-utils/createRenderer';
+import { AsyncScatterPlot } from '@mui/x-charts/AsyncScatterPlot';
+import { isJSDOM } from 'test/utils/skipIf';
+
+describe('<AsyncScatterPlot />', () => {
+  const { render } = createRenderer();
+
+  it('renders the skeleton placeholder on initial mount', () => {
+    render(
+      <AsyncScatterPlot
+        data={[
+          { x: 0, y: 0 },
+          { x: 1, y: 1 },
+        ]}
+        width={400}
+        height={200}
+      />,
+    );
+
+    expect(screen.getByText('Loading…')).not.to.equal(null);
+  });
+
+  it('renders custom loading content when provided', () => {
+    render(
+      <AsyncScatterPlot
+        data={[
+          { x: 0, y: 0 },
+          { x: 1, y: 1 },
+        ]}
+        width={400}
+        height={200}
+        loading={<text data-testid="custom-skeleton">custom</text>}
+      />,
+    );
+
+    expect(screen.getByTestId('custom-skeleton')).not.to.equal(null);
+  });
+
+  it.skipIf(isJSDOM)('swaps the skeleton for path elements after the worker returns', async () => {
+    const onLoadEnd = spy();
+    const { container } = render(
+      <AsyncScatterPlot
+        data={[
+          { x: 0, y: 0 },
+          { x: 1, y: 1 },
+          { x: 2, y: 0.5 },
+        ]}
+        width={400}
+        height={200}
+        onLoadEnd={onLoadEnd}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(onLoadEnd.called).to.equal(true);
+    });
+
+    expect(container.querySelectorAll('path').length).to.be.greaterThan(0);
+    const info = onLoadEnd.firstCall.args[0];
+    expect(info.pointCount).to.equal(3);
+  });
+});

--- a/packages/x-charts/src/AsyncScatterPlot/AsyncScatterPlot.tsx
+++ b/packages/x-charts/src/AsyncScatterPlot/AsyncScatterPlot.tsx
@@ -1,0 +1,196 @@
+'use client';
+import * as React from 'react';
+
+export interface AsyncScatterPlotDomain {
+  xMin: number;
+  xMax: number;
+  yMin: number;
+  yMax: number;
+}
+
+export interface AsyncScatterPlotProps {
+  /**
+   * The data points. Either:
+   * - a `Float64Array` of `(x, y)` pairs (length = 2 * point count). The buffer is
+   *   transferred to the worker (zero-copy); after passing it to this component, it must
+   *   not be reused on the caller side.
+   * - an array of `{ x, y }` objects. This shape is structured-cloned to the worker, which
+   *   is convenient but adds ~50–100 ms of copy cost at 1M points.
+   */
+  data: Float64Array | readonly { x: number; y: number }[];
+  /**
+   * The chart width in pixels.
+   */
+  width: number;
+  /**
+   * The chart height in pixels.
+   */
+  height: number;
+  /**
+   * Marker radius in pixels.
+   * @default 2
+   */
+  markerSize?: number;
+  /**
+   * Marker fill color.
+   * @default '#1976d2'
+   */
+  color?: string;
+  /**
+   * Inset between the SVG edge and the plot area.
+   * @default 20
+   */
+  padding?: number;
+  /**
+   * Optional content rendered while the worker is computing. If omitted, a default
+   * "loading" placeholder is shown.
+   */
+  loading?: React.ReactNode;
+  /**
+   * Called once the worker finishes processing the data.
+   */
+  onLoadEnd?: (info: {
+    pointCount: number;
+    processingMs: number;
+    domain: AsyncScatterPlotDomain;
+  }) => void;
+  /**
+   * Called if the worker errors.
+   */
+  onError?: (error: ErrorEvent | Error) => void;
+}
+
+interface WorkerOutput {
+  paths: string[];
+  processingMs: number;
+  pointCount: number;
+  domain: AsyncScatterPlotDomain;
+}
+
+function toFloat64(data: AsyncScatterPlotProps['data']): Float64Array {
+  if (data instanceof Float64Array) {
+    return data;
+  }
+  const out = new Float64Array(data.length * 2);
+  for (let i = 0; i < data.length; i += 1) {
+    out[2 * i] = data[i].x;
+    out[2 * i + 1] = data[i].y;
+  }
+  return out;
+}
+
+/**
+ * **Experimental.** A scatter renderer that offloads scale computation and SVG path
+ * generation to a Web Worker, rendering a skeleton placeholder until the worker returns.
+ * Suitable for very large datasets (~50k points and up) where the regular `ScatterChart`
+ * blocks the main thread for too long.
+ *
+ * Trade-offs versus `ScatterChart`:
+ * - Bypasses the chart provider pipeline — no axes, no legend, no highlight/tooltip.
+ *   This is a renderer, not a full chart component.
+ * - Renders a single-color, single-series scatter plot.
+ * - Requires the consumer's bundler to support `new Worker(new URL(...), { type: 'module' })`
+ *   (Vite, Webpack 5, Next, esbuild all do).
+ *
+ * The skeleton state is fully customisable via the `loading` prop.
+ */
+export function AsyncScatterPlot(props: AsyncScatterPlotProps) {
+  const {
+    data,
+    width,
+    height,
+    markerSize = 2,
+    color = '#1976d2',
+    padding = 20,
+    loading,
+    onLoadEnd,
+    onError,
+  } = props;
+
+  const [output, setOutput] = React.useState<WorkerOutput | null>(null);
+  const onLoadEndRef = React.useRef(onLoadEnd);
+  const onErrorRef = React.useRef(onError);
+  React.useEffect(() => {
+    onLoadEndRef.current = onLoadEnd;
+    onErrorRef.current = onError;
+  });
+
+  React.useEffect(() => {
+    if (typeof Worker === 'undefined') {
+      // Server-side rendering or environment without Web Worker support — leave the
+      // skeleton in place. Consumers can detect this via the absence of an `onLoadEnd`
+      // call.
+      return undefined;
+    }
+
+    let cancelled = false;
+    setOutput(null);
+
+    const worker = new Worker(new URL('./scatterWorker', import.meta.url), {
+      type: 'module',
+    });
+
+    worker.onmessage = (event: MessageEvent<WorkerOutput>) => {
+      if (cancelled) {
+        return;
+      }
+      setOutput(event.data);
+      onLoadEndRef.current?.({
+        pointCount: event.data.pointCount,
+        processingMs: event.data.processingMs,
+        domain: event.data.domain,
+      });
+    };
+    worker.onerror = (event) => {
+      if (cancelled) {
+        return;
+      }
+      onErrorRef.current?.(event);
+    };
+
+    const flat = toFloat64(data);
+    worker.postMessage({ data: flat, width, height, padding, markerSize }, [flat.buffer]);
+
+    return () => {
+      cancelled = true;
+      worker.terminate();
+    };
+  }, [data, width, height, padding, markerSize]);
+
+  if (output === null) {
+    return (
+      <svg width={width} height={height} role="img" aria-label="loading scatter plot">
+        {loading ?? (
+          <React.Fragment>
+            <rect
+              x={padding}
+              y={padding}
+              width={width - 2 * padding}
+              height={height - 2 * padding}
+              fill="#f5f5f5"
+            />
+            <text
+              x={width / 2}
+              y={height / 2}
+              textAnchor="middle"
+              dominantBaseline="middle"
+              fontSize={14}
+              fill="#666"
+            >
+              Loading…
+            </text>
+          </React.Fragment>
+        )}
+      </svg>
+    );
+  }
+
+  return (
+    <svg width={width} height={height} role="img">
+      {output.paths.map((d, i) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <path key={i} fill={color} d={d} />
+      ))}
+    </svg>
+  );
+}

--- a/packages/x-charts/src/AsyncScatterPlot/index.ts
+++ b/packages/x-charts/src/AsyncScatterPlot/index.ts
@@ -1,0 +1,1 @@
+export * from './AsyncScatterPlot';

--- a/packages/x-charts/src/AsyncScatterPlot/scatterWorker.ts
+++ b/packages/x-charts/src/AsyncScatterPlot/scatterWorker.ts
@@ -1,0 +1,84 @@
+/* eslint-disable no-restricted-globals */
+/**
+ * Worker entry for `AsyncScatterPlot`. Receives a Float64Array of (x, y) pairs
+ * plus viewport metrics, computes the linear scale, and returns SVG path
+ * strings (one per ~1000-point chunk, matching the existing BatchScatter
+ * convention).
+ *
+ * @internal
+ */
+
+interface ScatterWorkerInput {
+  data: Float64Array;
+  width: number;
+  height: number;
+  padding: number;
+  markerSize: number;
+}
+
+interface ScatterWorkerOutput {
+  paths: string[];
+  processingMs: number;
+  pointCount: number;
+  domain: { xMin: number; xMax: number; yMin: number; yMax: number };
+}
+
+const ALMOST_ZERO = 0.01;
+const MAX_POINTS_PER_PATH = 1000;
+
+self.addEventListener('message', (event: MessageEvent<ScatterWorkerInput>) => {
+  const { data, width, height, padding, markerSize } = event.data;
+  const t0 = performance.now();
+
+  let xMin = Infinity;
+  let xMax = -Infinity;
+  let yMin = Infinity;
+  let yMax = -Infinity;
+  for (let i = 0; i < data.length; i += 2) {
+    const x = data[i];
+    const y = data[i + 1];
+    if (x < xMin) {
+      xMin = x;
+    }
+    if (x > xMax) {
+      xMax = x;
+    }
+    if (y < yMin) {
+      yMin = y;
+    }
+    if (y > yMax) {
+      yMax = y;
+    }
+  }
+
+  const innerW = width - 2 * padding;
+  const innerH = height - 2 * padding;
+  const xRange = xMax - xMin || 1;
+  const yRange = yMax - yMin || 1;
+
+  const paths: string[] = [];
+  const buf: string[] = [];
+  let inBuf = 0;
+  for (let i = 0; i < data.length; i += 2) {
+    const sx = padding + ((data[i] - xMin) / xRange) * innerW;
+    const sy = height - padding - ((data[i + 1] - yMin) / yRange) * innerH;
+    buf.push(`M${sx - markerSize} ${sy} a${markerSize} ${markerSize} 0 1 1 0 ${ALMOST_ZERO}`);
+    inBuf += 1;
+    if (inBuf >= MAX_POINTS_PER_PATH) {
+      paths.push(buf.join(''));
+      buf.length = 0;
+      inBuf = 0;
+    }
+  }
+  if (buf.length) {
+    paths.push(buf.join(''));
+  }
+
+  const result: ScatterWorkerOutput = {
+    paths,
+    processingMs: performance.now() - t0,
+    pointCount: data.length / 2,
+    domain: { xMin, xMax, yMin, yMax },
+  };
+  (self as unknown as Worker).postMessage(result);
+});

--- a/packages/x-charts/src/index.ts
+++ b/packages/x-charts/src/index.ts
@@ -21,6 +21,7 @@ export * from './BarChart';
 export * from './LineChart';
 export * from './PieChart';
 export * from './ScatterChart';
+export * from './AsyncScatterPlot';
 export * from './SparkLineChart';
 export * from './Gauge';
 export * from './RadarChart';

--- a/test/performance-charts/tests/AsyncScatterPlot.bench.tsx
+++ b/test/performance-charts/tests/AsyncScatterPlot.bench.tsx
@@ -1,0 +1,88 @@
+import * as React from 'react';
+import { benchmark } from '@mui/internal-benchmark';
+import { ScatterChart } from '@mui/x-charts/ScatterChart';
+import { AsyncScatterPlot } from '@mui/x-charts/AsyncScatterPlot';
+
+function generateFlat(n: number) {
+  const data = new Float64Array(2 * n);
+  let s = 1;
+  for (let i = 0; i < 2 * n; i += 1) {
+    s = (s * 9301 + 49297) % 233280;
+    data[i] = s / 233280;
+  }
+  return data;
+}
+
+function generateObjects(n: number) {
+  const data = new Array<{ id: number; x: number; y: number }>(n);
+  let s = 1;
+  for (let i = 0; i < n; i += 1) {
+    s = (s * 9301 + 49297) % 233280;
+    const x = s / 233280;
+    s = (s * 9301 + 49297) % 233280;
+    const y = s / 233280;
+    data[i] = { id: i, x, y };
+  }
+  return data;
+}
+
+const SIZES = [100_000, 1_000_000] as const;
+const WIDTH = 800;
+const HEIGHT = 400;
+
+const objectDatasets = new Map<number, ReturnType<typeof generateObjects>>();
+for (const n of SIZES) {
+  objectDatasets.set(n, generateObjects(n));
+}
+
+function AsyncRig({ n }: { n: number }) {
+  const data = React.useMemo(() => generateFlat(n), [n]);
+  const [done, setDone] = React.useState(false);
+  return (
+    <React.Fragment>
+      <AsyncScatterPlot
+        data={data}
+        width={WIDTH}
+        height={HEIGHT}
+        markerSize={2}
+        onLoadEnd={() => setDone(true)}
+      />
+      {done && (
+        <span
+          elementtiming="async-done"
+          style={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            opacity: 0.01,
+            pointerEvents: 'none',
+            fontSize: 1,
+          }}
+        >
+          {'\xA0'}
+        </span>
+      )}
+    </React.Fragment>
+  );
+}
+
+for (const n of SIZES) {
+  benchmark(
+    `AsyncScatterPlot ${n.toLocaleString()} pts — async (lib export)`,
+    () => <AsyncRig n={n} />,
+    async ({ waitForElementTiming }) => {
+      await waitForElementTiming('async-done', 60_000);
+    },
+    { warmupRuns: 1, runs: 3 },
+  );
+
+  const syncData = objectDatasets.get(n)!;
+  const syncOpts = n >= 1_000_000 ? { warmupRuns: 1, runs: 3 } : undefined;
+  benchmark(
+    `AsyncScatterPlot ${n.toLocaleString()} pts — sync ScatterChart`,
+    () => (
+      <ScatterChart series={[{ data: syncData, markerSize: 2 }]} width={WIDTH} height={HEIGHT} />
+    ),
+    syncOpts,
+  );
+}


### PR DESCRIPTION
## Summary

First-pass proposal from the **Charts Performance — Data processing** study. Standalone \`AsyncScatterPlot\` component that offloads scale computation and SVG path generation to a Web Worker, with a skeleton placeholder until the worker returns.

\`\`\`tsx
<AsyncScatterPlot
  data={float64ArrayOrObjectArray}
  width={800}
  height={400}
  loading={<MyCustomSkeleton />}
  onLoadEnd={({ pointCount, processingMs, domain }) => {}}
/>
\`\`\`

## Bench (chromium, 800x400)

| Pts  | AsyncScatterPlot mount | ScatterChart mount | Speedup |
| ---- | ---------------------- | ------------------ | ------- |
| 100k | 12.5 ms                | 493 ms             | 39x     |
| 1M   | 112 ms                 | 5889 ms            | 53x     |

## Status: superseded

After review, the agreed direction (per \`charts-perf-data-processing.md\`) is to make every chart async via a core plugin, not to ship a parallel renderer component. The plugin-based implementation is on \`feat/async-chart-pipeline\` and applies to \`LineChart\`, \`BarChart\`, and \`ScatterChart\` uniformly.

**Closing in favour of the plugin-based proposal.** Kept as branch reference.