### PR TITLE
[charts][docs] Derive class name owners for shared charts classes

### DIFF
--- a/docs/pages/x/api/charts/bar-label.json
+++ b/docs/pages/x/api/charts/bar-label.json
@@ -30,37 +30,37 @@
   "classes": [
     {
       "key": "element",
-      "className": "MuiBarLabel-element",
+      "className": "MuiBarChart-element",
       "description": "Styles applied to an individual bar element.",
       "isGlobal": false
     },
     {
       "key": "label",
-      "className": "MuiBarLabel-label",
+      "className": "MuiBarChart-label",
       "description": "Styles applied to an individual bar label.",
       "isGlobal": false
     },
     {
       "key": "labelAnimate",
-      "className": "MuiBarLabel-labelAnimate",
+      "className": "MuiBarChart-labelAnimate",
       "description": "Styles applied to a bar label when it is animated.",
       "isGlobal": false
     },
     {
       "key": "root",
-      "className": "MuiBarLabel-root",
+      "className": "MuiBarChart-root",
       "description": "Styles applied to the bar plot element.",
       "isGlobal": false
     },
     {
       "key": "series",
-      "className": "MuiBarLabel-series",
+      "className": "MuiBarChart-series",
       "description": "Styles applied to the group surrounding a series' bar elements.",
       "isGlobal": false
     },
     {
       "key": "seriesLabels",
-      "className": "MuiBarLabel-seriesLabels",
+      "className": "MuiBarChart-seriesLabels",
       "description": "Styles applied to the group surrounding a series' labels.",
       "isGlobal": false
     }

--- a/docs/pages/x/api/charts/charts-axis-tooltip-content.json
+++ b/docs/pages/x/api/charts/charts-axis-tooltip-content.json
@@ -19,61 +19,61 @@
   "classes": [
     {
       "key": "axisValueCell",
-      "className": "MuiChartsAxisTooltipContent-axisValueCell",
+      "className": "MuiChartsTooltip-axisValueCell",
       "description": "Styles applied to the axisValueCell element. Only available for axis tooltip.",
       "isGlobal": false
     },
     {
       "key": "cell",
-      "className": "MuiChartsAxisTooltipContent-cell",
+      "className": "MuiChartsTooltip-cell",
       "description": "Styles applied to the cell element.",
       "isGlobal": false
     },
     {
       "key": "labelCell",
-      "className": "MuiChartsAxisTooltipContent-labelCell",
+      "className": "MuiChartsTooltip-labelCell",
       "description": "Styles applied to the labelCell element.",
       "isGlobal": false
     },
     {
       "key": "mark",
-      "className": "MuiChartsAxisTooltipContent-mark",
+      "className": "MuiChartsTooltip-mark",
       "description": "Styles applied to the mark element.",
       "isGlobal": false
     },
     {
       "key": "markContainer",
-      "className": "MuiChartsAxisTooltipContent-markContainer",
+      "className": "MuiChartsTooltip-markContainer",
       "description": "Styles applied to the markContainer element.",
       "isGlobal": false
     },
     {
       "key": "paper",
-      "className": "MuiChartsAxisTooltipContent-paper",
+      "className": "MuiChartsTooltip-paper",
       "description": "Styles applied to the paper element.",
       "isGlobal": false
     },
     {
       "key": "root",
-      "className": "MuiChartsAxisTooltipContent-root",
+      "className": "MuiChartsTooltip-root",
       "description": "Styles applied to the root element.",
       "isGlobal": false
     },
     {
       "key": "row",
-      "className": "MuiChartsAxisTooltipContent-row",
+      "className": "MuiChartsTooltip-row",
       "description": "Styles applied to the row element.",
       "isGlobal": false
     },
     {
       "key": "table",
-      "className": "MuiChartsAxisTooltipContent-table",
+      "className": "MuiChartsTooltip-table",
       "description": "Styles applied to the table element.",
       "isGlobal": false
     },
     {
       "key": "valueCell",
-      "className": "MuiChartsAxisTooltipContent-valueCell",
+      "className": "MuiChartsTooltip-valueCell",
       "description": "Styles applied to the valueCell element.",
       "isGlobal": false
     }

--- a/docs/pages/x/api/charts/charts-item-tooltip-content.json
+++ b/docs/pages/x/api/charts/charts-item-tooltip-content.json
@@ -10,61 +10,61 @@
   "classes": [
     {
       "key": "axisValueCell",
-      "className": "MuiChartsItemTooltipContent-axisValueCell",
+      "className": "MuiChartsTooltip-axisValueCell",
       "description": "Styles applied to the axisValueCell element. Only available for axis tooltip.",
       "isGlobal": false
     },
     {
       "key": "cell",
-      "className": "MuiChartsItemTooltipContent-cell",
+      "className": "MuiChartsTooltip-cell",
       "description": "Styles applied to the cell element.",
       "isGlobal": false
     },
     {
       "key": "labelCell",
-      "className": "MuiChartsItemTooltipContent-labelCell",
+      "className": "MuiChartsTooltip-labelCell",
       "description": "Styles applied to the labelCell element.",
       "isGlobal": false
     },
     {
       "key": "mark",
-      "className": "MuiChartsItemTooltipContent-mark",
+      "className": "MuiChartsTooltip-mark",
       "description": "Styles applied to the mark element.",
       "isGlobal": false
     },
     {
       "key": "markContainer",
-      "className": "MuiChartsItemTooltipContent-markContainer",
+      "className": "MuiChartsTooltip-markContainer",
       "description": "Styles applied to the markContainer element.",
       "isGlobal": false
     },
     {
       "key": "paper",
-      "className": "MuiChartsItemTooltipContent-paper",
+      "className": "MuiChartsTooltip-paper",
       "description": "Styles applied to the paper element.",
       "isGlobal": false
     },
     {
       "key": "root",
-      "className": "MuiChartsItemTooltipContent-root",
+      "className": "MuiChartsTooltip-root",
       "description": "Styles applied to the root element.",
       "isGlobal": false
     },
     {
       "key": "row",
-      "className": "MuiChartsItemTooltipContent-row",
+      "className": "MuiChartsTooltip-row",
       "description": "Styles applied to the row element.",
       "isGlobal": false
     },
     {
       "key": "table",
-      "className": "MuiChartsItemTooltipContent-table",
+      "className": "MuiChartsTooltip-table",
       "description": "Styles applied to the table element.",
       "isGlobal": false
     },
     {
       "key": "valueCell",
-      "className": "MuiChartsItemTooltipContent-valueCell",
+      "className": "MuiChartsTooltip-valueCell",
       "description": "Styles applied to the valueCell element.",
       "isGlobal": false
     }

--- a/docs/pages/x/api/charts/charts-tooltip-container.json
+++ b/docs/pages/x/api/charts/charts-tooltip-container.json
@@ -100,61 +100,61 @@
       "name": "root",
       "description": "The component that renders the root.",
       "default": "'div'",
-      "class": "MuiChartsTooltipContainer-root"
+      "class": "MuiChartsTooltip-root"
     }
   ],
   "classes": [
     {
       "key": "axisValueCell",
-      "className": "MuiChartsTooltipContainer-axisValueCell",
+      "className": "MuiChartsTooltip-axisValueCell",
       "description": "Styles applied to the axisValueCell element. Only available for axis tooltip.",
       "isGlobal": false
     },
     {
       "key": "cell",
-      "className": "MuiChartsTooltipContainer-cell",
+      "className": "MuiChartsTooltip-cell",
       "description": "Styles applied to the cell element.",
       "isGlobal": false
     },
     {
       "key": "labelCell",
-      "className": "MuiChartsTooltipContainer-labelCell",
+      "className": "MuiChartsTooltip-labelCell",
       "description": "Styles applied to the labelCell element.",
       "isGlobal": false
     },
     {
       "key": "mark",
-      "className": "MuiChartsTooltipContainer-mark",
+      "className": "MuiChartsTooltip-mark",
       "description": "Styles applied to the mark element.",
       "isGlobal": false
     },
     {
       "key": "markContainer",
-      "className": "MuiChartsTooltipContainer-markContainer",
+      "className": "MuiChartsTooltip-markContainer",
       "description": "Styles applied to the markContainer element.",
       "isGlobal": false
     },
     {
       "key": "paper",
-      "className": "MuiChartsTooltipContainer-paper",
+      "className": "MuiChartsTooltip-paper",
       "description": "Styles applied to the paper element.",
       "isGlobal": false
     },
     {
       "key": "row",
-      "className": "MuiChartsTooltipContainer-row",
+      "className": "MuiChartsTooltip-row",
       "description": "Styles applied to the row element.",
       "isGlobal": false
     },
     {
       "key": "table",
-      "className": "MuiChartsTooltipContainer-table",
+      "className": "MuiChartsTooltip-table",
       "description": "Styles applied to the table element.",
       "isGlobal": false
     },
     {
       "key": "valueCell",
-      "className": "MuiChartsTooltipContainer-valueCell",
+      "className": "MuiChartsTooltip-valueCell",
       "description": "Styles applied to the valueCell element.",
       "isGlobal": false
     }

--- a/docs/pages/x/api/charts/heatmap-tooltip-content.json
+++ b/docs/pages/x/api/charts/heatmap-tooltip-content.json
@@ -8,61 +8,61 @@
   "classes": [
     {
       "key": "axisValueCell",
-      "className": "MuiHeatmapTooltipContent-axisValueCell",
+      "className": "MuiChartsTooltip-axisValueCell",
       "description": "Styles applied to the axisValueCell element. Only available for axis tooltip.",
       "isGlobal": false
     },
     {
       "key": "cell",
-      "className": "MuiHeatmapTooltipContent-cell",
+      "className": "MuiChartsTooltip-cell",
       "description": "Styles applied to the cell element.",
       "isGlobal": false
     },
     {
       "key": "labelCell",
-      "className": "MuiHeatmapTooltipContent-labelCell",
+      "className": "MuiChartsTooltip-labelCell",
       "description": "Styles applied to the labelCell element.",
       "isGlobal": false
     },
     {
       "key": "mark",
-      "className": "MuiHeatmapTooltipContent-mark",
+      "className": "MuiChartsTooltip-mark",
       "description": "Styles applied to the mark element.",
       "isGlobal": false
     },
     {
       "key": "markContainer",
-      "className": "MuiHeatmapTooltipContent-markContainer",
+      "className": "MuiChartsTooltip-markContainer",
       "description": "Styles applied to the markContainer element.",
       "isGlobal": false
     },
     {
       "key": "paper",
-      "className": "MuiHeatmapTooltipContent-paper",
+      "className": "MuiChartsTooltip-paper",
       "description": "Styles applied to the paper element.",
       "isGlobal": false
     },
     {
       "key": "root",
-      "className": "MuiHeatmapTooltipContent-root",
+      "className": "MuiChartsTooltip-root",
       "description": "Styles applied to the root element.",
       "isGlobal": false
     },
     {
       "key": "row",
-      "className": "MuiHeatmapTooltipContent-row",
+      "className": "MuiChartsTooltip-row",
       "description": "Styles applied to the row element.",
       "isGlobal": false
     },
     {
       "key": "table",
-      "className": "MuiHeatmapTooltipContent-table",
+      "className": "MuiChartsTooltip-table",
       "description": "Styles applied to the table element.",
       "isGlobal": false
     },
     {
       "key": "valueCell",
-      "className": "MuiHeatmapTooltipContent-valueCell",
+      "className": "MuiChartsTooltip-valueCell",
       "description": "Styles applied to the valueCell element.",
       "isGlobal": false
     }

--- a/docs/pages/x/api/charts/heatmap-tooltip.json
+++ b/docs/pages/x/api/charts/heatmap-tooltip.json
@@ -100,61 +100,61 @@
   "classes": [
     {
       "key": "axisValueCell",
-      "className": "MuiHeatmapTooltip-axisValueCell",
+      "className": "MuiChartsTooltip-axisValueCell",
       "description": "Styles applied to the axisValueCell element. Only available for axis tooltip.",
       "isGlobal": false
     },
     {
       "key": "cell",
-      "className": "MuiHeatmapTooltip-cell",
+      "className": "MuiChartsTooltip-cell",
       "description": "Styles applied to the cell element.",
       "isGlobal": false
     },
     {
       "key": "labelCell",
-      "className": "MuiHeatmapTooltip-labelCell",
+      "className": "MuiChartsTooltip-labelCell",
       "description": "Styles applied to the labelCell element.",
       "isGlobal": false
     },
     {
       "key": "mark",
-      "className": "MuiHeatmapTooltip-mark",
+      "className": "MuiChartsTooltip-mark",
       "description": "Styles applied to the mark element.",
       "isGlobal": false
     },
     {
       "key": "markContainer",
-      "className": "MuiHeatmapTooltip-markContainer",
+      "className": "MuiChartsTooltip-markContainer",
       "description": "Styles applied to the markContainer element.",
       "isGlobal": false
     },
     {
       "key": "paper",
-      "className": "MuiHeatmapTooltip-paper",
+      "className": "MuiChartsTooltip-paper",
       "description": "Styles applied to the paper element.",
       "isGlobal": false
     },
     {
       "key": "root",
-      "className": "MuiHeatmapTooltip-root",
+      "className": "MuiChartsTooltip-root",
       "description": "Styles applied to the root element.",
       "isGlobal": false
     },
     {
       "key": "row",
-      "className": "MuiHeatmapTooltip-row",
+      "className": "MuiChartsTooltip-row",
       "description": "Styles applied to the row element.",
       "isGlobal": false
     },
     {
       "key": "table",
-      "className": "MuiHeatmapTooltip-table",
+      "className": "MuiChartsTooltip-table",
       "description": "Styles applied to the table element.",
       "isGlobal": false
     },
     {
       "key": "valueCell",
-      "className": "MuiHeatmapTooltip-valueCell",
+      "className": "MuiChartsTooltip-valueCell",
       "description": "Styles applied to the valueCell element.",
       "isGlobal": false
     }

--- a/docs/pages/x/api/charts/pie-arc-label.json
+++ b/docs/pages/x/api/charts/pie-arc-label.json
@@ -10,43 +10,43 @@
   "classes": [
     {
       "key": "animate",
-      "className": "MuiPieArcLabel-animate",
+      "className": "MuiPieChart-animate",
       "description": "Styles applied when animation is not skipped.",
       "isGlobal": false
     },
     {
       "key": "arc",
-      "className": "MuiPieArcLabel-arc",
+      "className": "MuiPieChart-arc",
       "description": "Styles applied to an individual pie arc element.",
       "isGlobal": false
     },
     {
       "key": "arcLabel",
-      "className": "MuiPieArcLabel-arcLabel",
+      "className": "MuiPieChart-arcLabel",
       "description": "Styles applied to an individual pie arc label element.",
       "isGlobal": false
     },
     {
       "key": "focusIndicator",
-      "className": "MuiPieArcLabel-focusIndicator",
+      "className": "MuiPieChart-focusIndicator",
       "description": "Styles applied to the focused pie arc element.",
       "isGlobal": false
     },
     {
       "key": "root",
-      "className": "MuiPieArcLabel-root",
+      "className": "MuiPieChart-root",
       "description": "Styles applied to the root element.",
       "isGlobal": false
     },
     {
       "key": "series",
-      "className": "MuiPieArcLabel-series",
+      "className": "MuiPieChart-series",
       "description": "Styles applied to the `g` element that contains all pie arcs of a series.",
       "isGlobal": false
     },
     {
       "key": "seriesLabels",
-      "className": "MuiPieArcLabel-seriesLabels",
+      "className": "MuiPieChart-seriesLabels",
       "description": "Styles applied to the `g` element that contains all pie arc labels of a series.",
       "isGlobal": false
     }

--- a/docs/pages/x/api/charts/pie-arc.json
+++ b/docs/pages/x/api/charts/pie-arc.json
@@ -13,43 +13,43 @@
   "classes": [
     {
       "key": "animate",
-      "className": "MuiPieArc-animate",
+      "className": "MuiPieChart-animate",
       "description": "Styles applied when animation is not skipped.",
       "isGlobal": false
     },
     {
       "key": "arc",
-      "className": "MuiPieArc-arc",
+      "className": "MuiPieChart-arc",
       "description": "Styles applied to an individual pie arc element.",
       "isGlobal": false
     },
     {
       "key": "arcLabel",
-      "className": "MuiPieArc-arcLabel",
+      "className": "MuiPieChart-arcLabel",
       "description": "Styles applied to an individual pie arc label element.",
       "isGlobal": false
     },
     {
       "key": "focusIndicator",
-      "className": "MuiPieArc-focusIndicator",
+      "className": "MuiPieChart-focusIndicator",
       "description": "Styles applied to the focused pie arc element.",
       "isGlobal": false
     },
     {
       "key": "root",
-      "className": "MuiPieArc-root",
+      "className": "MuiPieChart-root",
       "description": "Styles applied to the root element.",
       "isGlobal": false
     },
     {
       "key": "series",
-      "className": "MuiPieArc-series",
+      "className": "MuiPieChart-series",
       "description": "Styles applied to the `g` element that contains all pie arcs of a series.",
       "isGlobal": false
     },
     {
       "key": "seriesLabels",
-      "className": "MuiPieArc-seriesLabels",
+      "className": "MuiPieChart-seriesLabels",
       "description": "Styles applied to the `g` element that contains all pie arc labels of a series.",
       "isGlobal": false
     }

--- a/docs/pages/x/api/charts/piecewise-color-legend.json
+++ b/docs/pages/x/api/charts/piecewise-color-legend.json
@@ -53,79 +53,79 @@
   "classes": [
     {
       "key": "end",
-      "className": "MuiPiecewiseColorLegend-end",
+      "className": "MuiPiecewiseColorLegendClasses-end",
       "description": "Styles applied to the legend with the labels after the color marks.",
       "isGlobal": false
     },
     {
       "key": "extremes",
-      "className": "MuiPiecewiseColorLegend-extremes",
+      "className": "MuiPiecewiseColorLegendClasses-extremes",
       "description": "Styles applied to the legend with the labels on the extremes of the color marks.",
       "isGlobal": false
     },
     {
       "key": "horizontal",
-      "className": "MuiPiecewiseColorLegend-horizontal",
+      "className": "MuiPiecewiseColorLegendClasses-horizontal",
       "description": "Styles applied to the legend in row layout.",
       "isGlobal": false
     },
     {
       "key": "inlineEnd",
-      "className": "MuiPiecewiseColorLegend-inlineEnd",
+      "className": "MuiPiecewiseColorLegendClasses-inlineEnd",
       "description": "Styles applied to the legend with the labels inlined after the color marks.",
       "isGlobal": false
     },
     {
       "key": "inlineStart",
-      "className": "MuiPiecewiseColorLegend-inlineStart",
+      "className": "MuiPiecewiseColorLegendClasses-inlineStart",
       "description": "Styles applied to the legend with the labels inlined before the color marks.",
       "isGlobal": false
     },
     {
       "key": "item",
-      "className": "MuiPiecewiseColorLegend-item",
+      "className": "MuiPiecewiseColorLegendClasses-item",
       "description": "Styles applied to the list items.",
       "isGlobal": false
     },
     {
       "key": "label",
-      "className": "MuiPiecewiseColorLegend-label",
+      "className": "MuiPiecewiseColorLegendClasses-label",
       "description": "Styles applied to the series label.",
       "isGlobal": false
     },
     {
       "key": "mark",
-      "className": "MuiPiecewiseColorLegend-mark",
+      "className": "MuiPiecewiseColorLegendClasses-mark",
       "description": "Styles applied to the marks.",
       "isGlobal": false
     },
     {
       "key": "maxLabel",
-      "className": "MuiPiecewiseColorLegend-maxLabel",
+      "className": "MuiPiecewiseColorLegendClasses-maxLabel",
       "description": "Styles applied to the list item that renders the `maxLabel`.",
       "isGlobal": false
     },
     {
       "key": "minLabel",
-      "className": "MuiPiecewiseColorLegend-minLabel",
+      "className": "MuiPiecewiseColorLegendClasses-minLabel",
       "description": "Styles applied to the list item that renders the `minLabel`.",
       "isGlobal": false
     },
     {
       "key": "root",
-      "className": "MuiPiecewiseColorLegend-root",
+      "className": "MuiPiecewiseColorLegendClasses-root",
       "description": "Styles applied to the root element.",
       "isGlobal": false
     },
     {
       "key": "start",
-      "className": "MuiPiecewiseColorLegend-start",
+      "className": "MuiPiecewiseColorLegendClasses-start",
       "description": "Styles applied to the legend with the labels before the color marks.",
       "isGlobal": false
     },
     {
       "key": "vertical",
-      "className": "MuiPiecewiseColorLegend-vertical",
+      "className": "MuiPiecewiseColorLegendClasses-vertical",
       "description": "Styles applied to the legend in column layout.",
       "isGlobal": false
     }

--- a/docs/pages/x/api/charts/piecewise-color-legend.json
+++ b/docs/pages/x/api/charts/piecewise-color-legend.json
@@ -53,79 +53,79 @@
   "classes": [
     {
       "key": "end",
-      "className": "MuiPiecewiseColorLegendClasses-end",
+      "className": "MuiPiecewiseColorLegend-end",
       "description": "Styles applied to the legend with the labels after the color marks.",
       "isGlobal": false
     },
     {
       "key": "extremes",
-      "className": "MuiPiecewiseColorLegendClasses-extremes",
+      "className": "MuiPiecewiseColorLegend-extremes",
       "description": "Styles applied to the legend with the labels on the extremes of the color marks.",
       "isGlobal": false
     },
     {
       "key": "horizontal",
-      "className": "MuiPiecewiseColorLegendClasses-horizontal",
+      "className": "MuiPiecewiseColorLegend-horizontal",
       "description": "Styles applied to the legend in row layout.",
       "isGlobal": false
     },
     {
       "key": "inlineEnd",
-      "className": "MuiPiecewiseColorLegendClasses-inlineEnd",
+      "className": "MuiPiecewiseColorLegend-inlineEnd",
       "description": "Styles applied to the legend with the labels inlined after the color marks.",
       "isGlobal": false
     },
     {
       "key": "inlineStart",
-      "className": "MuiPiecewiseColorLegendClasses-inlineStart",
+      "className": "MuiPiecewiseColorLegend-inlineStart",
       "description": "Styles applied to the legend with the labels inlined before the color marks.",
       "isGlobal": false
     },
     {
       "key": "item",
-      "className": "MuiPiecewiseColorLegendClasses-item",
+      "className": "MuiPiecewiseColorLegend-item",
       "description": "Styles applied to the list items.",
       "isGlobal": false
     },
     {
       "key": "label",
-      "className": "MuiPiecewiseColorLegendClasses-label",
+      "className": "MuiPiecewiseColorLegend-label",
       "description": "Styles applied to the series label.",
       "isGlobal": false
     },
     {
       "key": "mark",
-      "className": "MuiPiecewiseColorLegendClasses-mark",
+      "className": "MuiPiecewiseColorLegend-mark",
       "description": "Styles applied to the marks.",
       "isGlobal": false
     },
     {
       "key": "maxLabel",
-      "className": "MuiPiecewiseColorLegendClasses-maxLabel",
+      "className": "MuiPiecewiseColorLegend-maxLabel",
       "description": "Styles applied to the list item that renders the `maxLabel`.",
       "isGlobal": false
     },
     {
       "key": "minLabel",
-      "className": "MuiPiecewiseColorLegendClasses-minLabel",
+      "className": "MuiPiecewiseColorLegend-minLabel",
       "description": "Styles applied to the list item that renders the `minLabel`.",
       "isGlobal": false
     },
     {
       "key": "root",
-      "className": "MuiPiecewiseColorLegendClasses-root",
+      "className": "MuiPiecewiseColorLegend-root",
       "description": "Styles applied to the root element.",
       "isGlobal": false
     },
     {
       "key": "start",
-      "className": "MuiPiecewiseColorLegendClasses-start",
+      "className": "MuiPiecewiseColorLegend-start",
       "description": "Styles applied to the legend with the labels before the color marks.",
       "isGlobal": false
     },
     {
       "key": "vertical",
-      "className": "MuiPiecewiseColorLegendClasses-vertical",
+      "className": "MuiPiecewiseColorLegend-vertical",
       "description": "Styles applied to the legend in column layout.",
       "isGlobal": false
     }

--- a/docs/pages/x/api/charts/sankey-tooltip-content.json
+++ b/docs/pages/x/api/charts/sankey-tooltip-content.json
@@ -8,61 +8,61 @@
   "classes": [
     {
       "key": "axisValueCell",
-      "className": "MuiSankeyTooltipContent-axisValueCell",
+      "className": "MuiChartsTooltip-axisValueCell",
       "description": "Styles applied to the axisValueCell element. Only available for axis tooltip.",
       "isGlobal": false
     },
     {
       "key": "cell",
-      "className": "MuiSankeyTooltipContent-cell",
+      "className": "MuiChartsTooltip-cell",
       "description": "Styles applied to the cell element.",
       "isGlobal": false
     },
     {
       "key": "labelCell",
-      "className": "MuiSankeyTooltipContent-labelCell",
+      "className": "MuiChartsTooltip-labelCell",
       "description": "Styles applied to the labelCell element.",
       "isGlobal": false
     },
     {
       "key": "mark",
-      "className": "MuiSankeyTooltipContent-mark",
+      "className": "MuiChartsTooltip-mark",
       "description": "Styles applied to the mark element.",
       "isGlobal": false
     },
     {
       "key": "markContainer",
-      "className": "MuiSankeyTooltipContent-markContainer",
+      "className": "MuiChartsTooltip-markContainer",
       "description": "Styles applied to the markContainer element.",
       "isGlobal": false
     },
     {
       "key": "paper",
-      "className": "MuiSankeyTooltipContent-paper",
+      "className": "MuiChartsTooltip-paper",
       "description": "Styles applied to the paper element.",
       "isGlobal": false
     },
     {
       "key": "root",
-      "className": "MuiSankeyTooltipContent-root",
+      "className": "MuiChartsTooltip-root",
       "description": "Styles applied to the root element.",
       "isGlobal": false
     },
     {
       "key": "row",
-      "className": "MuiSankeyTooltipContent-row",
+      "className": "MuiChartsTooltip-row",
       "description": "Styles applied to the row element.",
       "isGlobal": false
     },
     {
       "key": "table",
-      "className": "MuiSankeyTooltipContent-table",
+      "className": "MuiChartsTooltip-table",
       "description": "Styles applied to the table element.",
       "isGlobal": false
     },
     {
       "key": "valueCell",
-      "className": "MuiSankeyTooltipContent-valueCell",
+      "className": "MuiChartsTooltip-valueCell",
       "description": "Styles applied to the valueCell element.",
       "isGlobal": false
     }

--- a/docs/pages/x/api/charts/sankey-tooltip.json
+++ b/docs/pages/x/api/charts/sankey-tooltip.json
@@ -100,61 +100,61 @@
   "classes": [
     {
       "key": "axisValueCell",
-      "className": "MuiSankeyTooltip-axisValueCell",
+      "className": "MuiChartsTooltip-axisValueCell",
       "description": "Styles applied to the axisValueCell element. Only available for axis tooltip.",
       "isGlobal": false
     },
     {
       "key": "cell",
-      "className": "MuiSankeyTooltip-cell",
+      "className": "MuiChartsTooltip-cell",
       "description": "Styles applied to the cell element.",
       "isGlobal": false
     },
     {
       "key": "labelCell",
-      "className": "MuiSankeyTooltip-labelCell",
+      "className": "MuiChartsTooltip-labelCell",
       "description": "Styles applied to the labelCell element.",
       "isGlobal": false
     },
     {
       "key": "mark",
-      "className": "MuiSankeyTooltip-mark",
+      "className": "MuiChartsTooltip-mark",
       "description": "Styles applied to the mark element.",
       "isGlobal": false
     },
     {
       "key": "markContainer",
-      "className": "MuiSankeyTooltip-markContainer",
+      "className": "MuiChartsTooltip-markContainer",
       "description": "Styles applied to the markContainer element.",
       "isGlobal": false
     },
     {
       "key": "paper",
-      "className": "MuiSankeyTooltip-paper",
+      "className": "MuiChartsTooltip-paper",
       "description": "Styles applied to the paper element.",
       "isGlobal": false
     },
     {
       "key": "root",
-      "className": "MuiSankeyTooltip-root",
+      "className": "MuiChartsTooltip-root",
       "description": "Styles applied to the root element.",
       "isGlobal": false
     },
     {
       "key": "row",
-      "className": "MuiSankeyTooltip-row",
+      "className": "MuiChartsTooltip-row",
       "description": "Styles applied to the row element.",
       "isGlobal": false
     },
     {
       "key": "table",
-      "className": "MuiSankeyTooltip-table",
+      "className": "MuiChartsTooltip-table",
       "description": "Styles applied to the table element.",
       "isGlobal": false
     },
     {
       "key": "valueCell",
-      "className": "MuiSankeyTooltip-valueCell",
+      "className": "MuiChartsTooltip-valueCell",
       "description": "Styles applied to the valueCell element.",
       "isGlobal": false
     }

--- a/docs/pages/x/api/charts/scatter.json
+++ b/docs/pages/x/api/charts/scatter.json
@@ -22,31 +22,31 @@
       "name": "marker",
       "description": "The component that renders the marker for a scatter point.",
       "default": "ScatterMarker",
-      "class": "MuiScatter-marker"
+      "class": "MuiScatterChart-marker"
     }
   ],
   "classes": [
     {
       "key": "focusedMark",
-      "className": "MuiScatter-focusedMark",
+      "className": "MuiScatterChart-focusedMark",
       "description": "Styles applied to the focused scatter mark element.",
       "isGlobal": false
     },
     {
       "key": "highlightedMark",
-      "className": "MuiScatter-highlightedMark",
+      "className": "MuiScatterChart-highlightedMark",
       "description": "Styles applied to the highlighted scatter mark element.",
       "isGlobal": false
     },
     {
       "key": "root",
-      "className": "MuiScatter-root",
+      "className": "MuiScatterChart-root",
       "description": "Styles applied to the scatter plot element.",
       "isGlobal": false
     },
     {
       "key": "series",
-      "className": "MuiScatter-series",
+      "className": "MuiScatterChart-series",
       "description": "Styles applied to the group surrounding a series' scatter elements.",
       "isGlobal": false
     }

--- a/packages/x-charts-pro/src/ChartsZoomSlider/internals/chartsAxisZoomSliderThumbClasses.ts
+++ b/packages/x-charts-pro/src/ChartsZoomSlider/internals/chartsAxisZoomSliderThumbClasses.ts
@@ -24,13 +24,7 @@ const CORRECT_PREFIX = 'MuiChartsAxisZoomSliderThumb';
 const LEGACY_PREFIX = 'MuiChartAxisZoomSliderThumb';
 
 export const chartsAxisZoomSliderThumbClasses: ChartsAxisZoomSliderThumbClasses =
-  generateUtilityClasses(CORRECT_PREFIX, [
-    'root',
-    'horizontal',
-    'vertical',
-    'start',
-    'end',
-  ]);
+  generateUtilityClasses(CORRECT_PREFIX, ['root', 'horizontal', 'vertical', 'start', 'end']);
 
 // Returns both the correct and legacy class names so existing CSS targeting the legacy
 // prefix continues to work.

--- a/packages/x-charts-pro/src/ChartsZoomSlider/internals/chartsAxisZoomSliderThumbClasses.ts
+++ b/packages/x-charts-pro/src/ChartsZoomSlider/internals/chartsAxisZoomSliderThumbClasses.ts
@@ -18,8 +18,13 @@ export interface ChartsAxisZoomSliderThumbClasses {
 
 export type ChartsAxisZoomSliderThumbClassKey = keyof ChartsAxisZoomSliderThumbClasses;
 
+const CORRECT_PREFIX = 'MuiChartsAxisZoomSliderThumb';
+// TODO v10: remove `MuiChartAxisZoomSliderThumb`. Kept for backwards compatibility with
+// users targeting the historically-incorrect prefix (missing the `s` in `Charts`).
+const LEGACY_PREFIX = 'MuiChartAxisZoomSliderThumb';
+
 export const chartsAxisZoomSliderThumbClasses: ChartsAxisZoomSliderThumbClasses =
-  generateUtilityClasses('MuiChartAxisZoomSliderThumb', [
+  generateUtilityClasses(CORRECT_PREFIX, [
     'root',
     'horizontal',
     'vertical',
@@ -27,8 +32,10 @@ export const chartsAxisZoomSliderThumbClasses: ChartsAxisZoomSliderThumbClasses 
     'end',
   ]);
 
+// Returns both the correct and legacy class names so existing CSS targeting the legacy
+// prefix continues to work.
 export function getAxisZoomSliderThumbUtilityClass(slot: string) {
-  return generateUtilityClass('MuiChartAxisZoomSliderThumb', slot);
+  return `${generateUtilityClass(CORRECT_PREFIX, slot)} ${generateUtilityClass(LEGACY_PREFIX, slot)}`;
 }
 
 export const useUtilityClasses = (ownerState: ChartsZoomSliderThumbOwnerState) => {

--- a/packages/x-charts/src/ChartsLegend/piecewiseColorLegendClasses.ts
+++ b/packages/x-charts/src/ChartsLegend/piecewiseColorLegendClasses.ts
@@ -33,8 +33,14 @@ export interface PiecewiseColorLegendClasses {
   label: string;
 }
 
+const CORRECT_PREFIX = 'MuiPiecewiseColorLegend';
+// TODO v10: remove `MuiPiecewiseColorLegendClasses`. Kept for backwards compatibility with
+// users targeting the historically-incorrect prefix.
+const LEGACY_PREFIX = 'MuiPiecewiseColorLegendClasses';
+
+// Used by `useUtilityClasses` to also emit the legacy prefix in the rendered className.
 function getLegendUtilityClass(slot: string) {
-  return generateUtilityClass('MuiPiecewiseColorLegendClasses', slot);
+  return `${generateUtilityClass(CORRECT_PREFIX, slot)} ${generateUtilityClass(LEGACY_PREFIX, slot)}`;
 }
 
 export const useUtilityClasses = (props: PiecewiseColorLegendProps & ChartsLegendSlotExtension) => {
@@ -56,7 +62,7 @@ export const useUtilityClasses = (props: PiecewiseColorLegendProps & ChartsLegen
 };
 
 export const piecewiseColorLegendClasses: PiecewiseColorLegendClasses = generateUtilityClasses(
-  'MuiPiecewiseColorLegendClasses',
+  CORRECT_PREFIX,
   [
     'root',
     'minLabel',

--- a/scripts/buildApiDocs/chartsSettings/generateChartsClassName.ts
+++ b/scripts/buildApiDocs/chartsSettings/generateChartsClassName.ts
@@ -79,6 +79,55 @@ function resolveImportPath(fromFile: string, specifier: string): string | null {
   return null;
 }
 
+// Files that knowingly violate the consistency checks below for backwards-compatibility
+// reasons (they dual-emit a legacy `MuiXxx` prefix alongside the correct one). Remove these
+// entries when the legacy prefixes are dropped — tracked at #22675 for v10.
+const KNOWN_INCONSISTENT_CLASSES_FILES = new Set([
+  path.join(process.cwd(), 'packages/x-charts/src/ChartsLegend/piecewiseColorLegendClasses.ts'),
+  path.join(
+    process.cwd(),
+    'packages/x-charts-pro/src/ChartsZoomSlider/internals/chartsAxisZoomSliderThumbClasses.ts',
+  ),
+]);
+
+function collectMuiNamesInFile(content: string): { source: string; muiName: string }[] {
+  const found: { source: string; muiName: string }[] = [];
+  for (const match of content.matchAll(new RegExp(GENERATE_UTILITY_CLASS_CALL, 'g'))) {
+    found.push({ source: 'generateUtilityClass call', muiName: match[1] });
+  }
+  for (const match of content.matchAll(new RegExp(MUI_NAME_CONST, 'g'))) {
+    found.push({ source: `const declaration`, muiName: match[1] });
+  }
+  return found;
+}
+
+function assertConsistent(file: string, interfaceNames: Set<string>, muiName: string): void {
+  if (KNOWN_INCONSISTENT_CLASSES_FILES.has(file)) {
+    return;
+  }
+  if (muiName.endsWith('Classes')) {
+    // The interface name leaked into the muiName literal (e.g. `MuiFooClasses` instead of
+    // `MuiFoo`). This is the bug pattern that bit `piecewiseColorLegendClasses`.
+    throw new Error(
+      `[generateChartsClassName] Suspicious muiName "${muiName}" in ${file}: ends with "Classes". ` +
+        `Expected the interface name (${Array.from(interfaceNames).join(', ')}) ` +
+        `stripped of the "Classes" suffix, not the full interface name.`,
+    );
+  }
+  for (const interfaceName of interfaceNames) {
+    const interfaceCore = interfaceName.replace(/Classes$/, '');
+    const muiCore = muiName.replace(/^Mui/, '');
+    if (!muiCore.includes(interfaceCore)) {
+      // muiName doesn't reference the interface core anywhere — likely a typo (the
+      // `chartsAxisZoomSliderThumbClasses` file is missing the `s` in `Charts`).
+      throw new Error(
+        `[generateChartsClassName] muiName "${muiName}" in ${file} does not contain ` +
+          `the core of interface "${interfaceName}" ("${interfaceCore}"). Possible typo.`,
+      );
+    }
+  }
+}
+
 function collectClassesFiles(): {
   classesFiles: ClassesFileInfo[];
   factoryOwnerByFn: Map<string, string>;
@@ -91,8 +140,18 @@ function collectClassesFiles(): {
     const files = walk(root, (name) => /[Cc]lasses\.ts$/.test(name));
     for (const file of files) {
       const content = fs.readFileSync(file, 'utf8');
-      const muiNameMatch =
-        content.match(GENERATE_UTILITY_CLASS_CALL) ?? content.match(MUI_NAME_CONST);
+      const allMuiNames = collectMuiNamesInFile(content);
+      const distinctMuiNames = Array.from(new Set(allMuiNames.map((m) => m.muiName)));
+      if (distinctMuiNames.length > 1 && !KNOWN_INCONSISTENT_CLASSES_FILES.has(file)) {
+        // Different detection paths (literal call vs. const declaration) disagreed on the
+        // owner muiName for the same file. This is almost always a bug (a typo or a
+        // copy-paste error); add the file to `KNOWN_INCONSISTENT_CLASSES_FILES` if it's
+        // intentional (e.g. dual-emit for backwards compat).
+        throw new Error(
+          `[generateChartsClassName] Inconsistent muiNames in ${file}: ` +
+            `${allMuiNames.map((m) => `"${m.muiName}" (${m.source})`).join(', ')}.`,
+        );
+      }
       const interfaceNames = new Set<string>();
       for (const match of content.matchAll(EXPORT_INTERFACE_CLASSES)) {
         interfaceNames.add(match[1]);
@@ -101,8 +160,11 @@ function collectClassesFiles(): {
       for (const match of content.matchAll(EXPORT_FACTORY_FN)) {
         factoryFns.add(match[1]);
       }
-      const ownerMuiName = muiNameMatch?.[1];
+      const ownerMuiName = distinctMuiNames[0];
       if (ownerMuiName) {
+        if (interfaceNames.size > 0) {
+          assertConsistent(file, interfaceNames, ownerMuiName);
+        }
         result.push({ modulePath: file, ownerMuiName, interfaceNames, factoryFns });
         for (const fn of factoryFns) {
           if (!factoryOwnerByFn.has(fn)) {

--- a/scripts/buildApiDocs/chartsSettings/generateChartsClassName.ts
+++ b/scripts/buildApiDocs/chartsSettings/generateChartsClassName.ts
@@ -9,7 +9,8 @@ const PACKAGE_ROOTS = [
 ];
 
 const GENERATE_UTILITY_CLASS_CALL = /generateUtilityClass(?:es)?\(\s*['"](Mui[A-Za-z0-9]+)['"]/;
-const MUI_NAME_CONST = /(?:const|let|var)\s+[A-Za-z0-9_]+\s*(?::\s*[A-Za-z0-9_<>[\]]+)?\s*=\s*['"](Mui[A-Za-z0-9]+)['"]/;
+const MUI_NAME_CONST =
+  /(?:const|let|var)\s+[A-Za-z0-9_]+\s*(?::\s*[A-Za-z0-9_<>[\]]+)?\s*=\s*['"](Mui[A-Za-z0-9]+)['"]/;
 const EXPORT_INTERFACE_CLASSES = /export\s+interface\s+([A-Z][A-Za-z0-9]*Classes)\b/g;
 const EXPORT_FACTORY_FN = /export\s+function\s+(get[A-Z][A-Za-z0-9]*UtilityClass)\b/g;
 const COMPOSE_CLASSES_CALL = /composeClasses\s*\([^,]+,\s*([A-Za-z][A-Za-z0-9_]*)/g;
@@ -90,7 +91,8 @@ function collectClassesFiles(): {
     const files = walk(root, (name) => /[Cc]lasses\.ts$/.test(name));
     for (const file of files) {
       const content = fs.readFileSync(file, 'utf8');
-      const muiNameMatch = content.match(GENERATE_UTILITY_CLASS_CALL) ?? content.match(MUI_NAME_CONST);
+      const muiNameMatch =
+        content.match(GENERATE_UTILITY_CLASS_CALL) ?? content.match(MUI_NAME_CONST);
       const interfaceNames = new Set<string>();
       for (const match of content.matchAll(EXPORT_INTERFACE_CLASSES)) {
         interfaceNames.add(match[1]);

--- a/scripts/buildApiDocs/chartsSettings/generateChartsClassName.ts
+++ b/scripts/buildApiDocs/chartsSettings/generateChartsClassName.ts
@@ -9,6 +9,7 @@ const PACKAGE_ROOTS = [
 ];
 
 const GENERATE_UTILITY_CLASS_CALL = /generateUtilityClass(?:es)?\(\s*['"](Mui[A-Za-z0-9]+)['"]/;
+const MUI_NAME_CONST = /(?:const|let|var)\s+[A-Za-z0-9_]+\s*(?::\s*[A-Za-z0-9_<>[\]]+)?\s*=\s*['"](Mui[A-Za-z0-9]+)['"]/;
 const EXPORT_INTERFACE_CLASSES = /export\s+interface\s+([A-Z][A-Za-z0-9]*Classes)\b/g;
 const EXPORT_FACTORY_FN = /export\s+function\s+(get[A-Z][A-Za-z0-9]*UtilityClass)\b/g;
 const COMPOSE_CLASSES_CALL = /composeClasses\s*\([^,]+,\s*([A-Za-z][A-Za-z0-9_]*)/g;
@@ -89,7 +90,7 @@ function collectClassesFiles(): {
     const files = walk(root, (name) => /[Cc]lasses\.ts$/.test(name));
     for (const file of files) {
       const content = fs.readFileSync(file, 'utf8');
-      const muiNameMatch = content.match(GENERATE_UTILITY_CLASS_CALL);
+      const muiNameMatch = content.match(GENERATE_UTILITY_CLASS_CALL) ?? content.match(MUI_NAME_CONST);
       const interfaceNames = new Set<string>();
       for (const match of content.matchAll(EXPORT_INTERFACE_CLASSES)) {
         interfaceNames.add(match[1]);

--- a/scripts/buildApiDocs/chartsSettings/generateChartsClassName.ts
+++ b/scripts/buildApiDocs/chartsSettings/generateChartsClassName.ts
@@ -1,0 +1,323 @@
+import fs from 'fs';
+import path from 'path';
+import createGenerateClassName from '../createGenerateClassName';
+
+const PACKAGE_ROOTS = [
+  path.join(process.cwd(), 'packages/x-charts/src'),
+  path.join(process.cwd(), 'packages/x-charts-pro/src'),
+  path.join(process.cwd(), 'packages/x-charts-premium/src'),
+];
+
+const GENERATE_UTILITY_CLASS_CALL = /generateUtilityClass(?:es)?\(\s*['"](Mui[A-Za-z0-9]+)['"]/;
+const EXPORT_INTERFACE_CLASSES = /export\s+interface\s+([A-Z][A-Za-z0-9]*Classes)\b/g;
+const EXPORT_FACTORY_FN = /export\s+function\s+(get[A-Z][A-Za-z0-9]*UtilityClass)\b/g;
+const COMPOSE_CLASSES_CALL = /composeClasses\s*\([^,]+,\s*([A-Za-z][A-Za-z0-9_]*)/g;
+const IMPORT_STATEMENT =
+  /import\s+(?:type\s+)?(\{[^}]*\}|[A-Za-z0-9_*\s,]+?)?\s*from\s+['"]([^'"]+)['"]/g;
+const PARTIAL_CLASSES_USAGE = /Partial<\s*([A-Z][A-Za-z0-9]*Classes)\s*>/g;
+
+interface ClassesFileInfo {
+  modulePath: string;
+  ownerMuiName: string;
+  interfaceNames: Set<string>;
+  factoryFns: Set<string>;
+}
+
+function walk(dir: string, predicate: (name: string) => boolean): string[] {
+  const out: string[] = [];
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...walk(full, predicate));
+    } else if (entry.isFile() && predicate(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function readFile(file: string): string | null {
+  try {
+    return fs.readFileSync(file, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+const WORKSPACE_PACKAGE_PREFIX = /^@mui\/(x-charts(?:-pro|-premium)?)(\/.*)?$/;
+
+function resolveImportPath(fromFile: string, specifier: string): string | null {
+  let base: string;
+  if (specifier.startsWith('.')) {
+    base = path.resolve(path.dirname(fromFile), specifier);
+  } else {
+    const m = specifier.match(WORKSPACE_PACKAGE_PREFIX);
+    if (!m) {
+      return null;
+    }
+    base = path.join(process.cwd(), 'packages', m[1], 'src', m[2] ?? '');
+  }
+  const candidates = [
+    `${base}.ts`,
+    `${base}.tsx`,
+    path.join(base, 'index.ts'),
+    path.join(base, 'index.tsx'),
+  ];
+  for (const c of candidates) {
+    if (fs.existsSync(c)) {
+      return c;
+    }
+  }
+  return null;
+}
+
+function collectClassesFiles(): {
+  classesFiles: ClassesFileInfo[];
+  factoryOwnerByFn: Map<string, string>;
+} {
+  const result: ClassesFileInfo[] = [];
+  const factoryOwnerByFn = new Map<string, string>();
+  const pendingByFactory: Array<{ file: string; content: string; interfaceNames: Set<string> }> =
+    [];
+  for (const root of PACKAGE_ROOTS) {
+    const files = walk(root, (name) => /[Cc]lasses\.ts$/.test(name));
+    for (const file of files) {
+      const content = fs.readFileSync(file, 'utf8');
+      const muiNameMatch = content.match(GENERATE_UTILITY_CLASS_CALL);
+      const interfaceNames = new Set<string>();
+      for (const match of content.matchAll(EXPORT_INTERFACE_CLASSES)) {
+        interfaceNames.add(match[1]);
+      }
+      const factoryFns = new Set<string>();
+      for (const match of content.matchAll(EXPORT_FACTORY_FN)) {
+        factoryFns.add(match[1]);
+      }
+      const ownerMuiName = muiNameMatch?.[1];
+      if (ownerMuiName) {
+        result.push({ modulePath: file, ownerMuiName, interfaceNames, factoryFns });
+        for (const fn of factoryFns) {
+          if (!factoryOwnerByFn.has(fn)) {
+            factoryOwnerByFn.set(fn, ownerMuiName);
+          }
+        }
+      } else {
+        pendingByFactory.push({ file, content, interfaceNames });
+      }
+    }
+  }
+  for (const { file, content, interfaceNames } of pendingByFactory) {
+    for (const match of content.matchAll(COMPOSE_CLASSES_CALL)) {
+      const owner = factoryOwnerByFn.get(match[1]);
+      if (owner) {
+        result.push({
+          modulePath: file,
+          ownerMuiName: owner,
+          interfaceNames,
+          factoryFns: new Set(),
+        });
+        break;
+      }
+    }
+  }
+  return { classesFiles: result, factoryOwnerByFn };
+}
+
+const REEXPORT_STATEMENT = /export\s+(?:\*|\{[^}]*\}|type\s+\{[^}]*\})\s+from\s+['"]([^'"]+)['"]/g;
+
+function ownersInFileContent(
+  content: string,
+  byInterfaceName: Map<string, ClassesFileInfo>,
+  factoryOwnerByFn: Map<string, string>,
+  out: Set<string>,
+): void {
+  for (const match of content.matchAll(PARTIAL_CLASSES_USAGE)) {
+    const info = byInterfaceName.get(match[1]);
+    if (info) {
+      out.add(info.ownerMuiName);
+    }
+  }
+  for (const match of content.matchAll(COMPOSE_CLASSES_CALL)) {
+    const owner = factoryOwnerByFn.get(match[1]);
+    if (owner) {
+      out.add(owner);
+    }
+  }
+}
+
+function ownersInFileAndReexports(
+  file: string,
+  byInterfaceName: Map<string, ClassesFileInfo>,
+  factoryOwnerByFn: Map<string, string>,
+  byModulePath: Map<string, ClassesFileInfo>,
+  out: Set<string>,
+  visited: Set<string>,
+  depth: number,
+): void {
+  if (visited.has(file) || depth < 0) {
+    return;
+  }
+  visited.add(file);
+  const content = readFile(file);
+  if (content === null) {
+    return;
+  }
+  ownersInFileContent(content, byInterfaceName, factoryOwnerByFn, out);
+  for (const match of content.matchAll(IMPORT_STATEMENT)) {
+    const resolved = resolveImportPath(file, match[2]);
+    if (resolved) {
+      const classesInfo = byModulePath.get(resolved);
+      if (classesInfo) {
+        out.add(classesInfo.ownerMuiName);
+      }
+    }
+  }
+  if (depth === 0) {
+    return;
+  }
+  for (const match of content.matchAll(REEXPORT_STATEMENT)) {
+    const resolved = resolveImportPath(file, match[1]);
+    if (resolved) {
+      ownersInFileAndReexports(
+        resolved,
+        byInterfaceName,
+        factoryOwnerByFn,
+        byModulePath,
+        out,
+        visited,
+        depth - 1,
+      );
+    }
+  }
+}
+
+function findOwnerForComponent(
+  entryFile: string,
+  componentMuiName: string,
+  byInterfaceName: Map<string, ClassesFileInfo>,
+  factoryOwnerByFn: Map<string, string>,
+  byModulePath: Map<string, ClassesFileInfo>,
+): string | null {
+  const inFile = new Set<string>();
+  const content = readFile(entryFile);
+  if (content === null) {
+    return null;
+  }
+  ownersInFileContent(content, byInterfaceName, factoryOwnerByFn, inFile);
+  if (inFile.size === 1) {
+    return inFile.values().next().value!;
+  }
+  if (inFile.has(componentMuiName)) {
+    return componentMuiName;
+  }
+  if (inFile.size > 0) {
+    return inFile.values().next().value!;
+  }
+
+  for (const match of content.matchAll(IMPORT_STATEMENT)) {
+    const specifier = match[2];
+    const resolved = resolveImportPath(entryFile, specifier);
+    if (!resolved) {
+      continue;
+    }
+    const classesInfo = byModulePath.get(resolved);
+    if (classesInfo) {
+      return classesInfo.ownerMuiName;
+    }
+  }
+
+  const candidates = new Set<string>();
+  for (const match of content.matchAll(IMPORT_STATEMENT)) {
+    const namedImportsRaw = match[1] ?? '';
+    const specifier = match[2];
+    const resolved = resolveImportPath(entryFile, specifier);
+    if (!resolved) {
+      continue;
+    }
+    const dir = path.dirname(resolved);
+    const componentDir = path.dirname(entryFile);
+    const isSibling = dir === componentDir;
+    const basename = path.basename(resolved);
+    const isTypesOrClassesFile =
+      /\.types\.ts$/.test(basename) || /[Cc]lasses\.tsx?$/.test(basename);
+    const namedImports = namedImportsRaw
+      .replace(/[{}]/g, '')
+      .split(',')
+      .map(
+        (s) =>
+          s
+            .trim()
+            .replace(/^type\s+/, '')
+            .split(/\s+as\s+/)[0],
+      )
+      .filter(Boolean);
+    const hasOwnerStateOrPropsImport = namedImports.some((n) => /(?:OwnerState|Props)$/.test(n));
+    if (!isSibling && !isTypesOrClassesFile && !hasOwnerStateOrPropsImport) {
+      continue;
+    }
+    ownersInFileAndReexports(
+      resolved,
+      byInterfaceName,
+      factoryOwnerByFn,
+      byModulePath,
+      candidates,
+      new Set(),
+      1,
+    );
+  }
+  if (candidates.has(componentMuiName)) {
+    return componentMuiName;
+  }
+  if (candidates.size > 0) {
+    return candidates.values().next().value!;
+  }
+  return null;
+}
+
+function buildSharedClassNameOwners(): Record<string, string> {
+  const { classesFiles, factoryOwnerByFn } = collectClassesFiles();
+  const byInterfaceName = new Map<string, ClassesFileInfo>();
+  const byModulePath = new Map<string, ClassesFileInfo>();
+  for (const info of classesFiles) {
+    byModulePath.set(info.modulePath, info);
+    for (const interfaceName of info.interfaceNames) {
+      if (!byInterfaceName.has(interfaceName)) {
+        byInterfaceName.set(interfaceName, info);
+      }
+    }
+  }
+
+  const owners: Record<string, string> = {};
+  for (const root of PACKAGE_ROOTS) {
+    const componentFiles = walk(root, (name) => /\.tsx$/.test(name) && !/\.test\.tsx$/.test(name));
+    for (const file of componentFiles) {
+      const basename = path.basename(file, '.tsx');
+      if (!/^[A-Z]/.test(basename)) {
+        continue;
+      }
+      const componentMuiName = `Mui${basename}`;
+      const ownerMuiName = findOwnerForComponent(
+        file,
+        componentMuiName,
+        byInterfaceName,
+        factoryOwnerByFn,
+        byModulePath,
+      );
+      if (ownerMuiName && ownerMuiName !== componentMuiName) {
+        owners[componentMuiName] = ownerMuiName;
+      }
+    }
+  }
+  return owners;
+}
+
+export const sharedClassNameOwners = buildSharedClassNameOwners();
+
+const generateChartsClassName = createGenerateClassName(sharedClassNameOwners);
+
+export default generateChartsClassName;

--- a/scripts/buildApiDocs/chartsSettings/index.ts
+++ b/scripts/buildApiDocs/chartsSettings/index.ts
@@ -7,8 +7,9 @@ import {
   HookReactApi,
   findApiPages,
 } from '@mui/internal-api-docs-builder';
-import generateUtilityClass, { isGlobalState } from '@mui/utils/generateUtilityClass';
+import { isGlobalState } from '@mui/utils/generateUtilityClass';
 import { getComponentImports, getComponentInfo } from './getComponentInfo';
+import generateChartsClassName from './generateChartsClassName';
 
 type PageType = { pathname: string; title: string; plan?: 'community' | 'pro' | 'premium' };
 
@@ -143,7 +144,7 @@ export default chartsApiPages;
   sortingStrategies: {
     slotsSort: (a, b) => a.name.localeCompare(b.name),
   },
-  generateClassName: generateUtilityClass,
+  generateClassName: generateChartsClassName,
   isGlobalClassName: isGlobalState,
   nonComponentFolders: [
     ...getNonComponentFolders(),

--- a/scripts/buildApiDocs/createGenerateClassName.ts
+++ b/scripts/buildApiDocs/createGenerateClassName.ts
@@ -1,0 +1,25 @@
+import generateUtilityClass from '@mui/utils/generateUtilityClass';
+
+/**
+ * Creates a `generateClassName` for the API docs builder that remaps the prefix of
+ * components reusing another component's classes.
+ *
+ * Some components render a part of another component and reuse its classes (generated
+ * with `generateUtilityClass('MuiOwner', ...)`) instead of declaring their own
+ * `{ComponentName}Classes` interface. For those, the builder would derive the documented
+ * class name from the component's own `muiName`, producing a class that does not exist at
+ * runtime (e.g. `MuiAreaElement-area` instead of the real `MuiLineChart-area`).
+ *
+ * @param sharedClassNameOwners Map from a component `muiName` to the `muiName` of the
+ * component that owns the classes it reuses.
+ */
+export default function createGenerateClassName(
+  sharedClassNameOwners: Record<string, string>,
+): typeof generateUtilityClass {
+  return (componentName, slot, globalStatePrefix) =>
+    generateUtilityClass(
+      sharedClassNameOwners[componentName] ?? componentName,
+      slot,
+      globalStatePrefix,
+    );
+}


### PR DESCRIPTION
## Summary

Some charts subcomponents reuse a parent chart's classes (e.g. `AreaElement` renders with `MuiLineChart-area`) instead of declaring their own `{ComponentName}Classes` interface. The API docs builder was generating the documented class from the subcomponent's own `muiName`, producing class names that don't exist at runtime (e.g. `MuiAreaElement-area` instead of `MuiLineChart-area`).

Replaces the default `generateUtilityClass` with one that auto-derives the owner `muiName` for each charts component by scanning the source tree for `*Classes.ts` files, `Partial<XxxClasses>` references, and `composeClasses(..., getXxxUtilityClass, ...)` factories. No manual mapping needed: adding a new shared-classes subcomponent is picked up automatically.

12 charts API JSON files regenerated with corrected class names.

## Fix: dual-emit two misnamed prefixes

Two pre-existing source bugs surfaced where the runtime emitted the wrong `MuiXxx` prefix:

- `piecewiseColorLegendClasses` emitted `MuiPiecewiseColorLegendClasses-*` instead of `MuiPiecewiseColorLegend-*`.
- `chartsAxisZoomSliderThumbClasses` emitted `MuiChartAxisZoomSliderThumb-*` instead of `MuiChartsAxisZoomSliderThumb-*`.

Both components now render the correct *and* the legacy prefix on the DOM so existing CSS keeps working while new code can target the right name. The exported `*Classes` constants now expose the correct prefix.

Follow-up to drop the legacy prefixes in v10: #22675

Closes #22625