### PR TITLE
[code-infra] Revert nanoid@3.3.15 minimumReleaseAge exemption

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -92,9 +92,6 @@ minimumReleaseAge: 4320
 minimumReleaseAgeExclude:
   - '@mui/*'
   - '@base-ui/*'
-  # nanoid@3.3.14 fails the no-downgrade trust policy (no provenance); this forces the attested 3.3.15.
-  # Removable from 2026-06-25, once 3.3.15 ages past minimumReleaseAge.
-  - 'nanoid@3.3.15'
 trustPolicy: no-downgrade
 # Skip trust-policy checks for packages published more than 365 days ago.
 # Some widely-used legacy packages (notably semver@6.x — pulled in by @babel/core@7.x — plus


### PR DESCRIPTION
Reverts the temporary workaround from https://github.com/mui/mui-x/pull/22923.

## Why

`nanoid@3.3.15` (restored SLSA provenance) has now aged past the 3-day `minimumReleaseAge` soak window (it became installable at 2026-06-24 21:23 UTC) and is the newest `3.3.x`. So any re-resolution (the `react@^18` `package-overrides` install, `pnpm dedupe`) now lands on `3.3.15` and passes `trustPolicy: no-downgrade` on its own merit. The `minimumReleaseAgeExclude` entry is inert and can be removed.

## Verification

A re-resolving install on the repo's exact policy settings + `postcss@8.5.15`, with no nanoid exemption, succeeds and resolves `nanoid@3.3.15`.

Note: this self-heals only because nanoid's latest `3.3.x` is attested. If the maintainer later ships another provenance-less patch, the same `ERR_PNPM_TRUST_DOWNGRADE` can recur on the react_18 re-resolution and the one-line exemption (pointed at the next attested version) would be reintroduced.

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)