### PR TITLE
[docs] Add recipe for describing active filters in the toolbar

### DIFF
--- a/docs/data/data-grid/components/filter-panel/FilterPanelTriggerDescription.js
+++ b/docs/data/data-grid/components/filter-panel/FilterPanelTriggerDescription.js
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import {
+  DataGrid,
+  Toolbar,
+  ToolbarButton,
+  FilterPanelTrigger,
+  gridFilterActiveItemsSelector,
+  useGridApiContext,
+  useGridSelector,
+} from '@mui/x-data-grid';
+import { useDemoData } from '@mui/x-data-grid-generator';
+import Tooltip from '@mui/material/Tooltip';
+import FilterListIcon from '@mui/icons-material/FilterList';
+
+function useActiveFiltersDescription() {
+  const apiRef = useGridApiContext();
+  const activeFilters = useGridSelector(apiRef, gridFilterActiveItemsSelector);
+
+  if (activeFilters.length === 0) {
+    return 'Filters';
+  }
+
+  return activeFilters
+    .map((item) => {
+      const column = apiRef.current.getColumn(item.field);
+      const operator = column.filterOperators?.find(
+        (filterOperator) => filterOperator.value === item.operator,
+      );
+      return `${column.headerName ?? column.field} ${operator?.label ?? item.operator} ${item.value ?? ''}`.trim();
+    })
+    .join(', ');
+}
+
+function CustomToolbar() {
+  const description = useActiveFiltersDescription();
+
+  return (
+    <Toolbar>
+      <Tooltip title={description}>
+        <FilterPanelTrigger render={<ToolbarButton />}>
+          <FilterListIcon fontSize="small" />
+        </FilterPanelTrigger>
+      </Tooltip>
+    </Toolbar>
+  );
+}
+
+export default function FilterPanelTriggerDescription() {
+  const { data, loading } = useDemoData({
+    dataSet: 'Commodity',
+    rowLength: 10,
+    maxColumns: 10,
+  });
+
+  return (
+    <div style={{ height: 400, width: '100%' }}>
+      <DataGrid
+        {...data}
+        loading={loading}
+        slots={{ toolbar: CustomToolbar }}
+        showToolbar
+        initialState={{
+          ...data.initialState,
+          filter: {
+            filterModel: {
+              items: [{ field: 'quantity', operator: '>', value: '50000' }],
+            },
+          },
+        }}
+      />
+    </div>
+  );
+}

--- a/docs/data/data-grid/components/filter-panel/FilterPanelTriggerDescription.js
+++ b/docs/data/data-grid/components/filter-panel/FilterPanelTriggerDescription.js
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import {
-  DataGrid,
+  DataGridPro,
   Toolbar,
   ToolbarButton,
   FilterPanelTrigger,
   gridFilterActiveItemsSelector,
   useGridApiContext,
   useGridSelector,
-} from '@mui/x-data-grid';
+} from '@mui/x-data-grid-pro';
 import { useDemoData } from '@mui/x-data-grid-generator';
 import Tooltip from '@mui/material/Tooltip';
 import FilterListIcon from '@mui/icons-material/FilterList';
