### PR TITLE
[infra] Group Base UI renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,7 @@
     },
     {
       "groupName": "Base UI",
-      "matchPackageNames": ["@base-ui/react", "@base-ui/utils"]
+      "matchPackageNames": ["@base-ui/**"]
     },
     {
       "groupName": "bundling fixtures",

--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,10 @@
       "matchPackageNames": ["@react-spring/**"]
     },
     {
+      "groupName": "Base UI",
+      "matchPackageNames": ["@base-ui/react", "@base-ui/utils"]
+    },
+    {
       "groupName": "bundling fixtures",
       "matchFileNames": ["test/bundling/fixtures/**/package.json"],
       "schedule": "* * 1 1,7 *"


### PR DESCRIPTION
Bundles `@base-ui/react` and `@base-ui/utils` renovate bumps into a single PR, mirroring how `react-spring` and other related-package groups are handled in [renovate.json](renovate.json).