### PR TITLE
[test] Remove stale form-submit TODO from e2e suite

### DIFF
--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -758,22 +758,6 @@ async function initializeEnvironment(
           expect(await page.evaluate(() => document.activeElement?.textContent)).to.equal('MM');
         });
 
-        // TODO: enable when v7 fields form submitting is fixed
-        // it('should submit a form when clicking "Enter" key with v7 field', async () => {
-        //   await renderFixture('DatePicker/DesktopDatePickerFormV7');
-
-        //   const monthSpinbutton = page.getByRole(`spinbutton`, { name: 'Month' });
-        //   await monthSpinbutton.focus();
-        //   await monthSpinbutton.press('Enter');
-
-        //   expect(await page.getByRole('textbox', { includeHidden: true }).inputValue()).to.equal(
-        //     '04/17/2022',
-        //   );
-        //   const status = page.getByRole('status');
-        //   expect(await status.isVisible()).to.equal(true);
-        //   expect(await status.textContent()).to.equal('Submitted: 04/17/2022');
-        // });
-
         it('should correctly select a day in a calendar with "AdapterMomentJalaali"', async () => {
           await renderFixture('DatePicker/MomentJalaliDateCalendar');
 


### PR DESCRIPTION
## Summary

The commented-out e2e test in `test/e2e/index.test.ts` references a `DesktopDatePickerFormV7` fixture that was deleted by #14651 ("[fields] Enable the new field DOM structure by default") in October 2024. The April 2026 cleanup in #21966 removed the sibling non-accessible-DOM-structure tests but missed this one.

The Enter-to-submit behavior the test was guarding is now covered by unit tests:

- [`DatePicker.test.tsx:38`](https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/DatePicker/tests/DatePicker.test.tsx#L38) - "should submit the form when 'Enter' is pressed on the input"
- [`DateRangePicker.test.tsx:65`](https://github.com/mui/mui-x/blob/master/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.test.tsx#L65) - same for the range picker

Resurrecting the e2e variant would be redundant rather than just stale, so dropping the dead block.

Discovered while exploring: https://github.com/mui/mui-x/pull/22565