### PR TITLE
[docs] Add spacing between selects on charts overview demo

### DIFF
--- a/docs/src/modules/components/overview/charts/mainDemo/DownloadDemo.tsx
+++ b/docs/src/modules/components/overview/charts/mainDemo/DownloadDemo.tsx
@@ -69,7 +69,7 @@ export default function DownloadDemo() {
 
   return (
     <Stack spacing={1} direction="column" sx={{ height: '100%', minHeight: 0 }}>
-      <Stack direction="row" sx={{ justifyContent: 'space-between', width: '100%' }}>
+      <Stack direction="row" spacing={1} sx={{ justifyContent: 'space-between', width: '100%' }}>
         <Select
           size="small"
           sx={{ width: 200 }}


### PR DESCRIPTION
## Summary

- Adds `spacing={1}` to the row Stack wrapping the package/format Selects in the charts overview download demo, so they don't touch on narrow viewports.

## Before

<img  height="700" alt="image" src="https://github.com/user-attachments/assets/ec9680e8-63d7-45bb-9819-1c44e25e1c77" />

## After

<img width="393" height="681" alt="image" src="https://github.com/user-attachments/assets/516413b8-e3d8-4ef9-a047-0c3a3a2978ee" />

