### PR TITLE
Dont reset rows between grid operations when using `dataSource`

### DIFF
--- a/packages/x-data-grid/src/hooks/features/dataSource/useGridDataSourceBase.ts
+++ b/packages/x-data-grid/src/hooks/features/dataSource/useGridDataSourceBase.ts
@@ -371,7 +371,6 @@ export const useGridDataSourceBase = <Api extends GridPrivateApiCommunity>(
 
   const debouncedFetchRows = React.useMemo(() => debounce(fetchRows, 0), [fetchRows]);
   const handleFetchRowsOnParamsChange = React.useCallback(() => {
-    apiRef.current.setRows([]);
     stopPolling();
     debouncedFetchRows();
   }, [stopPolling, debouncedFetchRows, apiRef]);


### PR DESCRIPTION
Resolves #22458

Prevents data grids with a `dataSource` from hiding all rows while the `dataSource` processes new rows. This resolves two issues:

1.  The `noRowsOverlay` will no longer flicker briefly even when navigating between two cached states of the grid due to the debounced `fetchRows` taking an additional render cycle to have effect
2. The less intrusive loading variant will appear, instead of the skeleton loaders while rows are being fetched. This has the added benefit of not changing the heigh of grids with a fixed height during load.

Before:

https://github.com/user-attachments/assets/ab54ecf0-32ff-4cc2-baf5-948e58db4b3b

After:

https://github.com/user-attachments/assets/519abae5-7e5b-4e4a-b99c-dfa70d094d2d

This effect is even more jarring in particularly fast calls to `fetchRows`

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
