### PR TITLE
[core] Add remove-proptypes markers to generated propTypes

### DIFF
--- a/packages/x-charts-premium/src/ChartsDataProviderPremium/ChartsDataProviderPremium.tsx
+++ b/packages/x-charts-premium/src/ChartsDataProviderPremium/ChartsDataProviderPremium.tsx
@@ -111,7 +111,7 @@ function ChartsDataProviderPremium<
   );
 }
 
-ChartsDataProviderPremium.propTypes = {
+ChartsDataProviderPremium.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts-premium/src/ChartsGeoDataProviderPremium/ChartsGeoDataProviderPremium.tsx
+++ b/packages/x-charts-premium/src/ChartsGeoDataProviderPremium/ChartsGeoDataProviderPremium.tsx
@@ -90,7 +90,7 @@ function ChartsGeoDataProviderPremium<
   );
 }
 
-ChartsGeoDataProviderPremium.propTypes = {
+ChartsGeoDataProviderPremium.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts-premium/src/ChartsRadialDataProviderPremium/ChartsRadialDataProviderPremium.tsx
+++ b/packages/x-charts-premium/src/ChartsRadialDataProviderPremium/ChartsRadialDataProviderPremium.tsx
@@ -95,7 +95,7 @@ function ChartsRadialDataProviderPremium<
   );
 }
 
-ChartsRadialDataProviderPremium.propTypes = {
+ChartsRadialDataProviderPremium.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts-premium/src/Map/GeoDataPlot.tsx
+++ b/packages/x-charts-premium/src/Map/GeoDataPlot.tsx
@@ -55,7 +55,7 @@ function GeoDataPlot(props: GeoDataPlotProps) {
   );
 }
 
-GeoDataPlot.propTypes = {
+GeoDataPlot.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts-premium/src/Map/MapShape.tsx
+++ b/packages/x-charts-premium/src/Map/MapShape.tsx
@@ -50,7 +50,7 @@ function MapShape(props: MapShapeProps) {
   );
 }
 
-MapShape.propTypes = {
+MapShape.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts-premium/src/Map/MapShapePlot.tsx
+++ b/packages/x-charts-premium/src/Map/MapShapePlot.tsx
@@ -100,7 +100,7 @@ function MapShapePlot(props: MapShapePlotProps) {
   );
 }
 
-MapShapePlot.propTypes = {
+MapShapePlot.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts-premium/src/RadialLineChart/RadialAreaPlot.tsx
+++ b/packages/x-charts-premium/src/RadialLineChart/RadialAreaPlot.tsx
@@ -44,7 +44,7 @@ function RadialAreaPlot(props: RadialAreaPlotProps) {
   );
 }
 
-RadialAreaPlot.propTypes = {
+RadialAreaPlot.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts-premium/src/RadialLineChart/RadialLineHighlightElement.tsx
+++ b/packages/x-charts-premium/src/RadialLineChart/RadialLineHighlightElement.tsx
@@ -52,7 +52,7 @@ function RadialLineHighlightElement(props: RadialLineHighlightElementProps) {
   );
 }
 
-RadialLineHighlightElement.propTypes = {
+RadialLineHighlightElement.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts-premium/src/RadialLineChart/RadialLineHighlightPlot.tsx
+++ b/packages/x-charts-premium/src/RadialLineChart/RadialLineHighlightPlot.tsx
@@ -126,7 +126,7 @@ function RadialLineHighlightPlot(props: RadialLineHighlightPlotProps) {
   );
 }
 
-RadialLineHighlightPlot.propTypes = {
+RadialLineHighlightPlot.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts-premium/src/RadialLineChart/RadialLinePlot.tsx
+++ b/packages/x-charts-premium/src/RadialLineChart/RadialLinePlot.tsx
@@ -41,7 +41,7 @@ function RadialLinePlot(props: RadialLinePlotProps) {
   );
 }
 
-RadialLinePlot.propTypes = {
+RadialLinePlot.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts-premium/src/RadialLineChart/RadialMarkPlot.tsx
+++ b/packages/x-charts-premium/src/RadialLineChart/RadialMarkPlot.tsx
@@ -74,7 +74,7 @@ function RadialMarkPlot(props: RadialMarkPlotProps) {
   );
 }
 
-RadialMarkPlot.propTypes = {
+RadialMarkPlot.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts-premium/src/ScatterChartPremium/ScatterPlotPremium.tsx
+++ b/packages/x-charts-premium/src/ScatterChartPremium/ScatterPlotPremium.tsx
@@ -42,7 +42,7 @@ function ScatterPlotPremium({ renderer, ...props }: ScatterPlotPremiumProps) {
   return <ScatterPlot renderer={renderer} {...props} />;
 }
 
-ScatterPlotPremium.propTypes = {
+ScatterPlotPremium.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts-pro/src/ChartsDataProviderPro/ChartsDataProviderPro.tsx
+++ b/packages/x-charts-pro/src/ChartsDataProviderPro/ChartsDataProviderPro.tsx
@@ -105,7 +105,7 @@ function ChartsDataProviderPro<
   );
 }
 
