### PR TITLE
[data grid][docs] Make product comparisons more explicit on Overview page

### DIFF
--- a/docs/data/data-grid/overview/overview.md
+++ b/docs/data/data-grid/overview/overview.md
@@ -5,7 +5,7 @@ packageName: '@mui/x-data-grid'
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/grid/
 ---
 
-# MUI X Data Grid
+# MUI X Data Grid
 
 <p class="description">A fast and extensible React data table and React data grid, with filtering, sorting, aggregation, and more.</p>
 
@@ -13,39 +13,39 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/grid/
 
 ## Overview
 
-The MUI X Data Grid is a TypeScript-based React component that presents information in a structured format of rows and columns.
+The MUI X Data Grid is a TypeScript-based React component that presents information in a structured format of rows and columns.
 It provides developers with an intuitive API for implementing complex use cases; and end users with a smooth experience for manipulating an unlimited set of data.
 
-The Grid's theming features are designed to be frictionless when integrating with Material UI and other MUI X components, but it can also stand on its own and be customized to meet the needs of any design system.
+The Grid's theming features are designed to be frictionless when integrating with Material UI and other MUI X components, but it can also stand on its own and be customized to meet the needs of any design system.
 
-## Why choose the MUI X Data Grid?
+## Why choose the MUI X Data Grid?
 
 There are numerous solutions available for building a data table, each with distinct trade-offs and design philosophies.
-The MUI X Data Grid is built specifically for React, offering a batteries-included solution with a fully styled, accessible user interface out of the box.
+The MUI X Data Grid is built specifically for React, offering a batteries-included solution with a fully styled, accessible user interface out of the box.
 Unlike headless table libraries, you can start building immediately without implementing UI components yourself, while still maintaining full customization capabilities through theming and component composition.
 
 ### Comparison with AG Grid
 
 AG Grid is a framework-agnostic solution that supports React, Vue, and Angular.
-Here's how the MUI X Data Grid differs:
+Here's how the MUI X Data Grid differs:
 
-- **React-first design**: Built exclusively for React with hooks, TypeScript, and React patterns at its core, providing a more idiomatic React experience
-- **Material UI integration**: Seamless integration with Material UI's design system and theming, allowing you to maintain visual consistency across your application
-- **Component composition**: Highly composable architecture that lets you customize individual parts while maintaining the full-featured grid experience
+- **React-first design**: MUI X Data Grid is built exclusively for React with hooks, TypeScript, and React patterns at its core, providing a more idiomatic React experience
+- **Material UI integration**: MUI X Data Grid integrates seamlessly with Material UI's design system and theming, allowing you to maintain visual consistency across your application
+- **Component composition**: MUI X Data Grid's highly composable architecture lets you customize individual parts while maintaining the full-featured grid experience
 
 ### Comparison with TanStack Table
 
 TanStack Table (formerly React Table) is a headless table library that provides table logic without any UI.
-Here's how the MUI X Data Grid differs:
+Here's how the MUI X Data Grid differs:
 
-- **Complete UI included**: Fully styled, accessible components ready to use immediately—no need to build your own table UI, filters, or pagination controls
-- **Built-in features**: Advanced features like editing, filtering, sorting, and virtualization come pre-implemented with polished user interfaces
-- **Less boilerplate**: Get a production-ready data grid with minimal setup, rather than wiring together multiple libraries and building custom components
+- **Complete UI included**: MUI X Data Grid provides fully styled, accessible components ready to use immediately—no need to build your own table UI, filters, or pagination controls
+- **Built-in features**: MUI X Data Grid comes with advanced features like editing, filtering, sorting, and virtualization pre-implemented with polished user interfaces
+- **Less boilerplate**: MUI X Data Grid gives you a production-ready data grid with minimal setup, rather than wiring together multiple libraries and building custom components
 
 ## Data Grid packages
 
 The Data Grid is **open-core**: The Community version is MIT-licensed and free forever, while more advanced features require a Pro or Premium commercial license.
