### PR TITLE
[charts-premium] Regenerate ScatterPlotPremium propTypes

### DIFF
--- a/docs/translations/api-docs/charts/scatter-plot-premium/scatter-plot-premium.json
+++ b/docs/translations/api-docs/charts/scatter-plot-premium/scatter-plot-premium.json
@@ -2,7 +2,7 @@
   "componentDescription": "",
   "propDescriptions": {
     "onItemClick": {
-      "description": "Callback fired when clicking on a scatter item.",
+      "description": "Callback fired when a marker is clicked directly. For closest-point clicks (the <code>ScatterChart</code> default), pass <code>onItemClick</code> to the chart container instead.",
       "typeDescriptions": {
         "event": {
           "name": "event",

--- a/packages/x-charts-premium/src/ScatterChartPremium/ScatterPlotPremium.tsx
+++ b/packages/x-charts-premium/src/ScatterChartPremium/ScatterPlotPremium.tsx
@@ -50,7 +50,8 @@ ScatterPlotPremium.propTypes = {
   classes: PropTypes.object,
   className: PropTypes.string,
   /**
-   * Callback fired when clicking on a scatter item.
+   * Callback fired when a marker is clicked directly.
+   * For closest-point clicks (the `ScatterChart` default), pass `onItemClick` to the chart container instead.
    * @param {MouseEvent} event Mouse event recorded on the `<svg/>` element.
    * @param {ScatterItemIdentifier} scatterItemIdentifier The scatter item identifier.
    */


### PR DESCRIPTION
## Problem

The `onItemClick` JSDoc on the base `ScatterPlot` (`@mui/x-charts`) was updated, and its propTypes were regenerated. However, the premium wrapper `ScatterPlotPremium` (`@mui/x-charts-premium`) still carried the old description in its generated `propTypes` block.

As a result, running `pnpm proptypes` produces an uncommitted diff on `master`, which makes the `test_static` CI step fail on unrelated PRs (e.g. #22791).

## Fix

Ran `pnpm proptypes` and committed the single regenerated file. No source/logic change — only the generated propTypes description is synced with the base component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)