### PR TITLE
[data grid] Remove unused CSS

### DIFF
--- a/packages/x-data-grid/src/components/virtualization/GridVirtualScroller.tsx
+++ b/packages/x-data-grid/src/components/virtualization/GridVirtualScroller.tsx
@@ -95,11 +95,6 @@ const Viewport = styled('div', {
     top: 0,
     left: 0,
     overflow: 'hidden',
-
-    scrollbarWidth: 'none' /* Firefox */,
-    '&::-webkit-scrollbar': {
-      display: 'none' /* Safari and Chrome */,
-    },
   },
 });
 


### PR DESCRIPTION
The element is not a scroll container, it has `overflow: 'hidden'` so disabling the scrollbar width seem to have no purpose.

<img width="640" height="321" alt="SCR-20260510-rhxv" src="https://github.com/user-attachments/assets/1d4f29c0-6396-4e85-ba9c-b69f4ea7605a" />

A follow-up on #21616.