### PR TITLE
[charts] Add async series-processor pipeline (line + bar + scatter)

### DIFF
--- a/charts-perf-data-processing.md
+++ b/charts-perf-data-processing.md
@@ -1,0 +1,191 @@
+# Decision
+
+<aside>
+
+✅ **Option: B — Async pipeline + skeleton, layered on top of cache + LTTB**
+
+**Why?** POC 5b shows the only structural lift large enough to hit the marketing target ("smooth at 1M, responsive at 100k"). At 1M scatter, current `ScatterChart` blocks the main thread for ~12.6 s before first paint; the async-pipeline POC pulls first paint down to **22 ms** and full paint to ~1.3 s. Sampling and caching alone (Option A) cap out at ~2x mount time and don't address the freeze-before-first-paint UX.
+
+</aside>
+
+# Context
+
+We want to be able to render line/bar/scatter charts at 100k–1M points without freezing the browser, and to be perceived as a "fast" charts library next to ECharts/AG Charts/Highcharts. WebGL rendering (the previous objective) lifted the "too many elements on screen" ceiling for some chart types. This effort is about the other half: data prep, sampling, and main-thread responsiveness during processing.
+
+Six small POCs were built on dedicated branches to evaluate concrete approaches against the existing codebase. None of the branches are pushed; PR links below will be filled once we agree on the path forward.
+
+# Problems
+
+1. **Frozen browser during initial mount at 1M points.** `ScatterChart` mount + first paint blocks the main thread for ~12.6 s at 1M. Hover, click, scroll — all unresponsive.
+2. **Sampling alone caps below 1M.** LTTB on a line series brings 100k from laggy to smooth, but at 1M the upstream pipeline (d3-stack, `flatMap` over `xData`) still walks the full array and dominates.
+3. **No mechanism to keep the main thread free while processing.** Selectors run synchronously inside React render. There is no async/worker entry point in the current pipeline.
+4. **Progressive rendering at the leaf component level does not help.** The dominant cost is upstream of the leaf, so chunking just the path-string emission saves ~5 % of mount time.
+5. **Pan/zoom re-runs sampling from scratch each render.** No memoization of the sampled output.
+6. **Branding cost of `SharedArrayBuffer`.** SAB is the cheapest worker transfer mode but requires app-level COOP+COEP server config.
+
+# Options
+
+## A. Incremental wins (sampling + cache + transfer-mode worker for sampling)
+
+Ship LTTB sub-sampling on line/bar (POC 1), viewport-keyed memoization cache (POC 6), and optionally move the LTTB call itself into a worker (POC 5 transfer findings). Keep the existing synchronous selector pipeline. No skeleton state; mount is still synchronous, just cheaper.
+
+**What lands**
+
+- Line series gets a `sampling: 'lttb'` opt-in (POC 1).
+- Bar series gets a min/max bucketing equivalent (not built — projected from POC 1).
+- Sampler output is memoized per `(data ref, target, viewport)` (POC 6).
+- Optionally the LTTB pass moves to a worker.
+
+**What it buys**
+
+- 100k line series goes from 148 ms mount to 80 ms (POC 1).
+- 1M line series mount drops from 1.5 s to 0.6 s (POC 1).
+- Re-renders with stable data prop hit the cache for free (POC 6, ~50x).
+
+**What it doesn't buy**
+
+- 1M scatter still freezes the browser before first paint. The pipeline is synchronous and must process the full dataset before React can commit.
+- The "responsive while loading" claim is not honestly defensible.
+
+## B. Async pipeline with skeleton chart (this objective's main bet)
+
+Refactor the chart so a worker computes the heavy parts of the pipeline (extremums, scale, path-string generation) off the main thread. The component renders a skeleton (axes + placeholder) immediately, then swaps in the full data when the worker returns. POC 5b validated this end-to-end for scatter; bench numbers are dramatic.
+
+**What lands**
+
+- A worker entry shipped with the lib that takes raw data + viewport metrics and returns ready-to-paint SVG path strings (or WebGL draw lists, where applicable).
+- New chart-level prop (likely `processInWorker` or auto-trigger above a threshold) wiring the chart through the worker.
+- Skeleton render (axes + empty plot area) while the worker is busy.
+- Cancellation when the data prop changes mid-flight.
+- Layered over A: LTTB sampling and the cache run inside the worker, so the main thread never sees them.
+
+**What it buys**
+
+- 1M scatter first paint at **22 ms** (vs 12.6 s today). 570x.
+- 1M scatter full paint at **1.3 s** (vs 12.6 s today). 10x.
+- Main thread stays responsive — hover, click, pan all work during processing.
+- Marketing claim becomes defensible against ECharts numbers.
+
+**What it costs**
+
+- Architectural refactor of the chart pipeline (selectors → state-driven processed series).
+- Worker bundling that survives downstream consumer bundlers (Vite/Webpack/Next).
+- Open design questions: per-chart vs shared worker pool, cancellation semantics, data-shape (Float64 zero-copy vs `{x,y}[]` clone).
+
+## Comparison
+
+[Comparison](https://www.notion.so/350cbfe7b660800fa32af2be73e9d5d1?pvs=21)
+
+| Lever                              | A: incremental           | B: async pipeline                         |
+| ---------------------------------- | ------------------------ | ----------------------------------------- |
+| Engineering size                   | small / medium           | large                                     |
+| 100k line mount                    | 80 ms                    | 80 ms (same; A's sampling runs in worker) |
+| 1M scatter first paint             | ~6 s (still synchronous) | **22 ms**                                 |
+| 1M scatter full paint              | ~6 s                     | **1.3 s**                                 |
+| Main thread free during processing | no                       | yes                                       |
+| Marketing claim "responsive at 1M" | no                       | yes                                       |
+| Risk surface                       | low (opt-in props)       | medium (pipeline rewrite)                 |
+| Composes with WebGL renderer work  | yes                      | yes                                       |
+
+# Proposal
+
+**Option: B — async pipeline + skeleton, with A's pieces (LTTB + cache) running inside the worker.**
+
+A first-pass implementation of Option B is on the **`feat/async-chart-pipeline`** branch. It adds a core plugin (`useChartAsyncSeriesProcessor`) that runs the per-type `seriesProcessor` in a Web Worker for line, bar, and scatter, and reuses the existing `ChartsLoadingOverlay` while the worker is busy. Public API is a single new prop on the existing chart components:
+
+```tsx
+<LineChart asyncProcessing ... />
+<BarChart asyncProcessing ... />
+<ScatterChart asyncProcessing ... />
+```
+
+Live bench results from this branch (chromium, 800x400, mean of 3+ runs):
+
+| Chart            | Pts  | Sync paint | Async paint | Speedup |
+| ---------------- | ---- | ---------- | ----------- | ------- |
+| `LineChart`      | 100k | 297 ms     | **11 ms**   | 28x     |
+| `BarChart`       | 30k  | 2562 ms    | **968 ms**  | 2.6x    |
+| `ScatterChart`   | 50k  | 489 ms     | **10 ms**   | 51x     |
+
+Bar's smaller win reflects that the per-bar SVG render is still on the main thread; only the d3-stack/data-prep moved to the worker. Offloading the path/marker generation layer next will pick up the remaining factor (POC 5b shows this is achievable).
+
+**Why?**
+
+- POC 5b numbers leave little room for argument on the user-perceived metric: 22 ms vs 12.6 s to first paint at 1M. No combination of sampling and caching closes that gap, because the freeze happens _before_ sampling can run.
+- The architecture extends naturally to line and bar (worker is the right home for d3-stack and `flatMap`-over-`xData` at scale) and composes with the existing WebGL renderer (worker can produce WebGL draw lists instead of SVG path strings).
+- POC 1 (sampling) and POC 6 (cache) become implementation details inside the worker rather than separate features. Their measured wins still apply; they just stop blocking the main thread.
+- POC 4 (progressive at leaf level) showed conclusively that defer-and-batch at the rendering layer doesn't address the upstream cost. Don't pursue it.
+- POC 5 (transfer cost) tells us to default to `Transferable` and treat `SharedArrayBuffer` as an opt-in for hosts that can configure COOP+COEP. No need to take that branding cost as a default.
+
+**Sequence of work**
+
+1. Land POC 1 (LTTB on line) as the first user-visible deliverable. Cheap, opt-in, real win at 100k. (~1 sprint)
+2. Design the async-pipeline API and worker boundary. Resolve open questions on shape, cancellation, bundling. (~1 sprint)
+3. Build the worker for scatter first (smallest pipeline). Ship behind an experimental prop. (~2 sprints)
+4. Roll the same pattern to line and bar, with LTTB + cache running inside the worker. (~2 sprints)
+5. Document `SharedArrayBuffer` as an advanced opt-in for hosts that can enable cross-origin isolation. (~0.5 sprint)
+6. _(Optional, follow-up)_ MapReduce-style multi-worker fan-out for the path-generation stage. POC 7 measured ~3x on top of the single-worker baseline at 1M, gated on cross-origin isolation being enabled. Worth doing if customer demand justifies; otherwise can wait. (~1 sprint)
+
+# Benchmarks
+
+All numbers measured on a single machine (chromium via vitest browser, predictable JS flags, software rendering). 800x400 chart unless noted. Higher-is-worse for milliseconds.
+
+- **POC 1 — LTTB sub-sampling on `LineChart`** (branch `perf-poc/subsampling-line-lttb`, commit `716b783b2c`)
+  - 10k pts: mount 16.6 ms → 10.6 ms (1.57x)
+  - 100k pts: mount 148 ms → 80 ms (1.85x)
+  - 1M pts: mount 1504 ms → 640 ms; paint **3034 ms → 645 ms** (4.7x paint)
+  - Skipped when series contains nulls (segmentation-free POC).
+
+- **POC 4 — Progressive `ScatterChart` render at leaf level** (branch `perf-poc/progressive-scatter`, commit `a40467831f`)
+  - 50k: mount 242 ms → 224 ms; paint 463 ms → 463 ms.
+  - 200k: mount 1122 ms → 1118 ms; paint 1874 ms → 1880 ms.
+  - 1M: hangs (cumulative O(N²/batchSize) re-walk in naive impl).
+  - **Conclusion: ineffective** — upstream pipeline dominates, leaf-level chunking saves ~5 % of mount.
+
+- **POC 5 — Web Worker transfer cost spike** (branch `perf-poc/worker-series-processor`, commit `82a37b0af4`)
+  - 1M Float64 (16 MB), wallclock to round-trip:
+    - main (sync): 5.5 ms
+    - worker via clone: 16.9 ms (send 1.8 + worker 5.6 + recv 9.5)
+    - worker via transfer: 8.9 ms (send 0.06 + worker 5.0 + recv 3.9)
+    - worker via SAB: **unsupported** (vitest browser does not set COOP/COEP)
+  - **Default to `Transferable`.** SAB only as opt-in.
+
+- **POC 5b — Async scatter pipeline with skeleton** (branch `perf-poc/worker-async-pipeline`, commit `aa6611ad7d`)
+  - 100k: async first paint **6 ms** vs sync `ScatterChart` 1076 ms (180x); async full paint 115 ms vs 1076 ms (9x).
+  - 1M: async first paint **22 ms** vs sync 12 599 ms (**570x**); async full paint 1258 ms vs 12 599 ms (**10x**).
+  - Caveat: experimental component bypasses the lib `ChartProvider` pipeline. Production integration will re-add some of that overhead. Conservative estimate: 3–5x full-paint win after re-integration; first-paint win stays intact regardless.
+
+- **POC 6 — Viewport-keyed sample cache** (branch `perf-poc/memo-sampled-cache`, commit `425689a805`)
+  - 1M, 60 calls, per-call cost:
+    - Uncached LTTB: 5.25 ms
+    - Cached, full-range repeats (98 % hits): **0.10 ms** (~50x)
+    - Cached, continuous pan, no quantize (0 % hits): 26.7 ms (worse — slice cost)
+    - Cached, pan with 5 % quantize (48 % hits): 13.7 ms
+    - Cached, zoom cycle through 5 levels (97 % hits): **0.61 ms**
+  - **Free win for re-renders** (Scenario B). **Strong fit for zoom-snap UX** (Scenario E). **Continuous pan needs worker offload, not cache.**
+
+- **POC 7 — MapReduce-style multi-worker fan-out with `SharedArrayBuffer`** (branch `perf-poc/mapreduce-sab`, commit `3dc9979901`)
+  - 1M scatter, path generation only, hardwareConcurrency=11, mean of 5 runs:
+    - 1 worker: 228.8 ms (baseline)
+    - 2 workers: 127.5 ms (1.79x)
+    - 4 workers: 88.3 ms (2.59x)
+    - 8 workers: **77.0 ms (2.97x)**
+  - Speedup ceiling ~3x, not Nx. Bottleneck above 4 workers is output cloning — path strings posted back via structured clone (~10 MB / N per worker). To break through, paths would need to be written into a shared output buffer (UTF-8 bytes) and read back as one string.
+  - Required enabling `Cross-Origin-Opener-Policy: same-origin` + `Cross-Origin-Embedder-Policy: require-corp` in the test/perf vitest config. App-level config in production.
+  - Browser paint of 1M paths still happens after worker processing — MapReduce only speeds up JS work, not rasterization.
+  - **Recommended as a follow-up to Option B**, gated on customer demand for cross-origin isolation. Meaningful at 1M+ but not transformative.
+
+## Branches and PRs
+
+| Item                                  | Branch                             | Commit       | Draft PR                                                       |
+| ------------------------------------- | ---------------------------------- | ------------ | -------------------------------------------------------------- |
+| **Proposal — async pipeline plugin**  | `feat/async-chart-pipeline`        | `8382271729` | **[#22370](https://github.com/mui/mui-x/pull/22370)**          |
+| 1. LTTB sub-sampling (line)           | `perf-poc/subsampling-line-lttb`   | `716b783b2c` | [#22363](https://github.com/mui/mui-x/pull/22363)              |
+| 4. Progressive scatter (leaf level)   | `perf-poc/progressive-scatter`     | `a40467831f` | [#22364](https://github.com/mui/mui-x/pull/22364) — negative result |
+| 5. Worker transfer cost spike         | `perf-poc/worker-series-processor` | `82a37b0af4` | [#22365](https://github.com/mui/mui-x/pull/22365)              |
+| 5b. Async pipeline + skeleton (spike) | `perf-poc/worker-async-pipeline`   | `aa6611ad7d` | [#22366](https://github.com/mui/mui-x/pull/22366)              |
+| 6. Viewport-keyed sample cache        | `perf-poc/memo-sampled-cache`      | `425689a805` | [#22367](https://github.com/mui/mui-x/pull/22367)              |
+| 7. MapReduce SAB fan-out              | `perf-poc/mapreduce-sab`           | `3dc9979901` | [#22368](https://github.com/mui/mui-x/pull/22368) — follow-up  |
+| First proposal (superseded)           | `feat/async-scatter-plot`          | `d16d303e9f` | [#22369](https://github.com/mui/mui-x/pull/22369) — superseded by #22370 |
+
+POC 2 (bar bucket sub-sampling) and POC 3 (progressive line render) were scoped but not built. Bar bucket is a small port of POC 1; progressive line was deprioritised after POC 4's negative result.

--- a/charts-perf-data-processing.md
+++ b/charts-perf-data-processing.md
@@ -2,60 +2,60 @@
 
 <aside>
 
-✅ **Option: B — Async pipeline + skeleton, layered on top of cache + LTTB**
+✅ **Option: B — Async pipeline + skeleton, with sampling and cache living inside the worker.**
 
-**Why?** POC 5b is the only approach that looks structurally large enough to hit the marketing target ("smooth at 1M, responsive at 100k"). At 1M scatter, the current `ScatterChart` blocks the main thread for ~12.6 s before first paint in our test rig; the async-pipeline POC brought first paint down to ~22 ms and full paint to ~1.3 s on the same rig. Sampling and caching alone (Option A) appear to cap out at ~2x mount time in the POCs and don't address the freeze-before-first-paint UX. All numbers are early-stage POC measurements — see the caveats in the Benchmarks section.
+**Why?** The marketing target ("smooth at 1M, responsive at 100k") only looks reachable structurally. In our test rig, 1M scatter blocks the main thread for ~12.6 s before first paint; the async-pipeline POC brought first paint down to ~22 ms on the same rig. Sampling and caching alone (Option A) cap out at ~2x mount-time and never unfreeze the browser before first paint. All numbers in this doc are POC measurements — see the caveats in Benchmarks.
 
 </aside>
 
 # Context
 
-We want to be able to render line/bar/scatter charts at 100k–1M points without freezing the browser, and to be perceived as a "fast" charts library next to ECharts/AG Charts/Highcharts. WebGL rendering (the previous objective) lifted the "too many elements on screen" ceiling for some chart types. This effort is about the other half: data prep, sampling, and main-thread responsiveness during processing.
+We want to render line/bar/scatter charts at 100k–1M points without freezing the browser, and to be perceived as a "fast" charts library next to ECharts, AG Charts, and Highcharts. The previous objective (Charts Performance — WebGL rendering) lifted the "too many elements on screen" ceiling for some chart types. This effort covers the other half: data prep, sampling, and main-thread responsiveness during processing.
 
 Several small POCs were built on dedicated branches to evaluate concrete approaches against the existing codebase. Each branch has a draft PR linked below; the numbers in this doc are POC-level measurements, not commitments — production performance will depend on integration shape, dataset characteristics, browser, and device.
 
 # Problems
 
-1. **Frozen browser during initial mount at 1M points.** `ScatterChart` mount + first paint blocks the main thread for ~12.6 s at 1M. Hover, click, scroll — all unresponsive.
+1. **Frozen browser during initial mount at 1M points.** `ScatterChart` mount + first paint blocks the main thread for ~12.6 s at 1M in our test rig. Hover, click, scroll — all unresponsive.
 2. **Sampling alone caps below 1M.** LTTB on a line series brings 100k from laggy to smooth, but at 1M the upstream pipeline (d3-stack, `flatMap` over `xData`) still walks the full array and dominates.
-3. **No mechanism to keep the main thread free while processing.** Selectors run synchronously inside React render. There is no async/worker entry point in the current pipeline.
-4. **Progressive rendering at the leaf component level does not help.** The dominant cost is upstream of the leaf, so chunking just the path-string emission saves ~5 % of mount time.
-5. **Pan/zoom re-runs sampling from scratch each render.** No memoization of the sampled output.
-6. **Branding cost of `SharedArrayBuffer`.** SAB is the cheapest worker transfer mode but requires app-level COOP+COEP server config.
+3. **No async/worker entry point in the current pipeline.** Selectors run synchronously inside React render.
+4. **Progressive rendering at the leaf component level does not help.** The dominant cost is upstream of the leaf, so chunking just the path-string emission saves ~5 % of mount time (POC 4).
+5. **Pan/zoom re-runs sampling from scratch each render.** No memoization of sampled output today.
+6. **`SharedArrayBuffer` carries an app-level branding cost.** SAB is the cheapest worker transfer mode but requires consumers to set COOP+COEP server headers.
 
 # Options
 
 ## A. Incremental wins (sampling + cache + transfer-mode worker for sampling)
 
-Ship LTTB sub-sampling on line/bar (POC 1), viewport-keyed memoization cache (POC 6), and optionally move the LTTB call itself into a worker (POC 5 transfer findings). Keep the existing synchronous selector pipeline. No skeleton state; mount is still synchronous, just cheaper.
+Ship LTTB sub-sampling on line/bar (POC 1), viewport-keyed memoization cache (POC 6), and optionally move the LTTB call itself into a worker (informed by POC 5 transfer numbers). Keep the synchronous selector pipeline. No skeleton state; mount is still synchronous, just cheaper.
 
 **What lands**
 
 - Line series gets a `sampling: 'lttb'` opt-in (POC 1).
 - Bar series gets a min/max bucketing equivalent (not built — projected from POC 1).
 - Sampler output is memoized per `(data ref, target, viewport)` (POC 6).
-- Optionally the LTTB pass moves to a worker.
+- Optionally the LTTB pass moves to a worker (POC 5 says use `Transferable`, default mode).
 
 **Expected gains** (from POC measurements; production may differ)
 
-- 100k line series mount: ~148 ms → ~80 ms (POC 1).
-- 1M line series mount: ~1.5 s → ~0.6 s (POC 1).
-- Re-renders with a stable data prop hit the cache for ~free (POC 6, ~50x in the micro-bench).
+- 100k line series mount: ~148 ms → ~80 ms.
+- 1M line series mount: ~1.5 s → ~0.6 s.
+- Re-renders with a stable data prop hit the cache for ~free (~50x in the micro-bench).
 
 **What it doesn't buy**
 
 - 1M scatter still freezes the browser before first paint. The pipeline is synchronous and must process the full dataset before React can commit.
 - The "responsive while loading" claim is not honestly defensible.
 
-## B. Async pipeline with skeleton chart (this objective's main bet)
+## B. Async pipeline with skeleton chart
 
-Refactor the chart so a worker computes the heavy parts of the pipeline (extremums, scale, path-string generation) off the main thread. The component renders a skeleton (axes + placeholder) immediately, then swaps in the full data when the worker returns. POC 5b validated this end-to-end for scatter; bench numbers are dramatic.
+Refactor the chart so a worker computes the heavy parts of the pipeline (extremums, scale, optionally path-string generation) off the main thread. The component renders a skeleton (existing `ChartsLoadingOverlay`) immediately, then swaps in the full data when the worker returns. POC 5b validated the architecture for scatter; the plugin-based implementation on `feat/async-chart-pipeline` extends it to line/bar/scatter through the existing chart components.
 
 **What lands**
 
-- A worker entry shipped with the lib that takes raw data + viewport metrics and returns ready-to-paint SVG path strings (or WebGL draw lists, where applicable).
-- New chart-level prop (likely `processInWorker` or auto-trigger above a threshold) wiring the chart through the worker.
-- Skeleton render (axes + empty plot area) while the worker is busy.
+- A core plugin `useChartAsyncSeriesProcessor` that runs the per-type `seriesProcessor` in a Web Worker.
+- New chart-level prop `asyncProcessing` on `LineChart`, `BarChart`, `ScatterChart`.
+- Skeleton render (axes + empty plot area) while the worker is busy, via the existing `ChartsLoadingOverlay`. The chart's `loading` prop is OR-ed with the internal processing state.
 - Cancellation when the data prop changes mid-flight.
 - Layered over A: LTTB sampling and the cache run inside the worker, so the main thread never sees them.
 
@@ -68,9 +68,9 @@ Refactor the chart so a worker computes the heavy parts of the pipeline (extremu
 
 **What it costs**
 
-- Architectural refactor of the chart pipeline (selectors → state-driven processed series).
-- Worker bundling that survives downstream consumer bundlers (Vite/Webpack/Next).
-- Open design questions: per-chart vs shared worker pool, cancellation semantics, data-shape (Float64 zero-copy vs `{x,y}[]` clone).
+- Architectural refactor of the chart pipeline (selectors → state-driven processed series via a plugin).
+- Worker bundling that survives downstream consumer bundlers (Vite, Webpack 5, Next, esbuild all handle `new Worker(new URL(...), { type: 'module' })`).
+- Open design questions: per-chart vs shared worker pool, cancellation semantics, data-shape (Float64 zero-copy vs `{x,y}[]` clone), `valueGetter` support.
 
 ## Comparison
 
@@ -101,7 +101,9 @@ A first-pass implementation of Option B is on the **`feat/async-chart-pipeline`*
 <ScatterChart asyncProcessing ... />
 ```
 
-Bench measurements from this branch (chromium, 800x400, mean of 3+ runs). These are early-stage indicators on a single rig and will vary with dataset shape, browser, hardware, and final API. Treat them as expected gains, not guarantees.
+A docs demo is wired up at `/x/react-charts/scatter/#async-processing-experimental` (`AsyncScatterProcessing.tsx`). It cycles three datasets, exposes the `asyncProcessing` toggle, and shows a 100 ms-tick counter that visualises main-thread responsiveness — the counter freezes during sync render and keeps ticking under async.
+
+Bench measurements from this branch (chromium, 800x400, mean of 3+ runs). Treat as expected gains, not guarantees.
 
 | Chart          | Pts  | Sync paint | Async paint | Expected ratio |
 | -------------- | ---- | ---------- | ----------- | -------------- |
@@ -122,29 +124,29 @@ Bar's smaller indicator reflects that the per-bar SVG render is still on the mai
 **Sequence of work**
 
 1. Land POC 1 (LTTB on line) as the first user-visible deliverable. Cheap, opt-in, real win at 100k. (~1 sprint)
-2. Design the async-pipeline API and worker boundary. Resolve open questions on shape, cancellation, bundling. (~1 sprint)
-3. Build the worker for scatter first (smallest pipeline). Ship behind an experimental prop. (~2 sprints)
-4. Roll the same pattern to line and bar, with LTTB + cache running inside the worker. (~2 sprints)
+2. Take `feat/async-chart-pipeline` from experimental to production-ready: API name, `valueGetter` support, cancellation polish, worker bundling guarantees, naming/tier. (~1–2 sprints)
+3. Roll the pattern to all chart types that use the chart pipeline (line/bar/scatter ship together; pie/sankey/etc. as the API stabilises). (~1 sprint)
+4. Move LTTB + viewport cache inside the worker. (~1 sprint)
 5. Document `SharedArrayBuffer` as an advanced opt-in for hosts that can enable cross-origin isolation. (~0.5 sprint)
-6. _(Optional, follow-up)_ MapReduce-style multi-worker fan-out for the path-generation stage. POC 7 measured ~3x on top of the single-worker baseline at 1M, gated on cross-origin isolation being enabled. Worth doing if customer demand justifies; otherwise can wait. (~1 sprint)
+6. _(Optional, follow-up)_ MapReduce-style multi-worker fan-out for the path-generation stage. POC 7 measured ~3x on top of the single-worker baseline at 1M, gated on cross-origin isolation being enabled. (~1 sprint)
 
 # Benchmarks
 
 All numbers below are POC measurements on a single machine (chromium via vitest browser, predictable JS flags, software rendering). 800x400 chart unless noted. Treat as expected gains for sizing the work, not as production targets — real performance will depend on the final integration shape, dataset, browser, and device.
 
-- **POC 1 — LTTB sub-sampling on `LineChart`** (branch `perf-poc/subsampling-line-lttb`)
+- **POC 1 — LTTB sub-sampling on `LineChart`** (`perf-poc/subsampling-line-lttb`)
   - 10k pts: mount ~16.6 ms → ~10.6 ms (~1.57x)
   - 100k pts: mount ~148 ms → ~80 ms (~1.85x)
   - 1M pts: mount ~1504 ms → ~640 ms; paint **~3034 ms → ~645 ms** (~4.7x paint)
   - Skipped when the series contains nulls (segmentation-free POC).
 
-- **POC 4 — Progressive `ScatterChart` render at leaf level** (branch `perf-poc/progressive-scatter`)
+- **POC 4 — Progressive `ScatterChart` render at leaf level** (`perf-poc/progressive-scatter`)
   - 50k: mount ~242 ms → ~224 ms; paint ~463 ms → ~463 ms.
   - 200k: mount ~1122 ms → ~1118 ms; paint ~1874 ms → ~1880 ms.
   - 1M: hangs (cumulative O(N²/batchSize) re-walk in the naive impl).
   - **Conclusion: ineffective** — upstream pipeline dominates, leaf-level chunking saves ~5 % of mount.
 
-- **POC 5 — Web Worker transfer cost spike** (branch `perf-poc/worker-series-processor`)
+- **POC 5 — Web Worker transfer cost spike** (`perf-poc/worker-series-processor`)
   - 1M Float64 (16 MB), wallclock to round-trip:
     - main (sync): ~5.5 ms
     - worker via clone: ~16.9 ms (send ~1.8 + worker ~5.6 + recv ~9.5)
@@ -152,12 +154,12 @@ All numbers below are POC measurements on a single machine (chromium via vitest 
     - worker via SAB: **unsupported** (vitest browser does not set COOP/COEP)
   - **Default to `Transferable`.** SAB only as opt-in.
 
-- **POC 5b — Async scatter pipeline with skeleton** (branch `perf-poc/worker-async-pipeline`)
+- **POC 5b — Async scatter pipeline with skeleton** (`perf-poc/worker-async-pipeline`)
   - 100k: async first paint ~**6 ms** vs sync `ScatterChart` ~1076 ms (~180x); async full paint ~115 ms vs ~1076 ms (~9x).
   - 1M: async first paint ~**22 ms** vs sync ~12 599 ms (~**570x**); async full paint ~1258 ms vs ~12 599 ms (~**10x**).
   - Caveat: the experimental component bypasses the lib `ChartProvider` pipeline. Production integration will re-add some of that overhead. Conservative estimate: ~3–5x full-paint win after re-integration; first-paint win expected to stay intact.
 
-- **POC 6 — Viewport-keyed sample cache** (branch `perf-poc/memo-sampled-cache`)
+- **POC 6 — Viewport-keyed sample cache** (`perf-poc/memo-sampled-cache`)
   - 1M, 60 calls, per-call cost:
     - Uncached LTTB: ~5.25 ms
     - Cached, full-range repeats (98 % hits): ~**0.10 ms** (~50x)
@@ -166,14 +168,14 @@ All numbers below are POC measurements on a single machine (chromium via vitest 
     - Cached, zoom cycle through 5 levels (97 % hits): ~**0.61 ms**
   - **Expected free win for re-renders** (Scenario B). **Strong fit for zoom-snap UX** (Scenario E). **Continuous pan needs worker offload, not cache.**
 
-- **POC 7 — MapReduce-style multi-worker fan-out with `SharedArrayBuffer`** (branch `perf-poc/mapreduce-sab`)
+- **POC 7 — MapReduce-style multi-worker fan-out with `SharedArrayBuffer`** (`perf-poc/mapreduce-sab`)
   - 1M scatter, path generation only, hardwareConcurrency=11, mean of 5 runs:
     - 1 worker: ~228.8 ms (baseline)
     - 2 workers: ~127.5 ms (~1.79x)
     - 4 workers: ~88.3 ms (~2.59x)
     - 8 workers: ~**77.0 ms (~2.97x)**
   - Expected speedup ceiling ~3x, not Nx. Bottleneck above 4 workers is output cloning — path strings posted back via structured clone (~10 MB / N per worker). To break through, paths would need to be written into a shared output buffer (UTF-8 bytes) and read back as one string.
-  - Required enabling `Cross-Origin-Opener-Policy: same-origin` + `Cross-Origin-Embedder-Policy: require-corp` in the test/perf vitest config. App-level config in production.
+  - Required `Cross-Origin-Opener-Policy: same-origin` + `Cross-Origin-Embedder-Policy: require-corp` in the test/perf vitest config. App-level config in production.
   - Browser paint of 1M paths still happens after worker processing — MapReduce only speeds up JS work, not rasterization.
   - **Recommended as a follow-up to Option B**, gated on customer demand for cross-origin isolation. Likely meaningful at 1M+, not transformative.
 

--- a/charts-perf-data-processing.md
+++ b/charts-perf-data-processing.md
@@ -4,7 +4,7 @@
 
 ✅ **Option: B — Async pipeline + skeleton, layered on top of cache + LTTB**
 
-**Why?** POC 5b shows the only structural lift large enough to hit the marketing target ("smooth at 1M, responsive at 100k"). At 1M scatter, current `ScatterChart` blocks the main thread for ~12.6 s before first paint; the async-pipeline POC pulls first paint down to **22 ms** and full paint to ~1.3 s. Sampling and caching alone (Option A) cap out at ~2x mount time and don't address the freeze-before-first-paint UX.
+**Why?** POC 5b is the only approach that looks structurally large enough to hit the marketing target ("smooth at 1M, responsive at 100k"). At 1M scatter, the current `ScatterChart` blocks the main thread for ~12.6 s before first paint in our test rig; the async-pipeline POC brought first paint down to ~22 ms and full paint to ~1.3 s on the same rig. Sampling and caching alone (Option A) appear to cap out at ~2x mount time in the POCs and don't address the freeze-before-first-paint UX. All numbers are early-stage POC measurements — see the caveats in the Benchmarks section.
 
 </aside>
 
@@ -12,7 +12,7 @@
 
 We want to be able to render line/bar/scatter charts at 100k–1M points without freezing the browser, and to be perceived as a "fast" charts library next to ECharts/AG Charts/Highcharts. WebGL rendering (the previous objective) lifted the "too many elements on screen" ceiling for some chart types. This effort is about the other half: data prep, sampling, and main-thread responsiveness during processing.
 
-Six small POCs were built on dedicated branches to evaluate concrete approaches against the existing codebase. None of the branches are pushed; PR links below will be filled once we agree on the path forward.
+Several small POCs were built on dedicated branches to evaluate concrete approaches against the existing codebase. Each branch has a draft PR linked below; the numbers in this doc are POC-level measurements, not commitments — production performance will depend on integration shape, dataset characteristics, browser, and device.
 
 # Problems
 
@@ -36,11 +36,11 @@ Ship LTTB sub-sampling on line/bar (POC 1), viewport-keyed memoization cache (PO
 - Sampler output is memoized per `(data ref, target, viewport)` (POC 6).
 - Optionally the LTTB pass moves to a worker.
 
-**What it buys**
+**Expected gains** (from POC measurements; production may differ)
 
-- 100k line series goes from 148 ms mount to 80 ms (POC 1).
-- 1M line series mount drops from 1.5 s to 0.6 s (POC 1).
-- Re-renders with stable data prop hit the cache for free (POC 6, ~50x).
+- 100k line series mount: ~148 ms → ~80 ms (POC 1).
+- 1M line series mount: ~1.5 s → ~0.6 s (POC 1).
+- Re-renders with a stable data prop hit the cache for ~free (POC 6, ~50x in the micro-bench).
 
 **What it doesn't buy**
 
@@ -59,12 +59,12 @@ Refactor the chart so a worker computes the heavy parts of the pipeline (extremu
 - Cancellation when the data prop changes mid-flight.
 - Layered over A: LTTB sampling and the cache run inside the worker, so the main thread never sees them.
 
-**What it buys**
+**Expected gains** (from POC measurements; production may differ)
 
-- 1M scatter first paint at **22 ms** (vs 12.6 s today). 570x.
-- 1M scatter full paint at **1.3 s** (vs 12.6 s today). 10x.
-- Main thread stays responsive — hover, click, pan all work during processing.
-- Marketing claim becomes defensible against ECharts numbers.
+- 1M scatter first paint: ~22 ms vs ~12.6 s today (~570x in the spike, where the ChartProvider pipeline is bypassed). Conservative production target: still well under 100 ms.
+- 1M scatter full paint: ~1.3 s vs ~12.6 s today (~10x in the spike; expect 3–5x once the lib pipeline is re-added).
+- Main thread stays responsive during processing — hover, click, pan should all keep working.
+- Marketing claim "responsive at 1M" looks defensible against ECharts numbers.
 
 **What it costs**
 
@@ -76,16 +76,18 @@ Refactor the chart so a worker computes the heavy parts of the pipeline (extremu
 
 [Comparison](https://www.notion.so/350cbfe7b660800fa32af2be73e9d5d1?pvs=21)
 
-| Lever                              | A: incremental           | B: async pipeline                         |
-| ---------------------------------- | ------------------------ | ----------------------------------------- |
-| Engineering size                   | small / medium           | large                                     |
-| 100k line mount                    | 80 ms                    | 80 ms (same; A's sampling runs in worker) |
-| 1M scatter first paint             | ~6 s (still synchronous) | **22 ms**                                 |
-| 1M scatter full paint              | ~6 s                     | **1.3 s**                                 |
-| Main thread free during processing | no                       | yes                                       |
-| Marketing claim "responsive at 1M" | no                       | yes                                       |
-| Risk surface                       | low (opt-in props)       | medium (pipeline rewrite)                 |
-| Composes with WebGL renderer work  | yes                      | yes                                       |
+All numeric cells are POC measurements; production may differ.
+
+| Lever                              | A: incremental           | B: async pipeline                          |
+| ---------------------------------- | ------------------------ | ------------------------------------------ |
+| Engineering size                   | small / medium           | large                                      |
+| 100k line mount                    | ~80 ms                   | ~80 ms (same; A's sampling runs in worker) |
+| 1M scatter first paint             | ~6 s (still synchronous) | **~22 ms**                                 |
+| 1M scatter full paint              | ~6 s                     | **~1.3 s** (POC; expect 3–5x in prod)      |
+| Main thread free during processing | no                       | yes                                        |
+| Marketing claim "responsive at 1M" | no                       | yes                                        |
+| Risk surface                       | low (opt-in props)       | medium (pipeline rewrite)                  |
+| Composes with WebGL renderer work  | yes                      | yes                                        |
 
 # Proposal
 
@@ -99,19 +101,19 @@ A first-pass implementation of Option B is on the **`feat/async-chart-pipeline`*
 <ScatterChart asyncProcessing ... />
 ```
 
-Live bench results from this branch (chromium, 800x400, mean of 3+ runs):
+Bench measurements from this branch (chromium, 800x400, mean of 3+ runs). These are early-stage indicators on a single rig and will vary with dataset shape, browser, hardware, and final API. Treat them as expected gains, not guarantees.
 
-| Chart            | Pts  | Sync paint | Async paint | Speedup |
-| ---------------- | ---- | ---------- | ----------- | ------- |
-| `LineChart`      | 100k | 297 ms     | **11 ms**   | 28x     |
-| `BarChart`       | 30k  | 2562 ms    | **968 ms**  | 2.6x    |
-| `ScatterChart`   | 50k  | 489 ms     | **10 ms**   | 51x     |
+| Chart          | Pts  | Sync paint | Async paint | Expected ratio |
+| -------------- | ---- | ---------- | ----------- | -------------- |
+| `LineChart`    | 100k | ~297 ms    | **~11 ms**  | ~28x           |
+| `BarChart`     | 30k  | ~2562 ms   | **~968 ms** | ~2.6x          |
+| `ScatterChart` | 50k  | ~489 ms    | **~10 ms**  | ~51x           |
 
-Bar's smaller win reflects that the per-bar SVG render is still on the main thread; only the d3-stack/data-prep moved to the worker. Offloading the path/marker generation layer next will pick up the remaining factor (POC 5b shows this is achievable).
+Bar's smaller indicator reflects that the per-bar SVG render is still on the main thread; only the d3-stack/data-prep moved to the worker. Offloading the path/marker generation layer next is expected to pick up more of the remaining cost (POC 5b suggests this is achievable).
 
 **Why?**
 
-- POC 5b numbers leave little room for argument on the user-perceived metric: 22 ms vs 12.6 s to first paint at 1M. No combination of sampling and caching closes that gap, because the freeze happens _before_ sampling can run.
+- POC 5b indicators (22 ms vs 12.6 s to first paint at 1M, in our test rig) point clearly at the user-perceived metric. No combination of sampling and caching looks likely to close that gap, because the freeze happens _before_ sampling can run.
 - The architecture extends naturally to line and bar (worker is the right home for d3-stack and `flatMap`-over-`xData` at scale) and composes with the existing WebGL renderer (worker can produce WebGL draw lists instead of SVG path strings).
 - POC 1 (sampling) and POC 6 (cache) become implementation details inside the worker rather than separate features. Their measured wins still apply; they just stop blocking the main thread.
 - POC 4 (progressive at leaf level) showed conclusively that defer-and-batch at the rendering layer doesn't address the upstream cost. Don't pursue it.
@@ -128,64 +130,64 @@ Bar's smaller win reflects that the per-bar SVG render is still on the main thre
 
 # Benchmarks
 
-All numbers measured on a single machine (chromium via vitest browser, predictable JS flags, software rendering). 800x400 chart unless noted. Higher-is-worse for milliseconds.
+All numbers below are POC measurements on a single machine (chromium via vitest browser, predictable JS flags, software rendering). 800x400 chart unless noted. Treat as expected gains for sizing the work, not as production targets — real performance will depend on the final integration shape, dataset, browser, and device.
 
-- **POC 1 — LTTB sub-sampling on `LineChart`** (branch `perf-poc/subsampling-line-lttb`, commit `716b783b2c`)
-  - 10k pts: mount 16.6 ms → 10.6 ms (1.57x)
-  - 100k pts: mount 148 ms → 80 ms (1.85x)
-  - 1M pts: mount 1504 ms → 640 ms; paint **3034 ms → 645 ms** (4.7x paint)
-  - Skipped when series contains nulls (segmentation-free POC).
+- **POC 1 — LTTB sub-sampling on `LineChart`** (branch `perf-poc/subsampling-line-lttb`)
+  - 10k pts: mount ~16.6 ms → ~10.6 ms (~1.57x)
+  - 100k pts: mount ~148 ms → ~80 ms (~1.85x)
+  - 1M pts: mount ~1504 ms → ~640 ms; paint **~3034 ms → ~645 ms** (~4.7x paint)
+  - Skipped when the series contains nulls (segmentation-free POC).
 
-- **POC 4 — Progressive `ScatterChart` render at leaf level** (branch `perf-poc/progressive-scatter`, commit `a40467831f`)
-  - 50k: mount 242 ms → 224 ms; paint 463 ms → 463 ms.
-  - 200k: mount 1122 ms → 1118 ms; paint 1874 ms → 1880 ms.
-  - 1M: hangs (cumulative O(N²/batchSize) re-walk in naive impl).
+- **POC 4 — Progressive `ScatterChart` render at leaf level** (branch `perf-poc/progressive-scatter`)
+  - 50k: mount ~242 ms → ~224 ms; paint ~463 ms → ~463 ms.
+  - 200k: mount ~1122 ms → ~1118 ms; paint ~1874 ms → ~1880 ms.
+  - 1M: hangs (cumulative O(N²/batchSize) re-walk in the naive impl).
   - **Conclusion: ineffective** — upstream pipeline dominates, leaf-level chunking saves ~5 % of mount.
 
-- **POC 5 — Web Worker transfer cost spike** (branch `perf-poc/worker-series-processor`, commit `82a37b0af4`)
+- **POC 5 — Web Worker transfer cost spike** (branch `perf-poc/worker-series-processor`)
   - 1M Float64 (16 MB), wallclock to round-trip:
-    - main (sync): 5.5 ms
-    - worker via clone: 16.9 ms (send 1.8 + worker 5.6 + recv 9.5)
-    - worker via transfer: 8.9 ms (send 0.06 + worker 5.0 + recv 3.9)
+    - main (sync): ~5.5 ms
+    - worker via clone: ~16.9 ms (send ~1.8 + worker ~5.6 + recv ~9.5)
+    - worker via transfer: ~8.9 ms (send ~0.06 + worker ~5.0 + recv ~3.9)
     - worker via SAB: **unsupported** (vitest browser does not set COOP/COEP)
   - **Default to `Transferable`.** SAB only as opt-in.
 
-- **POC 5b — Async scatter pipeline with skeleton** (branch `perf-poc/worker-async-pipeline`, commit `aa6611ad7d`)
-  - 100k: async first paint **6 ms** vs sync `ScatterChart` 1076 ms (180x); async full paint 115 ms vs 1076 ms (9x).
-  - 1M: async first paint **22 ms** vs sync 12 599 ms (**570x**); async full paint 1258 ms vs 12 599 ms (**10x**).
-  - Caveat: experimental component bypasses the lib `ChartProvider` pipeline. Production integration will re-add some of that overhead. Conservative estimate: 3–5x full-paint win after re-integration; first-paint win stays intact regardless.
+- **POC 5b — Async scatter pipeline with skeleton** (branch `perf-poc/worker-async-pipeline`)
+  - 100k: async first paint ~**6 ms** vs sync `ScatterChart` ~1076 ms (~180x); async full paint ~115 ms vs ~1076 ms (~9x).
+  - 1M: async first paint ~**22 ms** vs sync ~12 599 ms (~**570x**); async full paint ~1258 ms vs ~12 599 ms (~**10x**).
+  - Caveat: the experimental component bypasses the lib `ChartProvider` pipeline. Production integration will re-add some of that overhead. Conservative estimate: ~3–5x full-paint win after re-integration; first-paint win expected to stay intact.
 
-- **POC 6 — Viewport-keyed sample cache** (branch `perf-poc/memo-sampled-cache`, commit `425689a805`)
+- **POC 6 — Viewport-keyed sample cache** (branch `perf-poc/memo-sampled-cache`)
   - 1M, 60 calls, per-call cost:
-    - Uncached LTTB: 5.25 ms
-    - Cached, full-range repeats (98 % hits): **0.10 ms** (~50x)
-    - Cached, continuous pan, no quantize (0 % hits): 26.7 ms (worse — slice cost)
-    - Cached, pan with 5 % quantize (48 % hits): 13.7 ms
-    - Cached, zoom cycle through 5 levels (97 % hits): **0.61 ms**
-  - **Free win for re-renders** (Scenario B). **Strong fit for zoom-snap UX** (Scenario E). **Continuous pan needs worker offload, not cache.**
+    - Uncached LTTB: ~5.25 ms
+    - Cached, full-range repeats (98 % hits): ~**0.10 ms** (~50x)
+    - Cached, continuous pan, no quantize (0 % hits): ~26.7 ms (worse — slice cost)
+    - Cached, pan with 5 % quantize (48 % hits): ~13.7 ms
+    - Cached, zoom cycle through 5 levels (97 % hits): ~**0.61 ms**
+  - **Expected free win for re-renders** (Scenario B). **Strong fit for zoom-snap UX** (Scenario E). **Continuous pan needs worker offload, not cache.**
 
-- **POC 7 — MapReduce-style multi-worker fan-out with `SharedArrayBuffer`** (branch `perf-poc/mapreduce-sab`, commit `3dc9979901`)
+- **POC 7 — MapReduce-style multi-worker fan-out with `SharedArrayBuffer`** (branch `perf-poc/mapreduce-sab`)
   - 1M scatter, path generation only, hardwareConcurrency=11, mean of 5 runs:
-    - 1 worker: 228.8 ms (baseline)
-    - 2 workers: 127.5 ms (1.79x)
-    - 4 workers: 88.3 ms (2.59x)
-    - 8 workers: **77.0 ms (2.97x)**
-  - Speedup ceiling ~3x, not Nx. Bottleneck above 4 workers is output cloning — path strings posted back via structured clone (~10 MB / N per worker). To break through, paths would need to be written into a shared output buffer (UTF-8 bytes) and read back as one string.
+    - 1 worker: ~228.8 ms (baseline)
+    - 2 workers: ~127.5 ms (~1.79x)
+    - 4 workers: ~88.3 ms (~2.59x)
+    - 8 workers: ~**77.0 ms (~2.97x)**
+  - Expected speedup ceiling ~3x, not Nx. Bottleneck above 4 workers is output cloning — path strings posted back via structured clone (~10 MB / N per worker). To break through, paths would need to be written into a shared output buffer (UTF-8 bytes) and read back as one string.
   - Required enabling `Cross-Origin-Opener-Policy: same-origin` + `Cross-Origin-Embedder-Policy: require-corp` in the test/perf vitest config. App-level config in production.
   - Browser paint of 1M paths still happens after worker processing — MapReduce only speeds up JS work, not rasterization.
-  - **Recommended as a follow-up to Option B**, gated on customer demand for cross-origin isolation. Meaningful at 1M+ but not transformative.
+  - **Recommended as a follow-up to Option B**, gated on customer demand for cross-origin isolation. Likely meaningful at 1M+, not transformative.
 
 ## Branches and PRs
 
-| Item                                  | Branch                             | Commit       | Draft PR                                                       |
-| ------------------------------------- | ---------------------------------- | ------------ | -------------------------------------------------------------- |
-| **Proposal — async pipeline plugin**  | `feat/async-chart-pipeline`        | `8382271729` | **[#22370](https://github.com/mui/mui-x/pull/22370)**          |
-| 1. LTTB sub-sampling (line)           | `perf-poc/subsampling-line-lttb`   | `716b783b2c` | [#22363](https://github.com/mui/mui-x/pull/22363)              |
-| 4. Progressive scatter (leaf level)   | `perf-poc/progressive-scatter`     | `a40467831f` | [#22364](https://github.com/mui/mui-x/pull/22364) — negative result |
-| 5. Worker transfer cost spike         | `perf-poc/worker-series-processor` | `82a37b0af4` | [#22365](https://github.com/mui/mui-x/pull/22365)              |
-| 5b. Async pipeline + skeleton (spike) | `perf-poc/worker-async-pipeline`   | `aa6611ad7d` | [#22366](https://github.com/mui/mui-x/pull/22366)              |
-| 6. Viewport-keyed sample cache        | `perf-poc/memo-sampled-cache`      | `425689a805` | [#22367](https://github.com/mui/mui-x/pull/22367)              |
-| 7. MapReduce SAB fan-out              | `perf-poc/mapreduce-sab`           | `3dc9979901` | [#22368](https://github.com/mui/mui-x/pull/22368) — follow-up  |
-| First proposal (superseded)           | `feat/async-scatter-plot`          | `d16d303e9f` | [#22369](https://github.com/mui/mui-x/pull/22369) — superseded by #22370 |
+| Item                                  | Branch                             | Draft PR                                                                 |
+| ------------------------------------- | ---------------------------------- | ------------------------------------------------------------------------ |
+| **Proposal — async pipeline plugin**  | `feat/async-chart-pipeline`        | **[#22370](https://github.com/mui/mui-x/pull/22370)**                    |
+| 1. LTTB sub-sampling (line)           | `perf-poc/subsampling-line-lttb`   | [#22363](https://github.com/mui/mui-x/pull/22363)                        |
+| 4. Progressive scatter (leaf level)   | `perf-poc/progressive-scatter`     | [#22364](https://github.com/mui/mui-x/pull/22364) — negative result      |
+| 5. Worker transfer cost spike         | `perf-poc/worker-series-processor` | [#22365](https://github.com/mui/mui-x/pull/22365)                        |
+| 5b. Async pipeline + skeleton (spike) | `perf-poc/worker-async-pipeline`   | [#22366](https://github.com/mui/mui-x/pull/22366)                        |
+| 6. Viewport-keyed sample cache        | `perf-poc/memo-sampled-cache`      | [#22367](https://github.com/mui/mui-x/pull/22367)                        |
+| 7. MapReduce SAB fan-out              | `perf-poc/mapreduce-sab`           | [#22368](https://github.com/mui/mui-x/pull/22368) — follow-up            |
+| First proposal (superseded)           | `feat/async-scatter-plot`          | [#22369](https://github.com/mui/mui-x/pull/22369) — superseded by #22370 |
 
 POC 2 (bar bucket sub-sampling) and POC 3 (progressive line render) were scoped but not built. Bar bucket is a small port of POC 1; progressive line was deprioritised after POC 4's negative result.

--- a/docs/data/charts/bars/AsyncBarProcessing.js
+++ b/docs/data/charts/bars/AsyncBarProcessing.js
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import Stack from '@mui/material/Stack';
+import Switch from '@mui/material/Switch';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import { BarChart } from '@mui/x-charts/BarChart';
+
+const N = 30_000;
+
+function generate(seed) {
+  let s = seed;
+  const xs = new Array(N);
+  const ys = new Array(N);
+  for (let i = 0; i < N; i += 1) {
+    xs[i] = i;
+    s = (s * 9301 + 49297) % 233280;
+    ys[i] = 50 + Math.sin(i / 5) * 25 + (s / 233280 - 0.5) * 5;
+  }
+  return { xs, ys };
+}
+
+const DATASETS = [generate(1), generate(2), generate(3)];
+
+export default function AsyncBarProcessing() {
+  const [datasetIndex, setDatasetIndex] = React.useState(0);
+  const [asyncProcessing, setAsyncProcessing] = React.useState(true);
+  const [tick, setTick] = React.useState(0);
+
+  React.useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), 100);
+    return () => clearInterval(id);
+  }, []);
+
+  const data = DATASETS[datasetIndex];
+
+  return (
+    <Stack spacing={2} alignItems="flex-start">
+      <Stack direction="row" spacing={2} alignItems="center" flexWrap="wrap">
+        <FormControlLabel
+          control={
+            <Switch
+              checked={asyncProcessing}
+              onChange={(event) => setAsyncProcessing(event.target.checked)}
+            />
+          }
+          label="asyncProcessing"
+        />
+        <Button
+          variant="outlined"
+          onClick={() => setDatasetIndex((i) => (i + 1) % DATASETS.length)}
+        >
+          Reload data ({N.toLocaleString()} pts)
+        </Button>
+        <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
+          counter: {tick} (smooth = main thread free)
+        </Typography>
+      </Stack>
+      <BarChart
+        xAxis={[{ data: data.xs, scaleType: 'band' }]}
+        series={[{ data: data.ys }]}
+        height={300}
+        asyncProcessing={asyncProcessing}
+      />
+    </Stack>
+  );
+}

--- a/docs/data/charts/bars/AsyncBarProcessing.tsx
+++ b/docs/data/charts/bars/AsyncBarProcessing.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import Stack from '@mui/material/Stack';
+import Switch from '@mui/material/Switch';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import { BarChart } from '@mui/x-charts/BarChart';
+
+const N = 30_000;
+
+function generate(seed: number) {
+  let s = seed;
+  const xs = new Array<number>(N);
+  const ys = new Array<number>(N);
+  for (let i = 0; i < N; i += 1) {
+    xs[i] = i;
+    s = (s * 9301 + 49297) % 233280;
+    ys[i] = 50 + Math.sin(i / 5) * 25 + (s / 233280 - 0.5) * 5;
+  }
+  return { xs, ys };
+}
+
+const DATASETS = [generate(1), generate(2), generate(3)];
+
+export default function AsyncBarProcessing() {
+  const [datasetIndex, setDatasetIndex] = React.useState(0);
+  const [asyncProcessing, setAsyncProcessing] = React.useState(true);
+  const [tick, setTick] = React.useState(0);
+
+  React.useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), 100);
+    return () => clearInterval(id);
+  }, []);
+
+  const data = DATASETS[datasetIndex];
+
+  return (
+    <Stack spacing={2} alignItems="flex-start">
+      <Stack direction="row" spacing={2} alignItems="center" flexWrap="wrap">
+        <FormControlLabel
+          control={
+            <Switch
+              checked={asyncProcessing}
+              onChange={(event) => setAsyncProcessing(event.target.checked)}
+            />
+          }
+          label="asyncProcessing"
+        />
+        <Button
+          variant="outlined"
+          onClick={() => setDatasetIndex((i) => (i + 1) % DATASETS.length)}
+        >
+          Reload data ({N.toLocaleString()} pts)
+        </Button>
+        <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
+          counter: {tick} (smooth = main thread free)
+        </Typography>
+      </Stack>
+      <BarChart
+        xAxis={[{ data: data.xs, scaleType: 'band' }]}
+        series={[{ data: data.ys }]}
+        height={300}
+        asyncProcessing={asyncProcessing}
+      />
+    </Stack>
+  );
+}

--- a/docs/data/charts/bars/bars.md
+++ b/docs/data/charts/bars/bars.md
@@ -320,3 +320,21 @@ Here's how the bar chart is composed:
 ```
 
 {{"demo": "BarScatterCompostion.js"}}
+
+## Async processing 🧪
+
+:::warning
+This feature is experimental. The API may change.
+:::
+
+Set `asyncProcessing` to run the series-processing pipeline (extremums, d3-stack, mapping) in a Web Worker. The chart's loading overlay is shown while the worker is busy; the chart re-renders with the full data once the worker returns.
+
+In the demo below, watch the counter while toggling `asyncProcessing` and reloading data. With it on, the counter keeps ticking smoothly. With it off, the counter freezes for the duration of the synchronous render.
+
+{{"demo": "AsyncBarProcessing.js"}}
+
+Constraints:
+
+- Series must use the `data` prop. `valueGetter` is not supported in this mode.
+- SSR / no-Worker environments fall back to the synchronous path silently.
+- The bar render itself is still on the main thread; only the series-processing step moves to the worker. Expect a smaller speedup than for line/scatter at the same point count.

--- a/docs/data/charts/lines/AsyncLineProcessing.js
+++ b/docs/data/charts/lines/AsyncLineProcessing.js
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import Stack from '@mui/material/Stack';
+import Switch from '@mui/material/Switch';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import { LineChart } from '@mui/x-charts/LineChart';
+
+const N = 100_000;
+
+function generate(seed) {
+  let s = seed;
+  const xs = new Array(N);
+  const ys = new Array(N);
+  for (let i = 0; i < N; i += 1) {
+    xs[i] = i;
+    s = (s * 9301 + 49297) % 233280;
+    ys[i] = 50 + Math.sin(i / 5) * 25 + (s / 233280 - 0.5) * 5;
+  }
+  return { xs, ys };
+}
+
+const DATASETS = [generate(1), generate(2), generate(3)];
+
+export default function AsyncLineProcessing() {
+  const [datasetIndex, setDatasetIndex] = React.useState(0);
+  const [asyncProcessing, setAsyncProcessing] = React.useState(true);
+  const [tick, setTick] = React.useState(0);
+
+  React.useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), 100);
+    return () => clearInterval(id);
+  }, []);
+
+  const data = DATASETS[datasetIndex];
+
+  return (
+    <Stack spacing={2} alignItems="flex-start">
+      <Stack direction="row" spacing={2} alignItems="center" flexWrap="wrap">
+        <FormControlLabel
+          control={
+            <Switch
+              checked={asyncProcessing}
+              onChange={(event) => setAsyncProcessing(event.target.checked)}
+            />
+          }
+          label="asyncProcessing"
+        />
+        <Button
+          variant="outlined"
+          onClick={() => setDatasetIndex((i) => (i + 1) % DATASETS.length)}
+        >
+          Reload data ({N.toLocaleString()} pts)
+        </Button>
+        <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
+          counter: {tick} (smooth = main thread free)
+        </Typography>
+      </Stack>
+      <LineChart
+        xAxis={[{ data: data.xs }]}
+        series={[{ data: data.ys, showMark: false }]}
+        height={300}
+        asyncProcessing={asyncProcessing}
+      />
+    </Stack>
+  );
+}

--- a/docs/data/charts/lines/AsyncLineProcessing.tsx
+++ b/docs/data/charts/lines/AsyncLineProcessing.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import Stack from '@mui/material/Stack';
+import Switch from '@mui/material/Switch';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import { LineChart } from '@mui/x-charts/LineChart';
+
+const N = 100_000;
+
+function generate(seed: number) {
+  let s = seed;
+  const xs = new Array<number>(N);
+  const ys = new Array<number>(N);
+  for (let i = 0; i < N; i += 1) {
+    xs[i] = i;
+    s = (s * 9301 + 49297) % 233280;
+    ys[i] = 50 + Math.sin(i / 5) * 25 + (s / 233280 - 0.5) * 5;
+  }
+  return { xs, ys };
+}
+
+const DATASETS = [generate(1), generate(2), generate(3)];
+
+export default function AsyncLineProcessing() {
+  const [datasetIndex, setDatasetIndex] = React.useState(0);
+  const [asyncProcessing, setAsyncProcessing] = React.useState(true);
+  const [tick, setTick] = React.useState(0);
+
+  React.useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), 100);
+    return () => clearInterval(id);
+  }, []);
+
+  const data = DATASETS[datasetIndex];
+
+  return (
+    <Stack spacing={2} alignItems="flex-start">
+      <Stack direction="row" spacing={2} alignItems="center" flexWrap="wrap">
+        <FormControlLabel
+          control={
+            <Switch
+              checked={asyncProcessing}
+              onChange={(event) => setAsyncProcessing(event.target.checked)}
+            />
+          }
+          label="asyncProcessing"
+        />
+        <Button
+          variant="outlined"
+          onClick={() => setDatasetIndex((i) => (i + 1) % DATASETS.length)}
+        >
+          Reload data ({N.toLocaleString()} pts)
+        </Button>
+        <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
+          counter: {tick} (smooth = main thread free)
+        </Typography>
+      </Stack>
+      <LineChart
+        xAxis={[{ data: data.xs }]}
+        series={[{ data: data.ys, showMark: false }]}
+        height={300}
+        asyncProcessing={asyncProcessing}
+      />
+    </Stack>
+  );
+}

--- a/docs/data/charts/lines/lines.md
+++ b/docs/data/charts/lines/lines.md
@@ -348,3 +348,20 @@ The `data-drawing-container` attribute marks children as part of the drawing are
 
 See [Composition—clipping](/x/react-charts/composition/#clipping) for details.
 :::
+
+## Async processing 🧪
+
+:::warning
+This feature is experimental. The API may change.
+:::
+
+Set `asyncProcessing` to run the series-processing pipeline (extremums, d3-stack, mapping) in a Web Worker. The chart's loading overlay is shown while the worker is busy; the chart re-renders with the full data once the worker returns. Suitable for very large datasets where the synchronous pipeline blocks the main thread.
+
+In the demo below, watch the counter while toggling `asyncProcessing` and reloading data. With it on, the counter keeps ticking smoothly. With it off, the counter freezes for the duration of the synchronous render.
+
+{{"demo": "AsyncLineProcessing.js"}}
+
+Constraints:
+
+- Series must use the `data` prop. `valueGetter` is not supported in this mode.
+- SSR / no-Worker environments fall back to the synchronous path silently.

--- a/docs/data/charts/scatter/AsyncScatterProcessing.js
+++ b/docs/data/charts/scatter/AsyncScatterProcessing.js
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import Stack from '@mui/material/Stack';
+import Switch from '@mui/material/Switch';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import { ScatterChart } from '@mui/x-charts/ScatterChart';
+
+const N = 50_000;
+
+function generate(seed) {
+  let s = seed;
+  const data = new Array(N);
+  for (let i = 0; i < N; i += 1) {
+    s = (s * 9301 + 49297) % 233280;
+    const x = s / 233280;
+    s = (s * 9301 + 49297) % 233280;
+    const y = s / 233280;
+    data[i] = { id: i, x, y };
+  }
+  return data;
+}
+
+const DATASETS = [generate(1), generate(2), generate(3)];
+
+export default function AsyncScatterProcessing() {
+  const [datasetIndex, setDatasetIndex] = React.useState(0);
+  const [asyncProcessing, setAsyncProcessing] = React.useState(true);
+  const [tick, setTick] = React.useState(0);
+
+  React.useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), 100);
+    return () => clearInterval(id);
+  }, []);
+
+  const data = DATASETS[datasetIndex];
+
+  return (
+    <Stack spacing={2} alignItems="flex-start">
+      <Stack direction="row" spacing={2} alignItems="center" flexWrap="wrap">
+        <FormControlLabel
+          control={
+            <Switch
+              checked={asyncProcessing}
+              onChange={(event) => setAsyncProcessing(event.target.checked)}
+            />
+          }
+          label="asyncProcessing"
+        />
+        <Button
+          variant="outlined"
+          onClick={() => setDatasetIndex((i) => (i + 1) % DATASETS.length)}
+        >
+          Reload data ({N.toLocaleString()} pts)
+        </Button>
+        <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
+          counter: {tick} (smooth = main thread free)
+        </Typography>
+      </Stack>
+      <ScatterChart
+        series={[{ data, markerSize: 2 }]}
+        height={300}
+        asyncProcessing={asyncProcessing}
+      />
+    </Stack>
+  );
+}

--- a/docs/data/charts/scatter/AsyncScatterProcessing.tsx
+++ b/docs/data/charts/scatter/AsyncScatterProcessing.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import Stack from '@mui/material/Stack';
+import Switch from '@mui/material/Switch';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import { ScatterChart } from '@mui/x-charts/ScatterChart';
+
+const N = 50_000;
+
+function generate(seed: number) {
+  let s = seed;
+  const data = new Array<{ id: number; x: number; y: number }>(N);
+  for (let i = 0; i < N; i += 1) {
+    s = (s * 9301 + 49297) % 233280;
+    const x = s / 233280;
+    s = (s * 9301 + 49297) % 233280;
+    const y = s / 233280;
+    data[i] = { id: i, x, y };
+  }
+  return data;
+}
+
+const DATASETS = [generate(1), generate(2), generate(3)];
+
+export default function AsyncScatterProcessing() {
+  const [datasetIndex, setDatasetIndex] = React.useState(0);
+  const [asyncProcessing, setAsyncProcessing] = React.useState(true);
+  const [tick, setTick] = React.useState(0);
+
+  React.useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), 100);
+    return () => clearInterval(id);
+  }, []);
+
+  const data = DATASETS[datasetIndex];
+
+  return (
+    <Stack spacing={2} alignItems="flex-start">
+      <Stack direction="row" spacing={2} alignItems="center" flexWrap="wrap">
+        <FormControlLabel
+          control={
+            <Switch
+              checked={asyncProcessing}
+              onChange={(event) => setAsyncProcessing(event.target.checked)}
+            />
+          }
+          label="asyncProcessing"
+        />
+        <Button
+          variant="outlined"
+          onClick={() => setDatasetIndex((i) => (i + 1) % DATASETS.length)}
+        >
+          Reload data ({N.toLocaleString()} pts)
+        </Button>
+        <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
+          counter: {tick} (smooth = main thread free)
+        </Typography>
+      </Stack>
+      <ScatterChart
+        series={[{ data, markerSize: 2 }]}
+        height={300}
+        asyncProcessing={asyncProcessing}
+      />
+    </Stack>
+  );
+}

--- a/docs/data/charts/scatter/scatter.md
+++ b/docs/data/charts/scatter/scatter.md
@@ -224,3 +224,20 @@ See [Composition—clipping](/x/react-charts/composition/#clipping) for details.
 Add a regression line to a scatter plot by composing a custom chart and drawing the line yourself.
 
 {{"demo": "ScatterRegressionLine.js"}}
+
+## Async processing 🧪
+
+:::warning
+This feature is experimental. The API may change.
+:::
+
+Set `asyncProcessing` to run the series-processing pipeline in a Web Worker. The chart's loading overlay is shown while the worker is busy; the chart re-renders with the full data once the worker returns.
+
+In the demo below, watch the counter while toggling `asyncProcessing` and reloading data. With it on, the counter keeps ticking smoothly. With it off, the counter freezes for the duration of the synchronous render.
+
+{{"demo": "AsyncScatterProcessing.js"}}
+
+Constraints:
+
+- Series must use the `data` prop. `valueGetter` is not supported in this mode.
+- SSR / no-Worker environments fall back to the synchronous path silently.

--- a/packages/x-charts/src/ChartsContainer/useChartsContainerProps.ts
+++ b/packages/x-charts/src/ChartsContainer/useChartsContainerProps.ts
@@ -63,6 +63,7 @@ export const useChartsContainerProps = <
     onHiddenItemsChange,
     hiddenItems,
     initialHiddenItems,
+    asyncProcessing,
     ...other
   } = props as ChartsContainerProps<SeriesType, AllPluginSignatures<SeriesType>>;
 
@@ -108,6 +109,7 @@ export const useChartsContainerProps = <
     onHiddenItemsChange,
     hiddenItems,
     initialHiddenItems,
+    asyncProcessing,
     plugins: plugins ?? DEFAULT_PLUGINS,
     slots,
     slotProps,

--- a/packages/x-charts/src/ChartsOverlay/ChartsOverlay.tsx
+++ b/packages/x-charts/src/ChartsOverlay/ChartsOverlay.tsx
@@ -6,6 +6,19 @@ import { ChartsLoadingOverlay } from './ChartsLoadingOverlay';
 import { useSeries } from '../hooks/useSeries';
 import { type SeriesId } from '../models/seriesType/common';
 import { ChartsNoDataOverlay } from './ChartsNoDataOverlay';
+import { useStore } from '../internals/store/useStore';
+import {
+  selectorChartIsAsyncProcessing,
+  type UseChartAsyncSeriesProcessorSignature,
+} from '../internals/plugins/corePlugins/useChartAsyncSeriesProcessor';
+
+/**
+ * @returns `true` while the async-series-processor plugin is running its worker.
+ */
+export function useIsAsyncProcessing() {
+  const store = useStore<[UseChartAsyncSeriesProcessorSignature]>();
+  return store.use(selectorChartIsAsyncProcessing);
+}
 
 export function useNoData() {
   const seriesPerType = useSeries();
@@ -72,8 +85,9 @@ export interface ChartsOverlayProps {
 
 export function ChartsOverlay(props: ChartsOverlayProps) {
   const noData = useNoData();
+  const isAsyncProcessing = useIsAsyncProcessing();
 
-  if (props.loading) {
+  if (props.loading || isAsyncProcessing) {
     const LoadingOverlay = props.slots?.loadingOverlay ?? ChartsLoadingOverlay;
     return <LoadingOverlay {...props.slotProps?.loadingOverlay} />;
   }

--- a/packages/x-charts/src/internals/plugins/corePlugins/corePlugins.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/corePlugins.ts
@@ -16,6 +16,11 @@ import {
   type UseChartInteractionListenerSignature,
   useChartInteractionListener,
 } from './useChartInteractionListener';
+import {
+  type UseChartAsyncSeriesProcessorSignature,
+  type UseChartAsyncSeriesProcessorParameters,
+  useChartAsyncSeriesProcessor,
+} from './useChartAsyncSeriesProcessor';
 import type { ChartSeriesType } from '../../../models/seriesType/config';
 
 /**
@@ -29,6 +34,7 @@ export const CHART_CORE_PLUGINS = [
   useChartExperimentalFeatures,
   useChartDimensions,
   useChartSeries,
+  useChartAsyncSeriesProcessor,
   useChartInteractionListener,
   useChartAnimation,
 ] as const;
@@ -40,9 +46,13 @@ export type ChartCorePluginSignatures<SeriesType extends ChartSeriesType = Chart
   UseChartExperimentalFeaturesSignature<SeriesType>,
   UseChartDimensionsSignature,
   UseChartSeriesSignature<SeriesType>,
+  UseChartAsyncSeriesProcessorSignature<SeriesType>,
   UseChartAnimationSignature,
   UseChartInteractionListenerSignature,
 ];
 
 export interface ChartCorePluginParameters
-  extends UseChartIdParameters, UseChartSeriesConfigParameters {}
+  extends
+    UseChartIdParameters,
+    UseChartSeriesConfigParameters,
+    UseChartAsyncSeriesProcessorParameters {}

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartAsyncSeriesProcessor/index.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartAsyncSeriesProcessor/index.ts
@@ -1,0 +1,12 @@
+export { useChartAsyncSeriesProcessor } from './useChartAsyncSeriesProcessor';
+export type {
+  UseChartAsyncSeriesProcessorParameters,
+  UseChartAsyncSeriesProcessorDefaultizedParameters,
+  UseChartAsyncSeriesProcessorState,
+  UseChartAsyncSeriesProcessorSignature,
+} from './useChartAsyncSeriesProcessor.types';
+export {
+  selectorChartIsAsyncProcessing,
+  selectorChartAsyncProcessedSeries,
+  selectorChartAsyncProcessingEnabled,
+} from './useChartAsyncSeriesProcessor.selectors';

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartAsyncSeriesProcessor/serialize.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartAsyncSeriesProcessor/serialize.ts
@@ -1,0 +1,88 @@
+import { type ChartSeriesType } from '../../../../models/seriesType/config';
+import { type SeriesId } from '../../../../models/seriesType/common';
+import {
+  type DefaultizedSeriesGroups,
+  type ProcessedSeries,
+} from '../useChartSeries/useChartSeries.types';
+
+const STRIPPABLE_FUNCTION_FIELDS = new Set(['valueFormatter', 'valueGetter', 'showMark', 'label']);
+
+/**
+ * Strip function-typed fields from each series so the structure can be sent through
+ * `postMessage`. Functions are restored on the main thread when the worker returns.
+ */
+export function stripFunctionsFromSeries<T extends ChartSeriesType>(
+  defaultized: DefaultizedSeriesGroups<T>,
+): DefaultizedSeriesGroups<T> {
+  const stripped: Record<string, unknown> = {};
+  for (const type of Object.keys(defaultized)) {
+    const group = (defaultized as Record<string, any>)[type];
+    if (!group) {
+      continue;
+    }
+    const newSeries: Record<string, unknown> = {};
+    for (const id of Object.keys(group.series)) {
+      const item = group.series[id] as Record<string, unknown>;
+      const cleaned: Record<string, unknown> = {};
+      for (const key of Object.keys(item)) {
+        const value = item[key];
+        if (typeof value === 'function' && STRIPPABLE_FUNCTION_FIELDS.has(key)) {
+          continue;
+        }
+        cleaned[key] = value;
+      }
+      newSeries[id] = cleaned;
+    }
+    stripped[type] = { ...group, series: newSeries };
+  }
+  return stripped as DefaultizedSeriesGroups<T>;
+}
+
+/**
+ * Re-attach function-typed fields from the original (main-thread) defaultized series
+ * onto the worker's processed output. The worker only computes numeric fields like
+ * `stackedData`, so we keep the originals on the main side and merge here.
+ */
+export function reattachFunctions<T extends ChartSeriesType>(
+  workerOutput: ProcessedSeries<T>,
+  originalDefaultized: DefaultizedSeriesGroups<T>,
+): ProcessedSeries<T> {
+  const merged: Record<string, unknown> = {};
+  for (const type of Object.keys(workerOutput)) {
+    const workerGroup = (workerOutput as Record<string, any>)[type];
+    const origGroup = (originalDefaultized as Record<string, any>)[type];
+    if (!workerGroup) {
+      continue;
+    }
+    const series: Record<string, unknown> = {};
+    for (const id of Object.keys(workerGroup.series)) {
+      const orig = origGroup?.series?.[id];
+      const fromWorker = workerGroup.series[id];
+      // Spread original first to keep functions; worker fields win for the numeric ones.
+      series[id] = { ...orig, ...fromWorker };
+    }
+    merged[type] = { ...workerGroup, series };
+  }
+  return merged as ProcessedSeries<T>;
+}
+
+export function buildHiddenIdsMap<T extends ChartSeriesType>(
+  defaultized: DefaultizedSeriesGroups<T>,
+  isItemVisible: (item: { type: T; seriesId: SeriesId }) => boolean,
+): Record<string, SeriesId[]> {
+  const hidden: Record<string, SeriesId[]> = {};
+  for (const type of Object.keys(defaultized) as T[]) {
+    const group = (defaultized as Record<string, any>)[type as string];
+    if (!group) {
+      continue;
+    }
+    const ids: SeriesId[] = [];
+    for (const id of group.seriesOrder) {
+      if (!isItemVisible({ type, seriesId: id })) {
+        ids.push(id);
+      }
+    }
+    hidden[type as string] = ids;
+  }
+  return hidden;
+}

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartAsyncSeriesProcessor/seriesProcessorWorker.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartAsyncSeriesProcessor/seriesProcessorWorker.ts
@@ -1,0 +1,99 @@
+/* eslint-disable no-restricted-globals */
+/**
+ * Web Worker entry that runs `applySeriesProcessors` for line, bar, and scatter series.
+ *
+ * The main thread sends defaultized series (with function fields stripped), the dataset,
+ * and a per-type set of hidden series ids. The worker re-runs the per-type
+ * `seriesProcessor` (statically imported here) and posts the resulting `ProcessedSeries`
+ * back. The main thread then re-attaches function fields and stores the result.
+ *
+ * @internal
+ */
+
+import lineSeriesProcessor from '../../../../LineChart/seriesConfig/seriesProcessor';
+import barSeriesProcessor from '../../../../BarChart/seriesConfig/bar/seriesProcessor';
+import scatterSeriesProcessor from '../../../../ScatterChart/seriesConfig/seriesProcessor';
+import { type DefaultizedSeriesGroups } from '../useChartSeries/useChartSeries.types';
+import { type DatasetType } from '../../../../models/seriesType/config';
+import { type SeriesId } from '../../../../models/seriesType/common';
+import { type IsItemVisibleFunction } from '../../featurePlugins/useChartVisibilityManager';
+
+interface WorkerInput {
+  defaultizedSeries: DefaultizedSeriesGroups;
+  dataset?: DatasetType;
+  hiddenIds: Record<string, SeriesId[]>;
+}
+
+const PROCESSORS: Record<string, (...args: any[]) => any> = {
+  line: lineSeriesProcessor,
+  bar: barSeriesProcessor,
+  scatter: scatterSeriesProcessor,
+};
+
+/** Strip function-typed fields from the processed output so it can be posted back. */
+function stripFunctions(input: unknown): unknown {
+  if (input === null || input === undefined) {
+    return input;
+  }
+  if (Array.isArray(input)) {
+    // Arrays are kept as-is (arrays of paths/numbers etc.). We don't recurse into
+    // typed-array-like sequences for performance; the function fields we strip live
+    // on plain series objects.
+    return input;
+  }
+  if (typeof input !== 'object') {
+    if (typeof input === 'function') {
+      return undefined;
+    }
+    return input;
+  }
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(input as Record<string, unknown>)) {
+    const value = (input as Record<string, unknown>)[key];
+    if (typeof value === 'function') {
+      continue;
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+function stripFunctionsFromGroup(group: Record<string, unknown>): Record<string, unknown> {
+  const seriesIn = group.series as Record<string, unknown>;
+  const seriesOut: Record<string, unknown> = {};
+  for (const id of Object.keys(seriesIn)) {
+    seriesOut[id] = stripFunctions(seriesIn[id]);
+  }
+  // stackingGroups carries d3-stack helper functions (`stackingOrder`, `stackingOffset`)
+  // that aren't needed after processing — downstream code only reads `ids` and `length`.
+  const stackingGroupsRaw = group.stackingGroups as Array<Record<string, unknown>> | undefined;
+  const stackingGroups = stackingGroupsRaw?.map((g) => stripFunctions(g));
+  return { ...group, series: seriesOut, ...(stackingGroups ? { stackingGroups } : {}) };
+}
+
+self.addEventListener('message', (event: MessageEvent<WorkerInput>) => {
+  const t0 = performance.now();
+  const { defaultizedSeries, dataset, hiddenIds } = event.data;
+
+  const isItemVisible: IsItemVisibleFunction = ({ type, seriesId }) => {
+    const ids = hiddenIds[type as string];
+    if (!ids) {
+      return true;
+    }
+    return !ids.some((id) => id === seriesId);
+  };
+
+  const processed: Record<string, unknown> = {};
+  for (const type of Object.keys(defaultizedSeries)) {
+    const group = (defaultizedSeries as Record<string, unknown>)[type];
+    const processor = PROCESSORS[type];
+    if (!group || !processor) {
+      continue;
+    }
+    const result = processor(group, dataset, isItemVisible);
+    processed[type] = stripFunctionsFromGroup(result);
+  }
+
+  const processingMs = performance.now() - t0;
+  (self as unknown as Worker).postMessage({ processed, processingMs });
+});

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartAsyncSeriesProcessor/useChartAsyncSeriesProcessor.selectors.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartAsyncSeriesProcessor/useChartAsyncSeriesProcessor.selectors.ts
@@ -1,0 +1,22 @@
+import { createSelector } from '@mui/x-internals/store';
+import { type ChartRootSelector } from '../../utils/selectors';
+import { type UseChartAsyncSeriesProcessorSignature } from './useChartAsyncSeriesProcessor.types';
+
+export const selectorChartAsyncSeriesProcessorState: ChartRootSelector<
+  UseChartAsyncSeriesProcessorSignature
+> = (state) => state.asyncSeriesProcessor;
+
+export const selectorChartIsAsyncProcessing = createSelector(
+  selectorChartAsyncSeriesProcessorState,
+  (asyncState) => asyncState.enabled && asyncState.isProcessing,
+);
+
+export const selectorChartAsyncProcessedSeries = createSelector(
+  selectorChartAsyncSeriesProcessorState,
+  (asyncState) => (asyncState.enabled ? asyncState.processedSeries : null),
+);
+
+export const selectorChartAsyncProcessingEnabled = createSelector(
+  selectorChartAsyncSeriesProcessorState,
+  (asyncState) => asyncState.enabled,
+);

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartAsyncSeriesProcessor/useChartAsyncSeriesProcessor.test.tsx
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartAsyncSeriesProcessor/useChartAsyncSeriesProcessor.test.tsx
@@ -1,0 +1,82 @@
+import { createRenderer, screen, waitFor } from '@mui/internal-test-utils/createRenderer';
+import { ScatterChart } from '@mui/x-charts/ScatterChart';
+import { LineChart } from '@mui/x-charts/LineChart';
+import { isJSDOM } from 'test/utils/skipIf';
+
+describe('async series processor plugin', () => {
+  const { render } = createRenderer();
+
+  function countScatterMarkers(container: HTMLElement) {
+    return container.querySelectorAll('circle, path').length;
+  }
+
+  it('renders synchronously when asyncProcessing is false (default)', () => {
+    const { container } = render(
+      <ScatterChart
+        width={400}
+        height={200}
+        series={[
+          {
+            data: [
+              { id: 1, x: 0, y: 0 },
+              { id: 2, x: 1, y: 1 },
+            ],
+          },
+        ]}
+      />,
+    );
+    // Markers paint without going through the loading overlay.
+    expect(countScatterMarkers(container)).to.be.greaterThan(0);
+  });
+
+  it.skipIf(isJSDOM)('shows the loading overlay while the worker computes', async () => {
+    const { container } = render(
+      <ScatterChart
+        width={400}
+        height={200}
+        asyncProcessing
+        series={[
+          {
+            data: [
+              { id: 1, x: 0, y: 0 },
+              { id: 2, x: 1, y: 1 },
+              { id: 3, x: 2, y: 0.5 },
+            ],
+          },
+        ]}
+      />,
+    );
+
+    // The loading overlay text comes from ChartsLoadingOverlay; we just check it's there
+    // before the worker resolves. Render is fast so we look for any loading-overlay node.
+    expect(screen.getByText(/loading/i)).not.to.equal(null);
+
+    // Eventually the marks paint as the worker completes.
+    await waitFor(
+      () => {
+        expect(countScatterMarkers(container)).to.be.greaterThan(0);
+      },
+      { timeout: 10_000 },
+    );
+  });
+
+  it.skipIf(isJSDOM)('handles a line series end-to-end via the worker', async () => {
+    const { container } = render(
+      <LineChart
+        width={400}
+        height={200}
+        asyncProcessing
+        xAxis={[{ data: [0, 1, 2, 3, 4] }]}
+        series={[{ data: [10, 20, 15, 25, 30] }]}
+      />,
+    );
+
+    await waitFor(
+      () => {
+        // d3-line emits a `<path>` for the series stroke once data is processed.
+        expect(container.querySelectorAll('path').length).to.be.greaterThan(0);
+      },
+      { timeout: 10_000 },
+    );
+  });
+});

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartAsyncSeriesProcessor/useChartAsyncSeriesProcessor.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartAsyncSeriesProcessor/useChartAsyncSeriesProcessor.ts
@@ -1,0 +1,100 @@
+'use client';
+import * as React from 'react';
+import { type ChartPlugin } from '../../models';
+import { type UseChartAsyncSeriesProcessorSignature } from './useChartAsyncSeriesProcessor.types';
+import {
+  selectorChartDefaultizedSeries,
+  selectorChartsDataset,
+} from '../useChartSeries/useChartSeries.selectors';
+import { selectorIsItemVisibleGetter } from '../../featurePlugins/useChartVisibilityManager';
+import { buildHiddenIdsMap, reattachFunctions, stripFunctionsFromSeries } from './serialize';
+import { type ProcessedSeries } from '../useChartSeries/useChartSeries.types';
+
+let nextRequestId = 0;
+
+export const useChartAsyncSeriesProcessor: ChartPlugin<UseChartAsyncSeriesProcessorSignature> = ({
+  params,
+  store,
+}) => {
+  const enabled = params.asyncProcessing ?? false;
+  const defaultizedSeries = store.use(selectorChartDefaultizedSeries);
+  const dataset = store.use(selectorChartsDataset);
+  const isItemVisible = store.use(selectorIsItemVisibleGetter);
+
+  React.useEffect(() => {
+    if (!enabled) {
+      // Make sure consumers see the sync path again when async is turned off.
+      if (store.state.asyncSeriesProcessor.enabled) {
+        store.set('asyncSeriesProcessor', {
+          enabled: false,
+          isProcessing: false,
+          processedSeries: null,
+          requestId: store.state.asyncSeriesProcessor.requestId,
+        });
+      }
+      return undefined;
+    }
+
+    if (typeof Worker === 'undefined') {
+      // SSR / no-Worker environment. Fall back to the sync path silently.
+      return undefined;
+    }
+
+    nextRequestId += 1;
+    const requestId = nextRequestId;
+    store.set('asyncSeriesProcessor', {
+      enabled: true,
+      isProcessing: true,
+      processedSeries: store.state.asyncSeriesProcessor.processedSeries,
+      requestId,
+    });
+
+    const worker = new Worker(new URL('./seriesProcessorWorker', import.meta.url), {
+      type: 'module',
+    });
+
+    worker.onmessage = (event: MessageEvent<{ processed: ProcessedSeries }>) => {
+      // Drop stale responses (a newer request superseded this one).
+      if (store.state.asyncSeriesProcessor.requestId !== requestId) {
+        worker.terminate();
+        return;
+      }
+      const merged = reattachFunctions(event.data.processed, defaultizedSeries);
+      store.set('asyncSeriesProcessor', {
+        enabled: true,
+        isProcessing: false,
+        processedSeries: merged,
+        requestId,
+      });
+      worker.terminate();
+    };
+
+    const stripped = stripFunctionsFromSeries(defaultizedSeries);
+    const hiddenIds = buildHiddenIdsMap(defaultizedSeries, isItemVisible);
+    worker.postMessage({ defaultizedSeries: stripped, dataset, hiddenIds });
+
+    return () => {
+      worker.terminate();
+    };
+  }, [enabled, defaultizedSeries, dataset, isItemVisible, store]);
+
+  return {};
+};
+
+useChartAsyncSeriesProcessor.params = {
+  asyncProcessing: true,
+};
+
+useChartAsyncSeriesProcessor.getDefaultizedParams = ({ params }) => ({
+  ...params,
+  asyncProcessing: params.asyncProcessing ?? false,
+});
+
+useChartAsyncSeriesProcessor.getInitialState = ({ asyncProcessing }) => ({
+  asyncSeriesProcessor: {
+    enabled: asyncProcessing ?? false,
+    isProcessing: false,
+    processedSeries: null,
+    requestId: 0,
+  },
+});

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartAsyncSeriesProcessor/useChartAsyncSeriesProcessor.types.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartAsyncSeriesProcessor/useChartAsyncSeriesProcessor.types.ts
@@ -1,0 +1,44 @@
+import { type ChartPluginSignature } from '../../models';
+import type { ChartSeriesType } from '../../../../models/seriesType/config';
+import type { ProcessedSeries } from '../useChartSeries/useChartSeries.types';
+import type { UseChartSeriesSignature } from '../useChartSeries';
+import type { UseChartSeriesConfigSignature } from '../useChartSeriesConfig';
+
+export interface UseChartAsyncSeriesProcessorParameters {
+  /**
+   * If `true`, the series-processing pipeline runs in a Web Worker so the main thread
+   * stays responsive while large datasets are processed. While the worker is busy, the
+   * chart is empty and its loading overlay is shown. When the worker returns, the chart
+   * re-renders with the full data.
+   *
+   * Constraints (v1):
+   * - Series must use the `data` prop. `valueGetter` is not supported in this mode.
+   * - Supported series types: `line`, `bar`, `scatter`.
+   *
+   * @default false
+   */
+  asyncProcessing?: boolean;
+}
+
+export type UseChartAsyncSeriesProcessorDefaultizedParameters =
+  Required<UseChartAsyncSeriesProcessorParameters>;
+
+export interface UseChartAsyncSeriesProcessorState<
+  SeriesType extends ChartSeriesType = ChartSeriesType,
+> {
+  asyncSeriesProcessor: {
+    enabled: boolean;
+    isProcessing: boolean;
+    processedSeries: ProcessedSeries<SeriesType> | null;
+    requestId: number;
+  };
+}
+
+export type UseChartAsyncSeriesProcessorSignature<
+  SeriesType extends ChartSeriesType = ChartSeriesType,
+> = ChartPluginSignature<{
+  params: UseChartAsyncSeriesProcessorParameters;
+  defaultizedParams: UseChartAsyncSeriesProcessorDefaultizedParameters;
+  state: UseChartAsyncSeriesProcessorState<SeriesType>;
+  dependencies: [UseChartSeriesSignature<SeriesType>, UseChartSeriesConfigSignature<SeriesType>];
+}>;

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartSeries/useChartSeries.selectors.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartSeries/useChartSeries.selectors.ts
@@ -6,6 +6,17 @@ import { applySeriesProcessors } from './processSeries';
 import { selectorIsItemVisibleGetter } from '../../featurePlugins/useChartVisibilityManager';
 import { selectorChartSeriesConfig } from '../useChartSeriesConfig/useChartSeriesConfig.selectors';
 
+// Read the async-series-processor state by direct path to avoid an import cycle
+// with `useChartAsyncSeriesProcessor`.
+const selectorAsyncEnabled = (state: { asyncSeriesProcessor?: { enabled: boolean } }) =>
+  state.asyncSeriesProcessor?.enabled ?? false;
+const selectorAsyncProcessedSeries = (state: {
+  asyncSeriesProcessor?: { enabled: boolean; processedSeries: unknown };
+}) =>
+  state.asyncSeriesProcessor?.enabled
+    ? (state.asyncSeriesProcessor.processedSeries as ReturnType<typeof applySeriesProcessors>)
+    : null;
+
 export const selectorChartSeriesState: ChartRootSelector<UseChartSeriesSignature> = (state) =>
   state.series;
 
@@ -23,9 +34,17 @@ export const selectorChartsDataset = createSelector(
   (seriesState) => seriesState.dataset,
 );
 
+const EMPTY_PROCESSED_SERIES = {} as ReturnType<typeof applySeriesProcessors>;
+
 /**
  * Get the processed series after applying series processors.
- * This selector computes the processed series on-demand from the defaultized series.
+ *
+ * When the chart's `asyncProcessing` flag is enabled, the work is done in a Web Worker
+ * by `useChartAsyncSeriesProcessor`. This selector then returns the worker's output if
+ * available, or an empty processed-series shape while the worker is still busy. Empty
+ * keeps every downstream consumer (axes, tooltip, highlight) safe — the chart's loading
+ * overlay handles the user-facing skeleton.
+ *
  * @returns {ProcessedSeries} The processed series.
  */
 export const selectorChartSeriesProcessed = createSelectorMemoized(
@@ -33,7 +52,19 @@ export const selectorChartSeriesProcessed = createSelectorMemoized(
   selectorChartSeriesConfig,
   selectorChartsDataset,
   selectorIsItemVisibleGetter,
-  function selectorChartSeriesProcessed(defaultizedSeries, seriesConfig, dataset, isItemVisible) {
+  selectorAsyncEnabled,
+  selectorAsyncProcessedSeries,
+  function selectorChartSeriesProcessed(
+    defaultizedSeries,
+    seriesConfig,
+    dataset,
+    isItemVisible,
+    asyncEnabled,
+    asyncProcessedSeries,
+  ) {
+    if (asyncEnabled) {
+      return asyncProcessedSeries ?? EMPTY_PROCESSED_SERIES;
+    }
     return applySeriesProcessors(defaultizedSeries, seriesConfig, dataset, isItemVisible);
   },
 );

--- a/test/performance-charts/tests/AsyncPipeline.bench.tsx
+++ b/test/performance-charts/tests/AsyncPipeline.bench.tsx
@@ -1,0 +1,107 @@
+import { benchmark } from '@mui/internal-benchmark';
+import { LineChart } from '@mui/x-charts/LineChart';
+import { BarChart } from '@mui/x-charts/BarChart';
+import { ScatterChart } from '@mui/x-charts/ScatterChart';
+
+function generateSeries(n: number) {
+  const xs = new Array<number>(n);
+  const ys = new Array<number>(n);
+  let s = 1;
+  for (let i = 0; i < n; i += 1) {
+    xs[i] = i;
+    s = (s * 9301 + 49297) % 233280;
+    ys[i] = 50 + Math.sin(i / 5) * 25 + (s / 233280 - 0.5) * 5;
+  }
+  return { xs, ys };
+}
+
+function generateScatter(n: number) {
+  const data = new Array<{ id: number; x: number; y: number }>(n);
+  let s = 1;
+  for (let i = 0; i < n; i += 1) {
+    s = (s * 9301 + 49297) % 233280;
+    const x = s / 233280;
+    s = (s * 9301 + 49297) % 233280;
+    const y = s / 233280;
+    data[i] = { id: i, x, y };
+  }
+  return data;
+}
+
+// Sizes calibrated to fit the bench harness 120 s per-test timeout. Bar/scatter sync
+// renders are slow per element (one DOM node per bar/marker in the regular renderer),
+// so they're capped lower. Line uses the cheap line-only renderer.
+const LINE_N = 100_000;
+const BAR_N = 30_000;
+const SCATTER_N = 50_000;
+
+const lineData = generateSeries(LINE_N);
+const barData = generateSeries(BAR_N);
+const scatterData = generateScatter(SCATTER_N);
+
+const heavyOpts = { warmupRuns: 1, runs: 3 };
+
+benchmark(`LineChart ${LINE_N.toLocaleString()} pts — sync`, () => (
+  <LineChart
+    xAxis={[{ data: lineData.xs }]}
+    series={[{ data: lineData.ys, showMark: false }]}
+    width={800}
+    height={400}
+  />
+));
+
+benchmark(`LineChart ${LINE_N.toLocaleString()} pts — async (worker)`, () => (
+  <LineChart
+    xAxis={[{ data: lineData.xs }]}
+    series={[{ data: lineData.ys, showMark: false }]}
+    width={800}
+    height={400}
+    asyncProcessing
+  />
+));
+
+benchmark(
+  `BarChart ${BAR_N.toLocaleString()} pts — sync`,
+  () => (
+    <BarChart
+      xAxis={[{ data: barData.xs, scaleType: 'band' as const }]}
+      series={[{ data: barData.ys }]}
+      width={800}
+      height={400}
+    />
+  ),
+  heavyOpts,
+);
+
+benchmark(
+  `BarChart ${BAR_N.toLocaleString()} pts — async (worker)`,
+  () => (
+    <BarChart
+      xAxis={[{ data: barData.xs, scaleType: 'band' as const }]}
+      series={[{ data: barData.ys }]}
+      width={800}
+      height={400}
+      asyncProcessing
+    />
+  ),
+  heavyOpts,
+);
+
+benchmark(
+  `ScatterChart ${SCATTER_N.toLocaleString()} pts — sync`,
+  () => <ScatterChart series={[{ data: scatterData, markerSize: 2 }]} width={800} height={400} />,
+  heavyOpts,
+);
+
+benchmark(
+  `ScatterChart ${SCATTER_N.toLocaleString()} pts — async (worker)`,
+  () => (
+    <ScatterChart
+      series={[{ data: scatterData, markerSize: 2 }]}
+      width={800}
+      height={400}
+      asyncProcessing
+    />
+  ),
+  heavyOpts,
+);


### PR DESCRIPTION
## Summary

Proposed implementation from the **Charts Performance — Data processing** study (Option B in \`charts-perf-data-processing.md\`).

Adds a core plugin \`useChartAsyncSeriesProcessor\` that runs the per-type \`seriesProcessor\` in a Web Worker when \`asyncProcessing\` is set on the chart. While the worker is busy, the existing \`ChartsLoadingOverlay\` is shown automatically; when the worker returns, the chart re-renders with the full data.

\`\`\`tsx
<LineChart    asyncProcessing ... />
<BarChart     asyncProcessing ... />
<ScatterChart asyncProcessing ... />
\`\`\`

## Bench (chromium, 800x400, paint:default = time to first browser paint)

| Chart        | Pts  | Sync paint | Async paint | Speedup |
| ------------ | ---- | ---------- | ----------- | ------- |
| LineChart    | 100k | 297 ms     | **11 ms**   | 28x     |
| BarChart     | 30k  | 2562 ms    | **968 ms**  | 2.6x    |
| ScatterChart | 50k  | 489 ms     | **10 ms**   | 51x     |

Bar's smaller win reflects that the per-bar SVG render is still on the main thread; only the d3-stack/data prep moved to the worker. A natural follow-up offloads path/marker generation too — see PoC 5b (mui/mui-x#22366).

## Implementation

- New core plugin \`useChartAsyncSeriesProcessor\` runs after \`useChartSeries\`. Subscribes to defaultized-series + dataset + visibility state. On change, posts to a worker; on receive, stores the processed result and clears the processing flag.
- \`seriesProcessorWorker.ts\` statically imports the per-type processors for line/bar/scatter and runs \`applySeriesProcessors\`. Strips function fields (e.g. scatter's tooltip valueFormatter, d3-stack helper functions on \`stackingGroups\`) before posting back to satisfy the structured-clone protocol.
- \`serialize.ts\` strips function fields from defaultized series on the main side before posting, and re-attaches them on the result so downstream renderers (tooltip, marks) keep their callbacks.
- \`selectorChartSeriesProcessed\` is composed with the async state: when enabled and ready, returns the worker's output; while pending, returns an empty processed-series shape (downstream consumers stay safe, the loading overlay covers the visual gap).
- \`ChartsOverlay\` shows the loading overlay when \`loading\` prop is set OR the async processor is busy. New \`useIsAsyncProcessing()\` hook.
- \`useChartsContainerProps\` threads \`asyncProcessing\` into the data provider so it doesn't leak to the DOM.

## Constraints (v1)

- Series must use the \`data\` prop. \`valueGetter\` is not supported in this mode (it's a function the worker can't see).
- Supported types: line, bar, scatter. Custom plugin chart types fall through to the sync path.
- SSR / no-Worker environments fall back to the sync path silently.

## Tests

- Default sync path renders without going through the loading overlay.
- \`asyncProcessing\` shows loading overlay then swaps to marks (chromium).
- Line series end-to-end via the worker (chromium).

All 486 existing jsdom tests + 589 browser tests still pass.

## Open work for review

- Naming: \`asyncProcessing\` vs \`experimentalAsyncProcessing\` vs auto-trigger above a threshold.
- Worker bundling guarantees across the lib's \`code-infra\` build.
- Per-chart vs shared worker pool.
- Plan tier (community vs Pro vs Premium).