### PR TITLE
[datagrid] Pass `type="button"` to GridLongTextCellCornerButton to avoid triggering form submission

### DIFF
--- a/packages/x-data-grid/src/components/cell/GridLongTextCell.tsx
+++ b/packages/x-data-grid/src/components/cell/GridLongTextCell.tsx
@@ -234,6 +234,7 @@ function GridLongTextCell(props: GridLongTextCellProps) {
         className={clsx(classes.expandButton, slotProps?.expandButton?.className)}
         onClick={handleExpandClick}
         onKeyDown={handleExpandKeyDown}
+        type="button"
       >
         <rootProps.slots.longTextCellExpandIcon fontSize="inherit" />
       </GridLongTextCellCornerButton>
@@ -287,6 +288,7 @@ function GridLongTextCell(props: GridLongTextCellProps) {
             {...slotProps?.collapseButton}
             className={clsx(classes.collapseButton, slotProps?.collapseButton?.className)}
             onClick={handleCollapseClick}
+            type="button"
           >
             <rootProps.slots.longTextCellCollapseIcon fontSize="inherit" />
           </GridLongTextCellCornerButton>


### PR DESCRIPTION
Fixes #22382
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
