### PR TITLE
[data-grid][docs] Include tree-data params in useDemoData cache key

### DIFF
--- a/packages/x-data-grid-generator/src/hooks/useDemoData.ts
+++ b/packages/x-data-grid-generator/src/hooks/useDemoData.ts
@@ -151,8 +151,8 @@ export const useDemoData = (options: UseDemoDataOptions): DemoDataReturnType => 
   });
 
   React.useEffect(() => {
-    const treeDataKey = options.treeData
-      ? `${options.treeData.maxDepth ?? 1}-${options.treeData.averageChildren ?? 2}-${options.treeData.groupingField ?? ''}`
+    const treeDataKey = (options.treeData?.maxDepth ?? 1) > 1
+      ? `${options.treeData?.maxDepth}-${options.treeData?.averageChildren ?? 2}-${options.treeData?.groupingField ?? ''}`
       : 'false';
     const cacheKey = `${options.dataSet}-${rowLength}-${index}-${options.maxColumns}-treeData:${treeDataKey}`;
 

--- a/packages/x-data-grid-generator/src/hooks/useDemoData.ts
+++ b/packages/x-data-grid-generator/src/hooks/useDemoData.ts
@@ -151,7 +151,10 @@ export const useDemoData = (options: UseDemoDataOptions): DemoDataReturnType => 
   });
 
   React.useEffect(() => {
-    const cacheKey = `${options.dataSet}-${rowLength}-${index}-${options.maxColumns}-treeData:${(options.treeData?.maxDepth || 1) > 1 ? 'true' : 'false'}`;
+    const treeDataKey = options.treeData
+      ? `${options.treeData.maxDepth ?? 1}-${options.treeData.averageChildren ?? 2}-${options.treeData.groupingField ?? ''}`
+      : 'false';
+    const cacheKey = `${options.dataSet}-${rowLength}-${index}-${options.maxColumns}-treeData:${treeDataKey}`;
 
     // Cache to allow fast switch between the JavaScript and TypeScript version
     // of the demos.

--- a/packages/x-data-grid-generator/src/hooks/useDemoData.ts
+++ b/packages/x-data-grid-generator/src/hooks/useDemoData.ts
@@ -151,9 +151,10 @@ export const useDemoData = (options: UseDemoDataOptions): DemoDataReturnType => 
   });
 
   React.useEffect(() => {
-    const treeDataKey = (options.treeData?.maxDepth ?? 1) > 1
-      ? `${options.treeData?.maxDepth}-${options.treeData?.averageChildren ?? 2}-${options.treeData?.groupingField ?? ''}`
-      : 'false';
+    const treeDataKey =
+      (options.treeData?.maxDepth ?? 1) > 1
+        ? `${options.treeData?.maxDepth}-${options.treeData?.averageChildren ?? 2}-${options.treeData?.groupingField ?? ''}`
+        : 'false';
     const cacheKey = `${options.dataSet}-${rowLength}-${index}-${options.maxColumns}-treeData:${treeDataKey}`;
 
     // Cache to allow fast switch between the JavaScript and TypeScript version


### PR DESCRIPTION
`useDemoData`'s LRU cache key collapses every tree-data shape into a single `treeData:true|false` flag, so two demos like

- `TreeDataReordering` — `{ maxDepth: 3, averageChildren: 2 }`
- `RowReorderingValidation` — `{ maxDepth: 2, averageChildren: 4 }`

share the cache entry `Employee-100-0-undefined-treeData:true`, and whichever renders first picks the tree shape. As a result `TreeDataReordering` ends up rendering RowReorderingValidation's 20-row depth-0 shape instead of its own 15-row one. The visible row count of a demo with tree data is a function of render order rather than its own options.

This PR includes `maxDepth`, `averageChildren` and `groupingField` in the cache key so each tree-data shape gets its own entry.


The issue came up in https://github.com/mui/mui-x/pull/22447 but can also be reproduced on the docs with:

- go to https://mui.com/x/react-data-grid/row-ordering/#row-reordering-with-row-grouping
- refresh the page
- scroll to the link "Tree data—Drag-and-drop tree data reordering" and click it
- look at the demo count (now it's 20)
- refresh the page
- look at the demo count (now it's 15)