### PR TITLE
[scheduler] Update feedback banner to say beta instead of alpha

### DIFF
--- a/docs/src/modules/components/overview/scheduler/SchedulerFeedbackBanner.tsx
+++ b/docs/src/modules/components/overview/scheduler/SchedulerFeedbackBanner.tsx
@@ -41,7 +41,7 @@ export default function SchedulerFeedbackBanner() {
           ...theme.applyDarkStyles({ color: 'primary.100' }),
         })}
       >
-        🚀 The Scheduler is in alpha — we&apos;d love your input.{' '}
+        🚀 The Scheduler is in beta — we&apos;d love your input.{' '}
         <Link
           href={FEEDBACK_FORM_URL}
           target="_blank"


### PR DESCRIPTION
# Summary

The Scheduler has moved from alpha to beta, but the docs feedback banner still says "The Scheduler is in alpha". This updates the banner copy to reflect the current beta status.

# Changes

`docs/src/modules/components/overview/scheduler/SchedulerFeedbackBanner.tsx`

- "🚀 The Scheduler is in alpha — we'd love your input." → "🚀 The Scheduler is in beta — we'd love your input."


- [x] I have followed (at least) the PR section of the contributing guide.
