### PR TITLE
[test] Fix flaky Data Grid Pro data source tree data tests

### DIFF
--- a/packages/x-data-grid-pro/src/tests/dataSourceTreeData.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/dataSourceTreeData.DataGridPro.test.tsx
@@ -397,9 +397,13 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
     });
 
     const cell11ChildrenCount = Number(cell11.innerText.split('(')[1].split(')')[0]);
-    expect(Object.keys(apiRef.current.state.rows.tree).length).to.equal(
-      10 + 1 + cell11ChildrenCount,
-    );
+    // `callCount` increments when the fetch starts, so wait for the children to
+    // actually be added to the tree before asserting on it.
+    await waitFor(() => {
+      expect(Object.keys(apiRef.current!.state.rows.tree).length).to.equal(
+        10 + 1 + cell11ChildrenCount,
+      );
+    });
   });
 
   it('should keep the nested data visible after the root level re-fetch and remove any stale rows', async () => {
@@ -441,9 +445,13 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
 
     // children are part of the tree
     const cell11ChildrenCount = Number(cell11.innerText.split('(')[1].split(')')[0]);
-    expect(Object.keys(apiRef.current!.state.rows.tree).length).to.equal(
-      10 + 1 + cell11ChildrenCount,
-    );
+    // `callCount` increments when the fetch starts, so wait for the children to
+    // actually be added to the tree before asserting on it.
+    await waitFor(() => {
+      expect(Object.keys(apiRef.current!.state.rows.tree).length).to.equal(
+        10 + 1 + cell11ChildrenCount,
+      );
+    });
 
     // refetch the root level
     act(() => {
@@ -454,13 +462,14 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
       expect(fetchRowsSpy.callCount).to.equal(3);
     });
 
-    // children are still part of the tree
-    expect(Object.keys(apiRef.current!.state.rows.tree).length).to.equal(
-      10 + 1 + cell11ChildrenCount,
-    );
-
-    // test row is not part of the tree anymore
-    expect(apiRef.current!.state.rows.tree[testRowId]).to.equal(undefined);
+    // children are still part of the tree, and the stale test row has been
+    // removed once the background re-fetch settles.
+    await waitFor(() => {
+      expect(Object.keys(apiRef.current!.state.rows.tree).length).to.equal(
+        10 + 1 + cell11ChildrenCount,
+      );
+      expect(apiRef.current!.state.rows.tree[testRowId]).to.equal(undefined);
+    });
   });
 
   it('should collapse the nested data if refetching the root level with `keepChildrenExpanded` set to `false`', async () => {
@@ -479,9 +488,13 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
     });
 
     const cell11ChildrenCount = Number(cell11.innerText.split('(')[1].split(')')[0]);
-    expect(Object.keys(apiRef.current!.state.rows.tree).length).to.equal(
-      10 + 1 + cell11ChildrenCount,
-    );
+    // `callCount` increments when the fetch starts, so wait for the children to
+    // actually be added to the tree before asserting on it.
+    await waitFor(() => {
+      expect(Object.keys(apiRef.current!.state.rows.tree).length).to.equal(
+        10 + 1 + cell11ChildrenCount,
+      );
+    });
 
     fetchRowsSpy.resetHistory();
 
@@ -493,7 +506,10 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
       expect(fetchRowsSpy.callCount).to.equal(1);
     });
 
-    expect(Object.keys(apiRef.current!.state.rows.tree).length).to.equal(10 + 1);
+    // Children collapse once the re-fetch settles, leaving only the root rows.
+    await waitFor(() => {
+      expect(Object.keys(apiRef.current!.state.rows.tree).length).to.equal(10 + 1);
+    });
   });
 
   // https://github.com/mui/mui-x/issues/21269
@@ -590,9 +606,13 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
     });
 
     const cell11ChildrenCount = Number(cell11.innerText.split('(')[1].split(')')[0]);
-    expect(Object.keys(apiRef.current.state.rows.tree).length).to.equal(
-      10 + 1 + cell11ChildrenCount,
-    );
+    // `callCount` increments when the fetch starts, so wait for the children to
+    // actually be added to the tree before asserting on it.
+    await waitFor(() => {
+      expect(Object.keys(apiRef.current!.state.rows.tree).length).to.equal(
+        10 + 1 + cell11ChildrenCount,
+      );
+    });
   });
 
   // https://github.com/mui/mui-x/issues/21263

