### PR TITLE
[charts] Improve progressive scatter zoom

### DIFF
--- a/packages/x-charts-pro/src/ScatterChartPro/ScatterChartPro.progressive.test.tsx
+++ b/packages/x-charts-pro/src/ScatterChartPro/ScatterChartPro.progressive.test.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import { createRenderer, act, waitFor } from '@mui/internal-test-utils';
+import { scatterClasses } from '@mui/x-charts/ScatterChart';
+import { type ZoomData } from '@mui/x-charts/internals';
+import { ScatterChartPro } from './ScatterChartPro';
+
+describe('<ScatterChartPro /> - Progressive rendering', () => {
+  const { render } = createRenderer();
+
+  // 1500 points span 2 batches (batch size is 1000), so the first-batch cap is observable.
+  const data = Array.from({ length: 1500 }, (_, i) => ({
+    x: 10 + (i % 80),
+    y: 10 + (Math.floor(i / 80) % 80),
+  }));
+
+  const countMarkers = () => document.querySelectorAll(`.${scatterClasses.marker}`).length;
+
+  const fullZoom: ZoomData[] = [
+    { axisId: 'x', start: 0, end: 100 },
+    { axisId: 'y', start: 0, end: 100 },
+  ];
+
+  it('caps the reveal to the first batch while zooming and reveals the rest once it settles', async () => {
+    const { setProps } = render(
+      <ScatterChartPro
+        width={500}
+        height={500}
+        skipAnimation
+        renderer="svg-progressive"
+        series={[{ data }]}
+        xAxis={[{ id: 'x', zoom: true, min: 0, max: 100 }]}
+        yAxis={[{ id: 'y', zoom: true, min: 0, max: 100 }]}
+        zoomData={fullZoom}
+      />,
+    );
+
+    await waitFor(() => expect(countMarkers()).to.equal(1500));
+
+    // Changing the zoom marks the chart as interacting, capping the reveal to the first batch.
+    await act(async () => {
+      setProps({
+        zoomData: [
+          { axisId: 'x', start: 0, end: 95 },
+          { axisId: 'y', start: 0, end: 100 },
+        ],
+      });
+    });
+    expect(countMarkers()).to.equal(1000);
+
+    // After the interaction settles, the remaining batches are revealed again.
+    await waitFor(() => expect(countMarkers()).to.equal(1500));
+  });
+});

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useProgressiveRendering/useProgressiveRendering.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useProgressiveRendering/useProgressiveRendering.ts
@@ -10,6 +10,7 @@ import {
   selectorProgressiveTotalRounds,
   selectorShouldUseProgressiveRenderer,
 } from './useProgressiveRendering.selectors';
+import { selectorChartZoomIsInteracting } from '../useChartCartesianAxis';
 import type { RendererType } from '../../../../ScatterChart';
 
 const EMPTY_PLANS: ReadonlyMap<string, readonly SeriesId[]> = new Map();
@@ -30,6 +31,9 @@ const REVEAL_ROUNDS_PER_FRAME = 1;
  * give the browser more CPU headroom at the cost of a slower paint.
  */
 const REVEAL_FRAMES_SKIPPED = 0;
