### PR TITLE
[code-infra] Make screenshots stable across different ordering of the tests

### DIFF
--- a/packages/x-data-grid-generator/src/services/random-generator.ts
+++ b/packages/x-data-grid-generator/src/services/random-generator.ts
@@ -18,13 +18,17 @@ let chanceGuid: Chance.Chance;
 // eslint-disable-next-line @typescript-eslint/naming-convention, no-underscore-dangle
 declare const __DISABLE_CHANCE_RANDOM__: any;
 
-if (typeof __DISABLE_CHANCE_RANDOM__ !== 'undefined' && __DISABLE_CHANCE_RANDOM__) {
-  chance = new Chance(() => 0.5);
-  chanceGuid = new Chance(42);
-} else {
-  chance = new Chance();
-  chanceGuid = chance;
+export function resetRandomGenerators() {
+  if (typeof __DISABLE_CHANCE_RANDOM__ !== 'undefined' && __DISABLE_CHANCE_RANDOM__) {
+    chance = new Chance(() => 0.5);
+    chanceGuid = new Chance(42);
+  } else {
+    chance = new Chance();
+    chanceGuid = chance;
+  }
 }
+
+resetRandomGenerators();
 
 type ColumnDataGenerator<Value> = (data: any, context: GridDataGeneratorContext) => Value;
 

--- a/scripts/x-data-grid-generator.exports.json
+++ b/scripts/x-data-grid-generator.exports.json
@@ -79,6 +79,7 @@
   { "name": "renderRating", "kind": "Function" },
   { "name": "renderStatus", "kind": "Function" },
   { "name": "renderTotalPrice", "kind": "Function" },
+  { "name": "resetRandomGenerators", "kind": "Function" },
   { "name": "useBasicDemoData", "kind": "Variable" },
   { "name": "useDemoData", "kind": "Variable" },
   { "name": "UseDemoDataOptions", "kind": "Interface" },

--- a/test/regressions/index.tsx
+++ b/test/regressions/index.tsx
@@ -6,6 +6,7 @@ import { Globals } from '@react-spring/web';
 import '../utils/setupFakeClock';
 import { LicenseInfo } from '@mui/x-license';
 import { TEST_LICENSE_KEY_PREMIUM } from '@mui/x-license/test-keys';
+import { resetRandomGenerators } from '@mui/x-data-grid-generator';
 import TestViewer from './TestViewer';
 import { type Test, testsBySuite } from './testsBySuite';
 
@@ -51,7 +52,12 @@ function Root() {
 
   const navigate = useNavigate();
   React.useEffect(() => {
-    window.muiFixture.navigate = navigate;
+    window.muiFixture.navigate = (path) => {
+      // Each demo should observe the same seeded random sequence regardless
+      // of what was rendered before on this page.
+      resetRandomGenerators();
+      navigate(path);
+    };
     window.muiFixture.isReady = true;
   }, [navigate]);
 


### PR DESCRIPTION
`@mui/x-data-grid-generator`'s `chance` and `chanceGuid` are module-level seeded RNGs whose state persists across all routes visited on the same browser page. As long as routes were always visited in the same `forEach` order on one shared page, the consumed positions of the sequence were stable, so Argos screenshots stayed identical run-to-run. This prevents us from parallellizing the screenshot generation as they would run in different order/batches.

We can simply reset the generator before each test. We'll have to approve a screenshot change once in this PR.

This will unlock the optimization of https://github.com/mui/mui-x/pull/22447 which brings screenshot generation time down to [~3m16s](https://app.circleci.com/pipelines/github/mui/mui-x/129139/workflows/88be8e74-793d-49a5-8886-baeede52feec/jobs/826759/steps)