### PR TITLE
[test] Reduce flakiness in MobileTimeRangePicker multi-input describeValue tests

### DIFF
--- a/packages/x-date-pickers-pro/src/MobileTimeRangePicker/tests/describeValueMultiInput.MobileTimeRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/MobileTimeRangePicker/tests/describeValueMultiInput.MobileTimeRangePicker.test.tsx
@@ -65,7 +65,7 @@ describe('<MobileTimeRangePicker /> - Describe Value Multi Input', () => {
       }
 
       // Go to the start date or the end date
-      await user.click(screen.getByRole('tab', { name: setEndDate ? 'End' : 'Start' }));
+      await user.click(await screen.findByRole('tab', { name: setEndDate ? 'End' : 'Start' }));
 
       const hasMeridiem = adapterToUse.is12HourCycleInCurrentLocale();
       const hours = adapterToUse.format(
@@ -73,20 +73,24 @@ describe('<MobileTimeRangePicker /> - Describe Value Multi Input', () => {
         hasMeridiem ? 'hours12h' : 'hours24h',
       );
       const hoursNumber = adapterToUse.getHours(newValue[setEndDate ? 1 : 0]);
-      await user.click(screen.getByRole('option', { name: `${parseInt(hours, 10)} hours` }));
       await user.click(
-        screen.getByRole('option', {
+        await screen.findByRole('option', { name: `${parseInt(hours, 10)} hours` }),
+      );
+      await user.click(
+        await screen.findByRole('option', {
           name: `${adapterToUse.getMinutes(newValue[setEndDate ? 1 : 0])} minutes`,
         }),
       );
       if (hasMeridiem) {
-        await user.click(screen.getByRole('option', { name: hoursNumber >= 12 ? 'PM' : 'AM' }));
+        await user.click(
+          await screen.findByRole('option', { name: hoursNumber >= 12 ? 'PM' : 'AM' }),
+        );
       }
       // Close the picker
       if (!isOpened) {
         await user.keyboard('{Escape}');
       } else {
-        const toolbarHourButtons = screen.getAllByRole('button', {
+        const toolbarHourButtons = await screen.findAllByRole('button', {
           name: adapterToUse.format(newValue[0], hasMeridiem ? 'hours12h' : 'hours24h'),
         });
         // return to the start time view in case we'd like to repeat the selection process

--- a/packages/x-date-pickers-pro/src/MobileTimeRangePicker/tests/describeValueMultiInput.MobileTimeRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/MobileTimeRangePicker/tests/describeValueMultiInput.MobileTimeRangePicker.test.tsx
@@ -73,9 +73,7 @@ describe('<MobileTimeRangePicker /> - Describe Value Multi Input', () => {
         hasMeridiem ? 'hours12h' : 'hours24h',
       );
       const hoursNumber = adapterToUse.getHours(newValue[setEndDate ? 1 : 0]);
-      await user.click(
-        await screen.findByRole('option', { name: `${parseInt(hours, 10)} hours` }),
-      );
+      await user.click(await screen.findByRole('option', { name: `${parseInt(hours, 10)} hours` }));
       await user.click(
         await screen.findByRole('option', {
           name: `${adapterToUse.getMinutes(newValue[setEndDate ? 1 : 0])} minutes`,


### PR DESCRIPTION
## Summary

The describeValue suite for the multi-input `MobileTimeRangePicker` has been observed to flake on `test_browser` (recent example: https://circleci.com/gh/mui/mui-x/823672), with one retry hitting `AssertionError: expected 4 to equal 3` on `onChange.callCount` inside `testPickerOpenCloseLifeCycle.tsx:237` and the other retries timing out at 60s. The single-input variant of the same test file does not appear to flake.

This PR makes the `setNewValue` helper in `describeValueMultiInput.MobileTimeRangePicker.test.tsx` async-aware by replacing the synchronous `screen.getByRole` / `screen.getAllByRole` lookups with `findByRole` / `findAllByRole`. Each user click now waits for the next view's options (hours → minutes → meridiem → toolbar hour button) to be in the DOM before dispatching the pointer event, which should remove the race where the next click lands while the previous view is still tearing down and emits a spurious change event.