### PR TITLE
[code-infra] Fix react@^18 CI failing on nanoid trust-downgrade

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -92,6 +92,9 @@ minimumReleaseAge: 4320
 minimumReleaseAgeExclude:
   - '@mui/*'
   - '@base-ui/*'
+  # nanoid@3.3.14 fails the no-downgrade trust policy (no provenance); this forces the attested 3.3.15.
+  # Removable from 2026-06-25, once 3.3.15 ages past minimumReleaseAge.
+  - 'nanoid@3.3.15'
 trustPolicy: no-downgrade
 # Skip trust-policy checks for packages published more than 365 days ago.
 # Some widely-used legacy packages (notably semver@6.x — pulled in by @babel/core@7.x — plus


### PR DESCRIPTION
## Problem

All `*_react_18` CI jobs (`test_unit_react_18`, `test_browser_react_18`, `test_e2e_react_18`) started failing in the **Install js dependencies** step, before any test runs:

```
[ERR_PNPM_TRUST_DOWNGRADE] High-risk trust downgrade for "nanoid@3.3.14" (possible package takeover)
This error happened while installing the dependencies of postcss@8.5.15
```

Example: https://app.circleci.com/pipelines/github/mui/mui-x/134351/workflows/af018f65-9aac-4f38-86f8-06b220834647/jobs/868597

## Root cause

This is the repo's own `trustPolicy: no-downgrade` (pnpm supply-chain feature) firing on a false positive:

- `nanoid@3.3.13` was published via a staged/trusted publish; `nanoid@3.3.14` (2026-06-20) dropped all trust evidence, so `no-downgrade` rejects it as a downgrade. It is published by the legitimate maintainer (`ai`, also postcss's author), not a real takeover.
- `3.3.14` is the newest version old enough to pass `minimumReleaseAge: 4320` (3 days). `nanoid@3.3.15` restored SLSA provenance but is still inside the 3-day window, so the resolver can't pick it yet and falls back to the unattested `3.3.14`.
- **Why only the react@^18 jobs:** they install with `package-overrides` (`react@^18 ...`), which re-resolves the dependency graph and pulls in `nanoid@3.3.14`. The other jobs install the committed lockfile frozen, pinned to the trusted `nanoid@3.3.12`, so they never re-resolve. `pnpm dedupe` hits the same wall whenever it re-resolves nanoid (pnpm/pnpm#10329).

## Solutions considered

Two one-line fixes unblock CI. Both are self-expiring: they go inert once `nanoid@3.3.15` ages past the 3-day `minimumReleaseAge` window and resolves on its own.

**Option A (chosen) -- relax the soak gate for the attested version**

```yaml
minimumReleaseAgeExclude:
  - 'nanoid@3.3.15'
```

Lets the resolver reach `nanoid@3.3.15`, which has restored SLSA provenance and passes `no-downgrade` on its own merit. Only the time-soak gate is waived, for one explicitly-named, attested version; the trust check stays fully enforced.

**Option B (rejected) -- whitelist the unattested version in the trust policy**

```yaml
trustPolicyExclude:
  - 'nanoid@3.3.14'
```

Excludes `nanoid@3.3.14` from the trust check, allowing the unattested build through. The soak gate stays, the provenance/trust gate is relaxed.

### Comparison

| | Option A (chosen) | Option B |
|---|---|---|
| Resolves to | `nanoid@3.3.15` (SLSA provenance) | `nanoid@3.3.14` (no attestation) |
| Gate relaxed | time-soak only; trust stays enforced | trust/`no-downgrade`; soak stays |
| Baked into committed lockfile on re-resolve | attested `3.3.15`, passes a frozen re-verify | unattested `3.3.14`, fails frozen re-verify unless the exclude is carried repo-wide |
| Self-expiry | yes, once `3.3.15` ages in the entry is ignored | only once a later re-resolution moves off `3.3.14`; `3.3.14` never gains provenance |

### Why Option A

Re-resolution (the react@^18 overrides install, `pnpm dedupe`, Renovate, a lockfile regen) writes the chosen nanoid version into the committed lockfile, and frozen installs re-verify lockfile entries against the active policies (pnpm 11.1.3+). Committing the unattested `3.3.14` (Option B) is therefore a standing trust-policy exception that every frozen install repo-wide must carry, and `3.3.14` never gains provenance to clear it. Committing the attested `3.3.15` (Option A) passes cleanly, and the soak exemption self-expires within hours. Option A keeps the stronger guarantee (provenance) enforced and only waives the softer time-soak gate.

Honest trade-off: Option A does shave soak time off `3.3.15`, and soak time is the one gate that would catch malware shipped *with* valid provenance (e.g. a maintainer/CI compromise). Low-stakes here -- legitimate maintainer, the version has already soaked ~2.4 days, and the entry self-expires the same day -- but noted.

## Verification

Reproduced locally with the repo's trust settings + `postcss@8.5.15`:

- Baseline (no fix): install and `pnpm dedupe` both fail with `ERR_PNPM_TRUST_DOWNGRADE` on `3.3.14`.
- Option A: the re-resolving install and `pnpm dedupe` both succeed and resolve `nanoid@3.3.15`.
- Frozen re-verify: a committed `3.3.14` fails `no-downgrade` once the exclude is removed; a committed `3.3.15` only trips the (transient) soak gate and passes once aged in.

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