-See [MUI X Licensing](/x/introduction/licensing/) for complete details.
+See [MUI X Licensing](/x/introduction/licensing/) for complete details.
 
 ### Community version (free forever)
 
@@ -53,7 +53,7 @@ See [MUI X Licensing](/x/introduction/licensing/) for complete details.
 import { DataGrid } from '@mui/x-data-grid';
 ```
 
-The MIT-licensed Community version of the Data Grid is a more sophisticated implementation of the [Material UI Table](/material-ui/react-table/).
+The MIT-licensed Community version of the Data Grid is a more sophisticated implementation of the [Material UI Table](/material-ui/react-table/).
 
 It includes all of the main features listed in the navigation menu, such as editing, sorting, filtering, and pagination, as shown in the demo below:
 

--- a/docs/data/data-grid/overview/overview.md
+++ b/docs/data/data-grid/overview/overview.md
@@ -5,7 +5,7 @@ packageName: '@mui/x-data-grid'
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/grid/
 ---
 
-# MUI X Data Grid
+# MUI X Data Grid
 
 <p class="description">A fast and extensible React data table and React data grid, with filtering, sorting, aggregation, and more.</p>
 
@@ -13,39 +13,39 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/grid/
 
 ## Overview
 
-The MUI X Data Grid is a TypeScript-based React component that presents information in a structured format of rows and columns.
+The MUI X Data Grid is a TypeScript-based React component that presents information in a structured format of rows and columns.
 It provides developers with an intuitive API for implementing complex use cases; and end users with a smooth experience for manipulating an unlimited set of data.
 
-The Grid's theming features are designed to be frictionless when integrating with Material UI and other MUI X components, but it can also stand on its own and be customized to meet the needs of any design system.
+The Grid's theming features are designed to be frictionless when integrating with Material UI and other MUI X components, but it can also stand on its own and be customized to meet the needs of any design system.
 
-## Why choose the MUI X Data Grid?
+## Why choose the MUI X Data Grid?
 
 There are numerous solutions available for building a data table, each with distinct trade-offs and design philosophies.
-The MUI X Data Grid is built specifically for React, offering a batteries-included solution with a fully styled, accessible user interface out of the box.
+The MUI X Data Grid is built specifically for React, offering a batteries-included solution with a fully styled, accessible user interface out of the box.
 Unlike headless table libraries, you can start building immediately without implementing UI components yourself, while still maintaining full customization capabilities through theming and component composition.
 
 ### Comparison with AG Grid
 
 AG Grid is a framework-agnostic solution that supports React, Vue, and Angular.
-Here's how the MUI X Data Grid differs:
+Here's how the MUI X Data Grid differs:
 
-- **React-first design**: MUI X Data Grid is built exclusively for React with hooks, TypeScript, and React patterns at its core, providing a more idiomatic React experience
-- **Material UI integration**: MUI X Data Grid integrates seamlessly with Material UI's design system and theming, allowing you to maintain visual consistency across your application
-- **Component composition**: MUI X Data Grid's highly composable architecture lets you customize individual parts while maintaining the full-featured grid experience
+- **React-first design**: MUI X Data Grid is built exclusively for React with hooks, TypeScript, and React patterns at its core, providing a more idiomatic React experience
+- **Material UI integration**: MUI X Data Grid integrates seamlessly with Material UI's design system and theming, allowing you to maintain visual consistency across your application
+- **Component composition**: MUI X Data Grid's highly composable architecture lets you customize individual parts while maintaining the full-featured grid experience
 
 ### Comparison with TanStack Table
 
 TanStack Table (formerly React Table) is a headless table library that provides table logic without any UI.
-Here's how the MUI X Data Grid differs:
+Here's how the MUI X Data Grid differs:
 
-- **Complete UI included**: MUI X Data Grid provides fully styled, accessible components ready to use immediately—no need to build your own table UI, filters, or pagination controls
-- **Built-in features**: MUI X Data Grid comes with advanced features like editing, filtering, sorting, and virtualization pre-implemented with polished user interfaces
-- **Less boilerplate**: MUI X Data Grid gives you a production-ready data grid with minimal setup, rather than wiring together multiple libraries and building custom components
+- **Complete UI included**: MUI X Data Grid provides fully styled, accessible components ready to use immediately—no need to build your own table UI, filters, or pagination controls
+- **Built-in features**: MUI X Data Grid comes with advanced features like editing, filtering, sorting, and virtualization pre-implemented with polished user interfaces
+- **Less boilerplate**: MUI X Data Grid gives you a production-ready data grid with minimal setup, rather than wiring together multiple libraries and building custom components
 
 ## Data Grid packages
 
 The Data Grid is **open-core**: The Community version is MIT-licensed and free forever, while more advanced features require a Pro or Premium commercial license.
-See [MUI X Licensing](/x/introduction/licensing/) for complete details.
+See [MUI X Licensing](/x/introduction/licensing/) for complete details.
 
 ### Community version (free forever)
 
@@ -53,7 +53,7 @@ See [MUI X Licensing](/x/introduction/licensing/) for complete details.
 import { DataGrid } from '@mui/x-data-grid';
 ```
 
