### PR TITLE
[DataGrid] Strip dev-only warning messages from production bundles

### DIFF
--- a/packages/x-data-grid-pro/src/hooks/features/dataSource/useGridDataSourceBasePro.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/dataSource/useGridDataSourceBasePro.ts
@@ -242,7 +242,7 @@ export const useGridDataSourceBasePro = <Api extends GridPrivateApiPro>(
               cause: childrenFetchError,
             }),
           );
-        } else {
+        } else if (process.env.NODE_ENV !== 'production') {
           warnOnce(
             [
               'MUI X: A call to `dataSource.getRows()` threw an error which was not handled because `onDataSourceError()` is missing.',

--- a/packages/x-data-grid-pro/src/hooks/features/rowReorder/reorderExecutor.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/rowReorder/reorderExecutor.ts
@@ -46,12 +46,14 @@ export class RowReorderExecutor {
       }
     }
 
-    warnOnce(
-      [
-        'MUI X: The parameters provided to the API method resulted in a no-op.',
-        'Consider looking at the documentation at https://mui.com/x/react-data-grid/row-ordering/',
-      ],
-      'warning',
-    );
+    if (process.env.NODE_ENV !== 'production') {
+      warnOnce(
+        [
+          'MUI X: The parameters provided to the API method resulted in a no-op.',
+          'Consider looking at the documentation at https://mui.com/x/react-data-grid/row-ordering/',
+        ],
+        'warning',
+      );
+    }
   }
 }

