### PR TITLE
[scheduler][docs] Fix indexation of Scheduler

### DIFF
--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,3 +1,2 @@
 User-agent: *
 Allow: /
-Disallow: /x/react-scheduler/


### PR DESCRIPTION
This logic was added in #17239 to have private docs. This is now in public alpha, so let's remove it.

To be clear, the disallow directive is about preventing crawling, not indexing. A page is indexed if discovered when crawling a website (disallow prevents this) or when following a link from another website (disallow doesn't prevent this). It's why we have those Scheduler pages already indexed by Google. cc @flaviendelangle for awareness as it's counterintuitive. To block SEO indexation, the `noindex` directives would do the job.

(I discovered this playing with https://isitagentready.com/)