### PR TITLE
fix(deps): pin nanoid to 3.3.15 to avoid pnpm trust downgrade error

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -122,3 +122,6 @@ overrides:
   # @TODO: Debug a fix separately and remove the override
   stylis: ^4.4.0
   caniuse-lite: ^1.0.30001793
+  # Pin nanoid to a version with provenance to avoid pnpm trust downgrade error on 3.3.14 (possible package takeover)
+  # @TODO: Remove this override once postcss resolves to a trusted nanoid version on its own
+  nanoid: 3.3.15


### PR DESCRIPTION
## Problem

Fresh installs fail with:

```
[ERR_PNPM_TRUST_DOWNGRADE] High-risk trust downgrade for "nanoid@3.3.14" (possible package takeover)

This error happened while installing the dependencies of postcss@8.5.15
```

`nanoid@3.3.14` has no trust evidence while earlier versions had staged-publish evidence, so pnpm's `no-downgrade` trust policy blocks it as a possible supply-chain incident. `nanoid` is a transitive dependency pulled in exclusively through `postcss`.

## Fix

Pin `nanoid` to `3.3.15` (which has provenance) via a pnpm workspace override in `pnpm-workspace.yaml`:

```yaml
overrides:
  # Pin nanoid to a version with provenance to avoid pnpm trust downgrade error on 3.3.14 (possible package takeover)
  # @TODO: Remove this override once postcss resolves to a trusted nanoid version on its own
  nanoid: 3.3.15
```

A `@TODO` comment is included so the override is removed once `postcss` resolves to a trusted `nanoid` version on its own.

## Note on the lockfile

`pnpm-lock.yaml` is intentionally **not** regenerated in this PR. At the time of writing, `nanoid@3.3.15` (published 2026-06-21) is still within the repo's `minimumReleaseAge: 4320` (3-day) window, so `pnpm install` aborts with `ERR_PNPM_NO_MATURE_MATCHING_VERSION`. The repo's supply-chain trust/release-age policy was deliberately left untouched. Once `3.3.15` ages past the 3-day window, run `pnpm install` to regenerate the lockfile so the override takes effect.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X58rVv9TDSKDWCh7F4bWfp)_