-ChartsDataProviderPro.propTypes = {
+ChartsDataProviderPro.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts-pro/src/ChartsToolbarPro/ChartsToolbarPro.tsx
+++ b/packages/x-charts-pro/src/ChartsToolbarPro/ChartsToolbarPro.tsx
@@ -230,7 +230,7 @@ function ChartsToolbarPro({
   return <Toolbar {...other}>{children}</Toolbar>;
 }
 
-ChartsToolbarPro.propTypes = {
+ChartsToolbarPro.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts-pro/src/FunnelChart/FunnelPlot.tsx
+++ b/packages/x-charts-pro/src/FunnelChart/FunnelPlot.tsx
@@ -202,7 +202,7 @@ function FunnelPlot(props: FunnelPlotProps) {
   );
 }
 
-FunnelPlot.propTypes = {
+FunnelPlot.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts-pro/src/Heatmap/HeatmapTooltip/HeatmapTooltip.tsx
+++ b/packages/x-charts-pro/src/Heatmap/HeatmapTooltip/HeatmapTooltip.tsx
@@ -16,7 +16,7 @@ function HeatmapTooltip(props: HeatmapTooltipProps) {
   );
 }
 
-HeatmapTooltip.propTypes = {
+HeatmapTooltip.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts-pro/src/Heatmap/HeatmapTooltip/HeatmapTooltipContent.tsx
+++ b/packages/x-charts-pro/src/Heatmap/HeatmapTooltip/HeatmapTooltipContent.tsx
@@ -77,7 +77,7 @@ export function HeatmapTooltipContent(props: HeatmapTooltipContentProps) {
   );
 }
 
-HeatmapTooltipContent.propTypes = {
+HeatmapTooltipContent.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts-pro/src/SankeyChart/SankeyDataProvider.tsx
+++ b/packages/x-charts-pro/src/SankeyChart/SankeyDataProvider.tsx
@@ -36,7 +36,7 @@ function SankeyDataProvider(props: SankeyDataProviderProps) {
   );
 }
 
-SankeyDataProvider.propTypes = {
+SankeyDataProvider.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts-pro/src/SankeyChart/SankeyLinkLabelPlot.tsx
+++ b/packages/x-charts-pro/src/SankeyChart/SankeyLinkLabelPlot.tsx
@@ -43,7 +43,7 @@ function SankeyLinkLabelPlot(props: SankeyLinkLabelPlotProps) {
   );
 }
 
-SankeyLinkLabelPlot.propTypes = {
+SankeyLinkLabelPlot.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts-pro/src/SankeyChart/SankeyLinkPlot.tsx
+++ b/packages/x-charts-pro/src/SankeyChart/SankeyLinkPlot.tsx
@@ -66,7 +66,7 @@ function SankeyLinkPlot(props: SankeyLinkPlotProps) {
   );
 }
 
-SankeyLinkPlot.propTypes = {
+SankeyLinkPlot.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts-pro/src/SankeyChart/SankeyNodeLabelPlot.tsx
+++ b/packages/x-charts-pro/src/SankeyChart/SankeyNodeLabelPlot.tsx
@@ -44,7 +44,7 @@ function SankeyNodeLabelPlot(props: SankeyNodeLabelPlotProps) {
   );
 }
 
-SankeyNodeLabelPlot.propTypes = {
+SankeyNodeLabelPlot.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts-pro/src/SankeyChart/SankeyNodePlot.tsx
+++ b/packages/x-charts-pro/src/SankeyChart/SankeyNodePlot.tsx
@@ -60,7 +60,7 @@ function SankeyNodePlot(props: SankeyNodePlotProps) {
   );
 }
 
-SankeyNodePlot.propTypes = {
+SankeyNodePlot.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts-pro/src/SankeyChart/SankeyPlot.tsx
+++ b/packages/x-charts-pro/src/SankeyChart/SankeyPlot.tsx
@@ -83,7 +83,7 @@ function SankeyPlot(props: SankeyPlotProps) {
   );
 }
 
-SankeyPlot.propTypes = {
+SankeyPlot.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts-pro/src/SankeyChart/SankeyTooltip/SankeyTooltip.tsx
+++ b/packages/x-charts-pro/src/SankeyChart/SankeyTooltip/SankeyTooltip.tsx
@@ -15,7 +15,7 @@ function SankeyTooltip(props: SankeyTooltipProps) {
   );
 }
 
-SankeyTooltip.propTypes = {
+SankeyTooltip.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts-pro/src/SankeyChart/SankeyTooltip/SankeyTooltipContent.tsx
+++ b/packages/x-charts-pro/src/SankeyChart/SankeyTooltip/SankeyTooltipContent.tsx
@@ -46,7 +46,7 @@ export function SankeyTooltipContent(props: SankeyTooltipContentProps) {
   );
 }
 
-SankeyTooltipContent.propTypes = {
+SankeyTooltipContent.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/BarChart/BarElement.tsx
+++ b/packages/x-charts/src/BarChart/BarElement.tsx
@@ -121,7 +121,7 @@ function BarElement(props: BarElementProps) {
   return <Bar {...barProps} />;
 }
 
-BarElement.propTypes = {
+BarElement.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/ChartsAxis/ChartsAxis.tsx
+++ b/packages/x-charts/src/ChartsAxis/ChartsAxis.tsx
@@ -58,7 +58,7 @@ function ChartsAxis(props: ChartsAxisProps) {
   );
 }
 
-ChartsAxis.propTypes = {
+ChartsAxis.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/ChartsAxisHighlight/ChartsAxisHighlight.tsx
+++ b/packages/x-charts/src/ChartsAxisHighlight/ChartsAxisHighlight.tsx
@@ -40,7 +40,7 @@ function ChartsAxisHighlight(props: ChartsAxisHighlightProps) {
   );
 }
 
-ChartsAxisHighlight.propTypes = {
+ChartsAxisHighlight.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/ChartsBrushOverlay/ChartsBrushOverlay.tsx
+++ b/packages/x-charts/src/ChartsBrushOverlay/ChartsBrushOverlay.tsx
@@ -122,7 +122,7 @@ function ChartsBrushOverlay(props: ChartsBrushOverlayProps) {
   );
 }
 
-ChartsBrushOverlay.propTypes = {
+ChartsBrushOverlay.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/ChartsClipPath/ChartsClipPath.tsx
+++ b/packages/x-charts/src/ChartsClipPath/ChartsClipPath.tsx
@@ -38,7 +38,7 @@ function ChartsClipPath(props: ChartsClipPathProps) {
   );
 }
 
-ChartsClipPath.propTypes = {
+ChartsClipPath.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/ChartsDataProvider/ChartsDataProvider.tsx
+++ b/packages/x-charts/src/ChartsDataProvider/ChartsDataProvider.tsx
@@ -90,7 +90,7 @@ function ChartsDataProvider<
   );
 }
 
-ChartsDataProvider.propTypes = {
+ChartsDataProvider.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/ChartsGrid/ChartsGrid.tsx
+++ b/packages/x-charts/src/ChartsGrid/ChartsGrid.tsx
@@ -84,7 +84,7 @@ function ChartsGrid(inProps: ChartsGridProps) {
   );
 }
 
-ChartsGrid.propTypes = {
+ChartsGrid.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/ChartsLocalizationProvider/ChartsLocalizationProvider.tsx
+++ b/packages/x-charts/src/ChartsLocalizationProvider/ChartsLocalizationProvider.tsx
@@ -69,7 +69,7 @@ function ChartsLocalizationProvider(inProps: ChartsLocalizationProviderProps) {
   );
 }
 
-ChartsLocalizationProvider.propTypes = {
+ChartsLocalizationProvider.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/ChartsRadialAxisHighlight/ChartsRadialAxisHighlight.tsx
+++ b/packages/x-charts/src/ChartsRadialAxisHighlight/ChartsRadialAxisHighlight.tsx
@@ -40,7 +40,7 @@ function ChartsRadialAxisHighlight(props: ChartsRadialAxisHighlightProps) {
   );
 }
 
-ChartsRadialAxisHighlight.propTypes = {
+ChartsRadialAxisHighlight.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/ChartsRadialDataProvider/ChartsRadialDataProvider.tsx
+++ b/packages/x-charts/src/ChartsRadialDataProvider/ChartsRadialDataProvider.tsx
@@ -75,7 +75,7 @@ function ChartsRadialDataProvider<
   );
 }
 
-ChartsRadialDataProvider.propTypes = {
+ChartsRadialDataProvider.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/ChartsRadialGrid/ChartsRadialGrid.tsx
+++ b/packages/x-charts/src/ChartsRadialGrid/ChartsRadialGrid.tsx
@@ -93,7 +93,7 @@ function ChartsRadialGrid(inProps: ChartsRadialGridProps) {
   );
 }
 
-ChartsRadialGrid.propTypes = {
+ChartsRadialGrid.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/ChartsRadiusAxis/ChartsRadiusAxis.tsx
+++ b/packages/x-charts/src/ChartsRadiusAxis/ChartsRadiusAxis.tsx
@@ -168,7 +168,7 @@ function ChartsRadiusAxis(props: ChartsRadiusAxisProps) {
   );
 }
 
-ChartsRadiusAxis.propTypes = {
+ChartsRadiusAxis.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/ChartsReferenceLine/ChartsReferenceLine.tsx
+++ b/packages/x-charts/src/ChartsReferenceLine/ChartsReferenceLine.tsx
@@ -33,7 +33,7 @@ function ChartsReferenceLine(props: ChartsReferenceLineProps) {
   return <ChartsYReferenceLine {...props} />;
 }
 
-ChartsReferenceLine.propTypes = {
+ChartsReferenceLine.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/ChartsRotationAxis/ChartsRotationAxis.tsx
+++ b/packages/x-charts/src/ChartsRotationAxis/ChartsRotationAxis.tsx
@@ -145,7 +145,7 @@ function ChartsRotationAxis(props: ChartsRotationAxisProps) {
   );
 }
 
-ChartsRotationAxis.propTypes = {
+ChartsRotationAxis.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/ChartsText/ChartsText.tsx
+++ b/packages/x-charts/src/ChartsText/ChartsText.tsx
@@ -71,7 +71,7 @@ function ChartsText(props: ChartsTextProps) {
   );
 }
 
-ChartsText.propTypes = {
+ChartsText.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/ChartsTooltip/ChartsAxisTooltipContent.tsx
+++ b/packages/x-charts/src/ChartsTooltip/ChartsAxisTooltipContent.tsx
@@ -136,7 +136,7 @@ function DefaultContent<T extends CartesianChartSeriesType | PolarChartSeriesTyp
   );
 }
 
-DefaultContent.propTypes = {
+DefaultContent.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |
@@ -159,7 +159,7 @@ DefaultContent.propTypes = {
   }).isRequired,
 } as any;
 
