### PR TITLE
[scheduler][docs] Sync README with licensing/licensing.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ It's published under an [MIT license](https://www.tldrlegal.com/license/mit-lice
 - [`@mui/x-date-pickers`](https://www.npmjs.com/package/@mui/x-date-pickers)
 - [`@mui/x-charts`](https://www.npmjs.com/package/@mui/x-charts)
 - [`@mui/x-tree-view`](https://www.npmjs.com/package/@mui/x-tree-view)
+- [`@mui/x-scheduler`](https://www.npmjs.com/package/@mui/x-scheduler)
 
 #### Pro plan
 
@@ -91,6 +92,7 @@ The Premium version is available under a commercial license—visit the [Pricing
 
 - [`@mui/x-data-grid-premium`](https://www.npmjs.com/package/@mui/x-data-grid-premium)
 - [`@mui/x-charts-premium`](https://www.npmjs.com/package/@mui/x-charts-premium)
+- [`@mui/x-scheduler-premium`](https://www.npmjs.com/package/@mui/x-scheduler-premium)
 
 ## Support
 


### PR DESCRIPTION
Sync with https://mui.com/x/introduction/licensing/#community-plan, those two pieces of content were designed to be kept in sync.

*(Side note, the Premium plan is designed (its price) to only be about the data grid; we will need to solve that, it sets the wrong expectations for customers right now. But for another day)*