### PR TITLE
fix: avoid forwarding hideMenu to menu items

### DIFF
--- a/packages/x-data-grid/src/components/toolbar/GridToolbarExportContainer.tsx
+++ b/packages/x-data-grid/src/components/toolbar/GridToolbarExportContainer.tsx
@@ -89,6 +89,23 @@ const GridToolbarExportContainer = forwardRef<
             if (!React.isValidElement(child)) {
               return child;
             }
+            if (
+              child.type === rootProps.slots.baseMenuItem ||
+              (child.type as any).muiName === 'MenuItem'
+            ) {
+              const childProps = child.props as {
+                onClick?: React.MouseEventHandler<HTMLElement>;
+              };
+
+              return React.cloneElement<any>(child, {
+                onClick: (event: React.MouseEvent<HTMLElement>) => {
+                  childProps.onClick?.(event);
+                  if (!event.defaultPrevented) {
+                    handleMenuClose();
+                  }
+                },
+              });
+            }
             return React.cloneElement<any>(child, { hideMenu: handleMenuClose });
           })}
         </rootProps.slots.baseMenuList>

--- a/packages/x-data-grid/src/tests/export.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/export.DataGrid.test.tsx
@@ -1,6 +1,12 @@
 import { spy } from 'sinon';
 import type { SinonSpy } from 'sinon';
-import { DataGrid, GridToolbarExport } from '@mui/x-data-grid';
+import MenuItem from '@mui/material/MenuItem';
+import {
+  DataGrid,
+  GridToolbarContainer,
+  GridToolbarExport,
+  GridToolbarExportContainer,
+} from '@mui/x-data-grid';
 import type { DataGridProps } from '@mui/x-data-grid';
 import { useBasicDemoData } from '@mui/x-data-grid-generator';
 import { createRenderer, screen, fireEvent } from '@mui/internal-test-utils';
@@ -172,6 +178,25 @@ describe.skipIf(isJSDOM)('<DataGrid /> - Export', () => {
 
       expect(screen.queryByRole('menu')).not.to.equal(null);
       expect(screen.queryByRole('menuitem', { name: 'Download as CSV' })).to.equal(null);
+    });
+
+    it('should not forward hideMenu to a custom Material UI MenuItem', () => {
+      function CustomToolbar() {
+        return (
+          <GridToolbarContainer>
+            <GridToolbarExportContainer>
+              <MenuItem onClick={() => {}}>Export JSON</MenuItem>
+            </GridToolbarExportContainer>
+          </GridToolbarContainer>
+        );
+      }
+
+      expect(() => {
+        render(<TestCase slots={{ toolbar: CustomToolbar }} showToolbar />);
+        fireEvent.click(screen.getByRole('button', { name: 'Export' }));
+      }).not.toErrorDev();
+
+      expect(screen.queryByRole('menuitem', { name: 'Export JSON' })).not.to.equal(null);
     });
   });
 });


### PR DESCRIPTION
## Summary
- avoid passing the internal `hideMenu` prop to direct menu item children in `GridToolbarExportContainer`
- wrap direct Material UI/base menu item `onClick` handlers to close the export menu instead
- add a regression test for a custom toolbar using a bare Material UI `MenuItem`

Closes #22909

## Validation
- git diff --check
- npx pnpm@11.5.0 --version

Note: dependencies were not installed in this fresh local checkout, so I could not run the MUI X test suite locally before opening this PR.