-ChartsAxisTooltipContent.propTypes = {
+ChartsAxisTooltipContent.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/ChartsTooltip/ChartsItemTooltipContent.tsx
+++ b/packages/x-charts/src/ChartsTooltip/ChartsItemTooltipContent.tsx
@@ -125,7 +125,7 @@ function DefaultMultipleValueContent({
   );
 }
 
-DefaultMultipleValueContent.propTypes = {
+DefaultMultipleValueContent.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |
@@ -212,7 +212,7 @@ function DefaultSingleValueContent<T extends ChartSeriesType>({
   );
 }
 
-DefaultSingleValueContent.propTypes = {
+DefaultSingleValueContent.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |
@@ -239,7 +239,7 @@ DefaultSingleValueContent.propTypes = {
   }).isRequired,
 } as any;
 
-ChartsItemTooltipContent.propTypes = {
+ChartsItemTooltipContent.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/ChartsTooltip/ChartsTooltip.tsx
+++ b/packages/x-charts/src/ChartsTooltip/ChartsTooltip.tsx
@@ -44,7 +44,7 @@ function ChartsTooltip<T extends TriggerOptions>(props: ChartsTooltipProps<T>) {
   );
 }
 
-ChartsTooltip.propTypes = {
+ChartsTooltip.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/ChartsTooltip/ChartsTooltipContainer.tsx
+++ b/packages/x-charts/src/ChartsTooltip/ChartsTooltipContainer.tsx
@@ -348,7 +348,7 @@ function ChartsTooltipContainer(inProps: ChartsTooltipContainerProps) {
   );
 }
 
-ChartsTooltipContainer.propTypes = {
+ChartsTooltipContainer.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
+++ b/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
@@ -37,7 +37,7 @@ function ChartsXAxis(inProps: ChartsXAxisProps) {
   return <ChartsXAxisImpl {...inProps} axis={axis} />;
 }
 
-ChartsXAxis.propTypes = {
+ChartsXAxis.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/ChartsYAxis/ChartsYAxis.tsx
+++ b/packages/x-charts/src/ChartsYAxis/ChartsYAxis.tsx
@@ -36,7 +36,7 @@ function ChartsYAxis(inProps: ChartsYAxisProps) {
   return <ChartsYAxisImpl {...inProps} axis={axis} />;
 }
 
-ChartsYAxis.propTypes = {
+ChartsYAxis.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/Gauge/GaugeValueArc.tsx
+++ b/packages/x-charts/src/Gauge/GaugeValueArc.tsx
@@ -54,7 +54,7 @@ function GaugeValueArc({
   );
 }
 
-GaugeValueArc.propTypes = {
+GaugeValueArc.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |
@@ -99,7 +99,7 @@ function AnimatedGaugeValueArc({
   return <StyledPath {...animatedProps} transform={`translate(${cx}, ${cy})`} {...other} />;
 }
 
-AnimatedGaugeValueArc.propTypes = {
+AnimatedGaugeValueArc.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/Gauge/GaugeValueText.tsx
+++ b/packages/x-charts/src/Gauge/GaugeValueText.tsx
@@ -42,7 +42,7 @@ function GaugeValueText(props: GaugeValueTextProps) {
   );
 }
 
-GaugeValueText.propTypes = {
+GaugeValueText.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/LineChart/AnimatedArea.tsx
+++ b/packages/x-charts/src/LineChart/AnimatedArea.tsx
@@ -53,7 +53,7 @@ function AnimatedArea(props: AnimatedAreaProps) {
   );
 }
 
-AnimatedArea.propTypes = {
+AnimatedArea.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/LineChart/AreaElement.tsx
+++ b/packages/x-charts/src/LineChart/AreaElement.tsx
@@ -114,7 +114,7 @@ function AreaElement(props: AreaElementProps) {
   return <Area {...other} {...areaProps} />;
 }
 
-AreaElement.propTypes = {
+AreaElement.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/LineChart/AreaPlot.tsx
+++ b/packages/x-charts/src/LineChart/AreaPlot.tsx
@@ -102,7 +102,7 @@ function AreaPlot(props: AreaPlotProps) {
   );
 }
 
-AreaPlot.propTypes = {
+AreaPlot.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/LineChart/LineElement.tsx
+++ b/packages/x-charts/src/LineChart/LineElement.tsx
@@ -121,7 +121,7 @@ function LineElement(props: LineElementProps) {
   return <Line {...other} {...lineProps} />;
 }
 
-LineElement.propTypes = {
+LineElement.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/LineChart/LineHighlightElement.tsx
+++ b/packages/x-charts/src/LineChart/LineHighlightElement.tsx
@@ -64,7 +64,7 @@ function LineHighlightElement(props: LineHighlightElementProps) {
   );
 }
 
-LineHighlightElement.propTypes = {
+LineHighlightElement.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/LineChart/LineHighlightPlot.tsx
+++ b/packages/x-charts/src/LineChart/LineHighlightPlot.tsx
@@ -173,7 +173,7 @@ function getStartEndMarkIndex(data: readonly (number | null)[], type: 'start' | 
   return index < 0 ? undefined : index;
 }
 
-LineHighlightPlot.propTypes = {
+LineHighlightPlot.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/LineChart/LinePlot.tsx
+++ b/packages/x-charts/src/LineChart/LinePlot.tsx
@@ -101,7 +101,7 @@ function LinePlot(props: LinePlotProps) {
   );
 }
 
-LinePlot.propTypes = {
+LinePlot.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/LineChart/MarkElement.tsx
+++ b/packages/x-charts/src/LineChart/MarkElement.tsx
@@ -129,7 +129,7 @@ function MarkElement(props: MarkElementProps) {
   );
 }
 
-MarkElement.propTypes = {
+MarkElement.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/LineChart/MarkPlot.tsx
+++ b/packages/x-charts/src/LineChart/MarkPlot.tsx
@@ -143,7 +143,7 @@ function MarkPlot(props: MarkPlotProps) {
   );
 }
 
-MarkPlot.propTypes = {
+MarkPlot.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/PieChart/FocusedPieArc.tsx
+++ b/packages/x-charts/src/PieChart/FocusedPieArc.tsx
@@ -79,7 +79,7 @@ function FocusedPieArc(
   );
 }
 
-FocusedPieArc.propTypes = {
+FocusedPieArc.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/PieChart/PieArcLabelPlot.tsx
+++ b/packages/x-charts/src/PieChart/PieArcLabelPlot.tsx
@@ -156,7 +156,7 @@ function PieArcLabelPlot(props: PieArcLabelPlotProps) {
   );
 }
 
-PieArcLabelPlot.propTypes = {
+PieArcLabelPlot.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/PieChart/PieArcPlot.tsx
+++ b/packages/x-charts/src/PieChart/PieArcPlot.tsx
@@ -134,7 +134,7 @@ function PieArcPlot(props: PieArcPlotProps) {
   );
 }
 
-PieArcPlot.propTypes = {
+PieArcPlot.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/PieChart/PiePlot.tsx
+++ b/packages/x-charts/src/PieChart/PiePlot.tsx
@@ -117,7 +117,7 @@ function PiePlot(props: PiePlotProps) {
   );
 }
 
-PiePlot.propTypes = {
+PiePlot.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/RadarChart/RadarAxis/RadarAxis.tsx
+++ b/packages/x-charts/src/RadarChart/RadarAxis/RadarAxis.tsx
@@ -73,7 +73,7 @@ function RadarAxis(props: RadarAxisProps) {
   );
 }
 
-RadarAxis.propTypes = {
+RadarAxis.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/RadarChart/RadarAxisHighlight/RadarAxisHighlight.tsx
+++ b/packages/x-charts/src/RadarChart/RadarAxisHighlight/RadarAxisHighlight.tsx
@@ -78,7 +78,7 @@ function RadarAxisHighlight(props: RadarAxisHighlightProps) {
   );
 }
 
-RadarAxisHighlight.propTypes = {
+RadarAxisHighlight.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/RadarChart/RadarGrid/RadarGrid.tsx
+++ b/packages/x-charts/src/RadarChart/RadarGrid/RadarGrid.tsx
@@ -72,7 +72,7 @@ function RadarGrid(props: RadarGridProps) {
   );
 }
 
-RadarGrid.propTypes = {
+RadarGrid.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/RadarChart/RadarSeriesPlot/RadarSeriesArea.tsx
+++ b/packages/x-charts/src/RadarChart/RadarSeriesPlot/RadarSeriesArea.tsx
@@ -83,7 +83,7 @@ function RadarSeriesArea(props: RadarSeriesAreaProps) {
   );
 }
 
-RadarSeriesArea.propTypes = {
+RadarSeriesArea.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/RadarChart/RadarSeriesPlot/RadarSeriesMarks.tsx
+++ b/packages/x-charts/src/RadarChart/RadarSeriesPlot/RadarSeriesMarks.tsx
@@ -78,7 +78,7 @@ function RadarSeriesMarks(props: RadarSeriesMarksProps) {
   );
 }
 
-RadarSeriesMarks.propTypes = {
+RadarSeriesMarks.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/RadarChart/RadarSeriesPlot/RadarSeriesPlot.tsx
+++ b/packages/x-charts/src/RadarChart/RadarSeriesPlot/RadarSeriesPlot.tsx
@@ -77,7 +77,7 @@ function RadarSeriesPlot(props: RadarSeriesPlotProps) {
   );
 }
 
-RadarSeriesPlot.propTypes = {
+RadarSeriesPlot.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/ScatterChart/Scatter.tsx
+++ b/packages/x-charts/src/ScatterChart/Scatter.tsx
@@ -162,7 +162,7 @@ function Scatter(props: ScatterProps) {
   );
 }
 
-Scatter.propTypes = {
+Scatter.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/ScatterChart/ScatterMarker.tsx
+++ b/packages/x-charts/src/ScatterChart/ScatterMarker.tsx
@@ -59,7 +59,7 @@ function ScatterMarker(props: ScatterMarkerProps) {
   );
 }
 
-ScatterMarker.propTypes = {
+ScatterMarker.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-charts/src/ScatterChart/ScatterPlot.tsx
+++ b/packages/x-charts/src/ScatterChart/ScatterPlot.tsx
@@ -156,7 +156,7 @@ function ScatterPlot(props: ScatterPlotProps) {
   );
 }
 
-ScatterPlot.propTypes = {
+ScatterPlot.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-chat/src/ChatConversationList/ChatConversationList.tsx
+++ b/packages/x-chat/src/ChatConversationList/ChatConversationList.tsx
@@ -336,7 +336,7 @@ const ChatConversationListItemSlot = React.forwardRef<HTMLDivElement, Conversati
   },
 );
 
-ChatConversationListItemSlot.propTypes = {
+ChatConversationListItemSlot.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |
@@ -382,7 +382,7 @@ const ChatConversationListItemAvatarStyled = React.forwardRef<
   );
 });
 
-ChatConversationListItemAvatarStyled.propTypes = {
+ChatConversationListItemAvatarStyled.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |
@@ -427,7 +427,7 @@ const ChatConversationListItemContentStyled = React.forwardRef<
   );
 });
 
-ChatConversationListItemContentStyled.propTypes = {
+ChatConversationListItemContentStyled.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |
@@ -472,7 +472,7 @@ const ChatConversationListTitleStyled = React.forwardRef<
   );
 });
 
-ChatConversationListTitleStyled.propTypes = {
+ChatConversationListTitleStyled.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |
@@ -517,7 +517,7 @@ const ChatConversationListPreviewStyled = React.forwardRef<
   );
 });
 
