### PR TITLE
[ci] Trigger e2e-website via CircleCI GitHub App pipeline-run

### DIFF
--- a/netlify/functions/deploy-succeeded.js
+++ b/netlify/functions/deploy-succeeded.js
@@ -16,8 +16,9 @@ exports.handler = async (event) => {
   // eslint-disable-next-line no-console
   console.info(`url:`, payload.deploy_ssl_url);
 
-  // for more details > https://circleci.com/docs/2.0/api-developers-guide/#
-  await fetch(`https://circleci.com/api/v2/project/gh/${repo[1]}/pipeline`, {
+  // Trigger via the GitHub App pipeline-run endpoint so the resulting checks report through
+  // the CircleCI GitHub App (not the legacy OAuth app). https://circleci.com/docs/api/v2/
+  await fetch(`https://circleci.com/api/v2/project/gh/${repo[1]}/pipeline/run`, {
     method: 'POST',
     headers: {
       'Content-type': 'application/json',
@@ -25,8 +26,19 @@ exports.handler = async (event) => {
       'Circle-Token': process.env.CIRCLE_CI_TOKEN,
     },
     body: JSON.stringify({
+      // CircleCI "GitHub App" pipeline-definition id for mui/mui-x (not a secret). Stable for
+      // the life of the pipeline definition: it does not change per run or when
+      // .circleci/config.yml changes, only if the project is reconnected to the GitHub App.
+      // To obtain/refresh it:
+      //   PROJECT_ID=$(curl -s -H "Circle-Token: $CIRCLE_CI_TOKEN" \
+      //     https://circleci.com/api/v2/project/gh/mui/mui-x | jq -r .id)
+      //   curl -s -H "Circle-Token: $CIRCLE_CI_TOKEN" \
+      //     "https://circleci.com/api/v2/projects/$PROJECT_ID/pipeline-definitions" \
+      //     | jq -r '.items[] | select(.config_source.provider=="github_app") | .id'
+      definition_id: '96663f15-ee8b-4362-a8f1-035e9ee1ae50',
       // For PR, /head is needed. https://support.circleci.com/hc/en-us/articles/360049841151
-      branch: `pull/${repo[2]}/head`,
+      config: { branch: `pull/${repo[2]}/head` },
+      checkout: { branch: `pull/${repo[2]}/head` },
       parameters: {
         // the parameters defined in .circleci/config.yml
         workflow: 'e2e-website', // name of the workflow


### PR DESCRIPTION
## Why

The `deploy-succeeded` Netlify function triggers the `e2e-website` CircleCI workflow through the **legacy GitHub OAuth** endpoint (`POST /project/gh/{repo}/pipeline`). Pipelines triggered that way report their status checks via the CircleCI **OAuth app** (`oa/4808`) rather than the **CircleCI Checks GitHub App** (`in/302869`).

This is part of moving mui-x's CircleCI status reporting fully onto the GitHub App, so the org can source-pin required status checks in branch rulesets (OAuth-app statuses can't be matched to a GitHub-App-pinned required check, which currently blocks merges for write-role users).

## What

Switch the trigger to the GitHub App **`/pipeline/run`** endpoint, which takes a per-call branch plus the pipeline `definition_id`, and reuses the existing `CIRCLE_CI_TOKEN`. A custom webhook trigger can't be used here because its checkout branch is fixed at creation time and can't take a per-PR `pull/{n}/head` ref.

The `definition_id` is the GitHub App pipeline definition for mui/mui-x; a comment documents how to re-fetch it.

> Note: this complements a CircleCI dashboard change (disconnecting the legacy OAuth integration so push/PR builds stop double-reporting via OAuth). On its own, this PR moves the Netlify-triggered `test_e2e_website` check onto the GitHub App.

## Verification

After merge, open a PR and confirm `ci/circleci: test_e2e_website` on the PR head reports from the GitHub App. Worth double-checking the GitHub App `/pipeline/run` endpoint checks out `pull/{n}/head` correctly (PR-ref handling differs from the legacy endpoint).