### PR TITLE
[docs] Add recipe for conditional master-detail panels

### DIFF
--- a/docs/data/data-grid/master-detail/DetailPanelConditional.js
+++ b/docs/data/data-grid/master-detail/DetailPanelConditional.js
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { DataGridPro } from '@mui/x-data-grid-pro';
+
+const columns = [
+  { field: 'id', headerName: 'Order ID' },
+  { field: 'customer', headerName: 'Customer', width: 200 },
+  { field: 'hasNotes', headerName: 'Has notes', type: 'boolean' },
+];
+
+const rows = [
+  { id: 1, customer: 'Matheus', hasNotes: true, notes: 'Requested gift wrapping.' },
+  { id: 2, customer: 'Olivier', hasNotes: false, notes: null },
+  { id: 3, customer: 'Flavien', hasNotes: true, notes: 'Asked for a refund.' },
+  { id: 4, customer: 'Danail', hasNotes: false, notes: null },
+];
+
+export default function DetailPanelConditional() {
+  // Rows without notes return `null`, which is enough to disable the toggle
+  // for that row, so no custom toggle column is needed to hide it manually.
+  const getDetailPanelContent = React.useCallback(
+    ({ row }) => (row.notes ? <Box sx={{ p: 2 }}>{row.notes}</Box> : null),
+    [],
+  );
+
+  const getDetailPanelHeight = React.useCallback(() => 'auto', []);
+
+  return (
+    <Box sx={{ width: '100%' }}>
+      <Typography sx={{ mb: 1 }} variant="body2">
+        Only rows with notes have an enabled toggle.
+      </Typography>
+      <Box sx={{ height: 300 }}>
+        <DataGridPro
+          columns={columns}
+          rows={rows}
+          getDetailPanelHeight={getDetailPanelHeight}
+          getDetailPanelContent={getDetailPanelContent}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/docs/data/data-grid/master-detail/DetailPanelConditional.tsx
+++ b/docs/data/data-grid/master-detail/DetailPanelConditional.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { DataGridPro, DataGridProProps, GridColDef } from '@mui/x-data-grid-pro';
+
+const columns: GridColDef<(typeof rows)[number]>[] = [
+  { field: 'id', headerName: 'Order ID' },
+  { field: 'customer', headerName: 'Customer', width: 200 },
+  { field: 'hasNotes', headerName: 'Has notes', type: 'boolean' },
+];
+
+const rows = [
+  { id: 1, customer: 'Matheus', hasNotes: true, notes: 'Requested gift wrapping.' },
+  { id: 2, customer: 'Olivier', hasNotes: false, notes: null },
+  { id: 3, customer: 'Flavien', hasNotes: true, notes: 'Asked for a refund.' },
+  { id: 4, customer: 'Danail', hasNotes: false, notes: null },
+];
+
+export default function DetailPanelConditional() {
+  // Rows without notes return `null`, which is enough to disable the toggle
+  // for that row, so no custom toggle column is needed to hide it manually.
+  const getDetailPanelContent = React.useCallback<
+    NonNullable<DataGridProProps['getDetailPanelContent']>
+  >(({ row }) => (row.notes ? <Box sx={{ p: 2 }}>{row.notes}</Box> : null), []);
+
+  const getDetailPanelHeight = React.useCallback(() => 'auto' as const, []);
+
+  return (
+    <Box sx={{ width: '100%' }}>
+      <Typography sx={{ mb: 1 }} variant="body2">
+        Only rows with notes have an enabled toggle.
+      </Typography>
+      <Box sx={{ height: 300 }}>
+        <DataGridPro
+          columns={columns}
+          rows={rows}
+          getDetailPanelHeight={getDetailPanelHeight}
+          getDetailPanelContent={getDetailPanelContent}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/docs/data/data-grid/master-detail/DetailPanelConditional.tsx.preview
+++ b/docs/data/data-grid/master-detail/DetailPanelConditional.tsx.preview
@@ -1,0 +1,11 @@
+<Typography sx={{ mb: 1 }} variant="body2">
+  Only rows with notes have an enabled toggle.
+</Typography>
+<Box sx={{ height: 300 }}>
+  <DataGridPro
+    columns={columns}
+    rows={rows}
+    getDetailPanelHeight={getDetailPanelHeight}
+    getDetailPanelContent={getDetailPanelContent}
+  />
+</Box>

--- a/docs/data/data-grid/master-detail/master-detail.md
+++ b/docs/data/data-grid/master-detail/master-detail.md
@@ -109,6 +109,13 @@ The demo below shows how to implement this behavior using [react-hook-form](http
 
 {{"demo": "FormDetailPanel.js", "bg": "inline", "defaultCodeOpen": false}}
 
+## Conditional detail panels
+
+If only some rows have a detail panel, return `null` (or `undefined`) from `getDetailPanelContent` for the rows that don't.
+The default toggle button already disables itself when there's no content for the row, so no custom toggle column is needed just to hide it:
+
+{{"demo": "DetailPanelConditional.js", "bg": "inline", "defaultCodeOpen": false}}
+
 ## Customizing the detail panel toggle
 
 To change the icon used for the toggle, you can provide a different component for the [icon slot](/x/react-data-grid/components/#icons) as shown here:


### PR DESCRIPTION
Adds a demo showing that returning `null` from `getDetailPanelContent` is sufficient to disable the detail panel toggle for a given row, so no custom toggle column is needed just to hide it for rows without content.

Resolves #19146 