### PR TITLE
[core] Use CircleCI Gen2 resource classes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,6 +283,10 @@ jobs:
     executor:
       name: code-infra/mui-node-browser
       playwright-img-version: v1.60.0-noble
+    # Gen2 makes the WebGL benchmarks slow enough to consistently
+    # time out the ScatterChartPremium cases past vitest's 120s
+    # limit, even with the polling fix from #22535.
+    resource_class: medium
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,7 +220,6 @@ jobs:
     executor:
       name: code-infra/mui-node-browser
       playwright-img-version: v1.60.0-noble
-    # Gen2 showed only ~1.2x speedup here, not worth the price increase.
     resource_class: medium
     steps:
       - checkout
@@ -237,7 +236,6 @@ jobs:
     executor:
       name: code-infra/mui-node-browser
       playwright-img-version: v1.60.0-noble
-    # Gen2 showed only marginal speedup here, not worth the price increase.
     resource_class: medium
     steps:
       - checkout
@@ -249,7 +247,6 @@ jobs:
             PLAYWRIGHT_TEST_BASE_URL: << parameters.e2e-base-url >>
   test_package:
     <<: *default-job
-    # Gen2 showed no speedup here, not worth the price increase.
     resource_class: medium
     steps:
       - checkout
@@ -283,9 +280,6 @@ jobs:
     executor:
       name: code-infra/mui-node-browser
       playwright-img-version: v1.60.0-noble
-    # Gen2 makes the WebGL benchmarks slow enough to consistently
-    # time out the ScatterChartPremium cases past vitest's 120s
-    # limit, even with the polling fix from #22535.
     resource_class: medium
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,6 +220,8 @@ jobs:
     executor:
       name: code-infra/mui-node-browser
       playwright-img-version: v1.60.0-noble
+    # Gen2 showed only ~1.2x speedup here, not worth the price increase.
+    resource_class: medium
     steps:
       - checkout
       - install-deps:
@@ -245,6 +247,8 @@ jobs:
             PLAYWRIGHT_TEST_BASE_URL: << parameters.e2e-base-url >>
   test_package:
     <<: *default-job
+    # Gen2 showed no speedup here, not worth the price increase.
+    resource_class: medium
     steps:
       - checkout
       - install-deps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ default-job: &default-job
     BASE_BRANCH: master
   working_directory: /tmp/mui
   executor: code-infra/mui-node
-  resource_class: medium
+  resource_class: medium.gen2
 # CircleCI has disabled the cache across forks for security reasons.
 # Following their official statement, it was a quick solution, they
 # are working on providing this feature back with appropriate security measures.
@@ -84,7 +84,7 @@ commands:
 jobs:
   test_unit:
     <<: *default-job
-    resource_class: large
+    resource_class: large.gen2
     steps:
       - checkout
       - install-deps:
@@ -109,7 +109,7 @@ jobs:
     executor:
       name: code-infra/mui-node-browser
       playwright-img-version: v1.60.0-noble
-    resource_class: xlarge
+    resource_class: xlarge.gen2
     steps:
       - checkout
       - install-deps:
@@ -200,7 +200,7 @@ jobs:
             git add -A && git diff --exit-code --staged
   test_types:
     <<: *default-job
-    resource_class: large
+    resource_class: large.gen2
     steps:
       - checkout
       - install-deps
@@ -258,7 +258,7 @@ jobs:
     executor:
       name: code-infra/mui-node-browser
       playwright-img-version: v1.60.0-noble
-    resource_class: large
+    resource_class: large.gen2
     steps:
       - checkout
       - install-deps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,6 +237,8 @@ jobs:
     executor:
       name: code-infra/mui-node-browser
       playwright-img-version: v1.60.0-noble
+    # Gen2 showed only marginal speedup here, not worth the price increase.
+    resource_class: medium
     steps:
       - checkout
       - install-deps


### PR DESCRIPTION
## Summary

