### PR TITLE
[charts] Fix use of deprecated API in docs

### DIFF
--- a/docs/data/charts/lines/LineOverview.js
+++ b/docs/data/charts/lines/LineOverview.js
@@ -10,7 +10,7 @@ import { ChartsYAxis } from '@mui/x-charts-pro/ChartsYAxis';
 import { useDrawingArea, useXScale } from '@mui/x-charts-pro/hooks';
 import { ChartsTooltip } from '@mui/x-charts-pro/ChartsTooltip';
 import { ChartsGrid } from '@mui/x-charts-pro/ChartsGrid';
-import { ChartZoomSlider } from '@mui/x-charts-pro/ChartZoomSlider';
+import { ChartsZoomSlider } from '@mui/x-charts-pro/ChartsZoomSlider';
 import { ChartsClipPath } from '@mui/x-charts-pro/ChartsClipPath';
 import { ChartsAxisHighlight } from '@mui/x-charts/ChartsAxisHighlight';
 import { ChartsLegend } from '@mui/x-charts-pro/ChartsLegend';
@@ -172,7 +172,7 @@ export default function LineOverview() {
           <ChartsYAxis axisId="unemployment-axis" label="Unemployment Rate" />
           <ChartsYAxis axisId="gdp-axis" label="GDP per capita in US$" />
           <ChartsAxisHighlight x="line" />
-          <ChartZoomSlider />
+          <ChartsZoomSlider />
         </ChartsSurface>
         <ChartsTooltip />
       </ChartsDataProviderPro>

--- a/docs/data/charts/lines/LineOverview.tsx
+++ b/docs/data/charts/lines/LineOverview.tsx
@@ -10,7 +10,7 @@ import { ChartsYAxis } from '@mui/x-charts-pro/ChartsYAxis';
 import { useDrawingArea, useXScale } from '@mui/x-charts-pro/hooks';
 import { ChartsTooltip } from '@mui/x-charts-pro/ChartsTooltip';
 import { ChartsGrid } from '@mui/x-charts-pro/ChartsGrid';
-import { ChartZoomSlider } from '@mui/x-charts-pro/ChartZoomSlider';
+import { ChartsZoomSlider } from '@mui/x-charts-pro/ChartsZoomSlider';
 import { ChartsClipPath } from '@mui/x-charts-pro/ChartsClipPath';
 import { ChartsAxisHighlight } from '@mui/x-charts/ChartsAxisHighlight';
 import { ChartsLegend } from '@mui/x-charts-pro/ChartsLegend';
@@ -178,7 +178,7 @@ export default function LineOverview() {
           <ChartsYAxis axisId="unemployment-axis" label="Unemployment Rate" />
           <ChartsYAxis axisId="gdp-axis" label="GDP per capita in US$" />
           <ChartsAxisHighlight x="line" />
-          <ChartZoomSlider />
+          <ChartsZoomSlider />
         </ChartsSurface>
         <ChartsTooltip />
       </ChartsDataProviderPro>

--- a/docs/data/charts/references/ReferenceOverview.js
+++ b/docs/data/charts/references/ReferenceOverview.js
@@ -10,7 +10,7 @@ import { ChartsXAxis } from '@mui/x-charts-pro/ChartsXAxis';
 import { ChartsYAxis } from '@mui/x-charts-pro/ChartsYAxis';
 import { ChartsTooltip } from '@mui/x-charts-pro/ChartsTooltip';
 import { ChartsGrid } from '@mui/x-charts-pro/ChartsGrid';
-import { ChartZoomSlider } from '@mui/x-charts-pro/ChartZoomSlider';
+import { ChartsZoomSlider } from '@mui/x-charts-pro/ChartsZoomSlider';
 import { ChartsClipPath } from '@mui/x-charts-pro/ChartsClipPath';
 import { ChartsAxisHighlight } from '@mui/x-charts/ChartsAxisHighlight';
 import { ChartsLegend } from '@mui/x-charts-pro/ChartsLegend';
@@ -189,7 +189,7 @@ export default function ReferenceOverview() {
           <ChartsXAxis />
           <ChartsYAxis axisId="unemployment-axis" label="Unemployment Rate" />
           <ChartsYAxis axisId="gdp-axis" label="GDP per capita in US$" />
-          <ChartZoomSlider />
+          <ChartsZoomSlider />
         </ChartsSurface>
         <ChartsTooltip />
       </ChartsDataProviderPro>

--- a/docs/data/charts/references/ReferenceOverview.tsx
+++ b/docs/data/charts/references/ReferenceOverview.tsx
@@ -10,7 +10,7 @@ import { ChartsXAxis } from '@mui/x-charts-pro/ChartsXAxis';
 import { ChartsYAxis } from '@mui/x-charts-pro/ChartsYAxis';
 import { ChartsTooltip } from '@mui/x-charts-pro/ChartsTooltip';
 import { ChartsGrid } from '@mui/x-charts-pro/ChartsGrid';
-import { ChartZoomSlider } from '@mui/x-charts-pro/ChartZoomSlider';
+import { ChartsZoomSlider } from '@mui/x-charts-pro/ChartsZoomSlider';
 import { ChartsClipPath } from '@mui/x-charts-pro/ChartsClipPath';
 import { ChartsAxisHighlight } from '@mui/x-charts/ChartsAxisHighlight';
 import { ChartsLegend } from '@mui/x-charts-pro/ChartsLegend';
@@ -201,7 +201,7 @@ export default function ReferenceOverview() {
           <ChartsXAxis />
           <ChartsYAxis axisId="unemployment-axis" label="Unemployment Rate" />
           <ChartsYAxis axisId="gdp-axis" label="GDP per capita in US$" />
-          <ChartZoomSlider />
+          <ChartsZoomSlider />
         </ChartsSurface>
         <ChartsTooltip />
       </ChartsDataProviderPro>

--- a/docs/data/charts/zoom-and-pan/ZoomSliderComposition.js
+++ b/docs/data/charts/zoom-and-pan/ZoomSliderComposition.js
@@ -4,7 +4,7 @@ import { ChartsXAxis } from '@mui/x-charts/ChartsXAxis';
 import { LinePlot } from '@mui/x-charts/LineChart';
 import { ChartsContainerPro } from '@mui/x-charts-pro/ChartsContainerPro';
 import { ChartsClipPath } from '@mui/x-charts/ChartsClipPath';
-import { ChartZoomSlider } from '@mui/x-charts-pro/ChartZoomSlider';
+import { ChartsZoomSlider } from '@mui/x-charts-pro/ChartsZoomSlider';
 import { Chance } from 'chance';
 
 const chance = new Chance(42);
@@ -42,7 +42,7 @@ export default function ZoomSliderComposition() {
         <LinePlot />
       </g>
       <ChartsXAxis label="X axis" axisId="x-axis-id" />
-      <ChartZoomSlider />
+      <ChartsZoomSlider />
       <ChartsClipPath id={clipPathId} />
     </ChartsContainerPro>
   );

--- a/docs/data/charts/zoom-and-pan/ZoomSliderComposition.tsx
+++ b/docs/data/charts/zoom-and-pan/ZoomSliderComposition.tsx
@@ -43,7 +43,7 @@ export default function ZoomSliderComposition() {
       </g>
       <ChartsXAxis label="X axis" axisId="x-axis-id" />
       <ChartsZoomSlider />
-    s  <ChartsClipPath id={clipPathId} />
+      <ChartsClipPath id={clipPathId} />
     </ChartsContainerPro>
   );
 }

--- a/docs/data/charts/zoom-and-pan/ZoomSliderComposition.tsx
+++ b/docs/data/charts/zoom-and-pan/ZoomSliderComposition.tsx
@@ -4,7 +4,7 @@ import { ChartsXAxis } from '@mui/x-charts/ChartsXAxis';
 import { LinePlot } from '@mui/x-charts/LineChart';
 import { ChartsContainerPro } from '@mui/x-charts-pro/ChartsContainerPro';
 import { ChartsClipPath } from '@mui/x-charts/ChartsClipPath';
-import { ChartZoomSlider } from '@mui/x-charts-pro/ChartZoomSlider';
+import { ChartsZoomSlider } from '@mui/x-charts-pro/ChartsZoomSlider';
 import { Chance } from 'chance';
 
 const chance = new Chance(42);
@@ -42,8 +42,8 @@ export default function ZoomSliderComposition() {
         <LinePlot />
       </g>
       <ChartsXAxis label="X axis" axisId="x-axis-id" />
-      <ChartZoomSlider />
-      <ChartsClipPath id={clipPathId} />
+      <ChartsZoomSlider />
+    s  <ChartsClipPath id={clipPathId} />
     </ChartsContainerPro>
   );
 }


### PR DESCRIPTION
This is a continuation of #21553. We have deprecated ChartZoomSlider for ChartsZoomSlider in v8 and in v9.

People expect the docs of the major version they use to run without any deprecations. It's not the case right now. For example in https://mui.com/x/react-charts/zoom-and-pan/#composition, we get:

<img width="510" height="138" alt="SCR-20260515-popw" src="https://github.com/user-attachments/assets/52cf0b51-454e-483e-9fce-0c5a17c466a7" />

---

Since it's faster to open a PR than to open an issue (when I only start them 😁), and it's a regression of the docs experience (regressions take priority over the rest), here is a PR.

---

I have tested `npx @mui/x-codemod@latest v9.0.0/charts/rename-chart-zoom-slider .` It migrates the code correctly, so it seems we are good on this front.

---

There might be an opportunity to fix this at the root: https://github.com/mui/mui-public/issues/1467