### PR TITLE
[code-infra] Port codebase to use tsgo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,7 +205,7 @@ jobs:
             git add -A && git diff --exit-code --staged
   test_types:
     <<: *default-job
-    resource_class: large.gen2
+    resource_class: xlarge.gen2
     steps:
       - checkout
       - install-deps
@@ -218,8 +218,6 @@ jobs:
       - run:
           name: Tests TypeScript definitions
           command: pnpm typescript:ci
-          environment:
-            NODE_OPTIONS: --max-old-space-size=5120
   test_e2e:
     <<: *default-job
     executor:

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 # The best pattern to follow is ignoring editor files in a global .gitignore configuration file.
 # However, in order to prevent issues, editor files are ignored here.
 .idea
-.vscode
+.vscode/*
+!.vscode/settings.json
+!.vscode/extensions.json
 .cursor
 .claude/settings.local.json
 .claude/worktrees/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["TypeScriptTeam.native-preview"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "js/ts.experimental.useTsgo": true
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,7 +11,7 @@
     "icons": "rimraf public/static/icons/* && node ./scripts/buildIcons.js",
     "serve": "serve ./export -l 3010 -c ../serve.json",
     "create-playground": "node ./scripts/createPlayground.js",
-    "typescript": "tsc -p tsconfig.json",
+    "typescript": "tsgo -p tsconfig.json",
     "typescript:transpile": "cross-env BABEL_ENV=development node scripts/formattedTSDemos",
     "typescript:transpile:dev": "cross-env BABEL_ENV=development node scripts/formattedTSDemos --watch",
     "populate:demos": "tsx scripts/populatePickersDemos",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@types/sinon": "21.0.1",
     "@types/yargs": "17.0.35",
     "@typescript-eslint/parser": "catalog:",
-    "@typescript/native-preview": "7.0.0-dev.20260514.1",
+    "@typescript/native-preview": "7.0.0-dev.20260615.1",
     "@vitejs/plugin-react": "catalog:",
     "@vitest/browser": "catalog:",
     "@vitest/browser-playwright": "catalog:",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "@types/sinon": "21.0.1",
     "@types/yargs": "17.0.35",
     "@typescript-eslint/parser": "catalog:",
+    "@typescript/native-preview": "7.0.0-dev.20260514.1",
     "@vitejs/plugin-react": "catalog:",
     "@vitest/browser": "catalog:",
     "@vitest/browser-playwright": "catalog:",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -31,8 +31,8 @@
     "vitest": "catalog:"
   },
   "scripts": {
-    "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build --flat --bundle cjs --buildTypes false",
+    "typescript": "tsgo -p tsconfig.json",
+    "build": "code-infra build --tsgo --bundle cjs --buildTypes false",
     "build:local": "pnpm --filter \"@mui/mcp...\" build",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo",
     "mcp-inspector": "pnpm build:local && npx -y @modelcontextprotocol/inspector node build/stdio.js",

--- a/packages/x-agent-tools/package.json
+++ b/packages/x-agent-tools/package.json
@@ -14,8 +14,8 @@
     "directory": "build"
   },
   "scripts": {
-    "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build --flat",
+    "typescript": "tsgo -p tsconfig.json",
+    "build": "code-infra build --tsgo",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo",
     "test": "vitest run --config vitest.config.node.mts"
   },

--- a/packages/x-charts-premium/package.json
+++ b/packages/x-charts-premium/package.json
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build",
+    "build": "code-infra build --tsgo",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-charts-premium/package.json
+++ b/packages/x-charts-premium/package.json
@@ -23,7 +23,7 @@
     "charts"
   ],
   "scripts": {
-    "typescript": "tsc -p tsconfig.json",
+    "typescript": "tsgo -p tsconfig.json",
     "build": "code-infra build --tsgo",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },

--- a/packages/x-charts-premium/src/ChartsRadialDataProviderPremium/useChartsRadialDataProviderPremiumProps.ts
+++ b/packages/x-charts-premium/src/ChartsRadialDataProviderPremium/useChartsRadialDataProviderPremiumProps.ts
@@ -12,7 +12,7 @@ export const useChartsRadialDataProviderPremiumProps = <
   props: ChartsRadialDataProviderPremiumProps<SeriesType, TSignatures>,
 ) => {
   const { chartProviderProps, localeText, slots, slotProps, children } =
-    useChartsRadialDataProviderProps(props);
+    useChartsRadialDataProviderProps<SeriesType, TSignatures>(props);
 
   return {
     children,

--- a/packages/x-charts-premium/src/HeatmapPremium/HeatmapPremium.plugins.ts
+++ b/packages/x-charts-premium/src/HeatmapPremium/HeatmapPremium.plugins.ts
@@ -38,15 +38,16 @@ export type HeatmapPremiumPluginSignatures = [
   UseChartKeyboardNavigationSignature,
 ];
 
-export const HEATMAP_PREMIUM_PLUGINS = [
-  useChartZAxis,
-  useChartTooltip,
-  useChartInteraction,
-  useChartCartesianAxis,
-  useChartHighlight,
-  useChartProExport,
-  useChartBrush,
-  useChartProZoom,
-  useChartItemClick,
-  useChartKeyboardNavigation,
-] as ConvertSignaturesIntoPlugins<HeatmapPremiumPluginSignatures>;
+export const HEATMAP_PREMIUM_PLUGINS: ConvertSignaturesIntoPlugins<HeatmapPremiumPluginSignatures> =
+  [
+    useChartZAxis,
+    useChartTooltip,
+    useChartInteraction,
+    useChartCartesianAxis,
+    useChartHighlight,
+    useChartProExport,
+    useChartBrush,
+    useChartProZoom,
+    useChartItemClick,
+    useChartKeyboardNavigation,
+  ];

--- a/packages/x-charts-pro/package.json
+++ b/packages/x-charts-pro/package.json
@@ -23,8 +23,8 @@
     "charts"
   ],
   "scripts": {
-    "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build",
+    "typescript": "tsgo -p tsconfig.json",
+    "build": "code-infra build --tsgo",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-charts-pro/src/Heatmap/Heatmap.plugins.ts
+++ b/packages/x-charts-pro/src/Heatmap/Heatmap.plugins.ts
@@ -37,7 +37,7 @@ export type HeatmapPluginSignatures = [
   UseChartKeyboardNavigationSignature,
 ];
 
-export const HEATMAP_PLUGINS = [
+export const HEATMAP_PLUGINS: ConvertSignaturesIntoPlugins<HeatmapPluginSignatures> = [
   useChartZAxis,
   useChartTooltip,
   useChartInteraction,
@@ -48,4 +48,4 @@ export const HEATMAP_PLUGINS = [
   useChartProZoom,
   useChartItemClick,
   useChartKeyboardNavigation,
-] as ConvertSignaturesIntoPlugins<HeatmapPluginSignatures>;
+];

--- a/packages/x-charts/package.json
+++ b/packages/x-charts/package.json
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build --ignore 'src/**/*.bench.ts'",
+    "build": "code-infra build --tsgo --ignore 'src/**/*.bench.ts'",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo",
     "bench:jsdom": "pnpm vitest bench -c ./vitest.config.jsdom.mts",
     "bench:browser": "pnpm vitest bench -c ./vitest.config.browser.mts"

