### PR TITLE
[release] Fix release PR scripts

### DIFF
--- a/scripts/changelogUtils.mjs
+++ b/scripts/changelogUtils.mjs
@@ -630,7 +630,7 @@ async function findLatestTaggedVersionForMajor(majorVersion, upstreamRemote = 'o
   // Fetch all tags from all remotes to ensure we have the latest tags.
   await $`git fetch --tags --all`;
   const { stdout } =
-    await $`git describe --tags --abbrev=0 --match ${`v${majorVersion || ''}*`} ${upstreamRemote}/v${majorVersion}.x`; // only include "version-tags"
+    await $`git describe --tags --abbrev=0 --match ${`v${majorVersion || ''}*`} ${upstreamRemote}`; // only include "version-tags"
   return stdout.trim();
 }
 

--- a/scripts/changelogUtils.mjs
+++ b/scripts/changelogUtils.mjs
@@ -625,13 +625,24 @@ ${logOtherSection({
 /**
  * Fetches and returns the latest tagged version for a given major version.
  * @param {string | undefined} majorVersion
+ * @param {string} [upstreamRemote]
  */
 async function findLatestTaggedVersionForMajor(majorVersion, upstreamRemote = 'origin') {
   // Fetch all tags from all remotes to ensure we have the latest tags.
   await $`git fetch --tags --all`;
-  const { stdout } =
-    await $`git describe --tags --abbrev=0 --match ${`v${majorVersion || ''}*`} ${upstreamRemote}`; // only include "version-tags"
-  return stdout.trim();
+  const match = `v${majorVersion || ''}*`; // only include "version-tags"
+  // Tags for an older major are created on its `vN.x` version branch and are not ancestors of
+  // master, so they are invisible to `git describe` from HEAD. Describe from that branch when it
+  // exists. The current major releases from master (its version branch may not exist yet), so fall
+  // back to describing from HEAD, where its tags are reachable.
+  const versionBranch = `${upstreamRemote}/v${majorVersion}.x`;
+  try {
+    const { stdout } = await $`git describe --tags --abbrev=0 --match ${match} ${versionBranch}`;
+    return stdout.trim();
+  } catch {
+    const { stdout } = await $`git describe --tags --abbrev=0 --match ${match}`;
+    return stdout.trim();
+  }
 }
 
 /**

--- a/scripts/createReleasePR.mjs
+++ b/scripts/createReleasePR.mjs
@@ -217,8 +217,6 @@ async function findForkRemote() {
       console.log('No specific fork remote found, defaulting to "origin"');
       return 'origin';
     }
-
-    console.log(`Found fork remote: ${forkRemote}`);
     return forkRemote;
   } catch (error) {
     console.error('Error finding fork remote:', error);
@@ -806,7 +804,7 @@ async function main() {
 
     // Find the fork remote
     const forkRemote = await findForkRemote();
-    console.log(`Found fork remote: ${upstreamRemote}`);
+    console.log(`Found fork remote: ${forkRemote}`);
 
     const latestMajorVersion = await findLatestMajorVersion();
     console.log(`Found latest major version: ${latestMajorVersion}`);


### PR DESCRIPTION
## Summary

- `findLatestTaggedVersionForMajor`: drop `/v${majorVersion}.x` branch suffix from `git describe` ref — branch may not exist on the upstream remote.
- `findForkRemote`: remove duplicate `Found fork remote` log.
- `main`: log the actual `forkRemote` value instead of `upstreamRemote`.