### PR TITLE
[test] Disable animations in chart benchmarks

### DIFF
--- a/test/performance-charts/tests/BarChart.bench.tsx
+++ b/test/performance-charts/tests/BarChart.bench.tsx
@@ -12,5 +12,11 @@ const xData = data.map((d) => d.x);
 const yData = data.map((d) => d.y);
 
 benchmark('BarChart with big data amount', () => (
-  <BarChart xAxis={[{ data: xData }]} series={[{ data: yData }]} width={500} height={300} />
+  <BarChart
+    xAxis={[{ data: xData }]}
+    series={[{ data: yData }]}
+    width={500}
+    height={300}
+    skipAnimation
+  />
 ));

--- a/test/performance-charts/tests/BarChartPro.bench.tsx
+++ b/test/performance-charts/tests/BarChartPro.bench.tsx
@@ -18,5 +18,6 @@ benchmark('BarChartPro with big data amount', () => (
     series={[{ data: yData }]}
     width={500}
     height={300}
+    skipAnimation
   />
 ));

--- a/test/performance-charts/tests/FunnelChart.bench.tsx
+++ b/test/performance-charts/tests/FunnelChart.bench.tsx
@@ -10,5 +10,5 @@ const series = [
 ];
 
 benchmark('FunnelChart with big data amount', () => (
-  <FunnelChart series={series} width={500} height={300} />
+  <FunnelChart series={series} width={500} height={300} skipAnimation />
 ));

--- a/test/performance-charts/tests/Heatmap.bench.tsx
+++ b/test/performance-charts/tests/Heatmap.bench.tsx
@@ -18,5 +18,6 @@ benchmark('Heatmap: 100x100 grid', () => (
     series={[{ data }]}
     width={500}
     height={300}
+    skipAnimation
   />
 ));

--- a/test/performance-charts/tests/LineChart.bench.tsx
+++ b/test/performance-charts/tests/LineChart.bench.tsx
@@ -17,6 +17,7 @@ benchmark('LineChart with big data amount (with marks)', () => (
     series={[{ data: yData, showMark: true }]}
     width={500}
     height={300}
+    skipAnimation
   />
 ));
 
@@ -26,5 +27,6 @@ benchmark('Area chart with big data amount (no marks)', () => (
     series={[{ area: true, data: yData, showMark: false }]}
     width={500}
     height={300}
+    skipAnimation
   />
 ));

--- a/test/performance-charts/tests/LineChartPro.bench.tsx
+++ b/test/performance-charts/tests/LineChartPro.bench.tsx
@@ -18,5 +18,6 @@ benchmark('LineChartPro with big data amount and zoomed in (with marks)', () => 
     series={[{ data: yData, showMark: true }]}
     width={500}
     height={300}
+    skipAnimation
   />
 ));

--- a/test/performance-charts/tests/PieChart.bench.tsx
+++ b/test/performance-charts/tests/PieChart.bench.tsx
@@ -17,5 +17,6 @@ benchmark('PieChart with big data amount', () => (
     ]}
     width={500}
     height={300}
+    skipAnimation
   />
 ));

--- a/test/performance-charts/tests/SankeyChart.bench.tsx
+++ b/test/performance-charts/tests/SankeyChart.bench.tsx
@@ -30,5 +30,6 @@ benchmark('SankeyChart with big data amount', () => (
     }}
     width={500}
     height={300}
+    skipAnimation
   />
 ));

--- a/test/performance-charts/tests/ScatterChart.bench.tsx
+++ b/test/performance-charts/tests/ScatterChart.bench.tsx
@@ -16,5 +16,6 @@ benchmark('ScatterChart with big data amount', () => (
     series={[{ data }]}
     width={500}
     height={300}
+    skipAnimation
   />
 ));

--- a/test/performance-charts/tests/ScatterChartPro.bench.tsx
+++ b/test/performance-charts/tests/ScatterChartPro.bench.tsx
@@ -24,6 +24,7 @@ benchmark('ScatterChartPro with big data amount (single renderer)', () => (
     series={[{ data }]}
     width={500}
     height={300}
+    skipAnimation
   />
 ));
 
@@ -45,6 +46,7 @@ benchmark('ScatterChartPro with big data amount and zoomed in (single renderer)'
       { axisId: 'x', start: 50, end: 50.1 },
       { axisId: 'y', start: 50, end: 50.1 },
     ]}
+    skipAnimation
   />
 ));
 
@@ -63,6 +65,7 @@ benchmark('ScatterChartPro with big data amount (batch renderer)', () => (
     width={500}
     height={300}
     renderer="svg-batch"
+    skipAnimation
   />
 ));
 
@@ -85,5 +88,6 @@ benchmark('ScatterChartPro with big data amount and zoomed in (batch renderer)',
       { axisId: 'y', start: 50, end: 50.1 },
     ]}
     renderer="svg-batch"
+    skipAnimation
   />
 ));


### PR DESCRIPTION
Disables animations in all `test/performance-charts` benchmarks by passing `skipAnimation` to each chart. This removes animation-related overhead from benchmark timings so results reflect render/data work rather than transition durations. It also ensures the chart is visible on the first render.

