### PR TITLE
[docs-infra] Use tsconfig path aliases in nextjs config

### DIFF
--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -65,6 +65,9 @@ export default withDeploymentConfig({
   experimental: {
     esmExternals: undefined,
   },
+  typescript: {
+    tsconfigPath: './tsconfig.json',
+  },
   transpilePackages: [
     // This is needed because the package has next.js imports like `next/script` that need to be transpiled.
     '@mui/internal-core-docs',

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "docs:api:buildX": "tsx ./docs/scripts/api/buildApi.ts",
     "docs:llms:build": "rimraf --glob ./docs/public/x/ && tsx ./scripts/buildLlmsDocs/index.ts --projectSettings scripts/buildApiDocs/projectSettings.ts",
     "docs:link-check": "pnpm --filter docs link-check",
-    "docs:build": "pnpm docs:llms:build && pnpm --filter docs build",
+    "docs:build": "pnpm --filter @mui/x-charts-vendor build && pnpm docs:llms:build && pnpm --filter docs build",
     "docs:typescript:formatted": "pnpm --filter docs typescript:transpile",
     "docs:populate:demos": "pnpm --filter docs populate:demos",
     "docs:importDocsStatic": "node scripts/importDocsStatic.mjs",


### PR DESCRIPTION
Fix `docs:build` (Netlify) failing on `@mui/x-charts-vendor/d3-*` imports.

Two issues:

1. **Stale build output** — `@mui/x-*` source packages resolved to `build/` instead of `src`. Now aliased to source via `tsconfig.json` paths.

2. **Missing vendor build** — `x-charts-vendor/build/` (gitignored, built by `postinstall`) is absent on Netlify because the dependency cache makes `pnpm install` a no-op, skipping `postinstall`. `docs:build` now builds it explicitly first.
