### PR TITLE
[pickers] Use the Hijri day token in `AdapterMomentHijri` `normalDateWithWeekday`

### DIFF
--- a/packages/x-date-pickers/src/AdapterMomentHijri/AdapterMomentHijri.test.tsx
+++ b/packages/x-date-pickers/src/AdapterMomentHijri/AdapterMomentHijri.test.tsx
@@ -50,6 +50,7 @@ describe('<AdapterMomentHijri />', () => {
       expectDate('keyboardDate', '١٤٤١/٠٥/٠٦');
       expectDate('fullDate', '١٤٤١، جمادى الأولى ١');
       expectDate('normalDate', 'الأربعاء، ٦ جمادى ١');
+      expectDate('normalDateWithWeekday', 'أربعاء، ٦ جمادى الأولى');
       expectDate('shortDate', '٦ جمادى ١');
       expectDate('year', '١٤٤١');
       expectDate('month', 'جمادى الأولى');

--- a/packages/x-date-pickers/src/AdapterMomentHijri/AdapterMomentHijri.ts
+++ b/packages/x-date-pickers/src/AdapterMomentHijri/AdapterMomentHijri.ts
@@ -65,7 +65,7 @@ const defaultFormats: AdapterFormats = {
   fullDate: 'iYYYY, iMMMM Do',
   shortDate: 'iD iMMM',
   normalDate: 'dddd, iD iMMM',
-  normalDateWithWeekday: 'DD iMMMM',
+  normalDateWithWeekday: 'ddd, iD iMMMM',
 
   fullTime12h: 'hh:mm A',
   fullTime24h: 'HH:mm',


### PR DESCRIPTION
Fixes the Hijri adapter's `normalDateWithWeekday` format, which used the Gregorian day token `DD`.

`AdapterMomentHijri` defined `normalDateWithWeekday: 'DD iMMMM'`. `DD` is the Gregorian day-of-month token (not the Hijri `iD`), so it rendered the Gregorian day, and the format had no weekday despite its name. For 6 Jumada I 1441 (2020-01-01) it produced `٠١ جمادى الأولى` (Gregorian day `01`) instead of the Hijri `٦`.

The fix changes it to `'ddd, iD iMMMM'` (short weekday, Hijri day, full Hijri month). This restores the weekday the format name and its JSDoc contract require (`@example "Sun, Jan 1"`), and matches the sibling non-Gregorian Jalali adapters, whose `normalDateWithWeekday` is `'EEE, d MMMM'` (short weekday, day first, full month).

Impact is low because the toolbar only uses `normalDateWithWeekday` for English locales and the Hijri adapter is `ar-SA` (so it falls back to `normalDate`), but the format is public via `adapter.formats`.

Closes #22964

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