@@ -54,7 +54,7 @@ export default function FilterPanelTriggerDescription() {
 
   return (
     <div style={{ height: 400, width: '100%' }}>
-      <DataGrid
+      <DataGridPro
         {...data}
         loading={loading}
         slots={{ toolbar: CustomToolbar }}

--- a/docs/data/data-grid/components/filter-panel/FilterPanelTriggerDescription.tsx
+++ b/docs/data/data-grid/components/filter-panel/FilterPanelTriggerDescription.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import {
+  DataGrid,
+  Toolbar,
+  ToolbarButton,
+  FilterPanelTrigger,
+  gridFilterActiveItemsSelector,
+  useGridApiContext,
+  useGridSelector,
+} from '@mui/x-data-grid';
+import { useDemoData } from '@mui/x-data-grid-generator';
+import Tooltip from '@mui/material/Tooltip';
+import FilterListIcon from '@mui/icons-material/FilterList';
+
+function useActiveFiltersDescription() {
+  const apiRef = useGridApiContext();
+  const activeFilters = useGridSelector(apiRef, gridFilterActiveItemsSelector);
+
+  if (activeFilters.length === 0) {
+    return 'Filters';
+  }
+
+  return activeFilters
+    .map((item) => {
+      const column = apiRef.current.getColumn(item.field);
+      const operator = column.filterOperators?.find(
+        (filterOperator) => filterOperator.value === item.operator,
+      );
+      return `${column.headerName ?? column.field} ${operator?.label ?? item.operator} ${item.value ?? ''}`.trim();
+    })
+    .join(', ');
+}
+
+function CustomToolbar() {
+  const description = useActiveFiltersDescription();
+
+  return (
+    <Toolbar>
+      <Tooltip title={description}>
+        <FilterPanelTrigger render={<ToolbarButton />}>
+          <FilterListIcon fontSize="small" />
+        </FilterPanelTrigger>
+      </Tooltip>
+    </Toolbar>
+  );
+}
+
+export default function FilterPanelTriggerDescription() {
+  const { data, loading } = useDemoData({
+    dataSet: 'Commodity',
+    rowLength: 10,
+    maxColumns: 10,
+  });
+
+  return (
+    <div style={{ height: 400, width: '100%' }}>
+      <DataGrid
+        {...data}
+        loading={loading}
+        slots={{ toolbar: CustomToolbar }}
+        showToolbar
+        initialState={{
+          ...data.initialState,
+          filter: {
+            filterModel: {
+              items: [{ field: 'quantity', operator: '>', value: '50000' }],
+            },
+          },
+        }}
+      />
+    </div>
+  );
+}

--- a/docs/data/data-grid/components/filter-panel/FilterPanelTriggerDescription.tsx
+++ b/docs/data/data-grid/components/filter-panel/FilterPanelTriggerDescription.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import {
-  DataGrid,
+  DataGridPro,
   Toolbar,
   ToolbarButton,
   FilterPanelTrigger,
   gridFilterActiveItemsSelector,
   useGridApiContext,
   useGridSelector,
-} from '@mui/x-data-grid';
+} from '@mui/x-data-grid-pro';
 import { useDemoData } from '@mui/x-data-grid-generator';
 import Tooltip from '@mui/material/Tooltip';
 import FilterListIcon from '@mui/icons-material/FilterList';
@@ -54,7 +54,7 @@ export default function FilterPanelTriggerDescription() {
 
   return (
     <div style={{ height: 400, width: '100%' }}>
-      <DataGrid
+      <DataGridPro
         {...data}
         loading={loading}
         slots={{ toolbar: CustomToolbar }}

--- a/docs/data/data-grid/components/filter-panel/FilterPanelTriggerDescription.tsx.preview
+++ b/docs/data/data-grid/components/filter-panel/FilterPanelTriggerDescription.tsx.preview
@@ -1,0 +1,14 @@
+<DataGrid
+  {...data}
+  loading={loading}
+  slots={{ toolbar: CustomToolbar }}
+  showToolbar
+  initialState={{
+    ...data.initialState,
+    filter: {
+      filterModel: {
+        items: [{ field: 'quantity', operator: '>', value: '50000' }],
+      },
+    },
+  }}
+/>

--- a/docs/data/data-grid/components/filter-panel/FilterPanelTriggerDescription.tsx.preview
+++ b/docs/data/data-grid/components/filter-panel/FilterPanelTriggerDescription.tsx.preview
@@ -1,4 +1,4 @@
-<DataGrid
+<DataGridPro
   {...data}
   loading={loading}
   slots={{ toolbar: CustomToolbar }}

--- a/docs/data/data-grid/components/filter-panel/filter-panel.md
+++ b/docs/data/data-grid/components/filter-panel/filter-panel.md
@@ -45,6 +45,13 @@ import { FilterPanelTrigger } from '@mui/x-data-grid';
 `<FilterPanelTrigger />` is a button that opens and closes the filter panel.
 It renders the `baseButton` slot.
 
+## Describing the active filters
+
+`FilterPanelTrigger` only reports `filterCount` to its `render` callback. It doesn't generate a description of the active filters.
+To show one (for example, in a tooltip), build it yourself from `gridFilterActiveItemsSelector`, which lists the currently active `GridFilterItem` objects:
+
+{{"demo": "FilterPanelTriggerDescription.js", "bg": "inline", "defaultCodeOpen": false}}
+
 ## Custom elements
 
 Use the `render` prop to replace default elements.


### PR DESCRIPTION
Adds a demo to the filter panel docs showing how to build a human-readable description of the active filters using `gridFilterActiveItemsSelector` and display it in a tooltip on the `FilterPanelTrigger` button.

Fixes #19130 