### PR TITLE
[pnpm] Add security settings to pnpm-workspace.yaml

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -84,6 +84,21 @@ catalog:
   yargs: ^18.0.0
 
 engineStrict: true
+updateNotifier: false
+blockExoticSubdeps: true
+minimumReleaseAge: 4320
+minimumReleaseAgeExclude:
+  - '@mui/*'
+  - '@base-ui/*'
+trustPolicy: no-downgrade
+# Skip trust-policy checks for packages published more than 365 days ago.
+# Some widely-used legacy packages (notably semver@6.x — pulled in by @babel/core@7.x — plus
+# reselect@5.1.1 and parts of @octokit/*) dropped provenance attestation for specific releases,
+# triggering false-positive trust-downgrade errors. Packages that old have had ample time for
+# community review; supply-chain risk is most relevant within a shorter window.
+# TODO: drop once @babel/core stops depending on semver@^6.3.1 (no 6.x semver release has
+# provenance), and the other legacy packages restore provenance.
+trustPolicyIgnoreAfter: 525600
 
 ignoredBuiltDependencies:
   - core-js


### PR DESCRIPTION
Adds pnpm workspace-level security/hygiene settings to align with renovatebot configuration and supply chain hardening practices. Same change shipped in [mui/mui-public#1319](https://github.com/mui/mui-public/pull/1319) for the [tracking issue](https://github.com/mui/mui-public/issues/1273); base-ui equivalent at mui/base-ui#4929.

## Changes (`pnpm-workspace.yaml` only)

- **`updateNotifier: false`** — suppresses pnpm update noise in CI and local dev
- **`blockExoticSubdeps: true`** — rejects git/path/tarball URLs in transitive dependencies
- **`minimumReleaseAge: 4320`** — 4320 minutes (= 3 days), mirrors the `security:minimumReleaseAgeNpm` renovatebot preset already in use; `minimumReleaseAgeExclude` carves out `@mui/*` (our published scope incl. `@mui/x-*` and `@mui/internal-*`) and `@base-ui/*`
- **`trustPolicy: no-downgrade`** paired with **`trustPolicyIgnoreAfter: 525600`** (365 days) — skips trust checks for packages published more than a year ago, avoiding false positives from widely-used packages (e.g. `semver@6.3.1` via `@babel/core@7.x`, `reselect@5.1.1`, parts of `@octokit/*`) that dropped provenance for specific releases. TODO in the file to drop once upstreams restore provenance.

No new `overrides:` introduced — the existing `stylis` override is untouched. `trustPolicyIgnoreAfter` is a policy-only setting that doesn't change resolved versions, so end-user installs are unaffected.

Verified locally: `pnpm install`, `pnpm dedupe --check` clean.