--- a/packages/x-data-grid-pro/src/tests/dataSourceTreeData.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/dataSourceTreeData.DataGridPro.test.tsx
@@ -167,7 +167,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
 
   it('should periodically revalidate root rows when dataSourceRevalidateMs is set', async () => {
     const localFetchRowsSpy = spy();
-    const { unmount } = render(
+    const { setProps, unmount } = render(
       <TestDataSource
         dataSourceCache={null}
         dataSourceRevalidateMs={1}
@@ -179,22 +179,23 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
       expect(localFetchRowsSpy.callCount).to.be.greaterThan(0);
     });
 
-    vi.useFakeTimers();
-    localFetchRowsSpy.resetHistory();
+    const callCountAfterFirstFetch = localFetchRowsSpy.callCount;
 
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(100);
+    // With `dataSourceRevalidateMs` set, the grid refetches on an interval, so
+    // the call count keeps growing on its own without any further prop change.
+    await waitFor(() => {
+      expect(localFetchRowsSpy.callCount).to.be.greaterThan(callCountAfterFirstFetch);
     });
 
-    expect(localFetchRowsSpy.callCount).to.be.greaterThan(1);
-
-    vi.useRealTimers();
+    // Stop revalidation so an in-flight fetch can't re-arm the 1ms interval
+    // after unmount and leak polling into later tests.
+    setProps({ dataSourceRevalidateMs: 0 });
     unmount();
   });
 
   it('should periodically revalidate expanded nested rows when dataSourceRevalidateMs is set', async () => {
     const localFetchRowsSpy = spy();
-    const { user, unmount } = render(
+    const { setProps, user, unmount } = render(
       <TestDataSource
         dataSourceCache={null}
         dataSourceRevalidateMs={1}
@@ -214,27 +215,27 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
       expect(localFetchRowsSpy.callCount).to.be.greaterThan(1);
     });
 
-    vi.useFakeTimers();
     localFetchRowsSpy.resetHistory();
 
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(100);
+    // The expanded group is revalidated on the interval; wait for one of those
+    // background nested requests (a call carrying `groupKeys`) to be issued.
+    await waitFor(() => {
+      const hasNestedGroupRequest = localFetchRowsSpy.getCalls().some((call) => {
+        const url = new URL(call.firstArg as string);
+        const groupKeys = JSON.parse(url.searchParams.get('groupKeys') || '[]');
+        return groupKeys.length > 0;
+      });
+      expect(hasNestedGroupRequest).to.equal(true);
     });
 
-    const hasNestedGroupRequest = localFetchRowsSpy.getCalls().some((call) => {
-      const url = new URL(call.firstArg as string);
-      const groupKeys = JSON.parse(url.searchParams.get('groupKeys') || '[]');
-      return groupKeys.length > 0;
-    });
-
-    expect(hasNestedGroupRequest).to.equal(true);
-
-    vi.useRealTimers();
+    // Stop revalidation so an in-flight fetch can't re-arm the 1ms interval
+    // after unmount and leak polling into later tests.
+    setProps({ dataSourceRevalidateMs: 0 });
     unmount();
   });
 
   it('should keep selected nested rows selected during background nested revalidation', async () => {
-    const { user, unmount } = render(
+    const { setProps, user, unmount } = render(
       <TestDataSource dataSourceCache={null} dataSourceRevalidateMs={1} />,
     );
 
@@ -259,29 +260,29 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
     });
     expect(apiRef.current!.isRowSelected(firstChildId)).to.equal(true);
 
-    vi.useFakeTimers();
     fetchRowsSpy.resetHistory();
 
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(100);
+    // Wait for a background nested revalidation (a call carrying `groupKeys`).
+    await waitFor(() => {
+      const hasNestedGroupRequest = fetchRowsSpy.getCalls().some((call) => {
+        const url = new URL(call.firstArg as string);
+        const groupKeys = JSON.parse(url.searchParams.get('groupKeys') || '[]');
+        return groupKeys.length > 0;
+      });
+      expect(hasNestedGroupRequest).to.equal(true);
     });
-
-    const hasNestedGroupRequest = fetchRowsSpy.getCalls().some((call) => {
-      const url = new URL(call.firstArg as string);
-      const groupKeys = JSON.parse(url.searchParams.get('groupKeys') || '[]');
-      return groupKeys.length > 0;
-    });
-    expect(hasNestedGroupRequest).to.equal(true);
 
     expect(apiRef.current!.isRowSelected(firstChildId)).to.equal(true);
 
-    vi.useRealTimers();
+    // Stop revalidation so an in-flight fetch can't re-arm the 1ms interval
+    // after unmount and leak polling into later tests.
+    setProps({ dataSourceRevalidateMs: 0 });
     unmount();
   });
 
   it('should not set children loading state during background nested revalidation', async () => {
     const localFetchRowsSpy = spy();
-    const { user, unmount } = render(
+    const { setProps, user, unmount } = render(
       <TestDataSource
         dataSourceCache={null}
         dataSourceRevalidateMs={1}
@@ -303,28 +304,29 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
 
     const setChildrenLoadingSpy = spy(apiRef.current!.dataSource, 'setChildrenLoading');
 
-    vi.useFakeTimers();
     localFetchRowsSpy.resetHistory();
     setChildrenLoadingSpy.resetHistory();
 
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(100);
+    // Wait for a background nested revalidation (a call carrying `groupKeys`)...
+    await waitFor(() => {
+      const hasNestedGroupRequest = localFetchRowsSpy.getCalls().some((call) => {
+        const url = new URL(call.firstArg as string);
+        const groupKeys = JSON.parse(url.searchParams.get('groupKeys') || '[]');
+        return groupKeys.length > 0;
+      });
+      expect(hasNestedGroupRequest).to.equal(true);
     });
 
-    const hasNestedGroupRequest = localFetchRowsSpy.getCalls().some((call) => {
-      const url = new URL(call.firstArg as string);
-      const groupKeys = JSON.parse(url.searchParams.get('groupKeys') || '[]');
-      return groupKeys.length > 0;
-    });
-    expect(hasNestedGroupRequest).to.equal(true);
-
+    // ...and confirm it never put the expanded group into a loading state.
     const hasLoadingTrueCall = setChildrenLoadingSpy
       .getCalls()
       .some((call) => call.args[0] === expandedRowId && call.args[1] === true);
     setChildrenLoadingSpy.restore();
     expect(hasLoadingTrueCall).to.equal(false);
 
-    vi.useRealTimers();
+    // Stop revalidation so an in-flight fetch can't re-arm the 1ms interval
+    // after unmount and leak polling into later tests.
+    setProps({ dataSourceRevalidateMs: 0 });
     unmount();
   });
 


### PR DESCRIPTION
## Summary

De-flakes `packages/x-data-grid-pro/src/tests/dataSourceTreeData.DataGridPro.test.tsx`, which intermittently failed the `test_browser` CI job. Two independent timing issues were at play.

## 1. Revalidation tests mixed real and fake timers

`should periodically revalidate root rows when dataSourceRevalidateMs is set` failed with `expected 1 to be above 1`, surviving all 3 retries (e.g. [this job](https://app.circleci.com/pipelines/gh/mui/mui-x/131870/workflows/fad8ee18-1789-4db8-9fe6-e98690ecaa59/jobs/848526)).

With `dataSourceRevalidateMs={1}`, the grid auto-starts a `setInterval(revalidate, 1)` under real timers as soon as the initial data loads. The tests then switched to fake timers (`vi.useFakeTimers()`) after that interval was already running, reset the spy, and `await vi.advanceTimersByTimeAsync(100)`. Advancing the fake clock does not deterministically drive a pre-existing real interval, nor the mock server's `setTimeout(resolve, 0)` fetch resolution that reschedules polling, so the spy was sometimes called only once in the window. CI, being slower and noisier than local, hits that path relatively often.

Fix: assert revalidation on the real interval via `waitFor`, matching the pattern already used by the lazy loader revalidation test. Stop polling with `setProps({ dataSourceRevalidateMs: 0 })` before unmount so an in-flight request cannot re-arm the 1ms interval and leak into later tests. Applied consistently to all four tests in the file that shared the real to fake timer transition.

## 2. Tree assertions raced fetch completion

After the first fix, a different test in the file flaked: `should keep the nested data visible after the root level re-fetch` failed with `expected 11 to equal 16`.

`fetchRowsSpy` is incremented at the start of `getRows`, before the awaited fetch, so `waitFor(callCount === N)` resolves when a fetch starts, not when its response has been applied to the row tree. Several tests then read `state.rows.tree` synchronously right after that `waitFor`, before the children or refetch had landed.

Fix: wrap those tree assertions in `waitFor` so they retry until the fetch result is applied, matching the sibling `should remove stale rows` test which already does this.

## Testing

- 40 consecutive runs of the file pass: `pnpm test:browser --project "x-data-grid-pro" --run dataSourceTreeData`.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