--- a/packages/x-charts/package.json
+++ b/packages/x-charts/package.json
@@ -23,7 +23,7 @@
     "charts"
   ],
   "scripts": {
-    "typescript": "tsc -p tsconfig.json",
+    "typescript": "tsgo -p tsconfig.json",
     "build": "code-infra build --tsgo --ignore 'src/**/*.bench.ts'",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo",
     "bench:jsdom": "pnpm vitest bench -c ./vitest.config.jsdom.mts",

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartItemClick/useChartItemClick.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartItemClick/useChartItemClick.ts
@@ -5,7 +5,7 @@ import type { UseChartItemClickSignature } from './useChartItemClick.types';
 import type { SeriesItemIdentifierWithType } from '../../../../models/seriesType';
 import { getChartPoint } from '../../../getChartPoint';
 
-export const useChartItemClick: ChartPlugin<UseChartItemClickSignature> = ({
+export const useChartItemClick: ChartPlugin<UseChartItemClickSignature<any>> = ({
   params,
   store,
   instance,

--- a/packages/x-chat-headless/package.json
+++ b/packages/x-chat-headless/package.json
@@ -25,8 +25,8 @@
     "unstyled"
   ],
   "scripts": {
-    "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build",
+    "typescript": "tsgo -p tsconfig.json",
+    "build": "code-infra build --tsgo",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-chat/package.json
+++ b/packages/x-chat/package.json
@@ -36,8 +36,8 @@
     "llm"
   ],
   "scripts": {
-    "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build",
+    "typescript": "tsgo -p tsconfig.json",
+    "build": "code-infra build --tsgo --flat",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-chat/package.json
+++ b/packages/x-chat/package.json
@@ -37,7 +37,7 @@
   ],
   "scripts": {
     "typescript": "tsgo -p tsconfig.json",
-    "build": "code-infra build --tsgo --flat",
+    "build": "code-infra build --tsgo",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-codemod/package.json
+++ b/packages/x-codemod/package.json
@@ -14,9 +14,9 @@
     "jscodeshift"
   ],
   "scripts": {
-    "typescript": "tsc -p tsconfig.json",
+    "typescript": "tsgo -p tsconfig.json",
     "prebuild": "rimraf build",
-    "build": "code-infra build --bundle cjs --buildTypes false --ignore 'src/types.ts'"
+    "build": "code-infra build --tsgo --flat --bundle cjs --buildTypes false --ignore 'src/types.ts'"
   },
   "repository": {
     "type": "git",

--- a/packages/x-codemod/package.json
+++ b/packages/x-codemod/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "typescript": "tsgo -p tsconfig.json",
     "prebuild": "rimraf build",
-    "build": "code-infra build --tsgo --flat --bundle cjs --buildTypes false --ignore 'src/types.ts'"
+    "build": "code-infra build --tsgo --bundle cjs --buildTypes false --ignore 'src/types.ts'"
   },
   "repository": {
     "type": "git",

--- a/packages/x-data-grid-generator/package.json
+++ b/packages/x-data-grid-generator/package.json
@@ -17,8 +17,8 @@
     "mui-x"
   ],
   "scripts": {
-    "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build",
+    "typescript": "tsgo -p tsconfig.json",
+    "build": "code-infra build --tsgo --flat",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-data-grid-generator/package.json
+++ b/packages/x-data-grid-generator/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "typescript": "tsgo -p tsconfig.json",
-    "build": "code-infra build --tsgo --flat",
+    "build": "code-infra build --tsgo",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-data-grid-premium/package.json
+++ b/packages/x-data-grid-premium/package.json
@@ -29,8 +29,8 @@
     "data-grid"
   ],
   "scripts": {
-    "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build",
+    "typescript": "tsgo -p tsconfig.json",
+    "build": "code-infra build --tsgo --flat",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-data-grid-premium/package.json
+++ b/packages/x-data-grid-premium/package.json
@@ -30,7 +30,7 @@
   ],
   "scripts": {
     "typescript": "tsgo -p tsconfig.json",
-    "build": "code-infra build --tsgo --flat",
+    "build": "code-infra build --tsgo",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-data-grid-pro/package.json
+++ b/packages/x-data-grid-pro/package.json
@@ -29,8 +29,8 @@
     "data-grid"
   ],
   "scripts": {
-    "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build",
+    "typescript": "tsgo -p tsconfig.json",
+    "build": "code-infra build --tsgo --flat",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-data-grid-pro/package.json
+++ b/packages/x-data-grid-pro/package.json
@@ -30,7 +30,7 @@
   ],
   "scripts": {
     "typescript": "tsgo -p tsconfig.json",
-    "build": "code-infra build --tsgo --flat",
+    "build": "code-infra build --tsgo",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-data-grid/package.json
+++ b/packages/x-data-grid/package.json
@@ -34,7 +34,7 @@
   ],
   "scripts": {
     "typescript": "tsgo -p tsconfig.json",
-    "build": "code-infra build --tsgo --flat --copy \"src/**/*.css\" --copy \"src/**/*.css:esm\"",
+    "build": "code-infra build --tsgo --copy \"src/**/*.css\" --copy \"src/**/*.css:esm\"",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-data-grid/package.json
+++ b/packages/x-data-grid/package.json
@@ -33,8 +33,8 @@
     "data-grid"
   ],
   "scripts": {
-    "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build --copy \"src/**/*.css\" --copy \"src/**/*.css:esm\"",
+    "typescript": "tsgo -p tsconfig.json",
+    "build": "code-infra build --tsgo --flat --copy \"src/**/*.css\" --copy \"src/**/*.css:esm\"",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-data-grid/src/models/api/gridApiCommon.ts
+++ b/packages/x-data-grid/src/models/api/gridApiCommon.ts
@@ -81,7 +81,7 @@ export interface GridPrivateOnlyApiCommon<
 >
   extends
     GridCorePrivateApi<Api, PrivateApi, Props>,
-    GridStatePrivateApi<PrivateApi['state']>,
+    GridStatePrivateApi<Api['state']>,
     GridPipeProcessingPrivateApi,
     GridStrategyProcessingApi,
     GridColumnSpanningPrivateApi,

--- a/packages/x-date-pickers-pro/package.json
+++ b/packages/x-date-pickers-pro/package.json
@@ -27,7 +27,7 @@
   ],
   "scripts": {
     "typescript": "tsgo -p tsconfig.json",
-    "build": "code-infra build --tsgo --flat",
+    "build": "code-infra build --tsgo",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-date-pickers-pro/package.json
+++ b/packages/x-date-pickers-pro/package.json
@@ -26,8 +26,8 @@
     "datetimepicker"
   ],
   "scripts": {
-    "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build",
+    "typescript": "tsgo -p tsconfig.json",
+    "build": "code-infra build --tsgo --flat",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-date-pickers/package.json
+++ b/packages/x-date-pickers/package.json
@@ -29,8 +29,8 @@
     "datetimepicker"
   ],
   "scripts": {
-    "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build",
+    "typescript": "tsgo -p tsconfig.json",
+    "build": "code-infra build --tsgo --flat",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-date-pickers/package.json
+++ b/packages/x-date-pickers/package.json
@@ -30,7 +30,7 @@
   ],
   "scripts": {
     "typescript": "tsgo -p tsconfig.json",
-    "build": "code-infra build --tsgo --flat",
+    "build": "code-infra build --tsgo",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-internal-gestures/package.json
+++ b/packages/x-internal-gestures/package.json
@@ -34,8 +34,8 @@
     "directory": "packages/x-internal-gestures"
   },
   "scripts": {
-    "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build",
+    "typescript": "tsgo -p tsconfig.json",
+    "build": "code-infra build --tsgo --flat",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "dependencies": {

--- a/packages/x-internal-gestures/package.json
+++ b/packages/x-internal-gestures/package.json
@@ -35,7 +35,7 @@
   },
   "scripts": {
     "typescript": "tsgo -p tsconfig.json",
-    "build": "code-infra build --tsgo --flat",
+    "build": "code-infra build --tsgo",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "dependencies": {

--- a/packages/x-internals/package.json
+++ b/packages/x-internals/package.json
@@ -27,7 +27,7 @@
   ],
   "scripts": {
     "typescript": "tsgo -p tsconfig.json",
-    "build": "code-infra build --tsgo --flat",
+    "build": "code-infra build --tsgo",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-internals/package.json
+++ b/packages/x-internals/package.json
@@ -26,8 +26,8 @@
     "utils"
   ],
   "scripts": {
-    "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build",
+    "typescript": "tsgo -p tsconfig.json",
+    "build": "code-infra build --tsgo --flat",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-license/package.json
+++ b/packages/x-license/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "typescript": "tsgo -p tsconfig.json",
-    "build": "code-infra build --tsgo --flat",
+    "build": "code-infra build --tsgo",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-license/package.json
+++ b/packages/x-license/package.json
@@ -17,8 +17,8 @@
     "directory": "build"
   },
   "scripts": {
-    "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build",
+    "typescript": "tsgo -p tsconfig.json",
+    "build": "code-infra build --tsgo --flat",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-scheduler-internals-premium/package.json
+++ b/packages/x-scheduler-internals-premium/package.json
@@ -39,7 +39,7 @@
   ],
   "scripts": {
     "typescript": "tsgo -p tsconfig.json",
-    "build": "code-infra build --tsgo --flat --copy \"src/**/*.css\" --copy \"src/**/*.css:esm\"",
+    "build": "code-infra build --tsgo --copy \"src/**/*.css\" --copy \"src/**/*.css:esm\"",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-scheduler-internals-premium/package.json
+++ b/packages/x-scheduler-internals-premium/package.json
@@ -38,8 +38,8 @@
     "big-calendar"
   ],
   "scripts": {
-    "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build --copy \"src/**/*.css\" --copy \"src/**/*.css:esm\"",
+    "typescript": "tsgo -p tsconfig.json",
+    "build": "code-infra build --tsgo --flat --copy \"src/**/*.css\" --copy \"src/**/*.css:esm\"",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-scheduler-internals/package.json
+++ b/packages/x-scheduler-internals/package.json
@@ -56,8 +56,8 @@
     "big-calendar"
   ],
   "scripts": {
-    "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build --copy \"src/**/*.css\" --copy \"src/**/*.css:esm\"",
+    "typescript": "tsgo -p tsconfig.json",
+    "build": "code-infra build --tsgo --flat --copy \"src/**/*.css\" --copy \"src/**/*.css:esm\"",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-scheduler-internals/package.json
+++ b/packages/x-scheduler-internals/package.json
@@ -57,7 +57,7 @@
   ],
   "scripts": {
     "typescript": "tsgo -p tsconfig.json",
-    "build": "code-infra build --tsgo --flat --copy \"src/**/*.css\" --copy \"src/**/*.css:esm\"",
+    "build": "code-infra build --tsgo --copy \"src/**/*.css\" --copy \"src/**/*.css:esm\"",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-scheduler-premium/package.json
+++ b/packages/x-scheduler-premium/package.json
@@ -44,8 +44,8 @@
     "big-calendar"
   ],
   "scripts": {
-    "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build --copy \"src/**/*.css\" --copy \"src/**/*.css:esm\"",
+    "typescript": "tsgo -p tsconfig.json",
+    "build": "code-infra build --tsgo --flat --copy \"src/**/*.css\" --copy \"src/**/*.css:esm\"",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-scheduler-premium/package.json
+++ b/packages/x-scheduler-premium/package.json
@@ -45,7 +45,7 @@
   ],
   "scripts": {
     "typescript": "tsgo -p tsconfig.json",
-    "build": "code-infra build --tsgo --flat --copy \"src/**/*.css\" --copy \"src/**/*.css:esm\"",
+    "build": "code-infra build --tsgo --copy \"src/**/*.css\" --copy \"src/**/*.css:esm\"",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-scheduler/package.json
+++ b/packages/x-scheduler/package.json
@@ -50,8 +50,8 @@
     "big-calendar"
   ],
   "scripts": {
-    "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build --copy \"src/**/*.css\" --copy \"src/**/*.css:esm\"",
+    "typescript": "tsgo -p tsconfig.json",
+    "build": "code-infra build --tsgo --flat --copy \"src/**/*.css\" --copy \"src/**/*.css:esm\"",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-scheduler/package.json
+++ b/packages/x-scheduler/package.json
@@ -51,7 +51,7 @@
   ],
   "scripts": {
     "typescript": "tsgo -p tsconfig.json",
-    "build": "code-infra build --tsgo --flat --copy \"src/**/*.css\" --copy \"src/**/*.css:esm\"",
+    "build": "code-infra build --tsgo --copy \"src/**/*.css\" --copy \"src/**/*.css:esm\"",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-telemetry/package.json
+++ b/packages/x-telemetry/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "typescript": "tsgo -p tsconfig.json",
-    "build": "code-infra build --tsgo --flat && pnpm build:update-pkg-json",
+    "build": "code-infra build --tsgo && pnpm build:update-pkg-json",
     "build:update-pkg-json": "node ./scripts/addPackageScripts.js",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },

--- a/packages/x-telemetry/package.json
+++ b/packages/x-telemetry/package.json
@@ -13,8 +13,8 @@
     "directory": "build"
   },
   "scripts": {
-    "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build && pnpm build:update-pkg-json",
+    "typescript": "tsgo -p tsconfig.json",
+    "build": "code-infra build --tsgo --flat && pnpm build:update-pkg-json",
     "build:update-pkg-json": "node ./scripts/addPackageScripts.js",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },

--- a/packages/x-tree-view-pro/package.json
+++ b/packages/x-tree-view-pro/package.json
@@ -28,7 +28,7 @@
   ],
   "scripts": {
     "typescript": "tsgo -p tsconfig.json",
-    "build": "code-infra build --tsgo --flat",
+    "build": "code-infra build --tsgo",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-tree-view-pro/package.json
+++ b/packages/x-tree-view-pro/package.json
@@ -27,8 +27,8 @@
     "treeview"
   ],
   "scripts": {
-    "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build",
+    "typescript": "tsgo -p tsconfig.json",
+    "build": "code-infra build --tsgo --flat",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-tree-view-pro/src/internals/plugins/lazyLoading/utils.ts
+++ b/packages/x-tree-view-pro/src/internals/plugins/lazyLoading/utils.ts
@@ -15,19 +15,19 @@ export enum RequestStatus {
  * Determines the status of a request based on the enum `RequestStatus`
  * Uses `ParentId` to uniquely identify a request
  */
-export class NestedDataManager {
+export class NestedDataManager<R extends TreeViewValidItem<R>> {
   private pendingRequests: Set<TreeViewItemId> = new Set();
 
   private queuedRequests: Set<TreeViewItemId> = new Set();
 
   private settledRequests: Set<TreeViewItemId> = new Set();
 
-  private lazyLoadingPlugin: TreeViewLazyLoadingPlugin<TreeViewValidItem<any>>;
+  private lazyLoadingPlugin: TreeViewLazyLoadingPlugin<R>;
 
   private maxConcurrentRequests: number;
 
   constructor(
-    lazyLoadingPlugin: TreeViewLazyLoadingPlugin<TreeViewValidItem<any>>,
+    lazyLoadingPlugin: TreeViewLazyLoadingPlugin<R>,
     maxConcurrentRequests = MAX_CONCURRENT_REQUESTS,
   ) {
     this.lazyLoadingPlugin = lazyLoadingPlugin;

--- a/packages/x-tree-view/package.json
+++ b/packages/x-tree-view/package.json
@@ -28,7 +28,7 @@
   ],
   "scripts": {
     "typescript": "tsgo -p tsconfig.json",
-    "build": "code-infra build --tsgo --flat",
+    "build": "code-infra build --tsgo",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-tree-view/package.json
+++ b/packages/x-tree-view/package.json
@@ -27,8 +27,8 @@
     "treeview"
   ],
   "scripts": {
-    "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build",
+    "typescript": "tsgo -p tsconfig.json",
+    "build": "code-infra build --tsgo --flat",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-tree-view/src/internals/plugins/labelEditing/TreeViewLabelEditingPlugin.ts
+++ b/packages/x-tree-view/src/internals/plugins/labelEditing/TreeViewLabelEditingPlugin.ts
@@ -4,9 +4,9 @@ import { labelSelectors } from './selectors';
 import { useLabelEditingItemPlugin } from './itemPlugin';
 
 export class TreeViewLabelEditingPlugin {
-  private store: ExtendableRichTreeViewStore<any, any>;
+  private store: ExtendableRichTreeViewStore<any, any, any, any>;
 
-  constructor(store: ExtendableRichTreeViewStore<any, any>) {
+  constructor(store: ExtendableRichTreeViewStore<any, any, any, any>) {
     this.store = store;
     store.itemPluginManager.register(useLabelEditingItemPlugin, null);
   }

--- a/packages/x-virtualizer/package.json
+++ b/packages/x-virtualizer/package.json
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "typescript": "tsgo -p tsconfig.json",
-    "build": "code-infra build --tsgo --flat",
+    "build": "code-infra build --tsgo",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-virtualizer/package.json
+++ b/packages/x-virtualizer/package.json
@@ -23,8 +23,8 @@
     "virtualization"
   ],
   "scripts": {
-    "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build",
+    "typescript": "tsgo -p tsconfig.json",
+    "build": "code-infra build --tsgo --flat",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -281,7 +281,7 @@ importers:
         version: 1.0.9-canary.84(@types/node@22.20.0)(esbuild@0.28.0)(jiti@2.7.0)(rolldown@1.1.4)(terser@5.48.0)(tsx@4.22.5)(yaml@2.9.0)
       '@mui/internal-code-infra':
         specifier: 0.0.4-canary.86
-        version: 0.0.4-canary.86(@next/eslint-plugin-next@16.2.10)(@types/node@22.20.0)(@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(@typescript/native-preview@7.0.0-dev.20260514.1)(@vitest/expect@4.1.9)(eslint@10.4.1(jiti@2.7.0))(postcss@8.5.16)(prettier@3.9.4)(stylelint@17.14.0(typescript@6.0.3))(typescript@6.0.3)(vitest@4.1.9)
+        version: 0.0.4-canary.86(@next/eslint-plugin-next@16.2.10)(@types/node@22.20.0)(@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(@typescript/native-preview@7.0.0-dev.20260615.1)(@vitest/expect@4.1.9)(eslint@10.4.1(jiti@2.7.0))(postcss@8.5.16)(prettier@3.9.4)(stylelint@17.14.0(typescript@6.0.3))(typescript@6.0.3)(vitest@4.1.9)
       '@mui/internal-core-docs':
         specifier: 'catalog:'
         version: 9.1.2-canary.2(b24527e4043cae4159d3c18295c1bf55)
@@ -343,8 +343,8 @@ importers:
         specifier: 'catalog:'
         version: 8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
       '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260514.1
-        version: 7.0.0-dev.20260514.1
+        specifier: 7.0.0-dev.20260615.1
+        version: 7.0.0-dev.20260615.1
       '@vitejs/plugin-react':
         specifier: 'catalog:'
         version: 6.0.3(babel-plugin-react-compiler@1.0.0)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.5)(yaml@2.9.0))
@@ -5984,50 +5984,50 @@ packages:
     resolution: {integrity: sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260514.1':
-    resolution: {integrity: sha512-mA/BLJumVJ8JrJaUgl1wTzMbelXl/vuXc2AglltWSxQEL7+NtU3uG1gO+lT6igsFks7378zjEukSMmxv8FEPNw==}
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260615.1':
+    resolution: {integrity: sha512-EHrtoVGEEhIhsnGe+b8w0FoM9JfIw5SkoPwO8ifaU0PrYm2UbyPbj2I2hOTxtk458t0irvGz2+8cshylBRbKng==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260514.1':
-    resolution: {integrity: sha512-ol5OctuUZDLzQrqDUfR758p3p4x7FDzbIzu6H0XffWi7FXj0eEyDthDfULyTQmTlE8dizxCmbzC7Uv0COeedrQ==}
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260615.1':
+    resolution: {integrity: sha512-BcDA56hkk6mrUpysaOVvrdACoX5d2SF1JTwHMoNjT1KysBicExS2wlH0eN0L01iDeqtB73XHl7A4zrKFmKzrBg==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260514.1':
-    resolution: {integrity: sha512-7bz4QVWdlYm2BsDhqzpmUFSAA/l0W8+1hFto3Ssl/FADEWGIqwLk8/nEzZRMYtnCYjQx5KnRwmrcxnnZtD25jA==}
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260615.1':
+    resolution: {integrity: sha512-TDAlBpyYCF7Z+ELTH+1tabDE6W3shl+H+Z+nmzaQio1I8pFvbwt2iLlE0Rc9CpRdIeaqr0ppMEgXHoeV3fZFWA==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260514.1':
-    resolution: {integrity: sha512-65TQUASi7+t81P94kyQopWchsVovWSfeXh5cPK2D5Oziga5of1Zzi6FQR1XUe48DYw5IBYN6DPXabcYG5Bd09A==}
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260615.1':
+    resolution: {integrity: sha512-YRXRS/7ZqrDKXBJhFQcZiOdnHRuRbWoL/QkggpoGfhIuSAh4HvTU0WEUnPM+jRnH2kUMfsSgd8EAnPvmuP7/VA==}
     engines: {node: '>=16.20.0'}
     cpu: [arm]
     os: [linux]
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260514.1':
-    resolution: {integrity: sha512-tdnkRgD+AUw+aJ2Uz1B/sAGcqCt7FgrQMyIdEmjJUiSneIb3PeS4oxsQKp7wnPsiqOcfUlpOp7/ZEJc1oJ5ySA==}
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260615.1':
+    resolution: {integrity: sha512-/QDmRWt6abB7fw3yMchjlyDXej/7Dr8mYG4wvGGf6c1hc5Il5UpDQWNHejatdeKvAu+sszz8JhTuL8et47fTTg==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [linux]
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260514.1':
-    resolution: {integrity: sha512-9nERcpvv1Ok+IlBdCa9XNvcmNaV9HO3lSTPL1heyrgKFkOyNMxycej/FYRodXFcqZE/FMJCZ5U4lpI5MvivQXQ==}
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260615.1':
+    resolution: {integrity: sha512-WTJOLoe2rxT0W1i8ndWk2MKrakxRFNki537JZxvKAmSTbyOZznHlW3O3dbryUtTBYA716DDqS3ci24kuIfvBdg==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260514.1':
-    resolution: {integrity: sha512-BFZ7ddWmFwpO+/zFEIsS2nZTD5jqixchvqeQGrPZMzd8y49RUfL5ztJm6h/jSUS8W3s/UGhQ2ibGfN0+rvfO+w==}
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260615.1':
+    resolution: {integrity: sha512-4cSCpXG7um18nwmLdU/SjoTv3OcO38/ufTiy1oWVccgGHLJqppiOP9/o+ElKIWhvrp78IaGy8+h3YqEjQ4/pcQ==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
 
-  '@typescript/native-preview@7.0.0-dev.20260514.1':
-    resolution: {integrity: sha512-gHvZOIbpls1d7Ly0wbVQxMX0EzJU+RBjsCX+AdbyMg3dfk+ET00HksIxn8E0W9+TH6z3ipW7Iitja3VgrgZaSA==}
+  '@typescript/native-preview@7.0.0-dev.20260615.1':
+    resolution: {integrity: sha512-JJ8X1l7H1GrnseK1k30qfQqB8Pz6jw3IALZVIj5oXQeRbUCe0Wx3ljkJEmOpunogdhEfA8IlOggskbUjVsXKBQ==}
     engines: {node: '>=16.20.0'}
     hasBin: true
 
@@ -14020,7 +14020,7 @@ snapshots:
       - tsx
       - yaml
 
-  '@mui/internal-code-infra@0.0.4-canary.86(@next/eslint-plugin-next@16.2.10)(@types/node@22.20.0)(@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(@typescript/native-preview@7.0.0-dev.20260514.1)(@vitest/expect@4.1.9)(eslint@10.4.1(jiti@2.7.0))(postcss@8.5.16)(prettier@3.9.4)(stylelint@17.14.0(typescript@6.0.3))(typescript@6.0.3)(vitest@4.1.9)':
+  '@mui/internal-code-infra@0.0.4-canary.86(@next/eslint-plugin-next@16.2.10)(@types/node@22.20.0)(@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(@typescript/native-preview@7.0.0-dev.20260615.1)(@vitest/expect@4.1.9)(eslint@10.4.1(jiti@2.7.0))(postcss@8.5.16)(prettier@3.9.4)(stylelint@17.14.0(typescript@6.0.3))(typescript@6.0.3)(vitest@4.1.9)':
     dependencies:
       '@argos-ci/core': 6.4.0(@types/node@22.20.0)
       '@babel/cli': 7.29.7(@babel/core@7.29.7)
@@ -14111,7 +14111,7 @@ snapshots:
       yaml: 2.9.0
       yargs: 18.0.0
     optionalDependencies:
-      '@typescript/native-preview': 7.0.0-dev.20260514.1
+      '@typescript/native-preview': 7.0.0-dev.20260615.1
       typescript: 6.0.3
     transitivePeerDependencies:
       - '@jest/globals'
@@ -15696,36 +15696,36 @@ snapshots:
       '@typescript-eslint/types': 8.61.0
       eslint-visitor-keys: 5.0.1
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260514.1':
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260615.1':
     optional: true
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260514.1':
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260615.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260514.1':
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260615.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260514.1':
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260615.1':
     optional: true
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260514.1':
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260615.1':
     optional: true
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260514.1':
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260615.1':
     optional: true
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260514.1':
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260615.1':
     optional: true
 
-  '@typescript/native-preview@7.0.0-dev.20260514.1':
+  '@typescript/native-preview@7.0.0-dev.20260615.1':
     optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260514.1
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260514.1
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260514.1
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260514.1
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260514.1
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260514.1
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260514.1
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260615.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260615.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260615.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260615.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260615.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260615.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260615.1
 
   '@ungap/structured-clone@1.3.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -281,7 +281,7 @@ importers:
         version: 1.0.9-canary.84(@types/node@22.20.0)(esbuild@0.28.0)(jiti@2.7.0)(rolldown@1.1.4)(terser@5.48.0)(tsx@4.22.5)(yaml@2.9.0)
       '@mui/internal-code-infra':
         specifier: 0.0.4-canary.86
-        version: 0.0.4-canary.86(@next/eslint-plugin-next@16.2.10)(@types/node@22.20.0)(@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(@vitest/expect@4.1.9)(eslint@10.4.1(jiti@2.7.0))(postcss@8.5.16)(prettier@3.9.4)(stylelint@17.14.0(typescript@6.0.3))(typescript@6.0.3)(vitest@4.1.9)
+        version: 0.0.4-canary.86(@next/eslint-plugin-next@16.2.10)(@types/node@22.20.0)(@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(@typescript/native-preview@7.0.0-dev.20260514.1)(@vitest/expect@4.1.9)(eslint@10.4.1(jiti@2.7.0))(postcss@8.5.16)(prettier@3.9.4)(stylelint@17.14.0(typescript@6.0.3))(typescript@6.0.3)(vitest@4.1.9)
       '@mui/internal-core-docs':
         specifier: 'catalog:'
         version: 9.1.2-canary.2(b24527e4043cae4159d3c18295c1bf55)
@@ -342,6 +342,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: 'catalog:'
         version: 8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260514.1
+        version: 7.0.0-dev.20260514.1
       '@vitejs/plugin-react':
         specifier: 'catalog:'
         version: 6.0.3(babel-plugin-react-compiler@1.0.0)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.5)(yaml@2.9.0))
@@ -5980,6 +5983,53 @@ packages:
   '@typescript-eslint/visitor-keys@8.61.0':
     resolution: {integrity: sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260514.1':
+    resolution: {integrity: sha512-mA/BLJumVJ8JrJaUgl1wTzMbelXl/vuXc2AglltWSxQEL7+NtU3uG1gO+lT6igsFks7378zjEukSMmxv8FEPNw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260514.1':
+    resolution: {integrity: sha512-ol5OctuUZDLzQrqDUfR758p3p4x7FDzbIzu6H0XffWi7FXj0eEyDthDfULyTQmTlE8dizxCmbzC7Uv0COeedrQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260514.1':
+    resolution: {integrity: sha512-7bz4QVWdlYm2BsDhqzpmUFSAA/l0W8+1hFto3Ssl/FADEWGIqwLk8/nEzZRMYtnCYjQx5KnRwmrcxnnZtD25jA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260514.1':
+    resolution: {integrity: sha512-65TQUASi7+t81P94kyQopWchsVovWSfeXh5cPK2D5Oziga5of1Zzi6FQR1XUe48DYw5IBYN6DPXabcYG5Bd09A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260514.1':
+    resolution: {integrity: sha512-tdnkRgD+AUw+aJ2Uz1B/sAGcqCt7FgrQMyIdEmjJUiSneIb3PeS4oxsQKp7wnPsiqOcfUlpOp7/ZEJc1oJ5ySA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260514.1':
+    resolution: {integrity: sha512-9nERcpvv1Ok+IlBdCa9XNvcmNaV9HO3lSTPL1heyrgKFkOyNMxycej/FYRodXFcqZE/FMJCZ5U4lpI5MvivQXQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260514.1':
+    resolution: {integrity: sha512-BFZ7ddWmFwpO+/zFEIsS2nZTD5jqixchvqeQGrPZMzd8y49RUfL5ztJm6h/jSUS8W3s/UGhQ2ibGfN0+rvfO+w==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/native-preview@7.0.0-dev.20260514.1':
+    resolution: {integrity: sha512-gHvZOIbpls1d7Ly0wbVQxMX0EzJU+RBjsCX+AdbyMg3dfk+ET00HksIxn8E0W9+TH6z3ipW7Iitja3VgrgZaSA==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -13970,7 +14020,7 @@ snapshots:
       - tsx
       - yaml
 
-  '@mui/internal-code-infra@0.0.4-canary.86(@next/eslint-plugin-next@16.2.10)(@types/node@22.20.0)(@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(@vitest/expect@4.1.9)(eslint@10.4.1(jiti@2.7.0))(postcss@8.5.16)(prettier@3.9.4)(stylelint@17.14.0(typescript@6.0.3))(typescript@6.0.3)(vitest@4.1.9)':
+  '@mui/internal-code-infra@0.0.4-canary.86(@next/eslint-plugin-next@16.2.10)(@types/node@22.20.0)(@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(@typescript/native-preview@7.0.0-dev.20260514.1)(@vitest/expect@4.1.9)(eslint@10.4.1(jiti@2.7.0))(postcss@8.5.16)(prettier@3.9.4)(stylelint@17.14.0(typescript@6.0.3))(typescript@6.0.3)(vitest@4.1.9)':
     dependencies:
       '@argos-ci/core': 6.4.0(@types/node@22.20.0)
       '@babel/cli': 7.29.7(@babel/core@7.29.7)
@@ -14061,6 +14111,7 @@ snapshots:
       yaml: 2.9.0
       yargs: 18.0.0
     optionalDependencies:
+      '@typescript/native-preview': 7.0.0-dev.20260514.1
       typescript: 6.0.3
     transitivePeerDependencies:
       - '@jest/globals'
@@ -15644,6 +15695,37 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.61.0
       eslint-visitor-keys: 5.0.1
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260514.1':
+    optional: true
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260514.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260514.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260514.1':
+    optional: true
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260514.1':
+    optional: true
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260514.1':
+    optional: true
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260514.1':
+    optional: true
+
+  '@typescript/native-preview@7.0.0-dev.20260514.1':
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260514.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260514.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260514.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260514.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260514.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260514.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260514.1
 
   '@ungap/structured-clone@1.3.0': {}
 

--- a/test/package.json
+++ b/test/package.json
@@ -2,7 +2,7 @@
   "name": "@mui-x-internal/test",
   "private": true,
   "scripts": {
-    "typescript": "tsc -p tsconfig.json"
+    "typescript": "tsgo -p tsconfig.json"
   },
   "devDependencies": {
     "@babel/runtime": "catalog:",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,14 @@
       "@mui/x-data-grid-pro/*": ["./packages/x-data-grid-pro/src/*"],
       "@mui/x-data-grid-premium": ["./packages/x-data-grid-premium/src"],
       "@mui/x-data-grid-premium/*": ["./packages/x-data-grid-premium/src/*"],
+      // Only needed for the docs, which import every Data Grid tier's `themeAugmentation` into one
+      // program, making `ComponentsPropsList` from `@mui/material/styles` extend conflicting
+      // `MuiDataGrid` types (TS2320); collapse them to the shared community one. Lives here (not in
+      // docs/tsconfig.json) because overriding `paths` there would replace the whole block.
+      "@mui/x-data-grid-pro/themeAugmentation": ["./packages/x-data-grid/src/themeAugmentation"],
+      "@mui/x-data-grid-premium/themeAugmentation": [
+        "./packages/x-data-grid/src/themeAugmentation"
+      ],
       "@mui/x-date-pickers": ["./packages/x-date-pickers/src"],
       "@mui/x-date-pickers/*": ["./packages/x-date-pickers/src/*"],
       "@mui/x-date-pickers-pro": ["./packages/x-date-pickers-pro/src"],


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

Ports the codebase to use [`tsgo`](https://github.com/microsoft/typescript-go) for type checking.

## CI typecheck speedup

Measured on the `test_types` CircleCI job, step "Tests TypeScript definitions":

| Branch | Typecheck time |
|--------|----------------|
| This PR (tsgo) | **~55s** |
| master (typical) | ~180–195s |

Roughly **3.5× faster** typechecks on CI (up to ~5× vs. slower master runs).

## CI credit cost

This PR bumps `test_types` to `xlarge.gen2` (48 credits/min); master runs on `large.gen2` (24 credits/min). CircleCI bills per-second on whole-job wall-clock.

| | Resource | Wall-clock | Credits |
|---|---|---|---|
| master | large.gen2 (24/min) | ~260s | ~104 |
| This PR (tsgo) | xlarge.gen2 (48/min) | ~105s | ~84 |
| **Saved per run** | — | **~155s** | **~20 (~19%)** |

Faster end-to-end (~2.5×) and still ~19% cheaper per run despite the larger box.

Verified via emitted .d.ts diff (master vs branch), both tsc and tsgo — outputs identical to each other. None are breaking. None require user action.

Only 2 changes alter the shipped .d.ts at all, both in internal surfaces and both type-compatible.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
