### PR TITLE
[data-grid] Deduplicate scroll-preserving focus logic

### DIFF
--- a/packages/x-data-grid/src/components/cell/GridCell.tsx
+++ b/packages/x-data-grid/src/components/cell/GridCell.tsx
@@ -12,7 +12,7 @@ import { forwardRef } from '@mui/x-internals/forwardRef';
 import { useStore } from '@mui/x-internals/store';
 import { Rowspan } from '@mui/x-virtualizer';
 import useEnhancedEffect from '@mui/utils/useEnhancedEffect';
-import { doesSupportPreventScroll } from '../../utils/doesSupportPreventScroll';
+import { focusElement } from '../../utils/focusElement';
 import { getDataGridUtilityClass, gridClasses } from '../../constants/gridClasses';
 import {
   type GridCellEventLookup,
@@ -363,13 +363,7 @@ const GridCell = forwardRef<HTMLDivElement, GridCellProps>(function GridCell(pro
       const focusableElement = cellRef.current!.querySelector<HTMLElement>('[tabindex="0"]');
       const elementToFocus = focusableElement || cellRef.current;
 
-      if (doesSupportPreventScroll()) {
-        elementToFocus.focus({ preventScroll: true });
-      } else {
-        const scrollPosition = apiRef.current.getScrollPosition();
-        elementToFocus.focus();
-        apiRef.current.scroll(scrollPosition);
-      }
+      focusElement(elementToFocus, apiRef);
     }
   }, [hasFocus, cellMode, apiRef]);
 

--- a/packages/x-data-grid/src/components/columnHeaders/GridColumnGroupHeader.tsx
+++ b/packages/x-data-grid/src/components/columnHeaders/GridColumnGroupHeader.tsx
@@ -5,7 +5,7 @@ import composeClasses from '@mui/utils/composeClasses';
 import capitalize from '@mui/utils/capitalize';
 import { useRtl } from '@mui/system/RtlProvider';
 import { useGridPrivateApiContext } from '../../hooks/utils/useGridPrivateApiContext';
-import { doesSupportPreventScroll } from '../../utils/doesSupportPreventScroll';
+import { focusElement } from '../../utils/focusElement';
 import type { GridAlignment } from '../../models/colDef/gridColDef';
 import { getDataGridUtilityClass } from '../../constants/gridClasses';
 import { useGridRootProps } from '../../hooks/utils/useGridRootProps';
@@ -151,13 +151,7 @@ function GridColumnGroupHeader(props: GridColumnGroupHeaderProps) {
       if (!elementToFocus) {
         return;
       }
-      if (doesSupportPreventScroll()) {
-        elementToFocus.focus({ preventScroll: true });
-      } else {
-        const scrollPosition = apiRef.current.getScrollPosition();
-        elementToFocus.focus();
-        apiRef.current.scroll(scrollPosition);
-      }
+      focusElement(elementToFocus, apiRef);
     }
   }, [apiRef, hasFocus]);
 

--- a/packages/x-data-grid/src/components/columnHeaders/GridColumnHeaderItem.tsx
+++ b/packages/x-data-grid/src/components/columnHeaders/GridColumnHeaderItem.tsx
@@ -7,7 +7,7 @@ import capitalize from '@mui/utils/capitalize';
 import useId from '@mui/utils/useId';
 import { fastMemo } from '@mui/x-internals/fastMemo';
 import { useRtl } from '@mui/system/RtlProvider';
-import { doesSupportPreventScroll } from '../../utils/doesSupportPreventScroll';
+import { focusElement } from '../../utils/focusElement';
 import type { GridStateColDef } from '../../models/colDef/gridColDef';
 import type { GridSortDirection } from '../../models/gridSortModel';
 import { useGridPrivateApiContext } from '../../hooks/utils/useGridPrivateApiContext';
