### PR TITLE
[charts] Let scatter chart tooltip ignore hidden series

### DIFF
--- a/docs/data/charts/scatter/ScatterBatchRenderer.js
+++ b/docs/data/charts/scatter/ScatterBatchRenderer.js
@@ -41,12 +41,22 @@ const scatterChartsParams = {
       },
     }),
   ),
-  xAxis: [{ min: 0, label: 'Electricity Generation (GWh)' }],
-  yAxis: [{ min: 0, width: 60, label: 'Life-cycle Carbon Intensity (gCO₂eq/kWh)' }],
+  xAxis: [
+    { min: 0, label: 'Electricity Generation (GWh)', domainSeries: 'visible' },
+  ],
+  yAxis: [
+    {
+      min: 0,
+      width: 60,
+      label: 'Life-cycle Carbon Intensity (gCO₂eq/kWh)',
+      domainSeries: 'visible',
+    },
+  ],
   height: 400,
   colors: schemePaired,
   slotProps: {
     legend: {
+      toggleVisibilityOnClick: true,
       position: { vertical: 'bottom' },
       sx: { justifyContent: 'center' },
     },

--- a/docs/data/charts/scatter/ScatterBatchRenderer.tsx
+++ b/docs/data/charts/scatter/ScatterBatchRenderer.tsx
@@ -45,12 +45,22 @@ const scatterChartsParams = {
       },
     }),
   ),
-  xAxis: [{ min: 0, label: 'Electricity Generation (GWh)' }],
-  yAxis: [{ min: 0, width: 60, label: 'Life-cycle Carbon Intensity (gCO₂eq/kWh)' }],
+  xAxis: [
+    { min: 0, label: 'Electricity Generation (GWh)', domainSeries: 'visible' },
+  ],
+  yAxis: [
+    {
+      min: 0,
+      width: 60,
+      label: 'Life-cycle Carbon Intensity (gCO₂eq/kWh)',
+      domainSeries: 'visible',
+    },
+  ],
   height: 400,
   colors: schemePaired,
   slotProps: {
     legend: {
+      toggleVisibilityOnClick: true,
       position: { vertical: 'bottom' },
       sx: { justifyContent: 'center' },
     },

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartClosestPoint/useChartClosestPoint.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartClosestPoint/useChartClosestPoint.ts
@@ -72,7 +72,7 @@ export const useChartClosestPoint: ChartPlugin<UseChartClosestPointSignature> = 
         const aSeries = (series ?? {})[seriesId];
         const flatbush = flatbushMap.get(seriesId);
 
-        if (!flatbush) {
+        if (!flatbush || aSeries.hidden) {
           continue;
         }
 


### PR DESCRIPTION
I was playing with https://mui.com/x/react-charts/scatter/#performance when I noticed that hidden series were still triggering item tooltip, which looks weird.

I've added the hidden series feature to the legend to make the demo funnier to play with

<img width="798" height="545" alt="image" src="https://github.com/user-attachments/assets/86643b82-bd6a-4c60-8eb7-39944acb6fbc" />
