### PR TITLE
[code-infra] Double test_unit compute and concurrency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,14 +93,13 @@ jobs:
           command: |
             # Fully saturate all the available CPUs by splitting the tests in 1 shard per CPU
             pnpm exec concurrently \
-              "pnpm test:unit:jsdom --no-file-parallelism --reporter=blob --reporter=dot --shard=1/8" \
-              "pnpm test:unit:jsdom --no-file-parallelism --reporter=blob --reporter=dot --shard=2/8" \
-              "pnpm test:unit:jsdom --no-file-parallelism --reporter=blob --reporter=dot --shard=3/8" \
-              "pnpm test:unit:jsdom --no-file-parallelism --reporter=blob --reporter=dot --shard=4/8" \
-              "pnpm test:unit:jsdom --no-file-parallelism --reporter=blob --reporter=dot --shard=5/8" \
-              "pnpm test:unit:jsdom --no-file-parallelism --reporter=blob --reporter=dot --shard=6/8" \
-              "pnpm test:unit:jsdom --no-file-parallelism --reporter=blob --reporter=dot --shard=7/8" \
-              "pnpm test:unit:jsdom --no-file-parallelism --reporter=blob --reporter=dot --shard=8/8" \
+              "pnpm test:unit:jsdom --no-file-parallelism --reporter=blob --reporter=dot --shard=1/7" \
+              "pnpm test:unit:jsdom --no-file-parallelism --reporter=blob --reporter=dot --shard=2/7" \
+              "pnpm test:unit:jsdom --no-file-parallelism --reporter=blob --reporter=dot --shard=3/7" \
+              "pnpm test:unit:jsdom --no-file-parallelism --reporter=blob --reporter=dot --shard=4/7" \
+              "pnpm test:unit:jsdom --no-file-parallelism --reporter=blob --reporter=dot --shard=5/7" \
+              "pnpm test:unit:jsdom --no-file-parallelism --reporter=blob --reporter=dot --shard=6/7" \
+              "pnpm test:unit:jsdom --no-file-parallelism --reporter=blob --reporter=dot --shard=7/7" \
               || TEST_EXIT_CODE=$?
             pnpm exec vitest run --merge-reports
             # Reports merged, we can now exit with the stored code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ commands:
 jobs:
   test_unit:
     <<: *default-job
-    resource_class: large
+    resource_class: xlarge
     steps:
       - checkout
       - install-deps:
@@ -93,10 +93,14 @@ jobs:
           command: |
             # Fully saturate all the available CPUs by splitting the tests in 1 shard per CPU
             pnpm exec concurrently \
-              "pnpm test:unit:jsdom --no-file-parallelism --reporter=blob --reporter=dot --shard=1/4" \
-              "pnpm test:unit:jsdom --no-file-parallelism --reporter=blob --reporter=dot --shard=2/4" \
-              "pnpm test:unit:jsdom --no-file-parallelism --reporter=blob --reporter=dot --shard=3/4" \
-              "pnpm test:unit:jsdom --no-file-parallelism --reporter=blob --reporter=dot --shard=4/4" \
+              "pnpm test:unit:jsdom --no-file-parallelism --reporter=blob --reporter=dot --shard=1/8" \
+              "pnpm test:unit:jsdom --no-file-parallelism --reporter=blob --reporter=dot --shard=2/8" \
+              "pnpm test:unit:jsdom --no-file-parallelism --reporter=blob --reporter=dot --shard=3/8" \
+              "pnpm test:unit:jsdom --no-file-parallelism --reporter=blob --reporter=dot --shard=4/8" \
+              "pnpm test:unit:jsdom --no-file-parallelism --reporter=blob --reporter=dot --shard=5/8" \
+              "pnpm test:unit:jsdom --no-file-parallelism --reporter=blob --reporter=dot --shard=6/8" \
+              "pnpm test:unit:jsdom --no-file-parallelism --reporter=blob --reporter=dot --shard=7/8" \
+              "pnpm test:unit:jsdom --no-file-parallelism --reporter=blob --reporter=dot --shard=8/8" \
               || TEST_EXIT_CODE=$?
             pnpm exec vitest run --merge-reports
             # Reports merged, we can now exit with the stored code


### PR DESCRIPTION
Bumps `test_unit` from `large` (4 vCPU / 8 GB) to `xlarge` (8 vCPU / 16 GB) and doubles the shard count from 4 to 8. Same "double the compute, double the concurrency" trade as the recent regression-test PR. Credits/min double but wall-clock should drop roughly in half, so the credit cost per run is roughly flat.

The current median is ~481 s (~8 min); aim is ~3–4 min.