### PR TITLE
[charts] Remove unused proptypes

### DIFF
--- a/packages/x-charts/src/ChartsLabel/ChartsLabelMark.tsx
+++ b/packages/x-charts/src/ChartsLabel/ChartsLabelMark.tsx
@@ -1,6 +1,5 @@
 'use client';
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { styled, useTheme, type SxProps, type Theme } from '@mui/material/styles';
 import { symbol as d3Symbol, symbolsFill as d3SymbolsFill } from '@mui/x-charts-vendor/d3-shape';
@@ -163,25 +162,5 @@ const ChartsLabelMark = consumeThemeProps(
     );
   },
 );
-
-ChartsLabelMark.propTypes = {
-  // ----------------------------- Warning --------------------------------
-  // | These PropTypes are generated from the TypeScript type definitions |
-  // | To update them edit the TypeScript types and run "pnpm proptypes"  |
-  // ----------------------------------------------------------------------
-  /**
-   * Override or extend the styles applied to the component.
-   */
-  classes: PropTypes.object,
-  /**
-   * The color of the mark.
-   */
-  color: PropTypes.string,
-  /**
-   * The type of the mark.
-   * @default 'square'
-   */
-  type: PropTypes.oneOf(['circle', 'line', 'square']),
-} as any;
 
 export { ChartsLabelMark };


### PR DESCRIPTION
Fix #22615

The component is internal and not updated by the proptypes script