### PR TITLE
[data grid] Fix scrollbar disappearing after multiple resizes

### DIFF
--- a/packages/x-data-grid/src/tests/layout.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/layout.DataGrid.test.tsx
@@ -1340,4 +1340,40 @@ describe('<DataGrid /> - Layout & warnings', () => {
       );
     },
   );
+
+  // See https://github.com/mui/mui-x/issues/22510
+  // Need layout
+  it.skipIf(isJSDOM)(
+    'should keep the vertical scrollbar after the container size oscillates across the threshold',
+    async () => {
+      function TestCase({ height }: { height: number }) {
+        return (
+          <div style={{ width: 300, height }}>
+            <DataGrid
+              rows={Array.from({ length: 3 }, (_, i) => ({ id: i, brand: `b${i}` }))}
+              columns={[{ field: 'brand' }]}
+              resizeThrottleMs={0}
+            />
+          </div>
+        );
+      }
+      const { setProps } = render(<TestCase height={150} />);
+      await waitFor(() => {
+        expect(getVariable('--DataGrid-hasScrollY')).to.equal('1');
+      });
+      // The pauses between size changes simulate real user-driven window resize,
+      // which is paced by mouse motion and is hundreds of milliseconds apart -
+      // unlike a layout feedback loop, which flips within one render frame.
+      await sleep(150);
+      setProps({ height: 400 });
+      await waitFor(() => {
+        expect(getVariable('--DataGrid-hasScrollY')).to.equal('0');
+      });
+      await sleep(150);
+      setProps({ height: 150 });
+      await waitFor(() => {
+        expect(getVariable('--DataGrid-hasScrollY')).to.equal('1');
+      });
+    },
+  );
 });

