### PR TITLE
[code-infra] Reduce Netlify build parallelism to 2

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -12,7 +12,7 @@
   # Cap the Next.js docs build worker count (read by `withDocsInfra`, which
   # otherwise defaults to `os.availableParallelism()`) to avoid OOM during the
   # static export build.
-  NEXT_PARALLELISM = "3"
+  NEXT_PARALLELISM = "2"
 
 # disabled because of https://github.com/mui/mui-public/issues/809
 # TODO: Re-enable after either:


### PR DESCRIPTION
## Overview

Netlify deploys have been failing too often (OOM during the static export build). This lowers the Next.js docs build worker count to reduce concurrent memory pressure.

## What changed

- `netlify.toml`: `NEXT_PARALLELISM` `3` -> `2`.

`NEXT_PARALLELISM` is read by `withDocsInfra`, which otherwise defaults to `os.availableParallelism()`. Capping it lower trades some build speed for lower peak memory usage during the static export build.

## Reviewer notes

This is a mitigation attempt, not a confirmed root-cause fix. If deploys stabilize at `2`, we keep it; if they still fail, the next step is to look further into the build's memory profile.
