### PR TITLE
[code-infra] Ignore docs/data/charts/dataset in ESLint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -114,6 +114,9 @@ export default defineConfig(
     materialUi: true,
   }),
   {
+    ignores: ['docs/data/charts/dataset/**'],
+  },
+  {
     name: 'MUI X Overrides',
     files: [`**/*${EXTENSION_TS}`],
     plugins: {


### PR DESCRIPTION
Skip lint on raw chart dataset files — large data-only modules with no source to enforce style on.