### PR TITLE
[charts][docs] Improve premium page header

### DIFF
--- a/docs/data/charts/candlestick/candlestick.md
+++ b/docs/data/charts/candlestick/candlestick.md
@@ -8,8 +8,9 @@ components: CandlestickChart, CandlestickPlot
 
 <p class="description">A candlestick chart is used to visualize price movement over time.</p>
 
-:::warning
-This feature is in preview. It is not yet ready for production use, and its API, visuals and behavior may change in future minor or patch releases.
+:::error
+This feature is in preview.
+It is not yet ready for production use, and its API, visuals, and behavior may change in future minor or patch releases.
 :::
 
 ## Overview

--- a/docs/data/charts/heatmap/heatmap.md
+++ b/docs/data/charts/heatmap/heatmap.md
@@ -116,9 +116,9 @@ Use the `cell` slot to replace the default cell shape or add labels.
 
 {{"demo": "CustomItem.js"}}
 
-## WebGL renderer [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan 'Premium plan')🧪
+## WebGL renderer [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan 'Premium plan') 🧪
 
-:::info
+:::warning
 This feature is in preview.
 It is ready for production use, but its API, visuals and behavior may change in future minor or patch releases.
 :::

--- a/docs/data/charts/lines/lines.md
+++ b/docs/data/charts/lines/lines.md
@@ -164,6 +164,11 @@ Note that `onAxisClick` runs for both bar and line series when you mix them.
 
 ### Pointer interaction 🧪
 
+:::warning
+This feature is in preview.
+It is ready for production use, and its API, visuals, and behavior may change in future minor or patch releases.
+:::
+
 By default, line and area series are highlighted when the pointer hovers directly over the SVG element (the line stroke or area fill).
 This can make it difficult to interact with thin lines.
 
@@ -172,11 +177,6 @@ For area series, it detects whether the pointer is inside the filled area.
 For line series (without area), it finds the series whose curve is closest to the pointer's vertical position.
 
 This uses the same curve interpolation as the rendered line (for example, `monotoneX`, `catmullRom`), so the hit detection matches the visual shape.
-
-:::warning
-This feature is experimental.
-Its API and behavior may change in future releases.
-:::
 
 {{"demo": "LinePointerInteraction.js"}}
 

--- a/docs/data/charts/radial-axes/radial-axes.md
+++ b/docs/data/charts/radial-axes/radial-axes.md
@@ -10,8 +10,9 @@ components: ChartsRadialDataProvider, ChartsRadialGrid, ChartsRadiusAxis, Charts
 
 ## Radial grid 🧪
 
-:::info
-This feature is in preview. It is ready for production use, but its API, visuals and behavior may change in future minor or patch releases.
+:::warning
+This feature is in preview.
+It is ready for production use, and its API, visuals, and behavior may change in future minor or patch releases.
 :::
 
 Similarly to the `ChartsGrid` we provide a `ChartsRadialGrid` for radial coordinates.

--- a/docs/data/charts/radial-bars/radial-bars.md
+++ b/docs/data/charts/radial-bars/radial-bars.md
@@ -8,8 +8,9 @@ components: ChartsRadialDataProvider, ChartsRadialDataProviderPremium, ChartsRad
 
 <p class="description">Use radial bar charts to compare values along periodic categories.</p>
 
-:::info
-This feature is in preview. It is ready for production use, but its API, visuals and behavior may change in future minor or patch releases.
+:::warning
+This feature is in preview.
+It is ready for production use, and its API, visuals, and behavior may change in future minor or patch releases.
 :::
 
 ## Basics

--- a/docs/data/charts/radial-lines/radial-lines.md
+++ b/docs/data/charts/radial-lines/radial-lines.md
@@ -8,8 +8,9 @@ components: ChartsRadialDataProvider, ChartsRadialDataProviderPremium, RadialLin
 
 <p class="description">Use radial line charts to show trends along periodic values.</p>
 
-:::info
-This feature is in preview. It is ready for production use, but its API, visuals and behavior may change in future minor or patch releases.
+:::warning
+This feature is in preview.
+It is ready for production use, and its API, visuals, and behavior may change in future minor or patch releases.
 :::
 
 ## Basics

--- a/docs/data/pages.ts
+++ b/docs/data/pages.ts
@@ -710,17 +710,19 @@ const pages: MuiPage[] = [
           },
           {
             pathname: '/x/react-charts/radial-bars',
+            title: 'Radial Bars',
             plan: 'premium',
             unstable: true,
           },
           {
             pathname: '/x/react-charts/radial-lines',
+            title: 'Radial Lines',
             plan: 'premium',
             unstable: true,
           },
           {
             pathname: '/x/react-charts/#planned-charts',
-            title: 'Future Components',
+            title: 'Future components',
             planned: true,
           },
           {

--- a/docs/pages/x/react-charts/radial-bars.js
+++ b/docs/pages/x/react-charts/radial-bars.js
@@ -2,5 +2,5 @@ import { MarkdownDocs } from '@mui/internal-core-docs/MarkdownDocs';
 import * as pageProps from 'docs/data/charts/radial-bars/radial-bars.md?muiMarkdown';
 
 export default function Page() {
-  return <MarkdownDocs {...pageProps} />;
+  return <MarkdownDocs {...pageProps} disableAd />;
 }

--- a/docs/pages/x/react-charts/radial-lines.js
+++ b/docs/pages/x/react-charts/radial-lines.js
@@ -2,5 +2,5 @@ import { MarkdownDocs } from '@mui/internal-core-docs/MarkdownDocs';
 import * as pageProps from 'docs/data/charts/radial-lines/radial-lines.md?muiMarkdown';
 
 export default function Page() {
-  return <MarkdownDocs {...pageProps} />;
+  return <MarkdownDocs {...pageProps} disableAd />;
 }


### PR DESCRIPTION
Iterate on https://mui.com/x/react-charts/candlestick/.

- info -> warning, we have to make it clear about the level of risk, it's feels more than an info.
- The one that is not ready for production use should use the error level, it's the most risky.
- disable ad for commercial code (we could automate this but that's a different thread)
- normalize the warning messages, for consistency.
- have 🧪 right next to the warning so people can associate the two a bit more.
- Fix the casing. Sentence case for normal headers. The side nav label should match the header of the h1.

Preview: https://deploy-preview-22474--material-ui-x.netlify.app/x/react-charts/candlestick/