### PR TITLE
[test] Fix flaky browser tests and optimize

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,10 +105,16 @@ jobs:
           path: test-results
   test_browser:
     <<: *default-job
+    parameters:
+      <<: *default-parameters
+      resource-class:
+        type: enum
+        enum: [large, xlarge]
+        default: xlarge
     executor:
       name: code-infra/mui-node-browser
       playwright-img-version: v1.59.1-noble
-    resource_class: xlarge
+    resource_class: << parameters.resource-class >>
     steps:
       - checkout
       - install-deps:
@@ -388,6 +394,7 @@ workflows:
           <<: *default-context
           name: test_browser_react_18
           react-version: ^18
+          resource-class: large
       - test_e2e:
           <<: *default-context
           name: test_e2e_react_18

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ jobs:
     executor:
       name: code-infra/mui-node-browser
       playwright-img-version: v1.59.1-noble
-    resource_class: large
+    resource_class: xlarge
     steps:
       - checkout
       - install-deps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,10 +93,10 @@ jobs:
           command: |
             # Fully saturate all the available CPUs by splitting the tests in 1 shard per CPU
             pnpm exec concurrently \
-              "pnpm test:unit:jsdom --reporter=blob --reporter=dot --shard=1/4" \
-              "pnpm test:unit:jsdom --reporter=blob --reporter=dot --shard=2/4" \
-              "pnpm test:unit:jsdom --reporter=blob --reporter=dot --shard=3/4" \
-              "pnpm test:unit:jsdom --reporter=blob --reporter=dot --shard=4/4" \
+              "pnpm test:unit:jsdom --no-file-parallelism --reporter=blob --reporter=dot --shard=1/4" \
+              "pnpm test:unit:jsdom --no-file-parallelism --reporter=blob --reporter=dot --shard=2/4" \
+              "pnpm test:unit:jsdom --no-file-parallelism --reporter=blob --reporter=dot --shard=3/4" \
+              "pnpm test:unit:jsdom --no-file-parallelism --reporter=blob --reporter=dot --shard=4/4" \
               || TEST_EXIT_CODE=$?
             pnpm exec vitest run --merge-reports
             # Reports merged, we can now exit with the stored code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,16 +105,10 @@ jobs:
           path: test-results
   test_browser:
     <<: *default-job
-    parameters:
-      <<: *default-parameters
-      resource-class:
-        type: enum
-        enum: [large, xlarge]
-        default: xlarge
     executor:
       name: code-infra/mui-node-browser
       playwright-img-version: v1.59.1-noble
-    resource_class: << parameters.resource-class >>
+    resource_class: xlarge
     steps:
       - checkout
       - install-deps:
@@ -394,7 +388,6 @@ workflows:
           <<: *default-context
           name: test_browser_react_18
           react-version: ^18
-          resource-class: large
       - test_e2e:
           <<: *default-context
           name: test_e2e_react_18

--- a/packages/x-date-pickers-pro/vitest.config.browser.mts
+++ b/packages/x-date-pickers-pro/vitest.config.browser.mts
@@ -14,7 +14,6 @@ export default mergeConfig(
         enabled: true,
         instances: [{ browser: 'chromium' }],
       },
-      sequence: { groupOrder: 1 },
     },
   }),
 );

--- a/packages/x-internal-gestures/vitest.config.browser.mts
+++ b/packages/x-internal-gestures/vitest.config.browser.mts
@@ -12,16 +12,7 @@ export default mergeConfig(
       isolate: true,
       browser: {
         enabled: true,
-        instances: [
-          { browser: 'chromium' },
-          // V8 Coverage in browser mode is not supported yet outside of chromium
-          // {
-          //   browser: 'webkit',
-          // },
-          // {
-          //   browser: 'firefox',
-          // },
-        ],
+        instances: [{ browser: 'chromium' }],
       },
     },
   }),

--- a/vitest.shared.mts
+++ b/vitest.shared.mts
@@ -119,7 +119,7 @@ export default defineConfig({
       // tests touch ~17s in CI, so 30s leaves no headroom for noise.
       testTimeout: 60000,
       // Retry failed tests up to 1 time. This is useful for flaky tests.
-      retry: 1,
+      retry: 3,
       maxWorkers: 12,
     }),
     exclude: ['**/*.spec.{js,ts,tsx}', '**/node_modules/**', '**/dist/**'],