+
+/** Rounds kept revealed while zooming or panning, so each interaction frame stays cheap. */
+const INTERACTION_REVEALED_ROUNDS = 1;
 
 /**
  * Chart-wide progressive rendering coordinator.
@@ -76,10 +80,22 @@ export const useProgressiveRendering: ChartPlugin<UseProgressiveRenderingSignatu
   );
 
   const plans = store.use(selectorProgressivePlans) ?? EMPTY_PLANS;
+  const isZoomInteracting = store.use(selectorChartZoomIsInteracting) ?? false;
 
   React.useEffect(() => {
     const startTotal = selectorProgressiveTotalRounds(store.state);
     if (startTotal === 0) {
+      return undefined;
+    }
+    // While zooming/panning, paint only the first batch so the interaction stays fluid.
+    if (isZoomInteracting) {
+      const capped = Math.min(startTotal, INTERACTION_REVEALED_ROUNDS);
+      if (store.state.progressiveRendering.revealedRounds !== capped) {
+        store.set('progressiveRendering', {
+          ...store.state.progressiveRendering,
+          revealedRounds: capped,
+        });
+      }
       return undefined;
     }
     if (typeof requestAnimationFrame !== 'function') {
@@ -95,7 +111,7 @@ export const useProgressiveRendering: ChartPlugin<UseProgressiveRenderingSignatu
     // Tracked in a closure variable, not derived inside a state updater (those
     // must be pure and StrictMode double-invokes them, which would schedule
     // the animation-frame chain twice).
-    let revealed = 0;
+    let revealed = store.state.progressiveRendering.revealedRounds;
 
     function scheduleNext() {
       let remaining = REVEAL_FRAMES_SKIPPED;
@@ -134,7 +150,7 @@ export const useProgressiveRendering: ChartPlugin<UseProgressiveRenderingSignatu
       cancelled = true;
       cancelAnimationFrame(frame);
     };
-  }, [plans, store]);
+  }, [plans, isZoomInteracting, store]);
 
   return { instance: { registerProgressivePlan } };
 };

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useProgressiveRendering/useProgressiveRendering.types.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useProgressiveRendering/useProgressiveRendering.types.ts
@@ -1,6 +1,7 @@
 import { type SeriesId } from '../../../../models/seriesType/common';
 import type { RendererType } from '../../../../ScatterChart';
 import { type ChartPluginSignature } from '../../models';
+import { type UseChartCartesianAxisSignature } from '../useChartCartesianAxis';
 
 export interface UseProgressiveRenderingState {
   progressiveRendering: {
@@ -38,4 +39,5 @@ export interface UseProgressiveRenderingInstance {
 export type UseProgressiveRenderingSignature = ChartPluginSignature<{
   state: UseProgressiveRenderingState;
   instance: UseProgressiveRenderingInstance;
+  dependencies: [UseChartCartesianAxisSignature];
 }>;


### PR DESCRIPTION
## Summary

Follow-up to #22518 (the progressive scatter renderer), requested in [this review comment](https://github.com/mui/mui-x/pull/22518#pullrequestreview-4418646710) and tracked in #22731.

When the progressive renderer is active on a large scatter dataset, zooming or panning used to repaint every visible point on each interaction frame. The progressive batching only protected the first paint, not the interaction, so large datasets could stutter while the user zoomed or panned.

This PR makes the progressive scheduler zoom aware: while a zoom or pan interaction is in progress, only the first batch of each series is painted, which keeps every interaction frame cheap. Once the interaction settles, the remaining batches are revealed progressively, exactly like the initial paint.

## How it works

- The scheduler now reads `selectorChartZoomIsInteracting`. While it is `true`, `revealedRounds` is capped to the first batch (`INTERACTION_REVEALED_ROUNDS = 1`).
- When it becomes `false` again, the existing animation frame ramp resumes from the current reveal count up to the full count.
- The "delay of inactivity" reuses the zoom plugin's existing 166ms `isInteracting` debounce, which is the same signal the line, bar, and area charts already use to skip animation during zoom. No new timer is introduced.
- `useProgressiveRendering` now declares `UseChartCartesianAxisSignature` as a dependency (it is always registered before progressive rendering in every chart), mirroring `useChartClosestPoint`.

## Behavior

- Pro charts with the progressive renderer: during zoom or pan only the first batch repaints; the rest fill in once the interaction stops.
- Community charts: no change. Zoom is a Pro feature, so `isInteracting` stays `false` and the renderer behaves exactly as before.
- No public API change.

## Testing

Added `ScatterChartPro.progressive.test.tsx`: it renders 1500 points with `renderer="svg-progressive"`, asserts all 1500 markers are revealed at rest, that the count drops to the first batch (1000) during a zoom interaction, and that it returns to 1500 after the interaction settles.

Verified locally: TypeScript (`x-charts`, `x-charts-pro`, `x-charts-premium`), ESLint, and the existing scatter test suites all pass.

Closes #22731

## Changelog

`[charts]` The progressive scatter renderer now stays fluid while zooming and panning: it paints only the first batch during the interaction and reveals the rest once it settles.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
