### PR TITLE
[pickers] Preserve typed sections when controlled value rejects partial input

### DIFF
--- a/packages/x-date-pickers-pro/src/SingleInputDateRangeField/tests/editing.SingleInputDateRangeField.test.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputDateRangeField/tests/editing.SingleInputDateRangeField.test.tsx
@@ -129,12 +129,13 @@ describe('<SingleInputDateRangeField /> - Editing', () => {
         expectFieldValue(view.getSectionsContainer(), '04 MMMM – DD MMMM');
 
         await view.pressKey('S');
-        // // We reset the value displayed because the `onChange` callback did not update the controlled value.
+        // The controlled value did not change, but we keep the user's input visible
+        // so they can keep editing (e.g. the "Only update for valid values" pattern).
         expect(onChange.callCount).to.equal(1);
         expect(onChange.lastCall.firstArg[0]).toEqualDateTime(new Date(2022, 8, 4));
         expect(onChange.lastCall.firstArg[1]).to.equal(null);
         await waitFor(() => {
-          expectFieldValue(view.getSectionsContainer(), 'DD MMMM – DD MMMM');
+          expectFieldValue(view.getSectionsContainer(), '04 Sep – DD MMMM');
         });
       });
     },

--- a/packages/x-date-pickers/src/DateField/tests/editing.DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/editing.DateField.test.tsx
@@ -56,11 +56,31 @@ describe('<DateField /> - Editing', () => {
         expectFieldValue(view.getSectionsContainer(), '04 MMMM');
 
         await view.pressKey('S');
-        // // We reset the value displayed because the `onChange` callback did not update the controlled value.
+        // The controlled value did not change, but we keep the user's input visible
+        // so they can keep editing (e.g. the "Only update for valid values" pattern).
         expect(onChange.callCount).to.equal(1);
         expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2022, 8, 4));
         await waitFor(() => {
-          expectFieldValue(view.getSectionsContainer(), 'DD MMMM');
+          expectFieldValue(view.getSectionsContainer(), '04 Sep');
+        });
+      });
+
+      // Regression: https://github.com/mui/mui-x/issues/22113
+      it('should preserve already filled sections when the published date is rejected by the controlled value', async () => {
+        const view = renderWithProps({
+          value: null,
+          // No onChange handler: the controlled `value` stays null no matter what the field publishes.
+        });
+
+        await view.selectSection('month');
+        await view.user.keyboard('06');
+        await view.user.keyboard('15');
+        await view.user.keyboard('2025');
+
+        // Typing "2025" completes a valid date, which the field publishes.
+        // The controlled value did not update, but every section the user typed must remain.
+        await waitFor(() => {
+          expectFieldValue(view.getSectionsContainer(), '06/15/2025');
         });
       });
     },

--- a/packages/x-date-pickers/src/internals/hooks/useField/useFieldState.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useFieldState.ts
@@ -356,7 +356,11 @@ export const useFieldState = <
           if (valueRef.current === value) {
             setState((prevState) => ({
               ...prevState,
-              sections: fieldValueManager.clearDateSections(state.sections, section),
+              // The published value was rejected (the controlled value did not change),
+              // so persist the user's input instead of clearing it.
+              // This lets patterns that filter out invalid values (see "Only update for valid values")
+              // keep partially typed sections visible while the user keeps editing.
+              sections: newSections,
               tempValueStrAndroid: null,
             }));
           }


### PR DESCRIPTION
Fixes #22113

## Summary

When `useFieldState` published a constructed date but the controlled `value` did not update (e.g. the [Only update for valid values](https://mui.com/x/react-date-pickers/lifecycle/#only-update-for-valid-values) pattern shown in the lifecycle docs), the cleanup timeout wiped every section of the active date via `clearDateSections`. That cleared MM and DD as soon as the user typed enough of YYYY to form a parseable date — which on dayjs strict mode happens once the year reaches 3 digits (`>= 100`), and on the other adapters as soon as YYYY is complete.

The fix is one line of behavior in the timeout: instead of clearing the sections, persist `newSections` (the user's input). If the controlled value later updates, the existing `value !== state.lastExternalValue` path still rebuilds sections from `value`, so nothing changes for the accept case.

## Why

The lifecycle docs example was effectively broken: every keystroke that finished a section reset the whole field, so the user could never reach a valid date without losing their input. The intent of that pattern — let the user keep typing until the date passes validation — only works if partial input survives across `validationError`.

## Reviewer notes

- Two existing tests had assertions documenting the old wipe behavior (with leading `// //` comments suggesting they were side observations rather than intentional UX). They are updated to assert preservation.
- Added a regression test that types `06/15/2025` into a `DateField` with a stuck-null controlled value (no `onChange`) and asserts every section stays visible.
- `clearDateSections` is no longer called anywhere but is left on the `FieldValueManager` interface and both value managers — removing it from the public-ish interface felt out of scope for this fix.

## Test plan

- [ ] Open the [lifecycle docs demo](https://mui.com/x/react-date-pickers/lifecycle/#only-update-for-valid-values), type `06/15/202` then `2` — MM and DD stay filled, YYYY shows the partial input