--- a/packages/x-data-grid/src/tests/layout.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/layout.DataGrid.test.tsx
@@ -1361,9 +1361,7 @@ describe('<DataGrid /> - Layout & warnings', () => {
       await waitFor(() => {
         expect(getVariable('--DataGrid-hasScrollY')).to.equal('1');
       });
-      // The pauses between size changes simulate real user-driven window resize,
-      // which is paced by mouse motion and is hundreds of milliseconds apart -
-      // unlike a layout feedback loop, which flips within one render frame.
+      // Pauses simulate user-paced resize (each flip > OSCILLATION_FLIP_WINDOW_MS apart).
       await sleep(150);
       setProps({ height: 400 });
       await waitFor(() => {
@@ -1382,11 +1380,7 @@ describe('<DataGrid /> - Layout & warnings', () => {
   it.skipIf(isJSDOM)(
     'should force the vertical scrollbar off when consecutive flips happen inside one render frame',
     async () => {
-      // Stub performance.now so we can control the elapsed-time check inside
-      // the oscillation detector. With two consecutive hasScrollY flips falling
-      // inside the 100ms window the detector should treat them as a layout
-      // feedback loop and force-suppress the scrollbar (the protection added
-      // by PR #21820).
+      // Stub performance.now to drive the oscillation detector's elapsed-time check.
       let mockTime = 1000;
       const performanceNowStub = stub(performance, 'now').callsFake(() => mockTime);
       try {
@@ -1405,14 +1399,13 @@ describe('<DataGrid /> - Layout & warnings', () => {
         await waitFor(() => {
           expect(getVariable('--DataGrid-hasScrollY')).to.equal('1');
         });
-        // First flip - starts a fresh oscillation sequence past the window.
+        // First flip outside the window — counter resets.
         mockTime += 200;
         setProps({ height: 400 });
         await waitFor(() => {
           expect(getVariable('--DataGrid-hasScrollY')).to.equal('0');
         });
-        // Second flip inside the window - the detector forces hasScrollY off
-        // even though the natural state at height 150 is "needs scrollbar".
+        // Second flip inside the window — force-suppressed despite needing the scrollbar.
         mockTime += 30;
         setProps({ height: 150 });
         await waitFor(() => {

--- a/packages/x-data-grid/src/tests/layout.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/layout.DataGrid.test.tsx
@@ -1376,4 +1376,51 @@ describe('<DataGrid /> - Layout & warnings', () => {
       });
     },
   );
+
+  // See https://github.com/mui/mui-x/issues/20539
+  // Need layout
+  it.skipIf(isJSDOM)(
+    'should force the vertical scrollbar off when consecutive flips happen inside one render frame',
+    async () => {
+      // Stub performance.now so we can control the elapsed-time check inside
+      // the oscillation detector. With two consecutive hasScrollY flips falling
+      // inside the 100ms window the detector should treat them as a layout
+      // feedback loop and force-suppress the scrollbar (the protection added
+      // by PR #21820).
+      let mockTime = 1000;
+      const performanceNowStub = stub(performance, 'now').callsFake(() => mockTime);
+      try {
+        function TestCase({ height }: { height: number }) {
+          return (
+            <div style={{ width: 300, height }}>
+              <DataGrid
+                rows={Array.from({ length: 3 }, (_, i) => ({ id: i, brand: `b${i}` }))}
+                columns={[{ field: 'brand' }]}
+                resizeThrottleMs={0}
+              />
+            </div>
+          );
+        }
+        const { setProps } = render(<TestCase height={150} />);
+        await waitFor(() => {
+          expect(getVariable('--DataGrid-hasScrollY')).to.equal('1');
+        });
+        // First flip - starts a fresh oscillation sequence past the window.
+        mockTime += 200;
+        setProps({ height: 400 });
+        await waitFor(() => {
+          expect(getVariable('--DataGrid-hasScrollY')).to.equal('0');
+        });
+        // Second flip inside the window - the detector forces hasScrollY off
+        // even though the natural state at height 150 is "needs scrollbar".
+        mockTime += 30;
+        setProps({ height: 150 });
+        await waitFor(() => {
+          expect(getVariable('--DataGrid-hasScrollY')).to.equal('0');
+        });
+      } finally {
+        performanceNowStub.restore();
+      }
+    },
+  );
 });

--- a/packages/x-virtualizer/src/features/dimensions.ts
+++ b/packages/x-virtualizer/src/features/dimensions.ts
@@ -14,6 +14,13 @@ import type { BaseState, ParamsWithDefaults } from '../useVirtualizer';
 /* eslint-disable import/export, @typescript-eslint/no-redeclare */
 /* eslint-disable no-underscore-dangle */
 
+// Boundary between an intra-frame layout feedback loop (consecutive hasScrollY
+// flips inside a single browser frame, see #20539) and user-paced resize flips
+// (separated by ResizeObserver ticks and resizeThrottleMs, see #22510). Two
+// flips inside this window are treated as oscillation and the vertical
+// scrollbar is force-suppressed; flips outside it reset the counter.
+const OSCILLATION_FLIP_WINDOW_MS = 100;
+
 export type DimensionsParams = {
   rowHeight: number;
   columnsTotalWidth?: number;
@@ -253,12 +260,14 @@ function useDimensions(store: Store<BaseState>, params: ParamsWithDefaults, _api
           }
 
           if (prevDimensions.isReady && hasScrollY !== prevDimensions.hasScrollY) {
-            const now = Date.now();
+            // performance.now is monotonic — Date.now reads the wall clock and
+            // could jump (NTP, manual time change), breaking the elapsed-time check.
+            const now = performance.now();
             // Reset when the previous flip is too old to be part of the same
             // synchronous render chain. Layout feedback loops flip within a single
             // browser frame; user-driven resize flips are paced by user input and
             // resizeThrottleMs (>= 60ms by default).
-            if (now - osc.lastFlipTimestamp > 100) {
+            if (now - osc.lastFlipTimestamp > OSCILLATION_FLIP_WINDOW_MS) {
               osc.counter = 0;
             }
             osc.lastFlipTimestamp = now;

--- a/packages/x-virtualizer/src/features/dimensions.ts
+++ b/packages/x-virtualizer/src/features/dimensions.ts
@@ -14,11 +14,7 @@ import type { BaseState, ParamsWithDefaults } from '../useVirtualizer';
 /* eslint-disable import/export, @typescript-eslint/no-redeclare */
 /* eslint-disable no-underscore-dangle */
 
-// Boundary between an intra-frame layout feedback loop (consecutive hasScrollY
-// flips inside a single browser frame, see #20539) and user-paced resize flips
-// (separated by ResizeObserver ticks and resizeThrottleMs, see #22510). Two
-// flips inside this window are treated as oscillation and the vertical
-// scrollbar is force-suppressed; flips outside it reset the counter.
+// Separates intra-frame feedback loops (#20539) from user-paced resize (#22510).
 const OSCILLATION_FLIP_WINDOW_MS = 100;
 
 export type DimensionsParams = {
@@ -134,15 +130,9 @@ function initializeState(params: ParamsWithDefaults): Dimensions.State {
 function useDimensions(store: Store<BaseState>, params: ParamsWithDefaults, _api: {}) {
   const isFirstSizing = React.useRef(true);
 
-  // Vertical scrollbar oscillation detector.
-  // Counts consecutive hasScrollY flips that happen with no row-height change
-  // and within the same synchronous render chain (consecutive flips occur within
-  // a few milliseconds, whereas user-driven resize flips are paced by user input
-  // and resizeThrottleMs and are separated by hundreds of milliseconds).
-  // After 2 flips it is certainly a layout feedback loop, so every further flip
-  // is forced to false (no scrollbar). The counter resets when row heights
-  // change or when enough time has passed since the previous flip.
-  // Only vertical scrollbar can oscillate because column widths are never 'auto'.
+  // Vertical scrollbar oscillation detector. After 2 hasScrollY flips with no
+  // row-height change and within OSCILLATION_FLIP_WINDOW_MS, force hasScrollY
+  // off — it's a layout feedback loop, not a real need for a scrollbar.
   // https://github.com/mui/mui-x/issues/20539
   // https://github.com/mui/mui-x/issues/22510
   const scrollYOscillation = React.useRef({
@@ -238,11 +228,7 @@ function useDimensions(store: Store<BaseState>, params: ParamsWithDefaults, _api
           }
         }
 
-        // Detect vertical scrollbar oscillation.
-        // Track consecutive hasScrollY flips with no row-height change.
-        // Once confirmed (≥ 2 flips), force hasScrollY off — the scrollbar is
-        // not genuinely needed, it is a layout feedback loop caused by stale
-        // rootSize or the horizontal scrollbar's height cascading.
+        // Detect vertical scrollbar oscillation (see scrollYOscillation above).
         {
           const osc = scrollYOscillation.current;
           const heightsChanged =
@@ -260,13 +246,8 @@ function useDimensions(store: Store<BaseState>, params: ParamsWithDefaults, _api
           }
 
           if (prevDimensions.isReady && hasScrollY !== prevDimensions.hasScrollY) {
-            // performance.now is monotonic — Date.now reads the wall clock and
-            // could jump (NTP, manual time change), breaking the elapsed-time check.
+            // performance.now is monotonic; Date.now can jump (NTP, clock change).
             const now = performance.now();
-            // Reset when the previous flip is too old to be part of the same
-            // synchronous render chain. Layout feedback loops flip within a single
-            // browser frame; user-driven resize flips are paced by user input and
-            // resizeThrottleMs (>= 60ms by default).
             if (now - osc.lastFlipTimestamp > OSCILLATION_FLIP_WINDOW_MS) {
               osc.counter = 0;
             }

--- a/packages/x-virtualizer/src/features/dimensions.ts
+++ b/packages/x-virtualizer/src/features/dimensions.ts
@@ -128,14 +128,20 @@ function useDimensions(store: Store<BaseState>, params: ParamsWithDefaults, _api
   const isFirstSizing = React.useRef(true);
 
   // Vertical scrollbar oscillation detector.
-  // Counts consecutive hasScrollY flips that happen with no row-height change.
+  // Counts consecutive hasScrollY flips that happen with no row-height change
+  // and within the same synchronous render chain (consecutive flips occur within
+  // a few milliseconds, whereas user-driven resize flips are paced by user input
+  // and resizeThrottleMs and are separated by hundreds of milliseconds).
   // After 2 flips it is certainly a layout feedback loop, so every further flip
-  // is forced to false (no scrollbar). The counter resets when row heights change.
+  // is forced to false (no scrollbar). The counter resets when row heights
+  // change or when enough time has passed since the previous flip.
   // Only vertical scrollbar can oscillate because column widths are never 'auto'.
   // https://github.com/mui/mui-x/issues/20539
+  // https://github.com/mui/mui-x/issues/22510
   const scrollYOscillation = React.useRef({
     counter: 0,
     heights: { content: 0, pinnedTop: 0, pinnedBottom: 0 },
+    lastFlipTimestamp: 0,
   });
 
   const {
@@ -247,6 +253,15 @@ function useDimensions(store: Store<BaseState>, params: ParamsWithDefaults, _api
           }
 
           if (prevDimensions.isReady && hasScrollY !== prevDimensions.hasScrollY) {
+            const now = Date.now();
+            // Reset when the previous flip is too old to be part of the same
+            // synchronous render chain. Layout feedback loops flip within a single
+            // browser frame; user-driven resize flips are paced by user input and
+            // resizeThrottleMs (>= 60ms by default).
+            if (now - osc.lastFlipTimestamp > 100) {
+              osc.counter = 0;
+            }
+            osc.lastFlipTimestamp = now;
             if (!heightsChanged) {
               osc.counter += 1;
             }

--- a/packages/x-virtualizer/src/features/dimensions.ts
+++ b/packages/x-virtualizer/src/features/dimensions.ts
@@ -14,7 +14,9 @@ import type { BaseState, ParamsWithDefaults } from '../useVirtualizer';
 /* eslint-disable import/export, @typescript-eslint/no-redeclare */
 /* eslint-disable no-underscore-dangle */
 
-// Separates intra-frame feedback loops (#20539) from user-paced resize (#22510).
+// Max time between hasScrollY flips that still counts as the same render
+// chain. Feedback loops (#20539) flip within one browser frame; user-paced
+// resize (#22510) flips are separated by ResizeObserver ticks + resizeThrottleMs.
 const OSCILLATION_FLIP_WINDOW_MS = 100;
 
 export type DimensionsParams = {
@@ -130,9 +132,12 @@ function initializeState(params: ParamsWithDefaults): Dimensions.State {
 function useDimensions(store: Store<BaseState>, params: ParamsWithDefaults, _api: {}) {
   const isFirstSizing = React.useRef(true);
 
-  // Vertical scrollbar oscillation detector. After 2 hasScrollY flips with no
-  // row-height change and within OSCILLATION_FLIP_WINDOW_MS, force hasScrollY
-  // off — it's a layout feedback loop, not a real need for a scrollbar.
+  // Vertical scrollbar oscillation detector. Counts consecutive hasScrollY
+  // flips with no row-height change. After 2 flips within
+  // OSCILLATION_FLIP_WINDOW_MS it is a layout feedback loop, so hasScrollY is
+  // forced off. The counter resets on row-height changes or when the previous
+  // flip is older than the window (user-paced resize, not a loop).
+  // Only vertical scrollbar can oscillate because column widths are never 'auto'.
   // https://github.com/mui/mui-x/issues/20539
   // https://github.com/mui/mui-x/issues/22510
   const scrollYOscillation = React.useRef({
@@ -228,7 +233,8 @@ function useDimensions(store: Store<BaseState>, params: ParamsWithDefaults, _api
           }
         }
 
-        // Detect vertical scrollbar oscillation (see scrollYOscillation above).
+        // Detect vertical scrollbar oscillation — caused by stale rootSize or
+        // the horizontal scrollbar's height cascading. See scrollYOscillation.
         {
           const osc = scrollYOscillation.current;
           const heightsChanged =


### PR DESCRIPTION
## Summary

- Fixes #22510 - vertical scrollbar permanently disappears after the user resizes the window across the "needs scrollbar" threshold twice.
- Root cause: the oscillation detector added in #21820 ([\`packages/x-virtualizer/src/features/dimensions.ts\`](https://github.com/mui/mui-x/blob/master/packages/x-virtualizer/src/features/dimensions.ts)) counted every \`hasScrollY\` flip and only ever reset the counter when row heights changed - so two genuine user-driven flips triggered the suppression and pinned \`hasScrollY\` to \`false\` forever.
- Fix: reset the counter when the previous flip is too old to be part of the same synchronous render chain (the layout feedback loop that #21820 was protecting against flips within a single browser frame; user-driven flips are paced by ResizeObserver + \`resizeThrottleMs\` and are separated by hundreds of milliseconds).

The fix preserves the original #20539 protection - a true intra-frame feedback loop's flips stay within the 100ms window so the counter still grows past 2 and the scrollbar is still force-suppressed.

## Test plan

- [x] New browser-mode regression test in [\`layout.DataGrid.test.tsx\`](https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/tests/layout.DataGrid.test.tsx) that toggles the container height across the threshold twice and asserts \`--DataGrid-hasScrollY\` ends at \`1\`. Verified to fail on master and pass with the fix.
- [x] \`pnpm test:browser --project "x-data-grid" --run src/tests/layout.DataGrid.test.tsx\` - all 54 layout tests pass.
- [x] \`pnpm typescript\` and \`pnpm eslint\` clean.
- [x] Manual repro on the reporter's StackBlitz: scrollbar now returns on the third resize.


___

Updated StackBlitz example: https://stackblitz.com/edit/np6qjadu?file=src%2FDemo.tsx