--- a/packages/x-data-grid-pro/src/hooks/features/rowReorder/utils.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/rowReorder/utils.ts
@@ -235,7 +235,7 @@ export function handleProcessRowUpdateError(
 ): void {
   if (onProcessRowUpdateError) {
     onProcessRowUpdateError(error);
-  } else {
+  } else if (process.env.NODE_ENV !== 'production') {
     warnOnce(
       [
         'MUI X: A call to `processRowUpdate()` threw an error which was not handled because `onProcessRowUpdateError()` is missing.',

--- a/packages/x-data-grid-pro/src/hooks/features/treeData/utils.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/treeData/utils.ts
@@ -32,11 +32,13 @@ export const buildTreeDataPath = (node: GridTreeNode, tree: GridRowTreeConfig): 
 };
 
 export function displaySetTreeDataPathWarning(operationName: string): void {
-  warnOnce(
-    `MUI X: ${operationName} requires \`setTreeDataPath()\` prop to update row data paths. ` +
-      'Please provide a `setTreeDataPath()` function to enable this feature.',
-    'warning',
-  );
+  if (process.env.NODE_ENV !== 'production') {
+    warnOnce(
+      `MUI X: ${operationName} requires \`setTreeDataPath()\` prop to update row data paths. ` +
+        'Please provide a `setTreeDataPath()` function to enable this feature.',
+      'warning',
+    );
+  }
 }
 
 export function removeNodeFromSourceParent(

--- a/packages/x-data-grid/src/components/cell/GridActionsCell.tsx
+++ b/packages/x-data-grid/src/components/cell/GridActionsCell.tsx
@@ -116,7 +116,7 @@ function GridActionsCell<
         });
       } else if (child.type === GridActionsCellItem || suppressChildrenValidation) {
         actions.push(child);
-      } else {
+      } else if (process.env.NODE_ENV !== 'production') {
         const childType = typeof child.type === 'function' ? child.type.name : child.type;
         warnOnce(
           `MUI X: Invalid child type in \`GridActionsCell\`. Expected \`GridActionsCellItem\` or \`React.Fragment\`, got \`${childType}\`.

--- a/packages/x-data-grid/src/hooks/features/dataSource/useGridDataSourceBase.ts
+++ b/packages/x-data-grid/src/hooks/features/dataSource/useGridDataSourceBase.ts
@@ -177,7 +177,7 @@ export const useGridDataSourceBase = <Api extends GridPrivateApiCommunity>(
                 cause: originalError as Error,
               }),
             );
-          } else {
+          } else if (process.env.NODE_ENV !== 'production') {
             warnOnce(
               [
                 'MUI X: A call to `dataSource.getRows()` threw an error which was not handled because `onDataSourceError()` is missing.',
@@ -352,7 +352,7 @@ export const useGridDataSourceBase = <Api extends GridPrivateApiCommunity>(
               cause: errorThrown as Error,
             }),
           );
-        } else {
+        } else if (process.env.NODE_ENV !== 'production') {
           warnOnce(
             [
               'MUI X: A call to `dataSource.updateRow()` threw an error which was not handled because `onDataSourceError()` is missing.',

--- a/packages/x-data-grid/src/hooks/features/editing/useGridCellEditing.ts
+++ b/packages/x-data-grid/src/hooks/features/editing/useGridCellEditing.ts
@@ -464,7 +464,7 @@ export const useGridCellEditing = (
 
           if (onProcessRowUpdateError) {
             onProcessRowUpdateError(errorThrown);
-          } else {
+          } else if (process.env.NODE_ENV !== 'production') {
             warnOnce(
               [
                 'MUI X: A call to `processRowUpdate()` threw an error which was not handled because `onProcessRowUpdateError()` is missing.',

--- a/packages/x-data-grid/src/hooks/features/editing/useGridRowEditing.ts
+++ b/packages/x-data-grid/src/hooks/features/editing/useGridRowEditing.ts
@@ -604,7 +604,7 @@ export const useGridRowEditing = (
 
           if (onProcessRowUpdateError) {
             onProcessRowUpdateError(errorThrown);
-          } else {
+          } else if (process.env.NODE_ENV !== 'production') {
             warnOnce(
               [
                 'MUI X: A call to `processRowUpdate()` threw an error which was not handled because `onProcessRowUpdateError()` is missing.',

--- a/packages/x-data-grid/src/hooks/features/export/serializers/csvSerializer.ts
+++ b/packages/x-data-grid/src/hooks/features/export/serializers/csvSerializer.ts
@@ -110,11 +110,13 @@ const serializeRow = ({
 
   columns.forEach((column) => {
     const cellParams = getCellParams(id, column.field);
-    if (String(cellParams.formattedValue) === '[object Object]') {
-      warnOnce([
-        'MUI X: When the value of a field is an object or a `renderCell` is provided, the CSV export might not display the value correctly.',
-        'You can provide a `valueFormatter` with a string representation to be used.',
-      ]);
+    if (process.env.NODE_ENV !== 'production') {
+      if (String(cellParams.formattedValue) === '[object Object]') {
+        warnOnce([
+          'MUI X: When the value of a field is an object or a `renderCell` is provided, the CSV export might not display the value correctly.',
+          'You can provide a `valueFormatter` with a string representation to be used.',
+        ]);
+      }
     }
     row.addValue(
       serializeCellValue(cellParams, {

--- a/packages/x-data-grid/src/hooks/features/filter/gridFilterUtils.ts
+++ b/packages/x-data-grid/src/hooks/features/filter/gridFilterUtils.ts
@@ -86,13 +86,15 @@ export const sanitizeFilterModel = (
 
   let items: GridFilterItem[];
   if (hasSeveralItems && disableMultipleColumnsFiltering) {
-    warnOnce(
-      [
-        'MUI X: The `filterModel` can only contain a single item when the `disableMultipleColumnsFiltering` prop is set to `true`.',
-        'If you are using the community version of the Data Grid, this prop is always `true`.',
-      ],
-      'error',
-    );
+    if (process.env.NODE_ENV !== 'production') {
+      warnOnce(
+        [
+          'MUI X: The `filterModel` can only contain a single item when the `disableMultipleColumnsFiltering` prop is set to `true`.',
+          'If you are using the community version of the Data Grid, this prop is always `true`.',
+        ],
+        'error',
+      );
+    }
     items = [model.items[0]];
   } else {
     items = model.items;
@@ -101,18 +103,20 @@ export const sanitizeFilterModel = (
   const hasItemsWithoutIds = hasSeveralItems && items.some((item) => item.id == null);
   const hasItemWithoutOperator = items.some((item) => item.operator == null);
 
-  if (hasItemsWithoutIds) {
-    warnOnce(
-      'MUI X: The `id` field is required on `filterModel.items` when you use multiple filters.',
-      'error',
-    );
-  }
+  if (process.env.NODE_ENV !== 'production') {
+    if (hasItemsWithoutIds) {
+      warnOnce(
+        'MUI X: The `id` field is required on `filterModel.items` when you use multiple filters.',
+        'error',
+      );
+    }
 
-  if (hasItemWithoutOperator) {
-    warnOnce(
-      'MUI X: The `operator` field is required on `filterModel.items`, one or more of your filtering item has no `operator` provided.',
-      'error',
-    );
+    if (hasItemWithoutOperator) {
+      warnOnce(
+        'MUI X: The `operator` field is required on `filterModel.items`, one or more of your filtering item has no `operator` provided.',
+        'error',
+      );
+    }
   }
 
   if (hasItemWithoutOperator || hasItemsWithoutIds) {

--- a/packages/x-data-grid/src/hooks/features/listView/useGridListView.tsx
+++ b/packages/x-data-grid/src/hooks/features/listView/useGridListView.tsx
@@ -76,12 +76,14 @@ export function useGridListView(
   }, [apiRef, props.listViewColumn]);
 
   React.useEffect(() => {
-    if (props.listView && !props.listViewColumn) {
-      warnOnce([
-        'MUI X: The `listViewColumn` prop must be set if `listView` is enabled.',
-        'To fix, pass a column definition to the `listViewColumn` prop, e.g. `{ field: "example", renderCell: (params) => <div>{params.row.id}</div> }`.',
-        'For more details, see https://mui.com/x/react-data-grid/list-view/',
-      ]);
+    if (process.env.NODE_ENV !== 'production') {
+      if (props.listView && !props.listViewColumn) {
+        warnOnce([
+          'MUI X: The `listViewColumn` prop must be set if `listView` is enabled.',
+          'To fix, pass a column definition to the `listViewColumn` prop, e.g. `{ field: "example", renderCell: (params) => <div>{params.row.id}</div> }`.',
+          'For more details, see https://mui.com/x/react-data-grid/list-view/',
+        ]);
+      }
     }
   }, [props.listView, props.listViewColumn]);
 }

--- a/packages/x-data-grid/src/hooks/features/sorting/gridSortingUtils.ts
+++ b/packages/x-data-grid/src/hooks/features/sorting/gridSortingUtils.ts
@@ -25,13 +25,15 @@ interface GridParsedSortItem {
 
 export const sanitizeSortModel = (model: GridSortModel, disableMultipleColumnsSorting: boolean) => {
   if (disableMultipleColumnsSorting && model.length > 1) {
-    warnOnce(
-      [
-        'MUI X: The `sortModel` can only contain a single item when the `disableMultipleColumnsSorting` prop is set to `true`.',
-        'If you are using the community version of the Data Grid, this prop is always `true`.',
-      ],
-      'error',
-    );
+    if (process.env.NODE_ENV !== 'production') {
+      warnOnce(
+        [
+          'MUI X: The `sortModel` can only contain a single item when the `disableMultipleColumnsSorting` prop is set to `true`.',
+          'If you are using the community version of the Data Grid, this prop is always `true`.',
+        ],
+        'error',
+      );
+    }
     return [model[0]];
   }
 

--- a/packages/x-data-grid/src/hooks/utils/useGridSelector.ts
+++ b/packages/x-data-grid/src/hooks/utils/useGridSelector.ts
@@ -59,11 +59,13 @@ export function useGridSelector<Api extends GridApiCommon, Args, T>(
   args: Args = undefined as Args,
   equals: <U = T>(a: U, b: U) => boolean = defaultCompare,
 ) {
-  if (!apiRef.current.state) {
-    warnOnce([
-      'MUI X: `useGridSelector` has been called before the initialization of the state.',
-      'This hook can only be used inside the context of the grid.',
-    ]);
+  if (process.env.NODE_ENV !== 'production') {
+    if (!apiRef.current.state) {
+      warnOnce([
+        'MUI X: `useGridSelector` has been called before the initialization of the state.',
+        'This hook can only be used inside the context of the grid.',
+      ]);
+    }
   }
 
   const refs = useLazyRef<Refs<T>, never>(createRefs);


### PR DESCRIPTION
Wrap unguarded warnOnce() call sites in
process.env.NODE_ENV !== 'production' checks, matching the convention already used across the codebase. warnOnce() is already a no-op in production, so behavior is unchanged, but the guard lets bundlers strip the warning message strings from production bundles.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
