### PR TITLE
[test] Speed up test_types job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,7 +200,7 @@ jobs:
             git add -A && git diff --exit-code --staged
   test_types:
     <<: *default-job
-    resource_class: medium+
+    resource_class: large
     steps:
       - checkout
       - install-deps

--- a/docs/scripts/formattedTSDemos.js
+++ b/docs/scripts/formattedTSDemos.js
@@ -17,20 +17,9 @@ const babel = require('@babel/core');
 const prettier = require('prettier');
 const yargs = require('yargs');
 const { hideBin } = require('yargs/helpers');
-const ts = require('typescript');
 const { fixBabelGeneratorIssues, fixLineEndings } = require('./helpers');
 
 const DOCS_ROOT = path.resolve(__dirname, '..');
-const tsConfigPath = path.resolve(DOCS_ROOT, './tsconfig.json');
-const tsConfigFile = ts.readConfigFile(tsConfigPath, (filePath) =>
-  fs.readFileSync(filePath).toString(),
-);
-
-const tsConfigFileContent = ts.parseJsonConfigFileContent(
-  tsConfigFile.config,
-  ts.sys,
-  path.dirname(tsConfigPath),
-);
 
 const babelConfig = {
   presets: ['@babel/preset-typescript'],
@@ -88,7 +77,7 @@ const previewOverride = {
   'docs/data/charts/sankey/SankeyDetailedDataStructure.tsx': { maxLines: 30 },
 };
 
-async function transpileFile(tsxPath, program, ignoreCache = false) {
+async function transpileFile(tsxPath, ignoreCache = false) {
   const jsPath = tsxPath.replace(/\.tsx?$/, '.js');
   try {
     if (!ignoreCache) {
@@ -154,15 +143,10 @@ async function main(argv) {
     ...(await getFiles(path.join(workspaceRoot, 'docs/data'), true)), // new structure
   ];
 
-  const program = ts.createProgram({
-    rootNames: tsxFiles,
-    options: tsConfigFileContent.options,
-  });
-
   let successful = 0;
   let failed = 0;
   let skipped = 0;
-  (await Promise.all(tsxFiles.map((file) => transpileFile(file, program, cacheDisabled)))).forEach(
+  (await Promise.all(tsxFiles.map((file) => transpileFile(file, cacheDisabled)))).forEach(
     (result) => {
       switch (result) {
         case TranspileResult.Success: {
@@ -205,7 +189,7 @@ async function main(argv) {
 
   tsxFiles.forEach((filePath) => {
     fs.watchFile(filePath, { interval: 500 }, async () => {
-      if ((await transpileFile(filePath, program, true)) === 0) {
+      if ((await transpileFile(filePath, true)) === 0) {
         console.log('Success - %s', filePath);
       }
     });

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "test:argos": "code-infra argos-push --folder test/regressions/screenshots/chrome",
     "test:charts-benchmark": "pnpm -F ./test/performance-charts test:performance",
     "typescript": "lerna run --no-bail --parallel typescript",
-    "typescript:ci": "lerna run --concurrency 2 --no-bail --no-sort typescript",
+    "typescript:ci": "lerna run --concurrency 3 --no-bail --no-sort typescript",
     "use-react-18": "code-infra set-version-overrides --pkg react@18",
     "use-material-ui-v6": "code-infra set-version-overrides --pkg @mui/material@6",
     "use-material-ui-next": "code-infra set-version-overrides --pkg @mui/material@next",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "test:argos": "code-infra argos-push --folder test/regressions/screenshots/chrome",
     "test:charts-benchmark": "pnpm -F ./test/performance-charts test:performance",
     "typescript": "lerna run --no-bail --parallel typescript",
-    "typescript:ci": "lerna run --concurrency 1 --no-bail --no-sort typescript",
+    "typescript:ci": "lerna run --concurrency 2 --no-bail --no-sort typescript",
     "use-react-18": "code-infra set-version-overrides --pkg react@18",
     "use-material-ui-v6": "code-infra set-version-overrides --pkg @mui/material@6",
     "use-material-ui-next": "code-infra set-version-overrides --pkg @mui/material@next",


### PR DESCRIPTION
Similar to https://github.com/mui/mui-x/pull/22431

Bumps the CircleCI `test_types` job from `medium+` to `large` (4 vCPUs / 8 GB) and raises `typescript:ci` from `--concurrency 1` to `--concurrency 3`, so three `tsc` invocations run in parallel.

Looks like it more than halves the runtime of the typescript job ([10m54s](https://app.circleci.com/insights/github/mui/mui-x/workflows/pipeline/jobs?branch=master&reporting-window=last-24-hours) => [4m42s](https://app.circleci.com/pipelines/github/mui/mui-x/129043/workflows/65522745-c0ad-4f9a-b48e-e10843be8ac1/jobs/825989)), so it's a net-positive operation in terms of credits. CPU is maxed out for most of the time. iirc it's pickers that takes a very long time to complete compared to other projects, that's what makes up that long tail of lower CPU.

Also remove unused typescript program from demo formatter