### PR TITLE
[docs][charts] Double point count in ScatterAsyncRenderer demo

### DIFF
--- a/docs/data/charts/scatter/ScatterAsyncRenderer.js
+++ b/docs/data/charts/scatter/ScatterAsyncRenderer.js
@@ -164,7 +164,9 @@ function RenderTimers(props) {
 }
 
 export default function ScatterAsyncRenderer() {
-  const [mode, setMode] = React.useState('sync');
+  // Default to progressive so first paint on docs load does not block the
+  // main thread while rendering all points at once.
+  const [mode, setMode] = React.useState('async');
   const series = mode === 'sync' ? syncSeries : asyncSeries;
 
   const containerRef = React.useRef(null);

--- a/docs/data/charts/scatter/ScatterAsyncRenderer.js
+++ b/docs/data/charts/scatter/ScatterAsyncRenderer.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import Stack from '@mui/material/Stack';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
+import Tooltip from '@mui/material/Tooltip';
 import { ScatterChartPro } from '@mui/x-charts-pro/ScatterChartPro';
 import Chance from 'chance';
 
@@ -65,18 +66,25 @@ function MainThreadSpinner() {
   }, []);
 
   return (
-    <div
-      ref={ref}
-      aria-label="main thread activity"
-      style={{
-        width: 16,
-        height: 16,
-        borderRadius: '50%',
-        border: '2px solid currentColor',
-        borderTopColor: 'transparent',
-        opacity: 0.6,
-      }}
-    />
+    <Tooltip
+      title="Animated on the main thread. It keeps spinning smoothly while the main thread is free, and stutters or freezes when the renderer blocks it — watch it while switching modes."
+      arrow
+    >
+      <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center' }}>
+        <div
+          ref={ref}
+          aria-label="main thread activity"
+          style={{
+            width: 16,
+            height: 16,
+            borderRadius: '50%',
+            border: '2px solid currentColor',
+            borderTopColor: 'transparent',
+            opacity: 0.6,
+          }}
+        />
+      </Stack>
+    </Tooltip>
   );
 }
 

--- a/docs/data/charts/scatter/ScatterAsyncRenderer.js
+++ b/docs/data/charts/scatter/ScatterAsyncRenderer.js
@@ -7,7 +7,7 @@ import Chance from 'chance';
 
 const NUMBER_OF_SERIES = 3;
 
-const POINT_COUNT = 20000;
+const POINT_COUNT = 40000;
 
 // Gaussian-ish blobs so the progressive, batched paint is easy to see. Points
 // are split into `NUMBER_OF_SERIES` contiguous series, each offset into its

--- a/docs/data/charts/scatter/ScatterAsyncRenderer.tsx
+++ b/docs/data/charts/scatter/ScatterAsyncRenderer.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import Stack from '@mui/material/Stack';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
+import Tooltip from '@mui/material/Tooltip';
 import { ScatterChartPro } from '@mui/x-charts-pro/ScatterChartPro';
 import Chance from 'chance';
 
@@ -65,18 +66,25 @@ function MainThreadSpinner() {
   }, []);
 
   return (
-    <div
-      ref={ref}
-      aria-label="main thread activity"
-      style={{
-        width: 16,
-        height: 16,
-        borderRadius: '50%',
-        border: '2px solid currentColor',
-        borderTopColor: 'transparent',
-        opacity: 0.6,
-      }}
-    />
+    <Tooltip
+      title="Animated on the main thread. It keeps spinning smoothly while the main thread is free, and stutters or freezes when the renderer blocks it — watch it while switching modes."
+      arrow
+    >
+      <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center' }}>
+        <div
+          ref={ref}
+          aria-label="main thread activity"
+          style={{
+            width: 16,
+            height: 16,
+            borderRadius: '50%',
+            border: '2px solid currentColor',
+            borderTopColor: 'transparent',
+            opacity: 0.6,
+          }}
+        />
+      </Stack>
+    </Tooltip>
   );
 }
 

--- a/docs/data/charts/scatter/ScatterAsyncRenderer.tsx
+++ b/docs/data/charts/scatter/ScatterAsyncRenderer.tsx
@@ -168,7 +168,9 @@ function RenderTimers(props: {
 }
 
 export default function ScatterAsyncRenderer() {
-  const [mode, setMode] = React.useState<'sync' | 'async'>('sync');
+  // Default to progressive so first paint on docs load does not block the
+  // main thread while rendering all points at once.
+  const [mode, setMode] = React.useState<'sync' | 'async'>('async');
   const series = mode === 'sync' ? syncSeries : asyncSeries;
 
   const containerRef = React.useRef<HTMLDivElement>(null);

--- a/docs/data/charts/scatter/ScatterAsyncRenderer.tsx
+++ b/docs/data/charts/scatter/ScatterAsyncRenderer.tsx
@@ -7,7 +7,7 @@ import Chance from 'chance';
 
 const NUMBER_OF_SERIES = 3;
 
-const POINT_COUNT = 20000;
+const POINT_COUNT = 40000;
 
 // Gaussian-ish blobs so the progressive, batched paint is easy to see. Points
 // are split into `NUMBER_OF_SERIES` contiguous series, each offset into its


### PR DESCRIPTION
Bumps `POINT_COUNT` from 20000 to 40000 in the `ScatterAsyncRenderer` demo to better exercise the progressive renderer.
Also adds a tooltip to explain spinner.
Make async the default

Docs-only change.