### PR TITLE
[docs-infra] Cap Netlify Next.js build parallelism to avoid OOM

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,6 +9,10 @@
   NODE_VERSION = "22.22.3"
   PNPM_FLAGS = "--frozen-lockfile"
   NODE_OPTIONS = "--max-old-space-size=6144"
+  # Cap the Next.js docs build worker count (read by `withDocsInfra`, which
+  # otherwise defaults to `os.availableParallelism()`) to avoid OOM during the
+  # static export build.
+  NEXT_PARALLELISM = "4"
 
 # disabled because of https://github.com/mui/mui-public/issues/809
 # TODO: Re-enable after either:


### PR DESCRIPTION
The Netlify docs build (`pnpm docs:build`) runs out of memory during the Next.js static export. The shared `withDocsInfra` wrapper defaults `experimental.cpus` to `os.availableParallelism()` (all cores) on CI, overridable via the `NEXT_PARALLELISM` env var.

Set `NEXT_PARALLELISM = "4"` in `netlify.toml` to cap the build worker count and lower peak memory — the same lever material-ui uses, rather than hardcoding `experimental.cpus` in `docs/next.config.ts`.