### PR TITLE
[code-infra] Stabilize DataGridScrollRestoration visual regression test

### DIFF
--- a/test/regressions/index.test.ts
+++ b/test/regressions/index.test.ts
@@ -80,11 +80,11 @@ const TEST_RULES: RouteRule[] = [
 
   {
     test: '/test-regressions-data-grid/DataGridScrollRestoration',
-    // The grid remounts when its async demo-data arrives
-    // (`key={String(loading)}`) and then restores its scroll. `aria-busy`
-    // doesn't cover that; sequential runs used to leave enough time, but
-    // pooled pages under concurrency don't, so wait for rendered rows.
-    waitForSelector: '.MuiDataGrid-row .MuiDataGrid-cell',
+    // The grid restores its scroll to top:2000/left:2000 after an async remount.
+    // `aria-rowindex` is the absolute dataset position, so a mid-viewport row for
+    // the restored scroll (top:2000, 52px rows => row ~41 => aria-rowindex 43)
+    // only enters the DOM once the virtualizer has rendered the scrolled window.
+    waitForSelector: '.MuiDataGrid-row[aria-rowindex="43"] .MuiDataGrid-cell',
   },
 ];
 
@@ -216,7 +216,10 @@ async function main() {
             );
 
             if (routeConfig?.waitForSelector) {
-              await page.waitForSelector(routeConfig.waitForSelector);
+              // Scope the wait to this route's testcase: pooled pages keep the
+              // previous route's DOM around briefly, and a global selector could
+              // match a leftover grid instead of the one being screenshotted.
+              await testcase.waitForSelector(routeConfig.waitForSelector);
             }
 
             await page.evaluate(async () => {


### PR DESCRIPTION
The `DataGridScrollRestoration` visual regression test (added in #22447) is still flaky on Argos — the screenshot intermittently captures the grid before scroll restoration has finished.

**Root cause:** the fixture renders `<DataGridPro initialState={{ scroll: { top: 2000, left: 2000 } }} />`. Restoration writes `scrollTop`/`scrollLeft` to the DOM, and the virtualizer recomputes which rows/columns to render in a separate async step (~200ms later). The existing gate `.MuiDataGrid-row .MuiDataGrid-cell` matches immediately - those cells always exist in the DOM, rendered for the stale scroll-0 window - so it never actually waits for restoration. Under the parallel runner's CPU contention the screenshot lands in that gap.

**Fix** (`test/regressions/index.test.ts`):
- Gate on `.MuiDataGrid-row[aria-rowindex="43"]`. `aria-rowindex` is the absolute dataset position, so a mid-viewport row for the restored scroll only enters the DOM once the virtualizer has rendered the scrolled window.
- Scope the wait to the route's `testcase` element - pooled pages keep the previous route's DOM around briefly, so a global `page.waitForSelector` could match a leftover grid.

Reproduced locally under 20× CPU throttling: old gate failed 2–4/10 runs (screenshot taken with the grid still at scroll 0), new gate 0/10.