-ChatConversationListPreviewStyled.propTypes = {
+ChatConversationListPreviewStyled.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |
@@ -562,7 +562,7 @@ const ChatConversationListTimestampStyled = React.forwardRef<
   );
 });
 
-ChatConversationListTimestampStyled.propTypes = {
+ChatConversationListTimestampStyled.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |
@@ -609,7 +609,7 @@ const ChatConversationListUnreadBadgeStyled = React.forwardRef<
 
 // Default inline SVG for the 3-dot "more" icon (MoreHoriz style).
 
-ChatConversationListUnreadBadgeStyled.propTypes = {
+ChatConversationListUnreadBadgeStyled.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |
@@ -666,7 +666,7 @@ const ChatConversationListItemActionsStyled = React.forwardRef<
   );
 });
 
-ChatConversationListItemActionsStyled.propTypes = {
+ChatConversationListItemActionsStyled.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-chat/src/ChatIndicators/ChatStreamingIndicator.tsx
+++ b/packages/x-chat/src/ChatIndicators/ChatStreamingIndicator.tsx
@@ -82,7 +82,7 @@ const ChatStreamingIndicator = React.forwardRef<HTMLDivElement, ChatStreamingInd
   },
 );
 
-ChatStreamingIndicator.propTypes = {
+ChatStreamingIndicator.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-chat/src/ChatMessage/ChatMessageContent.tsx
+++ b/packages/x-chat/src/ChatMessage/ChatMessageContent.tsx
@@ -395,7 +395,7 @@ function ChatToolPartRoot({
   );
 }
 
-ChatToolPartRoot.propTypes = {
+ChatToolPartRoot.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |
@@ -612,7 +612,7 @@ const ChatToolPartStateComponent = React.forwardRef<HTMLSpanElement, ChatToolPar
   },
 );
 
