### PR TITLE
[scheduler] Fix Event Timeline scrolling issues

### DIFF
--- a/packages/x-scheduler-premium/src/event-timeline-premium/content/EventTimelinePremiumContent.tsx
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/content/EventTimelinePremiumContent.tsx
@@ -214,6 +214,7 @@ const EventTimelinePremiumTitleScrollbar = styled('div', {
 })(({ theme }) => ({
   gridRow: 3,
   gridColumn: 1,
+  minHeight: PROXY_SCROLLBAR_SIZE,
   overflowX: 'auto',
   overflowY: 'hidden',
   scrollbarWidth: 'thin',
@@ -228,6 +229,7 @@ const EventTimelinePremiumEventsScrollbar = styled('div', {
 })({
   gridRow: 3,
   gridColumn: 2,
+  minHeight: PROXY_SCROLLBAR_SIZE,
   overflowX: 'auto',
   overflowY: 'hidden',
   scrollbarWidth: 'thin',
@@ -374,10 +376,6 @@ export const EventTimelinePremiumContent = React.forwardRef(function EventTimeli
   const titleScrollbarSpacerRef = React.useRef<HTMLDivElement | null>(null);
   const handleRef = useMergedRefs(forwardedRef, containerRef);
 
-  // Whether each column overflows horizontally, used to give its proxy scrollbar a real track height.
-  const [hasTitleScroll, setHasTitleScroll] = React.useState(false);
-  const [hasEventsScroll, setHasEventsScroll] = React.useState(false);
-
   // Selector hooks
   const adapter = useAdapterContext();
   const now = useStore(store, schedulerNowSelectors.nowUpdatedEveryMinute);
@@ -425,9 +423,11 @@ export const EventTimelinePremiumContent = React.forwardRef(function EventTimeli
       return undefined;
     }
     const updateWidth = () => {
-      const overflowing = subgrid.scrollWidth > subgrid.clientWidth;
-      setHasTitleScroll(overflowing);
-      spacer.style.width = overflowing ? `${subgrid.scrollWidth}px` : '';
+      if (subgrid.scrollWidth > subgrid.clientWidth) {
+        spacer.style.width = `${subgrid.scrollWidth}px`;
+      } else {
+        spacer.style.width = '';
+      }
     };
     updateWidth();
     if (typeof ResizeObserver === 'undefined') {
@@ -437,22 +437,6 @@ export const EventTimelinePremiumContent = React.forwardRef(function EventTimeli
     observer.observe(subgrid);
     return () => observer.disconnect();
   }, []);
-
-  // Track whether the events column overflows horizontally to size its proxy scrollbar track
-  React.useEffect(() => {
-    const scroller = eventsScrollerRef.current;
-    if (!scroller) {
-      return undefined;
-    }
-    const update = () => setHasEventsScroll(scroller.scrollWidth > scroller.clientWidth);
-    update();
-    if (typeof ResizeObserver === 'undefined') {
-      return undefined;
-    }
-    const observer = new ResizeObserver(update);
-    observer.observe(scroller);
-    return () => observer.disconnect();
-  }, [presetConfig.tickCount, presetConfig.tickWidth]);
 
   return (
     <EventTimelinePremiumContentRoot ref={handleRef} className={classes.content} {...props}>
@@ -525,18 +509,10 @@ export const EventTimelinePremiumContent = React.forwardRef(function EventTimeli
               )}
             </EventTimelinePremiumEventsSubGridWrapper>
           </EventTimelinePremiumBodyScroller>
-          <EventTimelinePremiumTitleScrollbar
-            ref={titleScrollbarRef}
-            aria-hidden
-            style={{ minHeight: hasTitleScroll ? PROXY_SCROLLBAR_SIZE : undefined }}
-          >
+          <EventTimelinePremiumTitleScrollbar ref={titleScrollbarRef} aria-hidden>
             <div ref={titleScrollbarSpacerRef} style={{ height: 1 }} />
           </EventTimelinePremiumTitleScrollbar>
-          <EventTimelinePremiumEventsScrollbar
-            ref={eventsScrollbarRef}
-            aria-hidden
-            style={{ minHeight: hasEventsScroll ? PROXY_SCROLLBAR_SIZE : undefined }}
-          >
+          <EventTimelinePremiumEventsScrollbar ref={eventsScrollbarRef} aria-hidden>
             <div
               style={{
                 width: 'calc(var(--unit-count) * var(--unit-width))',

--- a/packages/x-scheduler-premium/src/event-timeline-premium/content/EventTimelinePremiumContent.tsx
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/content/EventTimelinePremiumContent.tsx
@@ -30,6 +30,9 @@ import { EventTimelinePremiumEvent } from './timeline-event';
 import { EventTimelinePremiumSkeleton } from './event-skeleton';
 import { useEventTimelinePremiumStyledContext } from '../EventTimelinePremiumStyledContext';
 
+// Minimum track height so overlay scrollbars (e.g. macOS) render at the correct size.
+const PROXY_SCROLLBAR_SIZE = 14;
+
 const EventTimelinePremiumContentRoot = styled('section', {
   name: 'MuiEventTimeline',
   slot: 'Content',
@@ -120,6 +123,11 @@ const EventTimelinePremiumTitleSubGrid = styled(TimelineGrid.SubGrid, {
   overflowY: 'clip',
   scrollbarWidth: 'none',
   '&::-webkit-scrollbar': { display: 'none' },
+  // Touch devices have no proxy scrollbar to drag, so use the native scrollbar.
+  '@media (hover: none)': {
+    scrollbarWidth: 'auto',
+    '&::-webkit-scrollbar': { display: 'block' },
+  },
 }));
 
 const EventTimelinePremiumEventsSubGridWrapper = styled('div', {
@@ -130,6 +138,11 @@ const EventTimelinePremiumEventsSubGridWrapper = styled('div', {
   overflowY: 'clip',
   scrollbarWidth: 'none',
   '&::-webkit-scrollbar': { display: 'none' },
+  // Touch devices have no proxy scrollbar to drag, so use the native scrollbar.
+  '@media (hover: none)': {
+    scrollbarWidth: 'auto',
+    '&::-webkit-scrollbar': { display: 'block' },
+  },
   gridColumn: 2,
   display: 'grid',
   gridTemplateRows: 'subgrid',
@@ -205,6 +218,8 @@ const EventTimelinePremiumTitleScrollbar = styled('div', {
   overflowY: 'hidden',
   scrollbarWidth: 'thin',
   borderRight: `1px solid ${(theme.vars || theme).palette.divider}`,
+  // Replaced by the native scrollbar on touch devices.
+  '@media (hover: none)': { display: 'none' },
 }));
 
 const EventTimelinePremiumEventsScrollbar = styled('div', {
@@ -216,6 +231,8 @@ const EventTimelinePremiumEventsScrollbar = styled('div', {
   overflowX: 'auto',
   overflowY: 'hidden',
   scrollbarWidth: 'thin',
+  // Replaced by the native scrollbar on touch devices.
+  '@media (hover: none)': { display: 'none' },
 });
 
 function EventRowContent({
@@ -357,6 +374,10 @@ export const EventTimelinePremiumContent = React.forwardRef(function EventTimeli
   const titleScrollbarSpacerRef = React.useRef<HTMLDivElement | null>(null);
   const handleRef = useMergedRefs(forwardedRef, containerRef);
 
+  // Whether each column overflows horizontally, used to give its proxy scrollbar a real track height.
+  const [hasTitleScroll, setHasTitleScroll] = React.useState(false);
+  const [hasEventsScroll, setHasEventsScroll] = React.useState(false);
+
   // Selector hooks
   const adapter = useAdapterContext();
   const now = useStore(store, schedulerNowSelectors.nowUpdatedEveryMinute);
@@ -404,11 +425,9 @@ export const EventTimelinePremiumContent = React.forwardRef(function EventTimeli
       return undefined;
     }
     const updateWidth = () => {
-      if (subgrid.scrollWidth > subgrid.clientWidth) {
-        spacer.style.width = `${subgrid.scrollWidth}px`;
-      } else {
-        spacer.style.width = '';
-      }
+      const overflowing = subgrid.scrollWidth > subgrid.clientWidth;
+      setHasTitleScroll(overflowing);
+      spacer.style.width = overflowing ? `${subgrid.scrollWidth}px` : '';
     };
     updateWidth();
     if (typeof ResizeObserver === 'undefined') {
@@ -418,6 +437,22 @@ export const EventTimelinePremiumContent = React.forwardRef(function EventTimeli
     observer.observe(subgrid);
     return () => observer.disconnect();
   }, []);
+
+  // Track whether the events column overflows horizontally to size its proxy scrollbar track
+  React.useEffect(() => {
+    const scroller = eventsScrollerRef.current;
+    if (!scroller) {
+      return undefined;
+    }
+    const update = () => setHasEventsScroll(scroller.scrollWidth > scroller.clientWidth);
+    update();
+    if (typeof ResizeObserver === 'undefined') {
+      return undefined;
+    }
+    const observer = new ResizeObserver(update);
+    observer.observe(scroller);
+    return () => observer.disconnect();
+  }, [presetConfig.tickCount, presetConfig.tickWidth]);
 
   return (
     <EventTimelinePremiumContentRoot ref={handleRef} className={classes.content} {...props}>
@@ -490,10 +525,18 @@ export const EventTimelinePremiumContent = React.forwardRef(function EventTimeli
               )}
             </EventTimelinePremiumEventsSubGridWrapper>
           </EventTimelinePremiumBodyScroller>
-          <EventTimelinePremiumTitleScrollbar ref={titleScrollbarRef} aria-hidden>
+          <EventTimelinePremiumTitleScrollbar
+            ref={titleScrollbarRef}
+            aria-hidden
+            style={{ minHeight: hasTitleScroll ? PROXY_SCROLLBAR_SIZE : undefined }}
+          >
             <div ref={titleScrollbarSpacerRef} style={{ height: 1 }} />
           </EventTimelinePremiumTitleScrollbar>
-          <EventTimelinePremiumEventsScrollbar ref={eventsScrollbarRef} aria-hidden>
+          <EventTimelinePremiumEventsScrollbar
+            ref={eventsScrollbarRef}
+            aria-hidden
+            style={{ minHeight: hasEventsScroll ? PROXY_SCROLLBAR_SIZE : undefined }}
+          >
             <div
               style={{
                 width: 'calc(var(--unit-count) * var(--unit-width))',


### PR DESCRIPTION
# Closes #22389

The Event Timeline uses a custom proxy scrollbar setup (added in #21697): the real scroll containers hide their native scrollbars and a separate synced scrollbar is rendered at the bottom. That setup is pointer oriented and breaks in the three ways reported in the issue.

## Changes

All in `EventTimelinePremiumContent.tsx`.

1. **Scrollbar size on macOS Chrome.** The proxy scrollbar track used a 1px spacer. On platforms where scrollbars are overlaid and reserve no layout space (macOS, GNOME Web), the track collapsed and the scrollbar could not render at the right size. Added a `min-height` floor of 14px (the value the Data Grid already uses in `GridVirtualScrollbar`), applied only when the column actually overflows so no empty strip appears when there is nothing to scroll. On classic scrollbar platforms the track keeps auto growing, so behavior there is unchanged.

2. **Scrollbar not visible on iOS.** The horizontal scrollers hid the native scrollbar (`scrollbar-width: none` plus `::-webkit-scrollbar { display: none }`), the same root cause as #22386. Touch devices have no proxy scrollbar to grab, so a `@media (hover: none)` block now reveals the native scrollbar on the scrollers and hides the proxy scrollbars.

3. **Impossible to scroll with inertia on iOS.** With native scrollbars restored on touch, the columns scroll natively again with momentum instead of depending on the proxy scrollbar machinery.

Scope is limited to the Event Timeline. The Data Grid issue #22386 shares root cause 2 but is left for a separate PR.

## Testing

This behavior is not observable in jsdom or in CI (classic scrollbars, no touch), so it was verified manually:

- #1 on Chrome with overlay scrollbars enabled (`chrome://flags/#overlay-scrollbars`): the bottom scrollbar renders at a normal height instead of a 1px sliver.
- #2 and #3 on a real iPhone (Safari): the native scrollbar is now visible and horizontal scrolling works with momentum.

No unit test was added because a CI test would pass with or without the fix. Glad to add a Playwright `emulateMedia({ hover: 'none' })` test if preferred.

## Before / After

### Problem -1 (fixed)

**Before**
<img width="1298" height="716" alt="image" src="https://github.com/user-attachments/assets/bfc4baba-09e0-4cc4-a26a-d15ecf879048" />


**After** 
<img width="1317" height="713" alt="image" src="https://github.com/user-attachments/assets/31541448-ece6-45ca-868e-069579f88872" />

### Problem-2 and Problem-3 (fixed)

https://github.com/user-attachments/assets/7067ddae-1ca6-4f92-a4c3-a1cbf0fb3383


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
