### PR TITLE
[docs-infra] Fix immutable cache headers for /_next/static assets

### DIFF
--- a/docs/public/_headers
+++ b/docs/public/_headers
@@ -1,4 +1,4 @@
-/_next/*.js
+/_next/static/*
   Cache-Control: public, max-age=31536000, immutable
 
 /static/images/*


### PR DESCRIPTION
`/_next/*.js` only matched `.js`, so hashed `.css` and font assets fell back to `max-age=0,must-revalidate`. Use `/_next/static/*` to cover all fingerprinted assets.

Verified on preview: `.css` now `public,max-age=31536000,immutable`.