### PR TITLE
[pickers] Respect explicit `notched` prop on the outlined PickersTextField (#22875)

### DIFF
--- a/docs/pages/x/api/date-pickers/pickers-text-field.json
+++ b/docs/pages/x/api/date-pickers/pickers-text-field.json
@@ -79,6 +79,8 @@
       "isGlobal": false
     }
   ],
+  "spread": true,
+  "themeDefaultProps": null,
   "muiName": "MuiPickersTextField",
   "filename": "/packages/x-date-pickers/src/PickersTextField/PickersTextField.tsx",
   "inheritance": null,

--- a/packages/x-date-pickers/src/PickersTextField/PickersOutlinedInput/PickersOutlinedInput.tsx
+++ b/packages/x-date-pickers/src/PickersTextField/PickersOutlinedInput/PickersOutlinedInput.tsx
@@ -127,23 +127,29 @@ const PickersOutlinedInput = React.forwardRef(function PickersOutlinedInput(
   return (
     <PickersInputBase
       slots={{ root: PickersOutlinedInputRoot, input: PickersOutlinedInputSectionsContainer }}
-      renderSuffix={(state) => (
-        <Outline
-          shrink={Boolean(notched || state.adornedStart || state.focused || state.filled)}
-          notched={Boolean(notched || state.adornedStart || state.focused || state.filled)}
-          className={classes.notchedOutline}
-          label={
-            label != null && label !== '' && muiFormControl?.required ? (
-              <React.Fragment>
-                {label}
-                &thinsp;{'*'}
-              </React.Fragment>
-            ) : (
-              label
-            )
-          }
-        />
-      )}
+      renderSuffix={(state) => {
+        const isNotched =
+          typeof notched !== 'undefined'
+            ? notched
+            : Boolean(state.adornedStart || state.focused || state.filled);
+        return (
+          <Outline
+            shrink={isNotched}
+            notched={isNotched}
+            className={classes.notchedOutline}
+            label={
+              label != null && label !== '' && muiFormControl?.required ? (
+                <React.Fragment>
+                  {label}
+                  &thinsp;{'*'}
+                </React.Fragment>
+              ) : (
+                label
+              )
+            }
+          />
+        );
+      }}
       {...other}
       label={label}
       classes={classes}

--- a/packages/x-date-pickers/src/PickersTextField/PickersTextField.test.tsx
+++ b/packages/x-date-pickers/src/PickersTextField/PickersTextField.test.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { PickersTextField } from '@mui/x-date-pickers/PickersTextField';
+import { createPickerRenderer } from 'test/utils/pickers';
+
+const STUB_PROPS = {
+  areAllSectionsEmpty: true,
+  contentEditable: false,
+  elements: [
+    {
+      after: { children: null },
+      before: { children: null },
+      container: { children: null },
+      content: { children: null, 'data-range-position': 'start' },
+    },
+  ],
+} as any;
+
+describe('<PickersTextField /> - outlined notch', () => {
+  const { render } = createPickerRenderer();
+
+  // The collapsed legend keeps a fixed `0.01px` max-width, while the notched legend expands.
+  const COLLAPSED_LEGEND_MAX_WIDTH = '0.01px';
+
+  it('should notch the outline when the field is filled and `notched` is not set', () => {
+    render(<PickersTextField {...STUB_PROPS} areAllSectionsEmpty={false} label="My label" />);
+
+    const legend = document.querySelector('legend')!;
+    expect(window.getComputedStyle(legend).maxWidth).not.to.equal(COLLAPSED_LEGEND_MAX_WIDTH);
+  });
+
+  it('should remove the notch when `notched={false}` is passed, even when the field is filled', () => {
+    render(
+      <PickersTextField
+        {...STUB_PROPS}
+        areAllSectionsEmpty={false}
+        label="My label"
+        InputProps={{ notched: false } as any}
+      />,
+    );
+
+    const legend = document.querySelector('legend')!;
+    expect(window.getComputedStyle(legend).maxWidth).to.equal(COLLAPSED_LEGEND_MAX_WIDTH);
+  });
+});


### PR DESCRIPTION
Cherry-pick of #22875 to `v8.x`.

The automated cherry-pick ([run](https://github.com/mui/mui-x/actions/runs/27812832024/job/82306922111)) failed on a modify/delete conflict: the regression test was added to `PickersTextField.test.tsx`, which only exists on `master` (it was created by the `slotProps` refactor #22002, not present on `v8.x`).

Resolution:

- Ported the source fix in `PickersOutlinedInput.tsx` manually, keeping the `v8.x` component structure; only the `renderSuffix` notch logic changed so an explicit `notched` is respected.
- Re-added the regression test as a self-contained `PickersTextField.test.tsx`, adapted to the `v8.x` API (`InputProps={{ notched: false }}` instead of the master-only `slotProps.input`).