### PR TITLE
[pickers] Use calendar day tokens in `AdapterMomentHijri` and `AdapterMomentJalaali` formats

### DIFF
--- a/packages/x-date-pickers/src/AdapterMomentHijri/AdapterMomentHijri.test.tsx
+++ b/packages/x-date-pickers/src/AdapterMomentHijri/AdapterMomentHijri.test.tsx
@@ -48,7 +48,7 @@ describe('<AdapterMomentHijri />', () => {
       };
 
       expectDate('keyboardDate', '١٤٤١/٠٥/٠٦');
-      expectDate('fullDate', '١٤٤١، جمادى الأولى ١');
+      expectDate('fullDate', '١٤٤١، جمادى الأولى ٦');
       expectDate('normalDate', 'الأربعاء، ٦ جمادى ١');
       expectDate('shortDate', '٦ جمادى ١');
       expectDate('year', '١٤٤١');

--- a/packages/x-date-pickers/src/AdapterMomentHijri/AdapterMomentHijri.ts
+++ b/packages/x-date-pickers/src/AdapterMomentHijri/AdapterMomentHijri.ts
@@ -62,7 +62,7 @@ const defaultFormats: AdapterFormats = {
   minutes: 'mm',
   seconds: 'ss',
 
-  fullDate: 'iYYYY, iMMMM Do',
+  fullDate: 'iYYYY, iMMMM iD',
   shortDate: 'iD iMMM',
   normalDate: 'dddd, iD iMMM',
   normalDateWithWeekday: 'DD iMMMM',

--- a/packages/x-date-pickers/src/AdapterMomentJalaali/AdapterMomentJalaali.test.tsx
+++ b/packages/x-date-pickers/src/AdapterMomentJalaali/AdapterMomentJalaali.test.tsx
@@ -40,7 +40,8 @@ describe('<AdapterMomentJalaali />', () => {
         expect(adapter.format(date, format)).to.equal(expectedWithFaIR);
       };
 
-      expectDate('fullDate', '۱۳۹۸، بهمن ۱م');
+      expectDate('fullDate', '۱۳۹۸، بهمن ۱۲');
+      expectDate('normalDateWithWeekday', 'شنبه، ۱۲ بهمن');
       expectDate('keyboardDate', '۱۳۹۸/۱۱/۱۲');
       expectDate('keyboardDateTime12h', '۱۳۹۸/۱۱/۱۲ ۱۱:۴۴ ب.ظ');
       expectDate('keyboardDateTime24h', '۱۳۹۸/۱۱/۱۲ ۲۳:۴۴');

--- a/packages/x-date-pickers/src/AdapterMomentJalaali/AdapterMomentJalaali.ts
+++ b/packages/x-date-pickers/src/AdapterMomentJalaali/AdapterMomentJalaali.ts
@@ -61,11 +61,11 @@ const defaultFormats: AdapterFormats = {
   minutes: 'mm',
   seconds: 'ss',
 
-  fullDate: 'jYYYY, jMMMM Do',
+  fullDate: 'jYYYY, jMMMM jD',
   keyboardDate: 'jYYYY/jMM/jDD',
   shortDate: 'jD jMMM',
   normalDate: 'dddd, jD jMMM',
-  normalDateWithWeekday: 'DD MMMM',
+  normalDateWithWeekday: 'ddd, jD jMMMM',
 
   fullTime12h: 'hh:mm A',
   fullTime24h: 'HH:mm',


### PR DESCRIPTION
The Hijri and Jalaali moment adapters mixed Gregorian day/month tokens into their date formats, so they rendered Gregorian values instead of the calendar values. `moment-hijri` / `moment-jalaali` only override the `i` / `j` prefixed tokens; plain `Do`, `DD`, and `MMMM` stay Gregorian.

- `AdapterMomentHijri` `fullDate: 'iYYYY, iMMMM Do'` → `'iYYYY, iMMMM iD'`
- `AdapterMomentJalaali` `fullDate: 'jYYYY, jMMMM Do'` → `'jYYYY, jMMMM jD'`
- `AdapterMomentJalaali` `normalDateWithWeekday: 'DD MMMM'` → `'ddd, jD jMMMM'`

`Do` is the Gregorian ordinal day. Both adapters already declare `dayOfMonthFull: 'iD'` / `'jD'` with a comment that the full (ordinal) day format is not supported and falls back to the regular day token, so the calendar day token is `iD` / `jD`. The Jalaali `normalDateWithWeekday` also used the Gregorian day and month and had no weekday; it now matches the date-fns Jalali adapters (`'EEE, d MMMM'`), the same pattern used by the Hijri `normalDateWithWeekday` fix in #22972.

The existing adapter `Formatting` tests asserted the buggy Gregorian output, so they are updated to the correct calendar values, and a `normalDateWithWeekday` assertion is added for Jalaali.

Closes #22965

Related to #22964 (the Hijri `normalDateWithWeekday` bug, PR #22972). This PR touches disjoint lines from that one (Hijri `fullDate` vs `normalDateWithWeekday`), so they can be reviewed and merged independently.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
