### PR TITLE
[docs] Fix no longer valid link

### DIFF
--- a/docs/data/charts/content-security-policy/content-security-policy.md
+++ b/docs/data/charts/content-security-policy/content-security-policy.md
@@ -28,7 +28,7 @@ See the [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/
 ## Setting up a CSP
 
 MUI X Charts depends on Material UI.
-Follow Material UI's [CSP implementation guide](/material-ui/guides/content-security-policy/#how-does-one-implement-csp) to set up a CSP.
+Follow Material UI's [CSP implementation guide](/material-ui/guides/content-security-policy/) to set up a CSP.
 
 ### CSP for exporting charts
 


### PR DESCRIPTION
Fix breaking docs builds: https://app.netlify.com/projects/material-ui-x/deploys/69fc3fcdf13b3d0008004002

Updated [docs](https://mui.com/material-ui/guides/content-security-policy/) no longer have this section.