### PR TITLE
[core] Reduce e2e build concurrency to avoid OOM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,7 +230,7 @@ jobs:
           react-version: << parameters.react-version >>
       - run:
           name: Build packages
-          command: pnpm release:build --concurrency 5
+          command: pnpm release:build --concurrency 4
       - run:
           name: Run e2e tests
           command: pnpm test:e2e


### PR DESCRIPTION
The `test_e2e` "Build packages" step intermittently fails with out-of-memory during `pnpm release:build --concurrency 5`. Reducing lerna's build concurrency from 5 to 4 lowers peak memory usage to keep the job within the runner's limits.

Example failure: https://app.circleci.com/pipelines/github/mui/mui-x/133623/workflows/5a5ee3c2-4aca-4af3-b7cf-45f07eb4d3b6/jobs/862653/steps