### PR TITLE
[test] Wait for GridToolbarCustom rows before screenshot

### DIFF
--- a/test/regressions/index.test.ts
+++ b/test/regressions/index.test.ts
@@ -86,6 +86,14 @@ const TEST_RULES: RouteRule[] = [
     // only enters the DOM once the virtualizer has rendered the scrolled window.
     waitForSelector: '.MuiDataGrid-row[aria-rowindex="43"] .MuiDataGrid-cell',
   },
+  {
+    test: '/docs-data-grid-components-toolbar/GridToolbarCustom',
+    // The demo loads its rows asynchronously via `useDemoData`, which the
+    // `aria-busy` font gate doesn't track. Until the data resolves the grid
+    // shows the skeleton overlay (skeleton rows carry both `row` and
+    // `rowSkeleton`), so wait for a real, non-skeleton row before screenshotting.
+    waitForSelector: '.MuiDataGrid-row:not(.MuiDataGrid-rowSkeleton)',
+  },
 ];
 
 function getRouteConfig(routeUrl: string): RouteConfig | undefined {


### PR DESCRIPTION
The `docs-data-grid-components-toolbar/GridToolbarCustom` regression screenshot intermittently captures the grid's loading state on master. The demo loads rows asynchronously via `useDemoData`, which the screenshot harness's `aria-busy` gate only tracks for fonts — not async demo data — so the capture races the skeleton overlay.

Add a per-route `waitForSelector` rule that waits for a real (non-skeleton) data row before screenshotting. Skeleton overlay rows carry both `.MuiDataGrid-row` and `.MuiDataGrid-rowSkeleton`, so the selector excludes the latter.