### PR TITLE
[charts] Fix highlighted item crash

### DIFF
--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartHighlight/useChartHighlight.test.tsx
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartHighlight/useChartHighlight.test.tsx
@@ -147,34 +147,36 @@ describe('highlight', () => {
     expect(handleHighlight.callCount).to.equal(2);
   });
 
-it('should warn but not crash when switching highlightedItem from controlled to uncontrolled', () => {
-  const errorMock = vi.spyOn(console, 'error').mockImplementation(() => {});
+  it('should warn but not crash when switching highlightedItem from controlled to uncontrolled', () => {
+    const errorMock = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-  try {
-    const { setProps } = render(
-      <BarChart
-        height={100}
-        width={100}
-        skipAnimation
-        margin={0}
-        series={[{ id: 'A', data: [50, 100], highlightScope: { highlight: 'item' } }]}
-        highlightedItem={{ seriesId: 'A', dataIndex: 1 }}
-      />,
-    );
+    try {
+      const { setProps } = render(
+        <BarChart
+          height={100}
+          width={100}
+          skipAnimation
+          margin={0}
+          series={[{ id: 'A', data: [50, 100], highlightScope: { highlight: 'item' } }]}
+          highlightedItem={{ seriesId: 'A', dataIndex: 1 }}
+        />,
+      );
 
-    expect(() => {
-      setProps({
-        highlightedItem: undefined,
-      });
-    }).not.to.throw();
+      expect(() => {
+        setProps({
+          highlightedItem: undefined,
+        });
+      }).not.to.throw();
 
-    expect(errorMock.mock.calls.some(([message]) =>
-      String(message).includes(
-        'A component is changing the controlled highlightedItem state of Chart to be uncontrolled',
-      ),
-    )).to.equal(true);
-  } finally {
-    errorMock.mockRestore();
-  }
-});
+      expect(
+        errorMock.mock.calls.some(([message]) =>
+          String(message).includes(
+            'A component is changing the controlled highlightedItem state of Chart to be uncontrolled',
+          ),
+        ),
+      ).to.equal(true);
+    } finally {
+      errorMock.mockRestore();
+    }
+  });
 });

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartHighlight/useChartHighlight.test.tsx
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartHighlight/useChartHighlight.test.tsx
@@ -146,4 +146,35 @@ describe('highlight', () => {
     await user.pointer({ target: bars[0], coords: getCenter(bars[0]) });
     expect(handleHighlight.callCount).to.equal(2);
   });
+
+it('should warn but not crash when switching highlightedItem from controlled to uncontrolled', () => {
+  const errorMock = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+  try {
+    const { setProps } = render(
+      <BarChart
+        height={100}
+        width={100}
+        skipAnimation
+        margin={0}
+        series={[{ id: 'A', data: [50, 100], highlightScope: { highlight: 'item' } }]}
+        highlightedItem={{ seriesId: 'A', dataIndex: 1 }}
+      />,
+    );
+
+    expect(() => {
+      setProps({
+        highlightedItem: undefined,
+      });
+    }).not.to.throw();
+
+    expect(errorMock.mock.calls.some(([message]) =>
+      String(message).includes(
+        'A component is changing the controlled highlightedItem state of Chart to be uncontrolled',
+      ),
+    )).to.equal(true);
+  } finally {
+    errorMock.mockRestore();
+  }
+});
 });

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartHighlight/useChartHighlight.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartHighlight/useChartHighlight.ts
@@ -32,6 +32,10 @@ export const useChartHighlight: ChartPlugin<UseChartHighlightSignature<any>> = <
   });
 
   useEnhancedEffect(() => {
+    if (params.highlightedItem === undefined) {
+      return;
+    }
+
     if (store.state.highlight.item !== params.highlightedItem) {
       if (params.highlightedItem === null) {
         store.set('highlight', {


### PR DESCRIPTION
## Summary
This fixes a crash in the chart highlight plugin when [highlightedItem](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) becomes undefined during prop synchronization.

The controlled to uncontrolled transition is still unsupported and still warns, but it should not crash while emitting that warning.

## Problem
`useChartHighlight` synchronizes the internal highlight state from `params.highlightedItem` inside an effect.

Before this change, the sync logic handled null as the explicit “clear highlight” case, but it did not guard against undefined before calling `identifierWithType(...)`. In practice, the component already warns for this controlled/uncontrolled transition, but the warning path should not also cause a runtime exception.

In my application, this was triggered when moving between chart pages with the browser back button.

## Fix
The sync effect now returns early when `params.highlightedItem === undefined`.

This preserves the intended semantics:
 - undefined means uncontrolled, so the plugin should not try to sync from props
 - null means controlled and explicitly cleared
 - a non-null identifier means controlled and explicitly set

The warning for switching between controlled and uncontrolled state is unchanged.

This change is intentionally narrow. It fixes the runtime safety issue without changing the existing public warning behavior around controlled/uncontrolled model switching.




<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
