### PR TITLE
[charts-premium] Fix blurry WebGL canvas on Safari zoom

### DIFF
--- a/packages/x-charts-premium/src/utils/webgl/useWebGLResizeObserver.ts
+++ b/packages/x-charts-premium/src/utils/webgl/useWebGLResizeObserver.ts
@@ -17,9 +17,9 @@ function getDevicePixelContentBoxSize(entry: ResizeObserverEntry) {
 }
 
 /**
- * This hook calls the provided `onResize` callback whenever the WebGL canvas is resized.
- * It detects size changes when the element is resized, the browser zoom updates or the device pixel ratio changes.
- * These last two conditions aren't supported by Safari, so `onResize` won't be called in these cases on Safari.
+ * Calls `onResize` whenever the WebGL canvas changes size, including on browser zoom / device pixel
+ * ratio changes. Most browsers detect everything via the `ResizeObserver`; Safari needs a separate
+ * `matchMedia` listener for zoom (see below).
  * @param gl The WebGL2 rendering context whose canvas to observe.
  * @param onResize Callback invoked after the canvas and viewport are updated.
  */
@@ -31,32 +31,51 @@ export function useWebGLResizeObserver(gl: WebGL2RenderingContext | null, onResi
       return undefined;
     }
 
+    const resize = (width: number, height: number) => {
+      canvas.width = Math.max(1, width);
+      canvas.height = Math.max(1, height);
+      gl?.viewport(0, 0, canvas.width, canvas.height);
+
+      onResize();
+    };
+
     const observer = new ResizeObserver((entries) => {
       for (const entry of entries) {
         const { width, height } = getDevicePixelContentBoxSize(entry);
-
-        canvas.width = Math.max(1, width);
-        canvas.height = Math.max(1, height);
-
-        // Update WebGL viewport
-        gl?.viewport(0, 0, width, height);
-
-        onResize();
+        resize(width, height);
       }
     });
 
+    let observesDevicePixels = true;
     try {
-      /* We use 'device-pixel-content-box' to observe the size of the canvas in device pixels, rather than CSS pixels.
-       * This ensures that we correctly handle high-DPI displays and browser zoom.
-       * However, this is not supported in Safari, which throws, so we fall back to 'content-box'.
-       * WebKit Bug: https://www2.webkit.org/show_bug.cgi?id=219005 */
+      // 'device-pixel-content-box' reports device pixels (handles high-DPI + zoom), but Safari throws.
+      // WebKit bug: https://www2.webkit.org/show_bug.cgi?id=219005
       observer.observe(canvas, { box: 'device-pixel-content-box' });
     } catch {
+      observesDevicePixels = false;
       observer.observe(canvas, { box: 'content-box' });
+    }
+
+    /* The 'content-box' fallback (Safari) doesn't fire on zoom. Safari 26.5+ updates `devicePixelRatio`
+     * on zoom (WebKit bug https://bugs.webkit.org/show_bug.cgi?id=124862), so watch it via a matchMedia
+     * resolution query and re-derive the device-pixel size from the canvas' CSS size. The query is tied
+     * to the current dppx value, so re-point it after each change. Older Safari never fires it. */
+    // cspell:ignore dppx
+    let mql: MediaQueryList | null = null;
+    const handleDevicePixelRatioChange = () => {
+      resize(canvas.clientWidth * devicePixelRatio, canvas.clientHeight * devicePixelRatio);
+      mql?.removeEventListener('change', handleDevicePixelRatioChange);
+      mql = matchMedia(`(resolution: ${devicePixelRatio}dppx)`);
+      mql.addEventListener('change', handleDevicePixelRatioChange);
+    };
+    if (!observesDevicePixels) {
+      mql = matchMedia(`(resolution: ${devicePixelRatio}dppx)`);
+      mql.addEventListener('change', handleDevicePixelRatioChange);
     }
 
     return () => {
       observer.disconnect();
+      mql?.removeEventListener('change', handleDevicePixelRatioChange);
     };
   }, [gl, gl?.canvas, onResize]);
 }


### PR DESCRIPTION
## Problem

Safari does not support `ResizeObserver` `box: 'device-pixel-content-box'`, so `useWebGLResizeObserver` falls back to `'content-box'`. That box only fires on CSS-pixel size changes, so it misses browser zoom — the canvas backing store keeps its old device-pixel size and the WebGL plot renders blurry on zoom.

## Fix

Safari 26.5+ now updates `devicePixelRatio` on zoom ([WebKit bug 124862](https://bugs.webkit.org/show_bug.cgi?id=124862)). On the `content-box` fallback path, watch `devicePixelRatio` via a `matchMedia` resolution query and re-derive the device-pixel canvas size from the CSS size, keeping the canvas sharp on zoom.

- Non-Safari path (`device-pixel-content-box`) unchanged — already handles zoom.
- Older Safari never fires the listener (the very bug above), so no regression.

## Testing

Open a WebGL chart (e.g. `BarChartPremium renderer="webgl"`) in Safari 26.5+ and browser-zoom (⌘ +/−). Canvas stays crisp instead of blurring until the next window resize.