### PR TITLE
[charts] Add minSpanItems/maxSpanItems zoom options (prototype)

### DIFF
--- a/docs/data/charts/zoom-and-pan/ZoomSpanItems.js
+++ b/docs/data/charts/zoom-and-pan/ZoomSpanItems.js
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { BarChartPro } from '@mui/x-charts-pro/BarChartPro';
+
+// Deterministic dataset large enough that a percentage span would be unintuitive.
+const POINTS = 200;
+const data = Array.from({ length: POINTS }, (_, index) => {
+  const hash = Math.sin(index * 12.9898) * 43758.5453;
+  return Math.round(50 + (hash - Math.floor(hash)) * 100);
+});
+const categories = data.map((_, index) => String(index));
+
+export default function ZoomSpanItems() {
+  return (
+    <BarChartPro
+      height={300}
+      // Zoom window is bounded by item count, not a percentage: between 10 and 40 bars,
+      // independent of the dataset size.
+      xAxis={[{ data: categories, zoom: { minSpanItems: 10, maxSpanItems: 40 } }]}
+      series={[{ data, label: 'Value' }]}
+    />
+  );
+}

--- a/docs/data/charts/zoom-and-pan/ZoomSpanItems.tsx
+++ b/docs/data/charts/zoom-and-pan/ZoomSpanItems.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { BarChartPro } from '@mui/x-charts-pro/BarChartPro';
+
+// Deterministic dataset large enough that a percentage span would be unintuitive.
+const POINTS = 200;
+const data = Array.from({ length: POINTS }, (_, index) => {
+  const hash = Math.sin(index * 12.9898) * 43758.5453;
+  return Math.round(50 + (hash - Math.floor(hash)) * 100);
+});
+const categories = data.map((_, index) => String(index));
+
+export default function ZoomSpanItems() {
+  return (
+    <BarChartPro
+      height={300}
+      // Zoom window is bounded by item count, not a percentage: between 10 and 40 bars,
+      // independent of the dataset size.
+      xAxis={[{ data: categories, zoom: { minSpanItems: 10, maxSpanItems: 40 } }]}
+      series={[{ data, label: 'Value' }]}
+    />
+  );
+}

--- a/docs/data/charts/zoom-and-pan/ZoomSpanItems.tsx.preview
+++ b/docs/data/charts/zoom-and-pan/ZoomSpanItems.tsx.preview
@@ -1,0 +1,7 @@
+<BarChartPro
+  height={300}
+  // Zoom window is bounded by item count, not a percentage: between 10 and 40 bars,
+  // independent of the dataset size.
+  xAxis={[{ data: categories, zoom: { minSpanItems: 10, maxSpanItems: 40 } }]}
+  series={[{ data, label: 'Value' }]}
+/>

--- a/docs/data/charts/zoom-and-pan/zoom-and-pan.md
+++ b/docs/data/charts/zoom-and-pan/zoom-and-pan.md
@@ -58,6 +58,10 @@ Use `minSpanItems` and `maxSpanItems` to bound the zoom window by a number of da
 
 {{"demo": "ZoomSpanItems.js"}}
 
