### PR TITLE
[core] Bump @mui/internal-code-infra to 0.0.4-canary.54

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@mui/internal-babel-plugin-display-name": "1.0.4-canary.20",
     "@mui/internal-babel-plugin-minify-errors": "2.0.8-canary.27",
     "@mui/internal-bundle-size-checker": "1.0.9-canary.81",
-    "@mui/internal-code-infra": "0.0.4-canary.50",
+    "@mui/internal-code-infra": "0.0.4-canary.54",
     "@mui/internal-api-docs-builder": "1.0.1-canary.1",
     "@mui/internal-markdown": "3.0.8-canary.3",
     "@mui/internal-netlify-cache": "0.0.3-canary.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -270,8 +270,8 @@ importers:
         specifier: 1.0.9-canary.81
         version: 1.0.9-canary.81(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(rolldown@1.0.2)(terser@5.43.1)(tsx@4.22.3)(yaml@2.8.1)
       '@mui/internal-code-infra':
-        specifier: 0.0.4-canary.50
-        version: 0.0.4-canary.50(@next/eslint-plugin-next@16.2.6)(@types/node@22.19.19)(@typescript-eslint/eslint-plugin@8.58.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(jest-diff@30.2.0)(postcss@8.5.15)(prettier@3.8.3)(stylelint@17.12.0(typescript@5.9.3))(typescript@5.9.3)(vitest@4.1.7)
+        specifier: 0.0.4-canary.54
+        version: 0.0.4-canary.54(@next/eslint-plugin-next@16.2.6)(@types/node@22.19.19)(@typescript-eslint/eslint-plugin@8.58.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(jest-diff@30.2.0)(postcss@8.5.15)(prettier@3.8.3)(stylelint@17.12.0(typescript@5.9.3))(typescript@5.9.3)(vitest@4.1.7)
       '@mui/internal-core-docs':
         specifier: 'catalog:'
         version: 9.0.2-canary.0(d8e367cf86b76a7e470fa936eb287212)
@@ -4255,8 +4255,8 @@ packages:
     resolution: {integrity: sha512-omgJCN/8RNOpO3FF0/ilW0PaImjDXeqDZStIGSaf6BEH1L7VwcXU7812ivHzMtTwLh8et/pq7q07j0j46B31JA==}
     hasBin: true
 
-  '@mui/internal-code-infra@0.0.4-canary.50':
-    resolution: {integrity: sha512-VMq33Xgn30ZtCQvsTvsMSwihDSMB9h54u3ZMWZ4XbFgSHo3FH5m7SM0xKG3pguOH+eeeldXltIqOhLQDBJWmsA==}
+  '@mui/internal-code-infra@0.0.4-canary.54':
+    resolution: {integrity: sha512-tfzg6HfyQAjxxtk10rGXx+QNBivH6DqwDCrjK6PFn93850s/2QB1GUu693qVHYuaBafLBnzcMFlqRsi0w2XM+Q==}
     hasBin: true
     peerDependencies:
       '@next/eslint-plugin-next': '*'
@@ -13304,7 +13304,7 @@ snapshots:
       - tsx
       - yaml
 
-  '@mui/internal-code-infra@0.0.4-canary.50(@next/eslint-plugin-next@16.2.6)(@types/node@22.19.19)(@typescript-eslint/eslint-plugin@8.58.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(jest-diff@30.2.0)(postcss@8.5.15)(prettier@3.8.3)(stylelint@17.12.0(typescript@5.9.3))(typescript@5.9.3)(vitest@4.1.7)':
+  '@mui/internal-code-infra@0.0.4-canary.54(@next/eslint-plugin-next@16.2.6)(@types/node@22.19.19)(@typescript-eslint/eslint-plugin@8.58.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(jest-diff@30.2.0)(postcss@8.5.15)(prettier@3.8.3)(stylelint@17.12.0(typescript@5.9.3))(typescript@5.9.3)(vitest@4.1.7)':
     dependencies:
       '@argos-ci/core': 6.0.1
       '@babel/cli': 7.29.7(@babel/core@7.29.7)


### PR DESCRIPTION
## Summary

Bumps `@mui/internal-code-infra` from `0.0.4-canary.50` to `0.0.4-canary.54`.

This fixes `pnpm code-infra publish` (e.g. `CI=1 pnpm code-infra publish --ci --github-release --dry-run`) crashing with:

```
Unexpected non-whitespace character after JSON at position 3 (line 1 column 4)
```

### Root cause

`getReleaseVersion()` in code-infra ran `pnpm pkg get version` and `JSON.parse`d the output. Under **pnpm 11** (this repo's pinned `packageManager`), a single-field `pnpm pkg get version` returns the **raw** value `9.4.0` instead of quoted JSON `"9.4.0"`. `JSON.parse("9.4.0")` reads `9.4` as a number then chokes on the second `.`.

canary.54 adds the `--json` flag, which forces quoted JSON output across pnpm 9/10/11.

### Test

```
CI=1 pnpm code-infra publish --ci --github-release --dry-run
```

Before: crashed at the discovery step.
After: proceeds past version detection (`📋 Release version: 9.4.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)