### PR TITLE
[charts] Fix `DefaultContent` false-positive PropTypes warning for `formattedValue`

### DIFF
--- a/packages/x-charts/src/ChartsTooltip/ChartsAxisTooltipContent.tsx
+++ b/packages/x-charts/src/ChartsTooltip/ChartsAxisTooltipContent.tsx
@@ -100,8 +100,8 @@ function ChartsAxisTooltipContent(props: ChartsAxisTooltipContentProps) {
   );
 }
 
-function DefaultContent<T extends CartesianChartSeriesType | PolarChartSeriesType>(
-  props: AxisTooltipContentProps<T>,
+function DefaultContent(
+  props: AxisTooltipContentProps<Exclude<CartesianChartSeriesType, 'ohlc'> | PolarChartSeriesType>,
 ) {
   const classes = useUtilityClasses(props.classes);
   const { item } = props;
@@ -146,14 +146,24 @@ DefaultContent.propTypes /* remove-proptypes */ = {
   item: PropTypes.shape({
     color: PropTypes.string.isRequired,
     formattedLabel: PropTypes.string,
-    formattedValue: PropTypes.object.isRequired,
+    formattedValue: PropTypes.string.isRequired,
     markShape: PropTypes.oneOf(['circle', 'cross', 'diamond', 'square', 'star', 'triangle', 'wye']),
     markType: PropTypes.oneOfType([
       PropTypes.oneOf(['circle', 'line', 'line+mark', 'square']),
       PropTypes.func,
     ]),
     seriesId: PropTypes.string.isRequired,
-    value: PropTypes.any.isRequired,
+    value: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.shape({
+        colorValue: PropTypes.any,
+        id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+        sizeValue: PropTypes.any,
+        x: PropTypes.number.isRequired,
+        y: PropTypes.number.isRequired,
+        z: PropTypes.any,
+      }),
+    ]),
   }).isRequired,
 } as any;
 


### PR DESCRIPTION
## Issue

Closes #22926

A false-positive PropTypes warning fires on every standard `LineChart`/`BarChart` whose series uses a `valueFormatter` returning a string:

> Warning: Failed prop type: Invalid prop `item.formattedValue` of type `string` supplied to `DefaultContent`, expected `object`.

## Root cause

`DefaultContent` was generic over `T extends CartesianChartSeriesType | PolarChartSeriesType`. Because `T` was a bare type parameter, the conditional type behind `SeriesItem<T>.formattedValue` —

```ts
formattedValue: T extends 'ohlc'
  ? { open: string | null; high: string | null; low: string | null; close: string | null }
  : string;
```

— stayed *deferred*, and the `pnpm proptypes` generator resolved it to `PropTypes.object`. That contradicts the component's own runtime guard, which only ever renders string values:

```ts
if (item.formattedValue == null || typeof item.formattedValue !== 'string') {
  return null;
}
```

## Fix

`DefaultContent` is the fallback renderer for non-ohlc series — candlestick (ohlc) supplies its own `AxisTooltipContent`. Making the component non-generic with a concrete type argument that excludes `'ohlc'` lets the conditional evaluate eagerly to `string`:

```ts
function DefaultContent(
  props: AxisTooltipContentProps<Exclude<CartesianChartSeriesType, 'ohlc'> | PolarChartSeriesType>,
) {
```

Regenerating proptypes (`pnpm proptypes`) now produces `formattedValue: PropTypes.string.isRequired` (and resolves `value` to a proper `oneOfType` instead of `any`).

## Verification

- `pnpm --filter "@mui/x-charts" run typescript` passes
- eslint clean on the changed file
- The repro from the issue no longer logs a PropTypes warning on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)