--- a/vitest.shared.mts
+++ b/vitest.shared.mts
@@ -108,6 +108,7 @@ export default defineConfig({
     },
     // Disable isolation to speed up the tests.
     isolate: false,
+    sequence: { groupOrder: 0 },
     // Performance improvements for the tests.
     // https://vitest.dev/guide/improving-performance.html#improving-performance
     ...(process.env.CI && {

--- a/vitest.shared.mts
+++ b/vitest.shared.mts
@@ -121,7 +121,7 @@ export default defineConfig({
       // Retry failed tests up to 3 times. This is useful for flaky tests.
       retry: 3,
       // Reduce the number of workers to avoid CI timeouts.
-      maxWorkers: 2,
+      maxWorkers: 4,
     }),
     exclude: ['**/*.spec.{js,ts,tsx}', '**/node_modules/**', '**/dist/**'],
   },

--- a/vitest.shared.mts
+++ b/vitest.shared.mts
@@ -111,8 +111,6 @@ export default defineConfig({
     // Performance improvements for the tests.
     // https://vitest.dev/guide/improving-performance.html#improving-performance
     ...(process.env.CI && {
-      // Important to avoid timeouts on CI.
-      fileParallelism: false,
       // Increase the timeout for the tests due to slow CI machines.
       // Tests run ~3x slower under React 19 stable than React 18 (CPU-bound,
       // mostly @testing-library/user-event async timing); the slowest legitimate
@@ -120,7 +118,6 @@ export default defineConfig({
       testTimeout: 60000,
       // Retry failed tests up to 1 time. This is useful for flaky tests.
       retry: 3,
-      maxWorkers: 12,
     }),
     exclude: ['**/*.spec.{js,ts,tsx}', '**/node_modules/**', '**/dist/**'],
   },

--- a/vitest.shared.mts
+++ b/vitest.shared.mts
@@ -118,8 +118,9 @@ export default defineConfig({
       // mostly @testing-library/user-event async timing); the slowest legitimate
       // tests touch ~17s in CI, so 30s leaves no headroom for noise.
       testTimeout: 60000,
-      // Retry failed tests up to 3 times. This is useful for flaky tests.
-      retry: 3,
+      // Retry failed tests up to 1 time. This is useful for flaky tests.
+      retry: 1,
+      maxWorkers: 12,
     }),
     exclude: ['**/*.spec.{js,ts,tsx}', '**/node_modules/**', '**/dist/**'],
   },

--- a/vitest.shared.mts
+++ b/vitest.shared.mts
@@ -108,7 +108,6 @@ export default defineConfig({
     },
     // Disable isolation to speed up the tests.
     isolate: false,
-    sequence: { groupOrder: 0 },
     // Performance improvements for the tests.
     // https://vitest.dev/guide/improving-performance.html#improving-performance
     ...(process.env.CI && {
@@ -122,7 +121,7 @@ export default defineConfig({
       // Retry failed tests up to 3 times. This is useful for flaky tests.
       retry: 3,
       // Reduce the number of workers to avoid CI timeouts.
-      maxWorkers: 1,
+      maxWorkers: 2,
     }),
     exclude: ['**/*.spec.{js,ts,tsx}', '**/node_modules/**', '**/dist/**'],
   },

--- a/vitest.shared.mts
+++ b/vitest.shared.mts
@@ -116,7 +116,7 @@ export default defineConfig({
       // mostly @testing-library/user-event async timing); the slowest legitimate
       // tests touch ~17s in CI, so 30s leaves no headroom for noise.
       testTimeout: 60000,
-      // Retry failed tests up to 3 time. This is useful for flaky tests.
+      // Retry failed tests up to 3 times. This is useful for flaky tests.
       retry: 3,
       maxWorkers: 2,
     }),

--- a/vitest.shared.mts
+++ b/vitest.shared.mts
@@ -116,7 +116,7 @@ export default defineConfig({
       // mostly @testing-library/user-event async timing); the slowest legitimate
       // tests touch ~17s in CI, so 30s leaves no headroom for noise.
       testTimeout: 60000,
-      // Retry failed tests up to 1 time. This is useful for flaky tests.
+      // Retry failed tests up to 3 time. This is useful for flaky tests.
       retry: 3,
       maxWorkers: 2,
     }),

--- a/vitest.shared.mts
+++ b/vitest.shared.mts
@@ -111,6 +111,8 @@ export default defineConfig({
     // Performance improvements for the tests.
     // https://vitest.dev/guide/improving-performance.html#improving-performance
     ...(process.env.CI && {
+      // Important to avoid timeouts on CI.
+      fileParallelism: false,
       // Increase the timeout for the tests due to slow CI machines.
       // Tests run ~3x slower under React 19 stable than React 18 (CPU-bound,
       // mostly @testing-library/user-event async timing); the slowest legitimate
@@ -118,8 +120,6 @@ export default defineConfig({
       testTimeout: 60000,
       // Retry failed tests up to 3 times. This is useful for flaky tests.
       retry: 3,
-      // Reduce the number of workers to avoid CI timeouts.
-      maxWorkers: 4,
     }),
     exclude: ['**/*.spec.{js,ts,tsx}', '**/node_modules/**', '**/dist/**'],
   },

--- a/vitest.shared.mts
+++ b/vitest.shared.mts
@@ -111,8 +111,6 @@ export default defineConfig({
     // Performance improvements for the tests.
     // https://vitest.dev/guide/improving-performance.html#improving-performance
     ...(process.env.CI && {
-      // Important to avoid timeouts on CI.
-      fileParallelism: false,
       // Increase the timeout for the tests due to slow CI machines.
       // Tests run ~3x slower under React 19 stable than React 18 (CPU-bound,
       // mostly @testing-library/user-event async timing); the slowest legitimate

--- a/vitest.shared.mts
+++ b/vitest.shared.mts
@@ -118,6 +118,7 @@ export default defineConfig({
       testTimeout: 60000,
       // Retry failed tests up to 1 time. This is useful for flaky tests.
       retry: 3,
+      maxWorkers: 2,
     }),
     exclude: ['**/*.spec.{js,ts,tsx}', '**/node_modules/**', '**/dist/**'],
   },


### PR DESCRIPTION
Bumps the CircleCI `test_browser` job from the `large` to `xlarge` resource class. Browser tests are starved of RAM at the moment. We can now bump up concurrency to 2, it now runs in [3m33s](https://app.circleci.com/pipelines/github/mui/mui-x/129018/workflows/68fd468d-71bc-41bb-819d-8eeef3f09781/jobs/825781). Roughly one third of what we were able to achieve on `large`