+:::warning
+These options take a **data-point count**, so they apply to axes that have a `data` array (band, point, and data-driven axes). They do not accept an axis-value span (a value range on a value axis, or a duration on a time axis, like ECharts' `minValueSpan`). Converting a value span to a percentage requires the computed axis domain, which isn't available where the zoom options are resolved, so it's left out for now.
+:::
+
 ## Zoom filtering
 
 Make the zoom of an axis affect one or more axes' extents by setting the `zoom.filterMode` prop on the axis config.

--- a/docs/data/charts/zoom-and-pan/zoom-and-pan.md
+++ b/docs/data/charts/zoom-and-pan/zoom-and-pan.md
@@ -59,7 +59,7 @@ Use `minSpanItems` and `maxSpanItems` to bound the zoom window by a number of da
 {{"demo": "ZoomSpanItems.js"}}
 
 :::warning
-These options take a **data-point count**, so they apply to axes that have a `data` array (band, point, and data-driven axes). They do not accept an axis-value span (a value range on a value axis, or a duration on a time axis, like ECharts' `minValueSpan`). Converting a value span to a percentage requires the computed axis domain, which isn't available where the zoom options are resolved, so it's left out for now.
+These options take a **data-point count**, so they apply to axes that have a `data` array (band, point, and data-driven axes). They do not accept an axis-value span (a value range on a value axis, or a duration on a time axis). Converting a value span to a percentage requires the computed axis domain, which isn't available where the zoom options are resolved, so it's left out for now.
 :::
 
 ## Zoom filtering

--- a/docs/data/charts/zoom-and-pan/zoom-and-pan.md
+++ b/docs/data/charts/zoom-and-pan/zoom-and-pan.md
@@ -46,9 +46,17 @@ The following options are available:
 - **step**: The step of the zooming function, which defines the granularity of the zoom
 - **minSpan**: Restricts the minimum span size
 - **maxSpan**: Restricts the maximum span size
+- **minSpanItems**: Restricts the minimum span as a number of data points
+- **maxSpanItems**: Restricts the maximum span as a number of data points
 - **panning**: Enables or disables panning
 
 {{"demo": "ZoomOptions.js", "hideToolbar": true, "bg": "playground"}}
+
+### Span limits by item count
+
+Use `minSpanItems` and `maxSpanItems` to bound the zoom window by a number of data points instead of a percentage. They are resolved against the axis `data` length and take precedence over `minSpan` and `maxSpan`, so the window stays meaningful no matter how large the dataset is.
+
+{{"demo": "ZoomSpanItems.js"}}
 
 ## Zoom filtering
 

--- a/packages/x-charts-pro/src/typeOverloads/modules.ts
+++ b/packages/x-charts-pro/src/typeOverloads/modules.ts
@@ -97,7 +97,8 @@ declare module '@mui/x-charts/internals' {
     };
   }
 
-  interface DefaultizedZoomOptions extends Required<ZoomOptions> {
+  interface DefaultizedZoomOptions
+    extends Required<Omit<ZoomOptions, 'minSpanItems' | 'maxSpanItems'>> {
     axisId: AxisId;
     axisDirection: 'x' | 'y';
   }

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/createZoomLookup.test.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/createZoomLookup.test.ts
@@ -1,0 +1,30 @@
+import { createZoomLookup } from './createZoomLookup';
+
+const axis = (zoom: any, dataLength: number) => [
+  { id: 'x', scaleType: 'band', data: Array.from({ length: dataLength }), zoom },
+];
+
+describe('createZoomLookup', () => {
+  it('resolves minSpanItems / maxSpanItems against the data length', () => {
+    const lookup = createZoomLookup('x')(
+      axis({ minSpanItems: 20, maxSpanItems: 100 }, 200) as any,
+    );
+    expect(lookup.x.minSpan).to.equal(10); // 20 / 200 -> 10%
+    expect(lookup.x.maxSpan).to.equal(50); // 100 / 200 -> 50%
+  });
+
+  it('lets the item limits take precedence over the percentage span', () => {
+    const lookup = createZoomLookup('x')(axis({ minSpan: 25, minSpanItems: 20 }, 200) as any);
+    expect(lookup.x.minSpan).to.equal(10);
+  });
+
+  it('keeps the percentage span when no item limits are set', () => {
+    const lookup = createZoomLookup('x')(axis({ minSpan: 25 }, 200) as any);
+    expect(lookup.x.minSpan).to.equal(25);
+  });
+
+  it('clamps to 100 when the requested items exceed the data length', () => {
+    const lookup = createZoomLookup('x')(axis({ minSpanItems: 50 }, 10) as any);
+    expect(lookup.x.minSpan).to.equal(100);
+  });
+});

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/createZoomLookup.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/createZoomLookup.ts
@@ -8,7 +8,7 @@ export const createZoomLookup =
   (axes: AxisConfig<ScaleName, any, ChartsCartesianAxisProps>[] = []) =>
     axes.reduce<Record<AxisId, DefaultizedZoomOptions>>((acc, v) => {
       // @ts-ignore
-      const { zoom, id: axisId, reverse, scaleType } = v;
+      const { zoom, id: axisId, reverse, scaleType, data } = v;
       const defaultizedZoom = defaultizeZoom(
         zoom,
         axisId,
@@ -16,6 +16,16 @@ export const createZoomLookup =
         getEffectiveZoomReverse(axisDirection, scaleType, reverse),
       );
       if (defaultizedZoom) {
+        // Resolve the item-count span limits against the data length; they win over the percentages.
+        const dataLength = Array.isArray(data) ? data.length : 0;
+        if (dataLength > 0 && typeof zoom === 'object') {
+          if (zoom.minSpanItems != null) {
+            defaultizedZoom.minSpan = Math.min(100, (100 * zoom.minSpanItems) / dataLength);
+          }
+          if (zoom.maxSpanItems != null) {
+            defaultizedZoom.maxSpan = Math.min(100, (100 * zoom.maxSpanItems) / dataLength);
+          }
+        }
         acc[axisId] = defaultizedZoom;
       }
       return acc;

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/createZoomLookup.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/createZoomLookup.ts
@@ -17,8 +17,8 @@ export const createZoomLookup =
       );
       if (defaultizedZoom) {
         // Resolve the item-count span limits against the data length; they win over the percentages.
-        // Only a data-point count is supported (not a value/time-axis value span like ECharts'
-        // minValueSpan): a value span needs the computed domain, which isn't known here (raw axes).
+        // Only a data-point count is supported (not a value/time-axis value span): a value span
+        // needs the computed domain, which isn't known here (raw axes).
         const dataLength = Array.isArray(data) ? data.length : 0;
         if (dataLength > 0 && typeof zoom === 'object') {
           if (zoom.minSpanItems != null) {

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/createZoomLookup.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/createZoomLookup.ts
@@ -17,6 +17,8 @@ export const createZoomLookup =
       );
       if (defaultizedZoom) {
         // Resolve the item-count span limits against the data length; they win over the percentages.
+        // Only a data-point count is supported (not a value/time-axis value span like ECharts'
+        // minValueSpan): a value span needs the computed domain, which isn't known here (raw axes).
         const dataLength = Array.isArray(data) ? data.length : 0;
         if (dataLength > 0 && typeof zoom === 'object') {
           if (zoom.minSpanItems != null) {

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxis.types.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxis.types.ts
@@ -108,7 +108,8 @@ export interface DefaultedZoomSliderOptions extends Omit<
   preview: boolean | ZoomSliderPreviewOptions;
 }
 
-export interface DefaultizedZoomOptions extends Required<Omit<ZoomOptions, 'slider'>> {
+export interface DefaultizedZoomOptions
+  extends Required<Omit<ZoomOptions, 'slider' | 'minSpanItems' | 'maxSpanItems'>> {
   axisId: AxisId;
   axisDirection: 'x' | 'y';
   slider: DefaultedZoomSliderOptions;

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/zoom.types.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/zoom.types.ts
@@ -62,11 +62,21 @@ export interface ZoomOptions {
    *
    * Useful to keep the zoom window meaningful regardless of the dataset size (the equivalent
    * percentage shrinks as the data grows).
+   *
+   * Inspired by ECharts' `minValueSpan`, but limited to a data-point count: it only applies to
+   * axes with a `data` array (band, point, and data-driven axes). It does not support an
+   * axis-value span on continuous value/time axes — see `maxSpanItems` for why.
    */
   minSpanItems?: number;
   /**
    * Restricts the maximum span as a number of data points, instead of a percentage.
    * Resolved against the axis `data` length, it takes precedence over `maxSpan`.
+   *
+   * Like `minSpanItems`, this is a data-point count, not an axis-value span. A value-unit span
+   * (ECharts' `maxValueSpan`) would need the computed axis domain (`max - min`) to convert to a
+   * percentage, which isn't available where zoom options are resolved (`createZoomLookup` runs on
+   * the raw axes, before the domain is computed). Supporting it would require resolving the span in
+   * a selector that has the computed scale, so it's intentionally left out of this iteration.
    */
   maxSpanItems?: number;
   /**

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/zoom.types.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/zoom.types.ts
@@ -63,9 +63,9 @@ export interface ZoomOptions {
    * Useful to keep the zoom window meaningful regardless of the dataset size (the equivalent
    * percentage shrinks as the data grows).
    *
-   * Inspired by ECharts' `minValueSpan`, but limited to a data-point count: it only applies to
-   * axes with a `data` array (band, point, and data-driven axes). It does not support an
-   * axis-value span on continuous value/time axes — see `maxSpanItems` for why.
+   * Limited to a data-point count: it only applies to axes with a `data` array (band, point, and
+   * data-driven axes). It does not support an axis-value span on continuous value/time axes —
+   * see `maxSpanItems` for why.
    */
   minSpanItems?: number;
   /**
@@ -73,10 +73,10 @@ export interface ZoomOptions {
    * Resolved against the axis `data` length, it takes precedence over `maxSpan`.
    *
    * Like `minSpanItems`, this is a data-point count, not an axis-value span. A value-unit span
-   * (ECharts' `maxValueSpan`) would need the computed axis domain (`max - min`) to convert to a
-   * percentage, which isn't available where zoom options are resolved (`createZoomLookup` runs on
-   * the raw axes, before the domain is computed). Supporting it would require resolving the span in
-   * a selector that has the computed scale, so it's intentionally left out of this iteration.
+   * would need the computed axis domain (`max - min`) to convert to a percentage, which isn't
+   * available where zoom options are resolved (`createZoomLookup` runs on the raw axes, before the
+   * domain is computed). Supporting it would require resolving the span in a selector that has the
+   * computed scale, so it's intentionally left out of this iteration.
    */
   maxSpanItems?: number;
   /**

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/zoom.types.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/zoom.types.ts
@@ -57,6 +57,19 @@ export interface ZoomOptions {
    */
   maxSpan?: number;
   /**
+   * Restricts the minimum span as a number of data points, instead of a percentage.
+   * Resolved against the axis `data` length, it takes precedence over `minSpan`.
+   *
+   * Useful to keep the zoom window meaningful regardless of the dataset size (the equivalent
+   * percentage shrinks as the data grows).
+   */
+  minSpanItems?: number;
+  /**
+   * Restricts the maximum span as a number of data points, instead of a percentage.
+   * Resolved against the axis `data` length, it takes precedence over `maxSpan`.
+   */
+  maxSpanItems?: number;
+  /**
    * Set to `false` to disable panning. Useful when you want to pan programmatically,
    * or to show only a specific section of the chart.
    *


### PR DESCRIPTION
## Summary

Prototype for bounding the zoom window by a **number of data points** instead of a percentage span. Spun out of the discussion in #22830.

Adds two zoom options:

- `minSpanItems` — minimum zoom window, in data points.
- `maxSpanItems` — maximum zoom window, in data points.

```tsx
<BarChartPro xAxis={[{ data, zoom: { minSpanItems: 10, maxSpanItems: 40 } }]} ... />
```

## How it works

Resolved in `createZoomLookup`, where the axis `data` is available: `minSpanItems / data.length * 100` → an effective `minSpan` percentage (same for `maxSpanItems`/`maxSpan`), clamped to `[0, 100]`. When set, they take precedence over the percentage `minSpan`/`maxSpan`. All downstream clamps keep working on percentages unchanged.

This keeps the zoom window meaningful regardless of dataset size — the equivalent percentage shrinks as the data grows, which is hard to set by hand.

## Deliberate limitation

Only the **data-point-count** case is implemented (category / point / data-driven axes). It does **not** support a value/time-axis value span (a value range, or a duration), intentionally for this iteration:

> Converting a value span to a percentage needs the computed axis domain (`max − min`). That domain isn't available where zoom options are resolved — `createZoomLookup` runs on the **raw** axes, before the domain is computed from the data/series. Supporting it properly would mean resolving the span in a selector that has the computed scale (or threading the raw value span into the clamp sites), a larger change. Scoped out here.

Documented in the option JSDoc, a code comment in `createZoomLookup`, and a docs callout.

## Open question

- **Naming**: `minSpanItems`/`maxSpanItems` reflects the item-count semantics. If the value-span case is added later, a `minValueSpan`-style name might fit better.

## Tests & docs

- Unit tests for the conversion (`createZoomLookup.test.ts`).
- Docs section + `ZoomSpanItems` demo, with a limitation callout.
