### PR TITLE
[docs] Stop link checker from crawling static assets

### DIFF
--- a/docs/scripts/reportBrokenLinks.mts
+++ b/docs/scripts/reportBrokenLinks.mts
@@ -13,6 +13,15 @@ async function main() {
       // TODO: Validate these against stored links once link-structure.json is
       // published for each product (e.g. mui.com/material-ui/link-structure.json).
       /^\/(material-ui|base-ui|joy-ui|system|store|toolpad|blog|pricing|about|careers)(\/|$)/,
+      // Build artifacts and static assets. `serve` renders an auto-generated
+      // directory listing (full of `<a href>` links) for any directory without
+      // an index.html. Following a link to such a directory (e.g. the export
+      // root) lets the crawler walk the entire build tree, fetching every
+      // `_next/static` chunk and static file one by one. That balloons the
+      // crawl to thousands of pages and times out the Netlify build. These
+      // assets are not navigable links worth checking, so skip them entirely.
+      /^\/_next(\/|$)/,
+      /^\/static(\/|$)/,
     ],
   });
 


### PR DESCRIPTION
## Problem

Netlify builds started timing out. The broken-links checker (`docs/scripts/reportBrokenLinks.mts`) serves the static export with `serve`, which auto-generates a directory-listing page (full of `<a href>` links) for any directory that lacks an `index.html` -- this behavior is on by default.

Once the crawler follows a link into such a directory (e.g. the export root, which has no root `index.html` in this `/x`-only export), it walks the *entire build tree*: `/` -> `/_next/` -> `/_next/static/` -> `/_next/static/chunks/` -> every JS chunk, plus all of `/static/`, fetching each file one at a time. That balloons the crawl to thousands of pages, takes ~11 minutes locally, and times out the build.

This was latent for a while; it started surfacing after #22707 stopped the checker from crashing early on a 404 known-targets fetch, so the crawl now runs to completion and hits the explosion.

## Fix

Ignore `/_next` and `/static` paths in the crawler's `ignoredPaths`:

    /^\/_next(\/|$)/,
    /^\/static(\/|$)/,

These are build artifacts/static assets, not navigable links worth checking. The crawler only follows `<a href>`, so image/script references were never checked anyway -- no meaningful link coverage is lost. The fix is robust to the exact entry point since both large asset trees are now skipped.

## Verification

Reproduced with the real crawler + `serve` against a synthetic export (a 3-link seed page plus a populated `_next/static` tree):

- Before: **572 pages crawled** (walked the whole tree).
- After: **4 pages crawled** (only the real doc pages remain).