### PR TITLE
[test] Increase test_types concurrency from 1 to 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "test:argos": "code-infra argos-push --folder test/regressions/screenshots/chrome",
     "test:charts-benchmark": "pnpm -F ./test/performance-charts test:performance",
     "typescript": "lerna run --no-bail --parallel typescript",
-    "typescript:ci": "lerna run --concurrency 1 --no-bail --no-sort typescript",
+    "typescript:ci": "lerna run --concurrency 2 --no-bail --no-sort typescript",
     "use-react-18": "code-infra set-version-overrides --pkg react@18",
     "use-material-ui-v6": "code-infra set-version-overrides --pkg @mui/material@6",
     "use-material-ui-next": "code-infra set-version-overrides --pkg @mui/material@next",


### PR DESCRIPTION
I'm playing around. On #22431, we have:

<img width="382" height="486" alt="SCR-20260513-oylu" src="https://github.com/user-attachments/assets/95d5feba-5244-48c5-b2d7-e6100beec087" />

https://app.circleci.com/pipelines/github/mui/mui-x/129022/workflows/2226a78b-d27e-4054-bda5-f6f7fdb61a85

The next bottleneck is type checking. The 3 CPUs are not really used:

<img width="1361" height="665" alt="SCR-20260513-ozbc" src="https://github.com/user-attachments/assets/8ea52d1c-4055-4956-b98a-5f9fe6f4eae8" />

There were two prior works on it #14110 and https://github.com/mui/mui-x/pull/21129/changes#r2930129733. I wonder if we can't x2. I suspect the actual fix was using the `--max-old-space-size` option.

Baseline job has a p95 of 13m20s https://app.circleci.com/insights/github/mui/mui-x/workflows/pipeline/jobs?branch=master

Run 1: 6m50s success
Run 2: 6m13s success
Run 3: 6m12s success