### PR TITLE
[pickers] Fix missing export of th-TH

### DIFF
--- a/packages/x-date-pickers/src/locales/index.ts
+++ b/packages/x-date-pickers/src/locales/index.ts
@@ -32,6 +32,7 @@ export * from './ruRU';
 export * from './skSK';
 export * from './svSE';
 export * from './trTR';
+export * from './thTH';
 export * from './ukUA';
 export * from './urPK';
 export * from './viVN';


### PR DESCRIPTION
Fix #22697

@Janpot To come back on my proposal about adding knip #21887 

This issue would have been avoided, because the `thTH` would be marked as an export never used