### PR TITLE
[data grid] Fix hideMenu prop leaking to DOM in GridToolbarExportContainer

### DIFF
--- a/packages/x-data-grid/src/components/toolbar/GridToolbarExportContainer.tsx
+++ b/packages/x-data-grid/src/components/toolbar/GridToolbarExportContainer.tsx
@@ -84,13 +84,9 @@ const GridToolbarExportContainer = forwardRef<
           className={gridClasses.menuList}
           aria-labelledby={exportButtonId}
           autoFocusItem={open}
+          onClick={handleMenuClose}
         >
-          {React.Children.map(children, (child) => {
-            if (!React.isValidElement(child)) {
-              return child;
-            }
-            return React.cloneElement<any>(child, { hideMenu: handleMenuClose });
-          })}
+          {children}
         </rootProps.slots.baseMenuList>
       </GridMenu>
     </React.Fragment>


### PR DESCRIPTION
Fixes #22909

## Problem

`GridToolbarExportContainer` uses `React.cloneElement` to inject a `hideMenu` prop into all children. When a user passes a bare `<MenuItem>` (or any component that forwards all props to the DOM), `hideMenu` leaks onto the DOM `<li>` element, triggering a React 19 warning:

> React does not recognize the `hideMenu` prop on a DOM element.

## Fix

Remove the `React.cloneElement` injection of `hideMenu` into children. Instead, close the export menu via an `onClick` handler on the `baseMenuList`. Click events from any child item bubble up to the list and trigger the menu close — same end behavior, no DOM prop leakage.

The built-in export menu items (`GridCsvExportMenuItem`, `GridPrintExportMenuItem`) already destructure `hideMenu` from their own props with `hideMenu?.()` optional chaining, so receiving `undefined` is safe.