-The MIT-licensed Community version of the Data Grid is a more sophisticated implementation of the [Material UI Table](/material-ui/react-table/).
+The MIT-licensed Community version of the Data Grid is a more sophisticated implementation of the [Material UI Table](/material-ui/react-table/).
 
 It includes all of the main features listed in the navigation menu, such as editing, sorting, filtering, and pagination, as shown in the demo below:
 

--- a/docs/data/data-grid/overview/overview.md
+++ b/docs/data/data-grid/overview/overview.md
@@ -24,9 +24,7 @@ There are numerous solutions available for building a data table, each with dist
 The MUI X Data Grid is built specifically for React, offering a batteries-included solution with a fully styled, accessible user interface out of the box.
 Unlike headless table libraries, you can start building immediately without implementing UI components yourself, while still maintaining full customization capabilities through theming and component composition.
 
-### Comparisons
-
-#### Comparison with AG Grid
+### Comparison with AG Grid
 
 AG Grid is a framework-agnostic solution that supports React, Vue, and Angular.
 Here's how the MUI X Data Grid differs:
@@ -35,7 +33,7 @@ Here's how the MUI X Data Grid differs:
 - **Material UI integration**: Seamless integration with Material UI's design system and theming, allowing you to maintain visual consistency across your application
 - **Component composition**: Highly composable architecture that lets you customize individual parts while maintaining the full-featured grid experience
 
-#### Comparison with TanStack Table
+### Comparison with TanStack Table
 
 TanStack Table (formerly React Table) is a headless table library that provides table logic without any UI.
 Here's how the MUI X Data Grid differs:

--- a/docs/data/data-grid/overview/overview.md
+++ b/docs/data/data-grid/overview/overview.md
@@ -26,7 +26,7 @@ Unlike headless table libraries, you can start building immediately without impl
 
 ### Comparisons
 
-#### AG Grid
+#### Comparison with AG Grid
 
 AG Grid is a framework-agnostic solution that supports React, Vue, and Angular.
 Here's how the MUI X Data Grid differs:
@@ -35,7 +35,7 @@ Here's how the MUI X Data Grid differs:
 - **Material UI integration**: Seamless integration with Material UI's design system and theming, allowing you to maintain visual consistency across your application
 - **Component composition**: Highly composable architecture that lets you customize individual parts while maintaining the full-featured grid experience
 
-#### TanStack Table
+#### Comparison with TanStack Table
 
 TanStack Table (formerly React Table) is a headless table library that provides table logic without any UI.
 Here's how the MUI X Data Grid differs:


### PR DESCRIPTION
The earlier version of this text could read like the bullet points were describing the competitor products rather than MUI X. This PR reworks the copy to make it more clear.