### PR TITLE
[scheduler] Fix MoreEventsPopover close listener leak

### DIFF
--- a/packages/x-scheduler/src/internals/components/more-events-popover/MoreEventsPopover.tsx
+++ b/packages/x-scheduler/src/internals/components/more-events-popover/MoreEventsPopover.tsx
@@ -70,7 +70,7 @@ export default function MoreEventsPopoverContent(props: MoreEventsPopoverProps) 
   const { subscribeCloseHandler } = useEventDialogContext();
 
   React.useEffect(() => {
-    subscribeCloseHandler(() => {
+    return subscribeCloseHandler(() => {
       onClose();
     });
   }, [subscribeCloseHandler, onClose]);

--- a/packages/x-scheduler/src/month-view/tests/MonthView.test.tsx
+++ b/packages/x-scheduler/src/month-view/tests/MonthView.test.tsx
@@ -171,6 +171,62 @@ describe('<MonthView />', () => {
     });
   });
 
+  describe('"more events" popover close handler', () => {
+    function renderCalendar() {
+      return render(
+        <EventCalendarProvider events={manyEvents} resources={[]}>
+          <EventDialogProvider>
+            <MonthView />
+          </EventDialogProvider>
+        </EventCalendarProvider>,
+      );
+    }
+
+    it('should close the popover when the event dialog it opened is closed', async () => {
+      const { user } = renderCalendar();
+
+      const moreButton = await screen.findByRole('button', { name: /more/i });
+      await user.click(moreButton);
+      const popover = await screen.findByRole('presentation');
+
+      await user.click(within(popover).getAllByRole('button')[0]);
+      const dialog = await screen.findByRole('dialog');
+      expect(document.body.contains(popover)).to.equal(true);
+
+      await user.click(within(dialog).getByRole('button', { name: 'Close' }));
+
+      await waitFor(() => {
+        expect(document.body.contains(popover)).to.equal(false);
+      });
+    });
+
+    it('should not leak close listeners when the popover is reopened', async () => {
+      const warn = spy(console, 'warn');
+
+      try {
+        const { user } = renderCalendar();
+
+        // EventManager warns past 20 listeners, so reopen enough times to cross it.
+        /* eslint-disable no-await-in-loop */
+        for (let i = 0; i < 22; i += 1) {
+          const moreButton = await screen.findByRole('button', { name: /more/i });
+          await user.click(moreButton);
+          await screen.findByRole('presentation');
+          await user.keyboard('{Escape}');
+          await waitFor(() => {
+            expect(screen.queryByRole('presentation')).to.equal(null);
+          });
+        }
+        /* eslint-enable no-await-in-loop */
+
+        const leaked = warn.getCalls().some((call) => /memory leak/i.test(String(call.args[0])));
+        expect(leaked).to.equal(false);
+      } finally {
+        warn.restore();
+      }
+    }, 30000);
+  });
+
   describe('All day events', () => {
     const allDayEvents = [
       EventBuilder.new()


### PR DESCRIPTION
# Description

The `"+ N more"` popover in the Month view (`MoreEventsPopoverContent`) subscribes to the `EventDialog`'s `close` event so it can close itself when a dialog opened from inside it is dismissed. The subscription is set up in a `useEffect`, but the effect did not return the unsubscribe function, so the listener was never removed.

Because the popover content mounts on every open and unmounts on every close, while the `EventDialogProvider` (and its `EventManager`) lives for the whole calendar lifetime, a dead `close` listener accumulated on each open. After 20 listeners, `EventManager` logs its `"Possible EventEmitter memory leak detected"` warning, and every real dialog close runs all the stale handlers.

`subscribeCloseHandler` already returns an unsubscribe function (see `createModal`), so the fix is to return it from the effect and let React clean it up on unmount.

# Steps to reproduce

1. Open an Event Calendar Month view with a day that has more events than fit in a cell, so a `"+ N more"` button is shown.
2. Open the browser console.
3. Click `"+ N more"` to open the popover, then dismiss it with Escape or an outside click.
4. Repeat the open and dismiss around 21 times.

Before: the console prints `Possible EventEmitter memory leak detected. 21 close listeners added.`

After: no warning appears, because the listener count stays at `1`.

# Changes

- `MoreEventsPopover.tsx`: return the unsubscribe from the `subscribeCloseHandler` effect.
- `MonthView.test.tsx`: add two tests under the `"more events"` popover:
  - the popover closes when the event dialog it opened is closed (guards the intended behavior),
  - reopening the popover past the 20 listener threshold does not trigger the leak warning (fails without the fix).

# Testing

- `pnpm test:unit --project "x-scheduler" --run` passes.
- Reverting the one-line fix makes the leak test fail, with the stack trace pointing at the `subscribeCloseHandler` call, which confirms the test guards the regression.
- `pnpm --filter "@mui/x-scheduler" run typescript` and `eslint` are clean.

# Changelog

Fixed a listener leak in the Event Calendar Month view, where opening the `"+ N more"` popover repeatedly accumulated `close` listeners on the event dialog and eventually logged an EventManager max listeners warning.

Closes #22755

- [x] I have followed (at least) the PR section of the contributing guide.