-ChatToolPartStateComponent.propTypes = {
+ChatToolPartStateComponent.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |
@@ -723,7 +723,7 @@ function ChatToolPartSection({
   );
 }
 
-ChatToolPartSection.propTypes = {
+ChatToolPartSection.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |
@@ -760,7 +760,7 @@ const ChatToolPartSectionSummary = React.forwardRef<HTMLElement, ChatToolPartSec
   },
 );
 
-ChatToolPartSectionSummary.propTypes = {
+ChatToolPartSectionSummary.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |
@@ -876,7 +876,7 @@ function ChatToolPartSectionContent({
   );
 }
 
-ChatToolPartSectionContent.propTypes = {
+ChatToolPartSectionContent.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |
@@ -1039,7 +1039,7 @@ const ChatReasoningPartSummary = React.forwardRef<HTMLElement, ChatReasoningSumm
   },
 );
 
-ChatReasoningPartSummary.propTypes = {
+ChatReasoningPartSummary.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-chat/src/ChatMessage/ChatMessageInlineMeta.tsx
+++ b/packages/x-chat/src/ChatMessage/ChatMessageInlineMeta.tsx
@@ -131,7 +131,7 @@ function ChatMessageInlineMeta(props: ChatMessageInlineMetaProps) {
   );
 }
 
-ChatMessageInlineMeta.propTypes = {
+ChatMessageInlineMeta.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-chat/src/ChatMessageError/ChatMessageError.tsx
+++ b/packages/x-chat/src/ChatMessageError/ChatMessageError.tsx
@@ -188,7 +188,7 @@ const ChatMessageError = React.forwardRef<HTMLDivElement, ChatMessageErrorProps>
   },
 );
 
-ChatMessageError.propTypes = {
+ChatMessageError.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid-premium/src/components/GridExcelExportMenuItem.tsx
+++ b/packages/x-data-grid-premium/src/components/GridExcelExportMenuItem.tsx
@@ -24,7 +24,7 @@ function GridExcelExportMenuItem(props: GridExcelExportMenuItemProps) {
   );
 }
 