- Switch most CircleCI jobs to [Gen2 x86 Docker resource classes](https://circleci.com/changelog/introducing-gen2-docker-x86-resource-classes/) (GA on 2026-05-04, advertised ~1.4x faster than Gen1).
- Keep IO-bound jobs (`test_e2e`, `test_e2e_website`, `test_package`) on Gen1 `medium`, where Gen2 shows little or no speedup so the price premium is not justified.
- Keep `test_charts_benchmark` on Gen1: the WebGL ScatterChartPremium benchmarks consistently time out at ~123s on Gen2 (past vitest's 120s test limit), 3-for-3 across PR runs. The polling fix from #22535 is in the branch but does not help -- Gen2 is genuinely slower on the WebGL software-rasterizer path.

## Final resource-class layout

| Class | Jobs |
|---|---|
| `medium.gen2` | default, `test_static`, `test_lint` |
| `large.gen2` | `test_unit`, `test_types`, `test_regressions`, `test_unit_react_18` |
| `xlarge.gen2` | `test_browser`, `test_browser_react_18` |
| `medium` (Gen1) | `test_e2e`, `test_e2e_react_18`, `test_e2e_website`, `test_package`, `test_charts_benchmark` |

`test_e2e_react_18` shares its job definition with `test_e2e` invoked under a different React version, so the resource-class override applies to both.

## Measured impact

Median across 3 PR runs vs `master` 24h Insights trend (`/api/v2/insights/.../workflows/{pipeline,test-react-18}/jobs?branch=master&reporting-window=last-24-hours`). Credits use the [public x86 Docker rate sheet](https://circleci.com/pricing/price-list/): `medium` 10/min, `medium.gen2` 12/min, `large` 20/min, `large.gen2` 24/min, `xlarge` 40/min, `xlarge.gen2` 48/min (Gen2 is +20% per minute, so break-even speedup is 1.20x).

### Per-job timing (Gen2 jobs)

| Job | Class | master median | PR median | Speedup |
|---|---|---|---|---|
| `test_unit` | large.gen2 | 9m21s | 5m23s | **1.74x** |
| `test_types` | large.gen2 | 5m15s | 3m12s | **1.63x** |
| `test_browser_react_18` | xlarge.gen2 | 4m33s | 2m50s | **1.60x** |
| `test_unit_react_18` | large.gen2 | 8m47s | 5m38s | **1.56x** |
| `test_browser` | xlarge.gen2 | 5m01s | 3m15s | **1.54x** |
| `test_static` | medium.gen2 | 4m05s | 2m40s | **1.53x** |
| `test_regressions` | large.gen2 | 3m35s | 2m32s | **1.41x** |
| `test_lint`* | medium.gen2 | 10m59s | 1m22s | *n/a* |

\* `test_lint` master median is bimodal (cache-hit vs cache-miss). All three PR runs landed in the fast mode, where Gen1 and Gen2 are indistinguishable. Real per-run change on this job is expected to be roughly break-even on credits and slightly faster on slow-mode runs.

### Per-job timing (Gen1 jobs, after revert)

| Job | master median | PR median (2 runs) | Δ time |
|---|---|---|---|
| `test_e2e` | 5m08s | 5m07s | -0.3% |
| `test_e2e_react_18` | 5m43s | 5m24s | -5.6% |
| `test_package` | 4m16s | 3m55s | -8.2% |

All sit within the master distribution -- no regression from staying on Gen1, no measurable gain forgone.

`test_e2e_website` (separate workflow, all-branches 24h): Gen1 median across 2,470+ runs is ~92s; the two Gen2 PR runs averaged 65s, but the spread (49s and 81s) sat inside the Gen1 p25-p75 band, so kept on Gen1.

`test_charts_benchmark`: 3 PR runs on `medium.gen2` all failed with the same ScatterChartPremium WebGL timeouts (122s, 123s, 124s vs vitest's 120s limit). Reverted to `medium` (Gen1) -- last known-good behavior.

### Credits cost per pipeline run

Master baseline uses the Insights API's true average (`total_credits_used / total_runs` across the 24h window). PR estimate is the 3-run median duration × the new resource class's per-minute rate.

#### `pipeline` workflow

| Job | master avg | PR estimate | Δ |
|---|---|---|---|
| `test_unit` | 179.0 | 129.4 (large.gen2) | -27.7% |
| `test_browser` | 199.9 | 156.3 (xlarge.gen2) | -21.8% |
| `test_types` | 104.1 | 77.1 (large.gen2) | -25.9% |
| `test_charts_benchmark` | 93.5 | 93.5 (medium, unchanged) | 0% |
| `test_lint` | 78.5 | 16.6 (medium.gen2)* | * |
| `test_regressions` | 69.5 | 61.1 (large.gen2) | -12.1% |
| `test_e2e` | 51.1 | 51.2 (medium, unchanged) | +0.2% |
| `test_package` | 41.9 | 39.1 (medium, unchanged) | -6.7% |
| `test_static` | 40.7 | 32.1 (medium.gen2) | -21.1% |
| **TOTAL** | **858** | **656** | **-23.5% (-202 cr/run)** |

#### `test-react-18` workflow

| Job | master avg | PR estimate | Δ |
|---|---|---|---|
| `test_browser_react_18` | 171.1 | 136.3 (xlarge.gen2) | -20.3% |
| `test_unit_react_18` | 159.8 | 135.4 (large.gen2) | -15.3% |
| `test_e2e_react_18` | 55.1 | 54.0 (medium, unchanged) | -2.0% |
| **TOTAL** | **386** | **326** | **-15.7% (-60 cr/run)** |

#### Combined per pipeline-run

| | master | PR estimate | Δ |
|---|---|---|---|
| Credits | 1,244 | 982 | **-21% (-262 cr/run)** |

\* `test_lint` PR estimate is an underestimate -- all 3 PR runs landed in the fast mode while the master average includes the cache-miss slow mode. Realistic per-run change for this job is closer to break-even on credits and a small win on time. Excluding `test_lint` from the totals: master 1,165 cr -> PR 965 cr = -17% per pipeline run.

## Test plan

- [x] CircleCI pipeline succeeds on this branch.
- [x] Per-job durations compared against `master` 24h Insights trend across 3 PR runs.
- [x] `test_charts_benchmark` passes on Gen1 (confirmed by master baseline; revert restores last-known-good config).
- [ ] Watch the first few `master` builds after merge for any unexpected regression on Gen1-retained jobs.