### PR TITLE
[test] Trim ffmpeg install in test_regressions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,9 +263,6 @@ jobs:
       - install-deps:
           react-version: << parameters.react-version >>
       - run:
-          name: Install ffmpeg
-          command: apt update && apt upgrade -y && apt install ffmpeg -y
-      - run:
           name: Build packages
           command: pnpm release:build
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,6 +263,9 @@ jobs:
       - install-deps:
           react-version: << parameters.react-version >>
       - run:
+          name: Install ffmpeg
+          command: apt-get update && apt-get install ffmpeg --no-install-recommends -y
+      - run:
           name: Build packages
           command: pnpm release:build
       - run:


### PR DESCRIPTION
Trim to `apt-get update && apt-get install ffmpeg --no-install-recommends -y`. Locally this measures ~10s vs ~20s, and `ffmpeg -demuxers` still lists `x11grab`.

In CI this seems to ~25s => ~5s