### PR TITLE
[scheduler] Fix `aria-labelledby` on events referencing non-existent header IDs

### DIFF
--- a/packages/x-scheduler/src/agenda-view/AgendaView.test.tsx
+++ b/packages/x-scheduler/src/agenda-view/AgendaView.test.tsx
@@ -4,6 +4,7 @@ import {
   adapter,
   createSchedulerRenderer,
   DEFAULT_TESTING_VISIBLE_DATE,
+  EventBuilder,
 } from 'test/utils/scheduler';
 import { EventCalendar, eventCalendarClasses } from '@mui/x-scheduler/event-calendar';
 import { StandaloneAgendaView } from '@mui/x-scheduler/agenda-view';
@@ -33,6 +34,21 @@ describe('<AgendaView />', () => {
       expect(
         document.querySelectorAll(`.${eventCalendarClasses.eventSkeleton}`).length,
       ).to.be.greaterThan(0);
+    });
+  });
+
+  it('should reference resolvable header IDs in each event aria-labelledby', () => {
+    const event = EventBuilder.new().title('My Event').build();
+
+    render(
+      <EventCalendar events={[event]} visibleDate={DEFAULT_TESTING_VISIBLE_DATE} view="agenda" />,
+    );
+
+    const eventButton = screen.getByRole('button', { name: /My Event/i });
+    const tokens = (eventButton.getAttribute('aria-labelledby') ?? '').split(' ').filter(Boolean);
+    expect(tokens.length).to.be.greaterThan(0);
+    tokens.forEach((token) => {
+      expect(document.getElementById(token), `aria-labelledby token "${token}"`).not.to.equal(null);
     });
   });
 

--- a/packages/x-scheduler/src/agenda-view/AgendaView.tsx
+++ b/packages/x-scheduler/src/agenda-view/AgendaView.tsx
@@ -275,7 +275,7 @@ export const AgendaView = React.memo(
                           occurrence={occurrence}
                           date={date}
                           variant="regular"
-                          ariaLabelledBy={`DayHeaderCell-${date.key}`}
+                          ariaLabelledBy={`${schedulerId}-DayHeaderCell-${date.key}`}
                         />
                       </EventDialogTrigger>
                     </li>

--- a/packages/x-scheduler/src/internals/components/more-events-popover/MoreEventsPopover.tsx
+++ b/packages/x-scheduler/src/internals/components/more-events-popover/MoreEventsPopover.tsx
@@ -93,7 +93,7 @@ export default function MoreEventsPopoverContent(props: MoreEventsPopoverProps) 
               variant={isOccurrenceAllDayOrMultipleDay(occurrence, adapter) ? 'filled' : 'compact'}
               occurrence={occurrence}
               date={day}
-              ariaLabelledBy={`PopoverHeader-${day.key}`}
+              ariaLabelledBy={`${schedulerId}-PopoverHeader-${day.key}`}
             />
           </EventDialogTrigger>
         ))}

--- a/packages/x-scheduler/src/month-view/tests/MonthView.test.tsx
+++ b/packages/x-scheduler/src/month-view/tests/MonthView.test.tsx
@@ -169,6 +169,23 @@ describe('<MonthView />', () => {
         expect(screen.queryByRole('dialog')).not.to.equal(null);
       });
     });
+
+    it('should reference resolvable header IDs in each event aria-labelledby', async () => {
+      const { popover } = await renderAndOpenPopover();
+
+      const eventButtons = within(popover).getAllByRole('button');
+      expect(eventButtons.length).to.be.greaterThan(0);
+
+      eventButtons.forEach((button) => {
+        const tokens = (button.getAttribute('aria-labelledby') ?? '').split(' ').filter(Boolean);
+        expect(tokens.length).to.be.greaterThan(0);
+        tokens.forEach((token) => {
+          expect(document.getElementById(token), `aria-labelledby token "${token}"`).not.to.equal(
+            null,
+          );
+        });
+      });
+    });
   });
 
   describe('All day events', () => {


### PR DESCRIPTION
Closes #22756

## Summary

Event items in the month "+N more" popover and the Agenda view referenced a header `id` in their `aria-labelledby` that didn't exist in the DOM: the real header IDs carry a `${schedulerId}-` prefix that the value passed to `EventItem` omitted. As a result the date/day part of each event's accessible name was a dangling reference, so screen readers didn't announce which day an event belonged to.

## Changes

Added the missing `${schedulerId}-` prefix in both call sites (both already had `schedulerId` in scope):

- `MoreEventsPopover.tsx` → `${schedulerId}-PopoverHeader-${day.key}`
- `AgendaView.tsx` (the `EventItem` call) → `${schedulerId}-DayHeaderCell-${date.key}`

### Regression tests

Added one test per affected surface, each asserting that **every** token in an event's `aria-labelledby` resolves to an existing element in the DOM:

- `MonthView.test.tsx` — events inside the "+N more" popover
- `AgendaView.test.tsx` — events in the agenda list

Both tests fail without the fix (the unprefixed `PopoverHeader-…` / `DayHeaderCell-…` token resolves to `null`) and pass with it.

### Audit

I checked every other `aria-labelledby` in the scheduler that points at a header. No other occurrences of this bug: the rest keep both sides in sync by sharing the same variable (`weekNumberId`), the same helper (`getCalendarGridHeaderCellId`), or an identical prefixed template (all-day header cell, timeline title cell).