@@ -311,13 +311,7 @@ function GridColumnHeaderItem(props: GridColumnHeaderItemProps) {
       if (!elementToFocus) {
         return;
       }
-      if (doesSupportPreventScroll()) {
-        elementToFocus.focus({ preventScroll: true });
-      } else {
-        const scrollPosition = apiRef.current.getScrollPosition();
-        elementToFocus.focus();
-        apiRef.current.scroll(scrollPosition);
-      }
+      focusElement(elementToFocus, apiRef);
     }
   }, [apiRef, hasFocus]);
 

--- a/packages/x-data-grid/src/hooks/features/focus/useGridFocus.ts
+++ b/packages/x-data-grid/src/hooks/features/focus/useGridFocus.ts
@@ -18,7 +18,7 @@ import {
   gridFocusCellSelector,
   gridFocusColumnGroupHeaderSelector,
 } from './gridFocusStateSelector';
-import { doesSupportPreventScroll } from '../../../utils/doesSupportPreventScroll';
+import { focusElement } from '../../../utils/focusElement';
 import type { GridStateInitializer } from '../../utils/useGridInitializeState';
 import { gridVisibleColumnDefinitionsSelector } from '../columns/gridColumnsSelector';
 import { getVisibleRows } from '../../utils/useGridVisibleRows';
@@ -104,13 +104,7 @@ export const useGridFocus = (
           return;
         }
 
-        if (doesSupportPreventScroll()) {
-          cellElement.focus({ preventScroll: true });
-        } else {
-          const scrollPosition = apiRef.current.getScrollPosition();
-          cellElement.focus();
-          apiRef.current.scroll(scrollPosition);
-        }
+        focusElement(cellElement, apiRef);
 
         return;
       }

--- a/packages/x-data-grid/src/utils/focusElement.ts
+++ b/packages/x-data-grid/src/utils/focusElement.ts
@@ -1,0 +1,22 @@
+import type * as React from 'react';
+import type { GridPrivateApiCommunity } from '../models/api/gridApiCommunity';
+import { doesSupportPreventScroll } from './doesSupportPreventScroll';
+
+/**
+ * Focuses an element while preserving the grid scroll position.
+ *
+ * Uses the native `preventScroll` focus option when supported, and otherwise
+ * restores the scroll position manually after focusing.
+ */
+export function focusElement(
+  element: HTMLElement,
+  apiRef: React.RefObject<GridPrivateApiCommunity>,
+): void {
+  if (doesSupportPreventScroll()) {
+    element.focus({ preventScroll: true });
+  } else {
+    const scrollPosition = apiRef.current.getScrollPosition();
+    element.focus();
+    apiRef.current.scroll(scrollPosition);
+  }
+}

--- a/packages/x-data-grid/src/utils/focusElement.ts
+++ b/packages/x-data-grid/src/utils/focusElement.ts
@@ -1,5 +1,5 @@
-import type * as React from 'react';
-import type { GridPrivateApiCommunity } from '../models/api/gridApiCommunity';
+import type { RefObject } from '@mui/x-internals/types';
+import type { GridScrollApi } from '../models/api/gridScrollApi';
 import { doesSupportPreventScroll } from './doesSupportPreventScroll';
 
 /**
@@ -8,9 +8,9 @@ import { doesSupportPreventScroll } from './doesSupportPreventScroll';
  * Uses the native `preventScroll` focus option when supported, and otherwise
  * restores the scroll position manually after focusing.
  */
-export function focusElement(
+export function focusElement<Api extends GridScrollApi>(
   element: HTMLElement,
-  apiRef: React.RefObject<GridPrivateApiCommunity>,
+  apiRef: RefObject<Api>,
 ): void {
   if (doesSupportPreventScroll()) {
     element.focus({ preventScroll: true });


### PR DESCRIPTION
The preventScroll-aware "focus an element while preserving the grid scroll position" block was copy-pasted in four places (GridCell, GridColumnHeaderItem, GridColumnGroupHeader, useGridFocus). Extract it into a shared `focusElement(element, apiRef)` utility. No behavior change