### PR TITLE
[docs] Fix typo in release instructions

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -100,7 +100,7 @@ In case of a problem, another method to generate the changelog is available at t
 
 3. Click "Run workflow"
 4. Refresh the page to see the newly created workflow, and click it.
-5. The next screen shows "@username requested your review to deploy to npm-publish", click "Review deployments" and authorize your workflow run. **Never approve workflow runs you didn't initiaite.**
+5. The next screen shows "@username requested your review to deploy to npm-publish", click "Review deployments" and authorize your workflow run. **Never approve workflow runs you didn't initiate.**
 
 The action publishes packages, and prepares the GitHub release. The release tag is created during GitHub release. The GitHub release is created in draft mode.
 


### PR DESCRIPTION
Ports the applicable fix from the base-ui release-instructions overhaul (mui/base-ui#5063) to this repo's `scripts/README.md`:

- Fix typo `initiaite` → `initiate`

The rest of that PR is base-ui-specific and does not apply here.

Reference: https://github.com/mui/base-ui/pull/5063