### PR TITLE
[data grid] Show sort icon on column header keyboard focus

### DIFF
--- a/packages/x-data-grid/src/components/containers/GridRootStyles.ts
+++ b/packages/x-data-grid/src/components/containers/GridRootStyles.ts
@@ -400,7 +400,7 @@ export const GridRootStyles = styled('div', {
       backgroundColor: headerBackground,
     },
     '@media (hover: hover)': {
-      [`& .${c.columnHeader}:hover`]: {
+      [`& .${c.columnHeader}:hover, & .${c.columnHeader}:focus-within`]: {
         [`& .${c.menuIcon}`]: {
           width: 'auto',
           visibility: 'visible',
@@ -411,6 +411,7 @@ export const GridRootStyles = styled('div', {
         },
       },
       [`& .${c.columnHeader}:not(.${c['columnHeader--sorted']}):hover .${c.sortButton},
+        & .${c.columnHeader}:not(.${c['columnHeader--sorted']}):focus-within .${c.sortButton},
         & .${c.pivotPanelField}:not(.${c['pivotPanelField--sorted']}):hover .${c.sortButton},
         & .${c.pivotPanelField}:not(.${c['pivotPanelField--sorted']}) .${c.sortButton}:focus-visible`]:
         {
@@ -418,6 +419,7 @@ export const GridRootStyles = styled('div', {
         },
       // Add opacity only to the button content to avoid affecting the background color
       [`& .${c.columnHeader}:not(.${c['columnHeader--sorted']}):hover .${c.sortButton} > *,
+        & .${c.columnHeader}:not(.${c['columnHeader--sorted']}):focus-within .${c.sortButton} > *,
         & .${c.pivotPanelField}:not(.${c['pivotPanelField--sorted']}):hover .${c.sortButton} > *,
         & .${c.pivotPanelField}:not(.${c['pivotPanelField--sorted']}) .${c.sortButton}:focus-visible > *`]:
         {


### PR DESCRIPTION
Fixes #22188

The sortable column header sort icon only appeared on mouse hover, leaving keyboard-only users with no visual indication that a column is sortable. This is a WCAG 2.4.7 (Focus Visible) violation.

Added `:focus-within` selectors alongside `:hover` for the three affected CSS rules in `GridRootStyles.ts`:

- `iconButtonContainer` visibility + width
- `sortButton` opacity  
- `sortButton > *` child opacity

This ensures the sort icon appears when keyboard focus lands inside a column header, matching the existing behavior for the pivot panel's `:focus-visible` rule.
