### PR TITLE
[core] Bump mui-public workflow pins to master

### DIFF
--- a/.github/workflows/add-release-reviewers.yml
+++ b/.github/workflows/add-release-reviewers.yml
@@ -10,7 +10,7 @@ permissions: {}
 
 jobs:
   add-reviewers-to-release-pr:
-    uses: mui/mui-public/.github/workflows/reusable-add-reviewers-to-pr.yml@d042ec6ff36891f5dafac56700d6b9a5afbbd6bd # master
+    uses: mui/mui-public/.github/workflows/reusable-add-reviewers-to-pr.yml@4e18082e2410a90d523866a414c4e67296b9892c # master
     with:
       team-slug: x
       label-name: release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,6 @@ permissions: {}
 jobs:
   continuous-releases:
     name: Continuous releases
-    uses: mui/mui-public/.github/workflows/ci-base.yml@d042ec6ff36891f5dafac56700d6b9a5afbbd6bd # master
+    uses: mui/mui-public/.github/workflows/ci-base.yml@4e18082e2410a90d523866a414c4e67296b9892c # master
     with:
       node-version: '22.22.3'

--- a/.github/workflows/closed-issue-message.yaml
+++ b/.github/workflows/closed-issue-message.yaml
@@ -11,7 +11,7 @@ jobs:
   add-comment:
     name: Add closing message
     if: github.event.issue.state_reason == 'completed'
-    uses: mui/mui-public/.github/workflows/issues_add-closing-message.yml@d042ec6ff36891f5dafac56700d6b9a5afbbd6bd # master
+    uses: mui/mui-public/.github/workflows/issues_add-closing-message.yml@4e18082e2410a90d523866a414c4e67296b9892c # master
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/create-cherry-pick-pr.yml
+++ b/.github/workflows/create-cherry-pick-pr.yml
@@ -19,7 +19,7 @@ permissions: {}
 jobs:
   create_pr:
     name: Create cherry-pick PR
-    uses: mui/mui-public/.github/workflows/prs_create-cherry-pick-pr.yml@d042ec6ff36891f5dafac56700d6b9a5afbbd6bd # master
+    uses: mui/mui-public/.github/workflows/prs_create-cherry-pick-pr.yml@4e18082e2410a90d523866a414c4e67296b9892c # master
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/issue-status-label-handler.yml
+++ b/.github/workflows/issue-status-label-handler.yml
@@ -18,4 +18,4 @@ jobs:
       issues: write
       actions: write
     name: Handle status labels
-    uses: mui/mui-public/.github/workflows/issues_status-label-handler.yml@d042ec6ff36891f5dafac56700d6b9a5afbbd6bd # master
+    uses: mui/mui-public/.github/workflows/issues_status-label-handler.yml@4e18082e2410a90d523866a414c4e67296b9892c # master

--- a/.github/workflows/new-issue-triage.yml
+++ b/.github/workflows/new-issue-triage.yml
@@ -9,7 +9,7 @@ permissions: {}
 jobs:
   issue_cleanup:
     name: Clean issue body
-    uses: mui/mui-public/.github/workflows/issues_body-cleanup.yml@d042ec6ff36891f5dafac56700d6b9a5afbbd6bd # master
+    uses: mui/mui-public/.github/workflows/issues_body-cleanup.yml@4e18082e2410a90d523866a414c4e67296b9892c # master
     permissions:
       contents: read
       issues: write
@@ -17,7 +17,7 @@ jobs:
     name: Validate order ID
     needs: issue_cleanup
     if: needs.issue_cleanup.outputs.orderId != ''
-    uses: mui/mui-public/.github/workflows/issues_order-id-validation.yml@d042ec6ff36891f5dafac56700d6b9a5afbbd6bd # master
+    uses: mui/mui-public/.github/workflows/issues_order-id-validation.yml@4e18082e2410a90d523866a414c4e67296b9892c # master
     secrets: inherit
     with:
       orderId: ${{ needs.issue_cleanup.outputs.orderId }}

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -16,4 +16,4 @@ jobs:
       issues: write
       pull-requests: write
     name: Handle stale issues and PRs
-    uses: mui/mui-public/.github/workflows/general_handle-stale-issues-and-prs.yml@d042ec6ff36891f5dafac56700d6b9a5afbbd6bd # master
+    uses: mui/mui-public/.github/workflows/general_handle-stale-issues-and-prs.yml@4e18082e2410a90d523866a414c4e67296b9892c # master

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
           ref: ${{ inputs.sha }}
           fetch-depth: 0 # Fetch full history for proper git operations
       - name: Prepare for publishing
-        uses: mui/mui-public/.github/actions/publish-prepare@d042ec6ff36891f5dafac56700d6b9a5afbbd6bd # master
+        uses: mui/mui-public/.github/actions/publish-prepare@4e18082e2410a90d523866a414c4e67296b9892c # master
       - name: Publish packages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Bumps all `mui/mui-public/...@<sha> # master` workflow pins from `d042ec6` to `4e18082`.

This is the mui-x-side follow-up to mui/mui-public#1518. The previous pin resolved to a `ci-publish` action that ran:

```sh
pkg-pr-new publish $(pnpm code-infra list-workspaces --public-only --output=publish-dir) ...
```

The `publish-dir` output choice was removed from `@mui/internal-code-infra` (the action installs `@canary`), so the command errored, `$(...)` was empty, and `pkg-pr-new` failed with `Publishing failed (400): No packages`. The new pin uses `--output=path`.

### Files

All `# master` pins to mui-public reusable workflows/actions:
- `ci.yml` (`ci-base.yml` — the pkg.pr.new break)
- `publish.yml`, `create-cherry-pick-pr.yml`, `add-release-reviewers.yml`
- `new-issue-triage.yml`, `issue-status-label-handler.yml`, `no-response.yml`, `closed-issue-message.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)