### PR TITLE
[core] Prepare for TypeScript 6 bump

### DIFF
--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -19,7 +19,8 @@
     "src",
     "pages/**/*.ts*",
     "data",
-    "../test/utils/addChaiAssertions.ts"
+    "../test/utils/addChaiAssertions.ts",
+    "../test/utils/momentLocale.d.ts"
   ],
   "exclude": ["docs/.next", "docs/export", "pages/playground"]
 }

--- a/packages/eslint-plugin-mui-x/package.json
+++ b/packages/eslint-plugin-mui-x/package.json
@@ -10,6 +10,7 @@
   },
   "devDependencies": {
     "@types/eslint": "9.6.1",
+    "@types/react": "catalog:",
     "@typescript-eslint/parser": "catalog:",
     "@typescript-eslint/rule-tester": "8.59.3"
   },

--- a/packages/eslint-plugin-mui-x/src/fixtures/tsconfig.json
+++ b/packages/eslint-plugin-mui-x/src/fixtures/tsconfig.json
@@ -5,7 +5,8 @@
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true,
-    "lib": ["es2015", "es2017", "esnext"]
+    "lib": ["es2015", "es2017", "esnext", "dom"],
+    "types": ["react"]
   },
   "include": ["file.ts"]
 }

--- a/packages/eslint-plugin-mui-x/src/rules/no-direct-state-access.test.mjs
+++ b/packages/eslint-plugin-mui-x/src/rules/no-direct-state-access.test.mjs
@@ -50,7 +50,7 @@ const useCustomHook = (api: any) => {
     {
       name: 'directly accessing variable inside received grid state',
       code: `
-type GridApiRef = React.MutableRefObject<any>;
+type GridApiRef = React.RefObject<any>;
 const useCustomHook = (apiRef: GridApiRef) => {
   const rows = apiRef.current.state.rows;
 }
@@ -60,7 +60,7 @@ const useCustomHook = (apiRef: GridApiRef) => {
     {
       name: 'directly accessing variable inside grid state from the hook context',
       code: `
-type GridApiRef = React.MutableRefObject<any>;
+type GridApiRef = React.RefObject<any>;
 const useGridApiContext = (): GridApiRef => { return {} };
 const useCustomHook = () => {
   const apiRef = useGridApiContext();
@@ -72,7 +72,7 @@ const useCustomHook = () => {
     {
       name: 'destructuring variable from grid state',
       code: `
-type GridApiRef = React.MutableRefObject<any>;
+type GridApiRef = React.RefObject<any>;
 const useGridApiContext = (): GridApiRef => { return {} };
 const useCustomHook = () => {
   const apiRef = useGridApiContext();

--- a/packages/x-date-pickers/tsconfig.json
+++ b/packages/x-date-pickers/tsconfig.json
@@ -10,5 +10,9 @@
     "noImplicitAny": false,
     "skipLibCheck": true
   },
-  "include": ["src/**/*", "../../test/utils/addChaiAssertions.ts"]
+  "include": [
+    "src/**/*",
+    "../../test/utils/addChaiAssertions.ts",
+    "../../test/utils/momentLocale.d.ts"
+  ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -766,6 +766,9 @@ importers:
       '@types/eslint':
         specifier: 9.6.1
         version: 9.6.1
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.14
       '@typescript-eslint/parser':
         specifier: 'catalog:'
         version: 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)

--- a/test/utils/init.ts
+++ b/test/utils/init.ts
@@ -1,4 +1,0 @@
-import '@mui/internal-test-utils/init';
-import './licenseRelease';
-import './addChaiAssertions';
-import './setupPickers';

--- a/test/utils/momentLocale.d.ts
+++ b/test/utils/momentLocale.d.ts
@@ -1,0 +1,9 @@
+// moment ships per-locale entry points as plain .js files without `.d.ts`
+// shims. Provide an ambient module declaration so TS accepts side-effect
+// imports like `import 'moment/locale/de'` under `noUncheckedSideEffectImports`
+// (which TS 6 turns on by default).
+//
+// Kept under `test/utils/` rather than in a package's `src/` so it stays
+// out of the published `.d.ts` build output. Reference this file from any
+// package's `tsconfig.json` `include` that needs it.
+declare module 'moment/locale/*' {}


### PR DESCRIPTION
## Summary

Pre-work for [#22405](https://github.com/mui/mui-x/pull/22405) (the renovate PR bumping `typescript` from `5.9.3` to `6.0.3`). All three changes are no-ops on the current TS 5.9.3 install but become required under TS 6.

- **`test/utils/momentLocale.d.ts` + per-package `tsconfig.json` `include`**: TS 6 flips `noUncheckedSideEffectImports`'s default to `true`, which rejects side-effect imports like `import 'moment/locale/de'` that have no `.d.ts` shim. Add an ambient `declare module 'moment/locale/*' {}` declaration and reference it from `x-date-pickers` and `docs` tsconfigs — the two packages that import moment locales. Scoped to the moment locale paths instead of globally disabling the new strict check (per @Janpot's review). File lives under `test/utils/` rather than a package's `src/` so it stays out of the published `.d.ts` build output (verified locally: `pnpm lerna run build --scope "@mui/x-date-pickers" --include-dependencies` produces no `momentLocale.*` artifacts).
- **`packages/eslint-plugin-mui-x/...`**: the `no-direct-state-access` rule fixture used `type GridApiRef = React.MutableRefObject<any>`, but the fixture tsconfig didn't load `@types/react`, so `React.MutableRefObject` resolved to bare `any`. TS 6 no longer preserves the alias chain when the target collapses to bare `any`, so `nodeType.aliasSymbol` became `undefined` and the rule stopped firing. Add `@types/react` to the plugin's devDependencies and load it via the fixture tsconfig (`lib: [..., "dom"]`, `types: ["react"]`) so the alias resolves to a real structural type. While there, switch the fixture from the React-19-deprecated `MutableRefObject` to `RefObject`. Verified 6/6 tests pass on both TS 5.9.3 and TS 6.0.3 (temporarily bumped + reverted root TS locally). The rule itself is unchanged and continues to work on real `GridApiRef` types in the codebase (`test_lint` already passes on the bump PR).
- **`test/utils/init.ts`**: dead code. Nothing imports it, and its side-effect import target (`@mui/internal-test-utils/init`) doesn't exist in the published package's `exports` map — the real entry is `initMatchers`. The active vitest setup file is `test/setupVitest.ts` (referenced in `vitest.shared.mts`).

After this lands, the remaining failures on #22405 are the `command` event missing from `packages/x-internal-gestures/src/core/utils/eventList.ts` (which only makes sense to add on the TS-6 branch since `command` isn't in TS 5.9's `GlobalEventHandlersEventMap`) and the docs/scripts duplicate-TS install — that one needs `@mui/internal-docs-utils` to publish a TS-6-compatible release upstream.

## Test plan

- [x] `pnpm typescript` stays green on both TS 5.9.3 and TS 6.0.3 (verified locally — moment locale errors resolved by the wildcard, only the known docs-scripts duplicate-TS and `command`-missing errors remain on TS 6)
- [x] `pnpm test:unit --project "eslint-plugin-mui-x" --run` stays green on both TS versions (6/6 tests pass)
- [x] `pnpm lerna run build --scope "@mui/x-date-pickers" --include-dependencies` produces no `momentLocale.*` build artifacts
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
