### PR TITLE
[docs-infra] Prefix /_next/static cache header rule with /x basePath

### DIFF
--- a/docs/public/_headers
+++ b/docs/public/_headers
@@ -1,6 +1,9 @@
 /_next/static/*
   Cache-Control: public, max-age=31536000, immutable
 
+/x/_next/static/*
+  Cache-Control: public, max-age=31536000, immutable
+
 /static/images/*
   Cache-Control: public, max-age=86400
 


### PR DESCRIPTION
Follow-up to the previous cache-header fix. The docs deploy under basePath `/x`, so assets are actually served at `/x/_next/static/...` — the bare `/_next/static/*` rule never matched, leaving hashed assets at `max-age=0,must-revalidate`.

Adds the `/x`-prefixed rule and keeps the bare one as a safety net.

Confirmed broken on prod: `curl -sI https://mui.com/x/_next/static/css/*.css` → `max-age=0`.
Verify after deploy → expect `immutable`.