### PR TITLE
[test] De-flake React 18 browser tests (multiSelect, chat)

### DIFF
--- a/packages/x-chat-headless/src/hooks/useChatActions.test.tsx
+++ b/packages/x-chat-headless/src/hooks/useChatActions.test.tsx
@@ -78,10 +78,15 @@ describe('useChatActions', () => {
   });
 
   it('throws outside a ChatProvider when called without the optional flag', () => {
+    // React 18's legacy renderer re-throws the caught error through `console.error`
+    // (the `invokeGuardedCallbackDev` path), which `vitest-fail-on-console` would
+    // otherwise treat as a failure. Silence it and assert the throw explicitly.
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     expect(() =>
       renderHook(() => useChatActions(), {
         // No wrapper — no provider.
       }),
     ).toThrow(/ChatProvider/);
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/packages/x-chat/src/ChatCodeBlock/ChatCodeBlock.test.tsx
+++ b/packages/x-chat/src/ChatCodeBlock/ChatCodeBlock.test.tsx
@@ -142,6 +142,12 @@ describe('ChatCodeBlock', () => {
 
     const writeText = installClipboardMock();
     writeText.mockImplementation(() => Promise.reject(new Error('denied')));
+    // When the async Clipboard API rejects, `useCopyToClipboard` falls back to the
+    // synchronous `document.execCommand('copy')` path. In a real browser that fallback
+    // can actually succeed (returning `true`), which flips the state to "copied" and
+    // makes this assertion flaky. Force the fallback to fail too so the error path is
+    // deterministic.
+    const execCommandSpy = vi.spyOn(document, 'execCommand').mockReturnValue(false);
 
     // eslint-disable-next-line testing-library/no-unnecessary-act
     await act(async () => {
@@ -150,5 +156,7 @@ describe('ChatCodeBlock', () => {
 
     expect(writeText).toHaveBeenCalled();
     expect(screen.getByRole('button', { name: 'Copy failed' })).not.toBe(null);
+
+    execCommandSpy.mockRestore();
   });
 });

--- a/packages/x-data-grid-pro/src/components/cell/GridEditMultiSelectCell.tsx
+++ b/packages/x-data-grid-pro/src/components/cell/GridEditMultiSelectCell.tsx
@@ -103,6 +103,20 @@ const GridEditMultiSelectChips = styled(GridMultiSelectChips)({
   },
 }) as typeof GridMultiSelectChips;
 
+// `baseModal` renders its child inside an MUI `FocusTrap`, which clones the child
+// and injects a `ref`. The popper slot (`basePopper`) is a ref-as-prop function
+// component (React 19 style) that simply drops the ref, so under React 18 the
+// injected ref triggers "Function components cannot be given refs" / "ref is not a
+// prop" warnings. This forwardRef boundary catches the FocusTrap ref on a real
+// element so it never reaches `basePopper`. The popper still positions against
+// `anchorEl`, so the wrapper has no layout impact.
+const GridEditMultiSelectModalChild = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(function GridEditMultiSelectModalChild(props, ref) {
+  return <div ref={ref} {...props} />;
+});
+
 export interface GridEditMultiSelectCellProps<
   V extends ValueOptions = ValueOptions,
 > extends GridRenderEditCellParams {
@@ -291,48 +305,50 @@ function GridEditMultiSelectCell<V extends ValueOptions = ValueOptions>(
           slotProps: { root: { style: { zIndex: 'auto' } }, backdrop: { invisible: true } },
         }}
       >
-        <GridEditMultiSelectCellPopper
-          as={rootProps.slots.basePopper}
-          ownerState={rootProps as OwnerState}
-          id={popupId}
-          role="dialog"
-          aria-label={colDef.headerName || field}
-          open={showPopup}
-          target={anchorEl}
-          placement="bottom-start"
-          flip
-          material={{
-            modifiers: [
-              {
-                name: 'offset',
-                options: { offset: [-1, -rowHeight + 1] }, // 1px compensate for the editing cell padding.
-              },
-            ],
-          }}
-          {...slotProps?.popper}
-          className={clsx(classes.popup, slotProps?.popper?.className)}
-        >
-          <GridEditMultiSelectCellPopperContent
-            onKeyDownCapture={handleKeyDownCapture}
-            {...slotProps?.popperContent}
-            className={clsx(classes.popperContent, slotProps?.popperContent?.className)}
-            style={
-              {
-                '--_width': `${colDef.computedWidth}px`,
-                '--_rowHeight': `${rowHeight}px`,
-              } as React.CSSProperties
-            }
+        <GridEditMultiSelectModalChild>
+          <GridEditMultiSelectCellPopper
+            as={rootProps.slots.basePopper}
+            ownerState={rootProps as OwnerState}
+            id={popupId}
+            role="dialog"
+            aria-label={colDef.headerName || field}
+            open={showPopup}
+            target={anchorEl}
+            placement="bottom-start"
+            flip
+            material={{
+              modifiers: [
+                {
+                  name: 'offset',
+                  options: { offset: [-1, -rowHeight + 1] }, // 1px compensate for the editing cell padding.
+                },
+              ],
+            }}
+            {...slotProps?.popper}
+            className={clsx(classes.popup, slotProps?.popper?.className)}
           >
-            <GridEditMultiSelectAutocomplete
-              {...(props as GridEditMultiSelectCellProps)}
-              valueOptions={valueOptions}
-              selectedOptions={selectedOptions}
-              getOptionValue={getOptionValue}
-              getOptionLabel={getOptionLabel}
-              onDismiss={() => setOpen(false)}
-            />
-          </GridEditMultiSelectCellPopperContent>
-        </GridEditMultiSelectCellPopper>
+            <GridEditMultiSelectCellPopperContent
+              onKeyDownCapture={handleKeyDownCapture}
+              {...slotProps?.popperContent}
+              className={clsx(classes.popperContent, slotProps?.popperContent?.className)}
+              style={
+                {
+                  '--_width': `${colDef.computedWidth}px`,
+                  '--_rowHeight': `${rowHeight}px`,
+                } as React.CSSProperties
+              }
+            >
+              <GridEditMultiSelectAutocomplete
+                {...(props as GridEditMultiSelectCellProps)}
+                valueOptions={valueOptions}
+                selectedOptions={selectedOptions}
+                getOptionValue={getOptionValue}
+                getOptionLabel={getOptionLabel}
+                onDismiss={() => setOpen(false)}
+              />
+            </GridEditMultiSelectCellPopperContent>
+          </GridEditMultiSelectCellPopper>
+        </GridEditMultiSelectModalChild>
       </rootProps.slots.baseModal>
     </React.Fragment>
   );


### PR DESCRIPTION
## Summary

The CircleCI `test_browser_react_18` job has been red on `master` independent of any single PR (for example, unrelated changes #22612 and #22801 both failed it), so these are pre-existing flakes that need de-flaking. `vitest-fail-on-console` turns any `console.error`/`console.warn` during a test into a failure, and three suites trip it under React 18 (one also flakes under React 19).

## Root cause and fix

### 1. multiSelect edit cell -- `editComponents.DataGridPro.test.tsx` (the `column type: multiSelect` block)

The multiSelect edit cell wraps its popper in `baseModal`. MUI `Modal` renders its child inside a `FocusTrap`, which clones the child and injects a `ref`. The popper slot (`basePopper`) is a ref-as-prop function component (React 19 style) that simply drops the ref, so under React 18 every mount logged:

- `Warning: Function components cannot be given refs ...` (on `MuiDataGridEditMultiSelectCellPopper`)
- `Warning: BasePopper: 'ref' is not a prop ...`

Because the injected ref was swallowed, `FocusTrap`'s root ref stayed `null`, and tearing down the still-open portal also threw `NotFoundError: Failed to execute 'insertBefore' on 'Node'` (React 18 / Emotion Global). That corrupted the shared document and made a following view-mode test fail too (12 failures total).

Fix: interpose a small `forwardRef` boundary (`GridEditMultiSelectModalChild`) as the modal child so the `FocusTrap` ref lands on a real element instead of the ref-as-prop `basePopper`. The popper still positions against `anchorEl`, so there is no layout or behavior change -- the ref was already discarded on both React 18 and React 19.

### 2. `useChatActions.test.tsx` -> "throws outside a ChatProvider when called without the optional flag"

React 18's legacy renderer re-reports the expected thrown error through `console.error` (the `invokeGuardedCallbackDev` path); React 19 does not. The test asserted the throw but did not tolerate the extra log. Fixed by spying on `console.error` around the assertion, matching the existing pattern in `ChatProvider.test.tsx` and `useChatPartRenderer.test.tsx`.

### 3. `ChatCodeBlock.test.tsx` -> "clipboard failure exposes \"Copy failed\" state"

When the async Clipboard API rejects, `useCopyToClipboard` falls back to the synchronous `document.execCommand('copy')` path. In a real browser that fallback can actually succeed (return `true`), flipping the state to "copied" and making the assertion flaky. Fixed by also stubbing `document.execCommand` to return `false` so the error path is deterministic.

## Test plan

Reproduced all failures locally by pinning react/react-dom to ^18 (mirroring the orb's `package-overrides`), then confirmed both React 18 and React 19 browser runs are green (the multiSelect run was repeated to check stability):

- `pnpm test:browser --project "x-data-grid-pro" --run editComponents` -> 42 passed
- `pnpm test:browser --project "x-chat-headless" --run useChatActions` -> 4 passed
- `pnpm test:browser --project "x-chat" --run ChatCodeBlock` -> 12 passed

`pnpm eslint`, `pnpm prettier`, `pnpm proptypes`, and TypeScript are all clean.
