### PR TITLE
[data grid] Fix `avg` aggregation when the average is zero

### DIFF
--- a/packages/x-data-grid-premium/src/hooks/features/aggregation/gridAggregationFunctions.ts
+++ b/packages/x-data-grid-premium/src/hooks/features/aggregation/gridAggregationFunctions.ts
@@ -18,10 +18,6 @@ const sumAgg: GridAggregationFunction<unknown, number> = {
 
 const avgAgg: GridAggregationFunction<unknown, number> = {
   apply: ({ values }) => {
-    if (values.length === 0) {
-      return null;
-    }
-
     let sum = 0;
     let valuesCount = 0;
     for (let i = 0; i < values.length; i += 1) {
@@ -32,7 +28,7 @@ const avgAgg: GridAggregationFunction<unknown, number> = {
       }
     }
 
-    if (sum === 0) {
+    if (valuesCount === 0) {
       return null;
     }
 

--- a/packages/x-data-grid-premium/src/tests/aggregation.DataGridPremium.test.tsx
+++ b/packages/x-data-grid-premium/src/tests/aggregation.DataGridPremium.test.tsx
@@ -1050,30 +1050,32 @@ describe('<DataGridPremium /> - Aggregation', () => {
     });
 
     describe('`avg`', () => {
+      const applyAvgAggregation = (values: unknown[]) =>
+        GRID_AGGREGATION_FUNCTIONS.avg.apply({
+          values,
+          field: 'value',
+          groupId: 0,
+        });
+
       it('should work with numbers', () => {
-        expect(
-          GRID_AGGREGATION_FUNCTIONS.avg.apply(
-            {
-              values: [0, 10, 12, 23],
-              field: 'value',
-              groupId: 0,
-            },
-            apiRef.current!,
-          ),
-        ).to.equal(11.25);
+        expect(applyAvgAggregation([0, 10, 12, 23])).to.equal(11.25);
       });
 
       it('should ignore non-numbers', () => {
         expect(
-          GRID_AGGREGATION_FUNCTIONS.avg.apply(
-            {
-              values: [0, 10, 12, 23, 'a', '', undefined, null, NaN, {}, true],
-              field: 'value',
-              groupId: 0,
-            },
-            apiRef.current!,
-          ),
+          applyAvgAggregation([0, 10, 12, 23, 'a', '', undefined, null, NaN, {}, true]),
         ).to.equal(11.25);
+      });
+
+      it('should return 0 when the numeric values average to 0', () => {
+        expect(applyAvgAggregation([-5, 5])).to.equal(0);
+        expect(applyAvgAggregation([0, 0])).to.equal(0);
+        expect(applyAvgAggregation([-10, 4, 6])).to.equal(0);
+        expect(applyAvgAggregation([0, 'a', '', undefined, null, NaN, {}, true])).to.equal(0);
+      });
+
+      it('should return null when there are no numeric values', () => {
+        expect(applyAvgAggregation(['a', '', undefined, null, NaN, {}, true])).to.equal(null);
       });
     });
 


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/22628

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
