### PR TITLE
[docs][charts] Fix scatter renderer table blocking column

### DIFF
--- a/docs/data/charts/scatter/scatter.md
+++ b/docs/data/charts/scatter/scatter.md
@@ -152,8 +152,8 @@ Set `experimentalFeatures.progressiveRendering` to `true` to get the renderer ch
 | :--------------------------------------------------------------------------------------------------- | :------------- | :-- | :----------- | :----------------------- | :--------------------------------- |
 | `svg-single`                                                                                         | `circle`       | Yes | Yes          | Blocks until fully drawn | Small datasets                     |
 | `svg-progressive`                                                                                    | `circle`       | Yes | Yes          | Stays responsive         | Large datasets that still need CSS |
-| `svg-batch`                                                                                          | grouped `path` | No  | Limited      | Stays responsive         | Very large datasets                |
-| `webgl` [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan 'Premium plan') | WebGL canvas   | No  | No           | Stays responsive         | Massive datasets                   |
+| `svg-batch`                                                                                          | grouped `path` | No  | Limited      | Blocks until fully drawn | Very large datasets                |
+| `webgl` [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan 'Premium plan') | WebGL canvas   | No  | No           | Blocks until fully drawn | Massive datasets                   |
 
 **CSS**: whether you can style individual points with CSS selectors.
 


### PR DESCRIPTION
## Problem

The scatter "Choosing a renderer" table claimed `svg-batch` and `webgl` keep the chart responsive while rendering. That is not true: both render in a single synchronous pass. They are fast, but they block the main thread until fully drawn.

Only `svg-progressive` actually stays responsive, by processing series/axes off the render path and painting points progressively across animation frames.

## Change

Set the **Blocking** column to "Blocks until fully drawn" for `svg-batch` and `webgl`.