### PR TITLE
docs(charts): document how to remove Antarctica from maps

### DIFF
--- a/docs/data/charts/map/RemoveAntarctica.js
+++ b/docs/data/charts/map/RemoveAntarctica.js
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import Checkbox from '@mui/material/Checkbox';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import { feature as topojsonFeature } from 'topojson-client';
+import countriesTopology from 'visionscarto-world-atlas/world/110m.json';
+import { Unstable_ChartsGeoDataProviderPremium as ChartsGeoDataProviderPremium } from '@mui/x-charts-premium/ChartsGeoDataProviderPremium';
+import { GeoDataPlot } from '@mui/x-charts-premium/Map';
+import { ChartsSurface } from '@mui/x-charts/ChartsSurface';
+
+const countries = topojsonFeature(countriesTopology, 'countries');
+
+const countriesWithoutAntarctica = {
+  ...countries,
+  features: countries.features.filter(
+    (feature) => feature.properties?.name !== 'Antarctica',
+  ),
+};
+
+export default function RemoveAntarctica() {
+  const [includeAntarctica, setIncludeAntarctica] = React.useState(false);
+
+  return (
+    <Stack
+      direction={{ xs: 'column', md: 'row' }}
+      spacing={2}
+      sx={{ width: '100%' }}
+    >
+      <Box sx={{ flexGrow: 1, maxWidth: 800 }}>
+        <ChartsGeoDataProviderPremium
+          geoData={includeAntarctica ? countries : countriesWithoutAntarctica}
+          projection="naturalEarth1"
+          height={360}
+        >
+          <ChartsSurface>
+            <GeoDataPlot fill="#e3f2fd" stroke="#0d47a1" strokeWidth={0.5} />
+          </ChartsSurface>
+        </ChartsGeoDataProviderPremium>
+      </Box>
+      <Stack spacing={2} sx={{ minWidth: 180 }}>
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={includeAntarctica}
+              onChange={(event) => setIncludeAntarctica(event.target.checked)}
+            />
+          }
+          label="Include Antarctica"
+        />
+      </Stack>
+    </Stack>
+  );
+}

--- a/docs/data/charts/map/RemoveAntarctica.tsx
+++ b/docs/data/charts/map/RemoveAntarctica.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import Checkbox from '@mui/material/Checkbox';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import { feature as topojsonFeature } from 'topojson-client';
+import countriesTopology from 'visionscarto-world-atlas/world/110m.json';
+import { Unstable_ChartsGeoDataProviderPremium as ChartsGeoDataProviderPremium } from '@mui/x-charts-premium/ChartsGeoDataProviderPremium';
+import { GeoDataPlot } from '@mui/x-charts-premium/Map';
+import { ChartsSurface } from '@mui/x-charts/ChartsSurface';
+import { type ExtendedFeatureCollection } from '@mui/x-charts-vendor/d3-geo';
+
+const countries = topojsonFeature(
+  countriesTopology as any,
+  'countries',
+) as unknown as ExtendedFeatureCollection;
+
+const countriesWithoutAntarctica: ExtendedFeatureCollection = {
+  ...countries,
+  features: countries.features.filter(
+    (feature) => feature.properties?.name !== 'Antarctica',
+  ),
+};
+
+export default function RemoveAntarctica() {
+  const [includeAntarctica, setIncludeAntarctica] = React.useState(false);
+
+  return (
+    <Stack
+      direction={{ xs: 'column', md: 'row' }}
+      spacing={2}
+      sx={{ width: '100%' }}
+    >
+      <Box sx={{ flexGrow: 1, maxWidth: 800 }}>
+        <ChartsGeoDataProviderPremium
+          geoData={includeAntarctica ? countries : countriesWithoutAntarctica}
+          projection="naturalEarth1"
+          height={360}
+        >
+          <ChartsSurface>
+            <GeoDataPlot fill="#e3f2fd" stroke="#0d47a1" strokeWidth={0.5} />
+          </ChartsSurface>
+        </ChartsGeoDataProviderPremium>
+      </Box>
+      <Stack spacing={2} sx={{ minWidth: 180 }}>
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={includeAntarctica}
+              onChange={(event) => setIncludeAntarctica(event.target.checked)}
+            />
+          }
+          label="Include Antarctica"
+        />
+      </Stack>
+    </Stack>
+  );
+}

--- a/docs/data/charts/map/map.md
+++ b/docs/data/charts/map/map.md
@@ -63,6 +63,26 @@ You can modify it with props
 
 {{"demo": "ProjectionMapShape.js"}}
 
+## Filtering the geographic data
+
+The `geoData` prop is a standard GeoJSON `FeatureCollection`, so you can change the rendered geography by filtering its `features` before passing it to the provider.
+
+Because the projection fits the drawing area to the bounds of `geoData` (unless you set an explicit `scale`), removing features also changes the projection.
+Antarctica is a common one to drop: it spans the bottom of most projections but rarely holds data, so excluding it lets the other landmasses fill the available space.
+
+```tsx
+const countriesWithoutAntarctica = {
+  ...countries,
+  features: countries.features.filter(
+    (feature) => feature.properties?.name !== 'Antarctica',
+  ),
+};
+```
+
+Toggle Antarctica in the demo to see how the projection adapts to the data it receives.
+
+{{"demo": "RemoveAntarctica.js"}}
+
 ## Plotting series with `MapShapePlot`
 
 `MapShapePlot` renders one path per item of every series with type `'mapShape'`.


### PR DESCRIPTION
## Description

Closes #22810.

The Map docs already mention that the projection auto-fits to the `geoData` bounds, but there was no example of how changing `geoData` affects that fit. This adds a short section and an interactive demo that show how to omit Antarctica, which is a common need since most datasets have nothing to render there.

## What changed

- New section "Filtering the geographic data" in `docs/data/charts/map/map.md`, placed right after "Modifying the projection".
- New demo `RemoveAntarctica.tsx` (plus the generated `.js`) with an "Include Antarctica" toggle.

## Why this shows the projection impact

The provider fits the projection to the bounding box of whatever features are in `geoData` (through `fitExtent`, when no explicit `scale` is set). Antarctica reaches the bottom of most projections, so including it forces the fit to reserve vertical space that is usually empty, which shrinks every other landmass. Filtering it out lets the populated regions fill the drawing area. Toggling the checkbox makes that refit visible.

The example filters by feature name, matching how series already join to features (`feature.properties.name`):

```tsx
const countriesWithoutAntarctica = {
  ...countries,
  features: countries.features.filter(
    (feature) => feature.properties?.name !== 'Antarctica',
  ),
};
```

## Validation

- `eslint` on both demo files: clean
- `vale` on `map.md`: no errors, warnings, or suggestions
- `tsc -p docs/tsconfig.json`: clean
- `.js` generated through the standard babel and prettier pipeline so it stays in sync with the `.tsx`

## Notes

- Docs only. No source or API changes, and no new translation keys.
- The Map is a Premium preview feature, so the demo shows the usual missing-license watermark in local dev without a license key. It does not appear on the published docs.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Preview: https://deploy-preview-22818--material-ui-x.netlify.app/x/react-charts/map/#filtering-the-geographic-data