### PR TITLE
[DataGrid] Define `overflowAnchor` style at the right element

### DIFF
--- a/packages/x-data-grid/src/components/containers/GridRootStyles.ts
+++ b/packages/x-data-grid/src/components/containers/GridRootStyles.ts
@@ -188,8 +188,11 @@ export const GridRootStyles = styled('div', {
     minHeight: 0,
     flexDirection: 'column',
     overflow: 'hidden',
-    overflowAnchor: 'none', // Keep the same scrolling position
     transform: 'translate(0, 0)', // Create a stacking context to keep scrollbars from showing on top
+
+    [`& .${c.virtualScroller}`]: {
+      overflowAnchor: 'none', // Keep the same scrolling position
+    },
 
     // Use `css` tagged template so the ignore-comment remains a sibling of the
     // `:first-child` rule in the stylis AST. Previously, the comment was embedded


### PR DESCRIPTION
We probably missed moving this style after the grid's layout change.

It prevents scroll jumps on row updates.

Before: https://stackblitz.com/edit/jazgusxa-p5mcbbvt?file=src%2FDemo.tsx
After: https://stackblitz.com/edit/jazgusxa-guydvgb4?file=package.json