### PR TITLE
[code-infra] Refresh CI Node pins to 22.22.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  code-infra: https://raw.githubusercontent.com/mui/mui-public/35aa25ced2bc6ff4f6c5266b073a0a725a362785/.circleci/orbs/code-infra.yml
+  code-infra: https://raw.githubusercontent.com/mui/mui-public/023c96ed6ca37cdb1ff687787e61257c0960285a/.circleci/orbs/code-infra.yml
 
 parameters:
   browserstack-force:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,4 +15,4 @@ jobs:
     name: Continuous releases
     uses: mui/mui-public/.github/workflows/ci-base.yml@8b0badde3f4948db33af81129bf69b51a619aa3a # master
     with:
-      node-version: '22.22'
+      node-version: '22.22.3'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,4 +15,4 @@ jobs:
     name: Continuous releases
     uses: mui/mui-public/.github/workflows/ci-base.yml@8b0badde3f4948db33af81129bf69b51a619aa3a # master
     with:
-      node-version: '22.18.0'
+      node-version: '22.22'

--- a/.github/workflows/l10n.yml
+++ b/.github/workflows/l10n.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Use Node.js 22.x
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22.22'
+          node-version: '22.22.3'
           cache: 'pnpm' # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
       - run: pnpm install --frozen-lockfile
       - name: pnpm l10n --report

--- a/.github/workflows/l10n.yml
+++ b/.github/workflows/l10n.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Use Node.js 22.x
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22.18.0
+          node-version: '22.22'
           cache: 'pnpm' # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
       - run: pnpm install --frozen-lockfile
       - name: pnpm l10n --report

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,7 @@
   command = "pnpm docs:build"
 
 [build.environment]
-  NODE_VERSION = "22.22"
+  NODE_VERSION = "22.22.3"
   PNPM_FLAGS = "--frozen-lockfile"
   NODE_OPTIONS = "--max-old-space-size=6144"
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,7 @@
   command = "pnpm docs:build"
 
 [build.environment]
-  NODE_VERSION = "22.18"
+  NODE_VERSION = "22.22"
   PNPM_FLAGS = "--frozen-lockfile"
   NODE_OPTIONS = "--max-old-space-size=6144"
 


### PR DESCRIPTION
Refreshes the Node version used in CI to the current latest v22 LTS patch (`22.22.3`), and picks up the matching `code-infra` orb digest from [mui/mui-public#1501](https://github.com/mui/mui-public/pull/1501).

Updated:

- `.circleci/config.yml` (code-infra orb digest `35aa25c` -> `023c96e`)
- `.github/workflows/ci.yml` (`22.18.0` -> `22.22.3`)
- `.github/workflows/l10n.yml` (`22.18.0` -> `22.22.3`)
- `netlify.toml` (`22.18` -> `22.22.3`)

Pinning to the exact patch keeps every CI run on a single deterministic Node version, so a freshly published patch can't show up in CI before the team has seen it. Future patches (`22.22.4`, `22.23.0`, ...) are auto-bumped by the Renovate customManagers added in [mui/mui-public#1501](https://github.com/mui/mui-public/pull/1501), so this doesn't trade away the "no follow-up PR" property.

The orb digest bump moves the `code-infra/mui-node` executor from Node 22.21.1 to 22.22.3, which is what unblocks the `test_unit_react_18` workflow that's been failing on master since `mute-stream@4.0.0` (transitive of `@mui/internal-code-infra` via `@inquirer/confirm`) declared `engines.node: "^22.22.2 || ^24.15.0 || >=26.0.0"`. `package.json` `engines.node` (`>=22.18`) is a minimum range and is still satisfied by `22.22.3`, so it is left untouched.