### PR TITLE
[charts] Fix names in PaletteOption component

### DIFF
--- a/packages/x-charts-premium/src/ChartsRenderer/components/PaletteOption.tsx
+++ b/packages/x-charts-premium/src/ChartsRenderer/components/PaletteOption.tsx
@@ -3,8 +3,8 @@ import { styled, useTheme } from '@mui/material/styles';
 import { GridChartsPaletteIcon } from '../icons';
 
 const PaletteOptionRoot = styled('div', {
-  name: 'MuiDataGrid',
-  slot: 'PaletteOptionRoot',
+  name: 'MuiChartsPaletteOption',
+  slot: 'Root',
 })(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
@@ -12,8 +12,8 @@ const PaletteOptionRoot = styled('div', {
 }));
 
 const PaletteOptionIcon = styled('div', {
-  name: 'MuiDataGrid',
-  slot: 'PaletteOptionIcon',
+  name: 'MuiChartsPaletteOption',
+  slot: 'Icon',
 })(({ theme }) => ({
   width: 24,
   height: 24,


### PR DESCRIPTION
Skimming through the code, I noticed a deviation in how component names are assigned. I'm unsure if this is intentional.