### PR TITLE
[docs] Fix New on bar charts docs

### DIFF
--- a/docs/data/pages.ts
+++ b/docs/data/pages.ts
@@ -647,7 +647,6 @@ const pages: MuiPage[] = [
           {
             pathname: '/x/react-charts-bars',
             title: 'Bars',
-            newFeature: true,
             children: [
               { pathname: '/x/react-charts/bars', title: 'Bars overview' },
               {


### PR DESCRIPTION
This is how the side nav current looks right now:

<img width="283" height="174" alt="SCR-20260515-qltb" src="https://github.com/user-attachments/assets/3a16dfed-5815-44db-a5c1-bcfef809712b" />

https://mui.com/x/react-charts/bars/

In practice, the Bars section is not new. The Range bar is new.

The problem is that the docs use the same visual clues to encode two different pieces of information. No, the Bar docs section is NOT new. The first time I saw this, I assumed the whole thing was new.

As a potential solution, we could introduce a different visual clue to encode "Some item in this section is new", it would be added automatically based on its children:

<img width="284" height="180" alt="SCR-20260516-qsrl" src="https://github.com/user-attachments/assets/6bdc9240-a662-43b0-94f6-707bbeb67c7b" />

but this is a broader problem with the docs-infra. And even for docs-infra, I wonder if this is really needed: people who go to the docs of the bar will discover the new section https://deploy-preview-22473--material-ui-x.netlify.app/x/react-charts/bars/. People who don't use bars might not need to see it in the first place, so I'm not sure there is a lot of value.