-GridExcelExportMenuItem.propTypes = {
+GridExcelExportMenuItem.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid-premium/src/components/chartsPanel/GridChartsPanel.tsx
+++ b/packages/x-data-grid-premium/src/components/chartsPanel/GridChartsPanel.tsx
@@ -134,7 +134,7 @@ function GridChartsPanelChartSelector(props: {
   );
 }
 
-GridChartsPanelChartSelector.propTypes = {
+GridChartsPanelChartSelector.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |
@@ -296,7 +296,7 @@ function GridChartsPanel(props: GridChartsPanelProps) {
   );
 }
 
-GridChartsPanel.propTypes = {
+GridChartsPanel.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid-premium/src/components/columnMenu/menuItems/GridColumnMenuAggregationItem.tsx
+++ b/packages/x-data-grid-premium/src/components/columnMenu/menuItems/GridColumnMenuAggregationItem.tsx
@@ -133,7 +133,7 @@ function GridColumnMenuAggregationItem(props: GridColumnMenuItemProps) {
   );
 }
 
-GridColumnMenuAggregationItem.propTypes = {
+GridColumnMenuAggregationItem.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid-premium/src/context/GridChartsRendererProxy.tsx
+++ b/packages/x-data-grid-premium/src/context/GridChartsRendererProxy.tsx
@@ -74,7 +74,7 @@ function GridChartsRendererProxy(props: GridChartsRendererProxyProps) {
   );
 }
 
-GridChartsRendererProxy.propTypes = {
+GridChartsRendererProxy.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid-pro/src/components/GridColumnMenuPinningItem.tsx
+++ b/packages/x-data-grid-pro/src/components/GridColumnMenuPinningItem.tsx
@@ -88,7 +88,7 @@ function GridColumnMenuPinningItem(props: GridColumnMenuItemProps) {
   );
 }
 
-GridColumnMenuPinningItem.propTypes = {
+GridColumnMenuPinningItem.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid-pro/src/components/GridDetailPanelToggleCell.tsx
+++ b/packages/x-data-grid-pro/src/components/GridDetailPanelToggleCell.tsx
@@ -72,7 +72,7 @@ function GridDetailPanelToggleCell(props: GridRenderCellParams) {
   );
 }
 
-GridDetailPanelToggleCell.propTypes = {
+GridDetailPanelToggleCell.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid-pro/src/components/GridRowReorderCell.tsx
+++ b/packages/x-data-grid-pro/src/components/GridRowReorderCell.tsx
@@ -169,7 +169,7 @@ function GridRowReorderCell(params: GridRenderCellParams) {
   );
 }
 
-GridRowReorderCell.propTypes = {
+GridRowReorderCell.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid-pro/src/components/GridTreeDataGroupingCell.tsx
+++ b/packages/x-data-grid-pro/src/components/GridTreeDataGroupingCell.tsx
@@ -88,7 +88,7 @@ function GridTreeDataGroupingCell(props: GridTreeDataGroupingCellProps) {
   );
 }
 
-GridTreeDataGroupingCell.propTypes = {
+GridTreeDataGroupingCell.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid-pro/src/components/cell/GridEditMultiSelectCell.tsx
+++ b/packages/x-data-grid-pro/src/components/cell/GridEditMultiSelectCell.tsx
@@ -456,7 +456,7 @@ function GridEditMultiSelectAutocomplete(props: GridEditMultiSelectAutocompleteP
   );
 }
 
-GridEditMultiSelectAutocomplete.propTypes = {
+GridEditMultiSelectAutocomplete.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |
@@ -551,7 +551,7 @@ GridEditMultiSelectAutocomplete.propTypes = {
   ).isRequired,
 } as any;
 
-GridEditMultiSelectCell.propTypes = {
+GridEditMultiSelectCell.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid-pro/src/components/cell/GridMultiSelectCell.tsx
+++ b/packages/x-data-grid-pro/src/components/cell/GridMultiSelectCell.tsx
@@ -320,7 +320,7 @@ function GridMultiSelectCell<V extends ValueOptions = ValueOptions>(
   );
 }
 
-GridMultiSelectCell.propTypes = {
+GridMultiSelectCell.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid-pro/src/components/headerFiltering/GridHeaderFilterMenu.tsx
+++ b/packages/x-data-grid-pro/src/components/headerFiltering/GridHeaderFilterMenu.tsx
@@ -92,7 +92,7 @@ function GridHeaderFilterMenu({
   );
 }
 
-GridHeaderFilterMenu.propTypes = {
+GridHeaderFilterMenu.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid-pro/src/components/headerFiltering/GridHeaderFilterMenuContainer.tsx
+++ b/packages/x-data-grid-pro/src/components/headerFiltering/GridHeaderFilterMenuContainer.tsx
@@ -96,7 +96,7 @@ function GridHeaderFilterMenuContainer(props: {
   );
 }
 
-GridHeaderFilterMenuContainer.propTypes = {
+GridHeaderFilterMenuContainer.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid-pro/src/components/panel/filterPanel/GridFilterInputMultipleMultiSelect.tsx
+++ b/packages/x-data-grid-pro/src/components/panel/filterPanel/GridFilterInputMultipleMultiSelect.tsx
@@ -113,7 +113,7 @@ function GridFilterInputMultipleMultiSelect(props: GridFilterInputMultipleMultiS
   );
 }
 
-GridFilterInputMultipleMultiSelect.propTypes = {
+GridFilterInputMultipleMultiSelect.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid/src/DataGrid/DataGrid.tsx
+++ b/packages/x-data-grid/src/DataGrid/DataGrid.tsx
@@ -77,7 +77,7 @@ interface DataGridComponent {
  */
 export const DataGrid = React.memo(forwardRef(DataGridRaw)) as DataGridComponent;
 
-DataGridRaw.propTypes = {
+DataGridRaw.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid/src/components/GridColumnUnsortedIcon.tsx
+++ b/packages/x-data-grid/src/components/GridColumnUnsortedIcon.tsx
@@ -21,7 +21,7 @@ function GridColumnUnsortedIcon(props: GridColumnUnsortedIconProps) {
   return Icon ? <Icon {...other} /> : null;
 }
 
-GridColumnUnsortedIcon.propTypes = {
+GridColumnUnsortedIcon.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid/src/components/cell/GridActionsCell.tsx
+++ b/packages/x-data-grid/src/components/cell/GridActionsCell.tsx
@@ -310,7 +310,7 @@ If this is intentional, you can suppress this warning by passing the \`suppressC
   );
 }
 
-GridActionsCell.propTypes = {
+GridActionsCell.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |
@@ -425,7 +425,7 @@ function GridActionsCellWrapper(props: GridRenderCellParams) {
   );
 }
 
-GridActionsCellWrapper.propTypes = {
+GridActionsCellWrapper.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid/src/components/cell/GridActionsCellItem.tsx
+++ b/packages/x-data-grid/src/components/cell/GridActionsCellItem.tsx
@@ -75,7 +75,7 @@ const GridActionsCellItem = forwardRef<HTMLElement, GridActionsCellItemProps>((p
   );
 });
 
-GridActionsCellItem.propTypes = {
+GridActionsCellItem.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid/src/components/cell/GridBooleanCell.tsx
+++ b/packages/x-data-grid/src/components/cell/GridBooleanCell.tsx
@@ -80,7 +80,7 @@ function GridBooleanCellRaw(props: GridBooleanCellProps) {
   );
 }
 
-GridBooleanCellRaw.propTypes = {
+GridBooleanCellRaw.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid/src/components/cell/GridEditBooleanCell.tsx
+++ b/packages/x-data-grid/src/components/cell/GridEditBooleanCell.tsx
@@ -110,7 +110,7 @@ function GridEditBooleanCell(props: GridEditBooleanCellProps) {
   );
 }
 
-GridEditBooleanCell.propTypes = {
+GridEditBooleanCell.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid/src/components/cell/GridEditDateCell.tsx
+++ b/packages/x-data-grid/src/components/cell/GridEditDateCell.tsx
@@ -175,7 +175,7 @@ function GridEditDateCell(props: GridEditDateCellProps) {
   );
 }
 
-GridEditDateCell.propTypes = {
+GridEditDateCell.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid/src/components/cell/GridEditInputCell.tsx
+++ b/packages/x-data-grid/src/components/cell/GridEditInputCell.tsx
@@ -142,7 +142,7 @@ const GridEditInputCell = forwardRef<HTMLInputElement, GridEditInputCellProps>((
   );
 });
 
-GridEditInputCell.propTypes = {
+GridEditInputCell.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid/src/components/cell/GridEditLongTextCell.tsx
+++ b/packages/x-data-grid/src/components/cell/GridEditLongTextCell.tsx
@@ -211,7 +211,7 @@ function GridEditLongTextCell(props: GridEditLongTextCellProps) {
   );
 }
 
-GridEditLongTextCell.propTypes = {
+GridEditLongTextCell.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |
@@ -361,7 +361,7 @@ function GridEditLongTextarea(props: GridEditLongTextCellProps) {
   );
 }
 
-GridEditLongTextarea.propTypes = {
+GridEditLongTextarea.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid/src/components/cell/GridEditSingleSelectCell.tsx
+++ b/packages/x-data-grid/src/components/cell/GridEditSingleSelectCell.tsx
@@ -173,7 +173,7 @@ function GridEditSingleSelectCell(props: GridEditSingleSelectCellProps) {
   );
 }
 
-GridEditSingleSelectCell.propTypes = {
+GridEditSingleSelectCell.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid/src/components/cell/GridLongTextCell.tsx
+++ b/packages/x-data-grid/src/components/cell/GridLongTextCell.tsx
@@ -299,7 +299,7 @@ function GridLongTextCell(props: GridLongTextCellProps) {
   );
 }
 
-GridLongTextCell.propTypes = {
+GridLongTextCell.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid/src/components/cell/GridSkeletonCell.tsx
+++ b/packages/x-data-grid/src/components/cell/GridSkeletonCell.tsx
@@ -120,7 +120,7 @@ function GridSkeletonCell(props: GridSkeletonCellProps) {
   );
 }
 
-GridSkeletonCell.propTypes = {
+GridSkeletonCell.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid/src/components/columnHeaders/GridColumnHeaderFilterIconButton.tsx
+++ b/packages/x-data-grid/src/components/columnHeaders/GridColumnHeaderFilterIconButton.tsx
@@ -42,7 +42,7 @@ function GridColumnHeaderFilterIconButtonWrapped(props: ColumnHeaderFilterIconBu
   return <GridColumnHeaderFilterIconButton {...props} />;
 }
 
-GridColumnHeaderFilterIconButtonWrapped.propTypes = {
+GridColumnHeaderFilterIconButtonWrapped.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |
@@ -125,7 +125,7 @@ function GridColumnHeaderFilterIconButton(props: ColumnHeaderFilterIconButtonPro
   );
 }
 
-GridColumnHeaderFilterIconButton.propTypes = {
+GridColumnHeaderFilterIconButton.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid/src/components/columnHeaders/GridColumnHeaderItem.tsx
+++ b/packages/x-data-grid/src/components/columnHeaders/GridColumnHeaderItem.tsx
@@ -372,7 +372,7 @@ function GridColumnHeaderItem(props: GridColumnHeaderItemProps) {
   );
 }
 
-GridColumnHeaderItem.propTypes = {
+GridColumnHeaderItem.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid/src/components/columnHeaders/GridColumnHeaderSeparator.tsx
+++ b/packages/x-data-grid/src/components/columnHeaders/GridColumnHeaderSeparator.tsx
@@ -65,7 +65,7 @@ function GridColumnHeaderSeparatorRaw(props: GridColumnHeaderSeparatorProps) {
 
 const GridColumnHeaderSeparator = React.memo(GridColumnHeaderSeparatorRaw);
 
-GridColumnHeaderSeparatorRaw.propTypes = {
+GridColumnHeaderSeparatorRaw.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid/src/components/columnHeaders/GridColumnHeaderSortIcon.tsx
+++ b/packages/x-data-grid/src/components/columnHeaders/GridColumnHeaderSortIcon.tsx
@@ -15,7 +15,7 @@ function GridColumnHeaderSortIconRaw(props: GridColumnHeaderSortIconProps) {
 
 const GridColumnHeaderSortIcon = React.memo(GridColumnHeaderSortIconRaw);
 
-GridColumnHeaderSortIconRaw.propTypes = {
+GridColumnHeaderSortIconRaw.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid/src/components/columnHeaders/GridColumnHeaderTitle.tsx
+++ b/packages/x-data-grid/src/components/columnHeaders/GridColumnHeaderTitle.tsx
@@ -88,7 +88,7 @@ function GridColumnHeaderTitle(props: GridColumnHeaderTitleProps) {
   );
 }
 
-GridColumnHeaderTitle.propTypes = {
+GridColumnHeaderTitle.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid/src/components/columnsManagement/GridColumnsManagement.tsx
+++ b/packages/x-data-grid/src/components/columnsManagement/GridColumnsManagement.tsx
@@ -354,7 +354,7 @@ function GridColumnsManagement(props: GridColumnsManagementProps) {
   );
 }
 
-GridColumnsManagement.propTypes = {
+GridColumnsManagement.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid/src/components/menu/GridMenu.tsx
+++ b/packages/x-data-grid/src/components/menu/GridMenu.tsx
@@ -120,7 +120,7 @@ function GridMenu(props: GridMenuProps) {
   );
 }
 
-GridMenu.propTypes = {
+GridMenu.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid/src/components/menu/columnMenu/GridColumnHeaderMenu.tsx
+++ b/packages/x-data-grid/src/components/menu/columnMenu/GridColumnHeaderMenu.tsx
@@ -65,7 +65,7 @@ function GridColumnHeaderMenu({
   );
 }
 
-GridColumnHeaderMenu.propTypes = {
+GridColumnHeaderMenu.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid/src/components/menu/columnMenu/menuItems/GridColumnMenuColumnsItem.tsx
+++ b/packages/x-data-grid/src/components/menu/columnMenu/menuItems/GridColumnMenuColumnsItem.tsx
@@ -13,7 +13,7 @@ function GridColumnMenuColumnsItem(props: GridColumnMenuItemProps) {
   );
 }
 
-GridColumnMenuColumnsItem.propTypes = {
+GridColumnMenuColumnsItem.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid/src/components/menu/columnMenu/menuItems/GridColumnMenuFilterItem.tsx
+++ b/packages/x-data-grid/src/components/menu/columnMenu/menuItems/GridColumnMenuFilterItem.tsx
@@ -31,7 +31,7 @@ function GridColumnMenuFilterItem(props: GridColumnMenuItemProps) {
   );
 }
 
-GridColumnMenuFilterItem.propTypes = {
+GridColumnMenuFilterItem.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid/src/components/menu/columnMenu/menuItems/GridColumnMenuHideItem.tsx
+++ b/packages/x-data-grid/src/components/menu/columnMenu/menuItems/GridColumnMenuHideItem.tsx
@@ -50,7 +50,7 @@ function GridColumnMenuHideItem(props: GridColumnMenuItemProps) {
   );
 }
 
-GridColumnMenuHideItem.propTypes = {
+GridColumnMenuHideItem.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid/src/components/menu/columnMenu/menuItems/GridColumnMenuManageItem.tsx
+++ b/packages/x-data-grid/src/components/menu/columnMenu/menuItems/GridColumnMenuManageItem.tsx
@@ -32,7 +32,7 @@ function GridColumnMenuManageItem(props: GridColumnMenuItemProps) {
   );
 }
 
-GridColumnMenuManageItem.propTypes = {
+GridColumnMenuManageItem.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid/src/components/menu/columnMenu/menuItems/GridColumnMenuSortItem.tsx
+++ b/packages/x-data-grid/src/components/menu/columnMenu/menuItems/GridColumnMenuSortItem.tsx
@@ -89,7 +89,7 @@ function GridColumnMenuSortItem(props: GridColumnMenuItemProps) {
   );
 }
 
-GridColumnMenuSortItem.propTypes = {
+GridColumnMenuSortItem.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid/src/components/panel/GridPanelContent.tsx
+++ b/packages/x-data-grid/src/components/panel/GridPanelContent.tsx
@@ -47,7 +47,7 @@ function GridPanelContent(props: React.HTMLAttributes<HTMLDivElement> & { sx?: S
   );
 }
 
-GridPanelContent.propTypes = {
+GridPanelContent.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid/src/components/panel/GridPanelFooter.tsx
+++ b/packages/x-data-grid/src/components/panel/GridPanelFooter.tsx
@@ -44,7 +44,7 @@ function GridPanelFooter(props: React.HTMLAttributes<HTMLDivElement> & { sx?: Sx
   );
 }
 
-GridPanelFooter.propTypes = {
+GridPanelFooter.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid/src/components/panel/GridPanelHeader.tsx
+++ b/packages/x-data-grid/src/components/panel/GridPanelHeader.tsx
@@ -44,7 +44,7 @@ function GridPanelHeader(props: React.HTMLAttributes<HTMLDivElement> & { sx?: Sx
   );
 }
 
-GridPanelHeader.propTypes = {
+GridPanelHeader.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid/src/components/panel/filterPanel/GridFilterInputBoolean.tsx
+++ b/packages/x-data-grid/src/components/panel/filterPanel/GridFilterInputBoolean.tsx
@@ -111,7 +111,7 @@ export function sanitizeFilterItemValue(value: any): boolean | undefined {
   return undefined;
 }
 
-GridFilterInputBoolean.propTypes = {
+GridFilterInputBoolean.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid/src/components/panel/filterPanel/GridFilterInputDate.tsx
+++ b/packages/x-data-grid/src/components/panel/filterPanel/GridFilterInputDate.tsx
@@ -117,7 +117,7 @@ function GridFilterInputDate(props: GridFilterInputDateProps) {
   );
 }
 
-GridFilterInputDate.propTypes = {
+GridFilterInputDate.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid/src/components/panel/filterPanel/GridFilterInputMultipleSingleSelect.tsx
+++ b/packages/x-data-grid/src/components/panel/filterPanel/GridFilterInputMultipleSingleSelect.tsx
@@ -89,7 +89,7 @@ function GridFilterInputMultipleSingleSelect(props: GridFilterInputMultipleSingl
   );
 }
 
-GridFilterInputMultipleSingleSelect.propTypes = {
+GridFilterInputMultipleSingleSelect.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid/src/components/panel/filterPanel/GridFilterInputMultipleValue.tsx
+++ b/packages/x-data-grid/src/components/panel/filterPanel/GridFilterInputMultipleValue.tsx
@@ -82,7 +82,7 @@ function GridFilterInputMultipleValue(props: GridFilterInputMultipleValueProps) 
   );
 }
 
-GridFilterInputMultipleValue.propTypes = {
+GridFilterInputMultipleValue.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid/src/components/panel/filterPanel/GridFilterInputSingleSelect.tsx
+++ b/packages/x-data-grid/src/components/panel/filterPanel/GridFilterInputSingleSelect.tsx
@@ -137,7 +137,7 @@ function GridFilterInputSingleSelect(props: GridFilterInputSingleSelectProps) {
   );
 }
 
-GridFilterInputSingleSelect.propTypes = {
+GridFilterInputSingleSelect.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid/src/components/panel/filterPanel/GridFilterInputValue.tsx
+++ b/packages/x-data-grid/src/components/panel/filterPanel/GridFilterInputValue.tsx
@@ -107,7 +107,7 @@ function sanitizeFilterItemValue(value: unknown) {
   return String(value);
 }
 
-GridFilterInputValue.propTypes = {
+GridFilterInputValue.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid/src/components/quickFilter/QuickFilter.tsx
+++ b/packages/x-data-grid/src/components/quickFilter/QuickFilter.tsx
@@ -216,7 +216,7 @@ function QuickFilter(props: QuickFilterProps) {
   return <QuickFilterContext.Provider value={contextValue}>{element}</QuickFilterContext.Provider>;
 }
 
-QuickFilter.propTypes = {
+QuickFilter.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid/src/components/toolbar/GridToolbarExport.tsx
+++ b/packages/x-data-grid/src/components/toolbar/GridToolbarExport.tsx
@@ -59,7 +59,7 @@ function GridCsvExportMenuItem(props: GridCsvExportMenuItemProps) {
   );
 }
 
-GridCsvExportMenuItem.propTypes = {
+GridCsvExportMenuItem.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |
@@ -98,7 +98,7 @@ function GridPrintExportMenuItem(props: GridPrintExportMenuItemProps) {
   );
 }
 
-GridPrintExportMenuItem.propTypes = {
+GridPrintExportMenuItem.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid/src/components/toolbar/GridToolbarQuickFilter.tsx
+++ b/packages/x-data-grid/src/components/toolbar/GridToolbarQuickFilter.tsx
@@ -192,7 +192,7 @@ function GridToolbarQuickFilter(props: GridToolbarQuickFilterProps) {
   );
 }
 
-GridToolbarQuickFilter.propTypes = {
+GridToolbarQuickFilter.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-data-grid/src/components/toolbarV8/GridToolbar.tsx
+++ b/packages/x-data-grid/src/components/toolbarV8/GridToolbar.tsx
@@ -74,7 +74,7 @@ function GridToolbarDivider(props: GridSlotProps['baseDivider']) {
   );
 }
 
-GridToolbarDivider.propTypes = {
+GridToolbarDivider.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |
@@ -217,7 +217,7 @@ function GridToolbar(props: GridToolbarProps) {
   );
 }
 
-GridToolbar.propTypes = {
+GridToolbar.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-date-pickers-pro/src/DateTimeRangePicker/DateTimeRangePickerTabs.tsx
+++ b/packages/x-date-pickers-pro/src/DateTimeRangePicker/DateTimeRangePickerTabs.tsx
@@ -216,7 +216,7 @@ const DateTimeRangePickerTabs = function DateTimeRangePickerTabs(
   );
 };
 
-DateTimeRangePickerTabs.propTypes = {
+DateTimeRangePickerTabs.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-date-pickers-pro/src/TimeRangePicker/TimeRangePickerTabs.tsx
+++ b/packages/x-date-pickers-pro/src/TimeRangePicker/TimeRangePickerTabs.tsx
@@ -130,7 +130,7 @@ const TimeRangePickerTabs = function TimeRangePickerTabs(inProps: TimeRangePicke
   );
 };
 
-TimeRangePickerTabs.propTypes = {
+TimeRangePickerTabs.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-date-pickers-pro/src/TimeRangePicker/TimeRangePickerToolbar.tsx
+++ b/packages/x-date-pickers-pro/src/TimeRangePicker/TimeRangePickerToolbar.tsx
@@ -191,7 +191,7 @@ function TimeRangePickerToolbarTimeElement(props: TimeRangePickerToolbarTimeElem
   );
 }
 
-TimeRangePickerToolbarTimeElement.propTypes = {
+TimeRangePickerToolbarTimeElement.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-date-pickers/src/DateTimePicker/DateTimePickerTabs.tsx
+++ b/packages/x-date-pickers/src/DateTimePicker/DateTimePickerTabs.tsx
@@ -140,7 +140,7 @@ const DateTimePickerTabs = function DateTimePickerTabs(inProps: DateTimePickerTa
   );
 };
 
-DateTimePickerTabs.propTypes = {
+DateTimePickerTabs.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-date-pickers/src/DateTimePicker/DateTimePickerToolbar.tsx
+++ b/packages/x-date-pickers/src/DateTimePicker/DateTimePickerToolbar.tsx
@@ -449,7 +449,7 @@ function DateTimePickerToolbar(inProps: DateTimePickerToolbarProps) {
   );
 }
 
-DateTimePickerToolbar.propTypes = {
+DateTimePickerToolbar.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-date-pickers/src/DayCalendarSkeleton/DayCalendarSkeleton.tsx
+++ b/packages/x-date-pickers/src/DayCalendarSkeleton/DayCalendarSkeleton.tsx
@@ -113,7 +113,7 @@ function DayCalendarSkeleton(inProps: DayCalendarSkeletonProps) {
   );
 }
 
-DayCalendarSkeleton.propTypes = {
+DayCalendarSkeleton.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-date-pickers/src/PickersActionBar/PickersActionBar.tsx
+++ b/packages/x-date-pickers/src/PickersActionBar/PickersActionBar.tsx
@@ -117,7 +117,7 @@ function PickersActionBarComponent(props: PickersActionBarProps) {
   return <PickersActionBarRoot {...other}>{buttons}</PickersActionBarRoot>;
 }
 
-PickersActionBarComponent.propTypes = {
+PickersActionBarComponent.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-date-pickers/src/PickersSectionList/PickersSectionList.tsx
+++ b/packages/x-date-pickers/src/PickersSectionList/PickersSectionList.tsx
@@ -123,7 +123,7 @@ function PickersSection(props: PickersSectionProps) {
   );
 }
 
-PickersSection.propTypes = {
+PickersSection.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-date-pickers/src/PickersShortcuts/PickersShortcuts.tsx
+++ b/packages/x-date-pickers/src/PickersShortcuts/PickersShortcuts.tsx
@@ -109,7 +109,7 @@ function PickersShortcuts<TValue extends PickerValidValue>(props: PickersShortcu
   );
 }
 
-PickersShortcuts.propTypes = {
+PickersShortcuts.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-date-pickers/src/TimePicker/TimePickerToolbar.tsx
+++ b/packages/x-date-pickers/src/TimePicker/TimePickerToolbar.tsx
@@ -251,7 +251,7 @@ function TimePickerToolbar(inProps: TimePickerToolbarProps) {
   );
 }
 
-TimePickerToolbar.propTypes = {
+TimePickerToolbar.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-tree-view/src/TreeItemDragAndDropOverlay/TreeItemDragAndDropOverlay.tsx
+++ b/packages/x-tree-view/src/TreeItemDragAndDropOverlay/TreeItemDragAndDropOverlay.tsx
@@ -62,7 +62,7 @@ function TreeItemDragAndDropOverlay(props: TreeItemDragAndDropOverlayProps) {
   return <TreeItemDragAndDropOverlayRoot {...props} />;
 }
 
-TreeItemDragAndDropOverlay.propTypes = {
+TreeItemDragAndDropOverlay.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-tree-view/src/TreeItemIcon/TreeItemIcon.tsx
+++ b/packages/x-tree-view/src/TreeItemIcon/TreeItemIcon.tsx
@@ -74,7 +74,7 @@ function TreeItemIcon(props: TreeItemIconProps) {
   return <Icon {...iconProps} />;
 }
 
-TreeItemIcon.propTypes = {
+TreeItemIcon.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |

--- a/packages/x-tree-view/src/TreeItemProvider/TreeItemProvider.tsx
+++ b/packages/x-tree-view/src/TreeItemProvider/TreeItemProvider.tsx
@@ -15,7 +15,7 @@ function TreeItemProvider(props: TreeItemProviderProps) {
   return <React.Fragment>{wrapItem({ children, itemId, store, idAttribute })}</React.Fragment>;
 }
 
-TreeItemProvider.propTypes = {
+TreeItemProvider.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |


### PR DESCRIPTION
Side effect of regenerating propTypes after #22750 (strip propTypes from production bundles).

The `/* remove-proptypes */` marker lets the babel plugin strip these `propTypes` blocks from production bundles. Regenerating propTypes after #22750 emitted the markers across all packages.