### PR TITLE
[internals] Fix `ERR_UNSUPPORTED_DIR_IMPORT` for `core-js-pure` in Node ESM

### DIFF
--- a/packages/x-internals/src/disposable/core-js-pure.d.ts
+++ b/packages/x-internals/src/disposable/core-js-pure.d.ts
@@ -1,12 +1,12 @@
 // `core-js-pure` ships no type declarations of its own. The classes its
 // per-feature entry points expose are spec-compliant ponyfills of the global
 // constructors, so we type them as the platform's own classes.
-declare module 'core-js-pure/actual/disposable-stack' {
+declare module 'core-js-pure/actual/disposable-stack/index.js' {
   const DisposableStack: typeof globalThis.DisposableStack;
   export default DisposableStack;
 }
 
-declare module 'core-js-pure/actual/async-disposable-stack' {
+declare module 'core-js-pure/actual/async-disposable-stack/index.js' {
   const AsyncDisposableStack: typeof globalThis.AsyncDisposableStack;
   export default AsyncDisposableStack;
 }

--- a/packages/x-internals/src/disposable/index.ts
+++ b/packages/x-internals/src/disposable/index.ts
@@ -1,5 +1,7 @@
 /// <reference path="./core-js-pure.d.ts" />
+// eslint-disable-next-line import/extensions
 import CoreJsDisposableStack from 'core-js-pure/actual/disposable-stack/index.js';
+// eslint-disable-next-line import/extensions
 import CoreJsAsyncDisposableStack from 'core-js-pure/actual/async-disposable-stack/index.js';
 
 /**

--- a/packages/x-internals/src/disposable/index.ts
+++ b/packages/x-internals/src/disposable/index.ts
@@ -1,6 +1,6 @@
 /// <reference path="./core-js-pure.d.ts" />
-import CoreJsDisposableStack from 'core-js-pure/actual/disposable-stack';
-import CoreJsAsyncDisposableStack from 'core-js-pure/actual/async-disposable-stack';
+import CoreJsDisposableStack from 'core-js-pure/actual/disposable-stack/index.js';
+import CoreJsAsyncDisposableStack from 'core-js-pure/actual/async-disposable-stack/index.js';
 
 /**
  * Well-known `Symbol.dispose`. Resolves to the native well-known symbol when


### PR DESCRIPTION
The `@mui/x-internals/disposable` module imported `core-js-pure` using bare directory paths (`core-js-pure/actual/disposable-stack`). Node's native ESM loader does not support directory imports for packages without an `exports` field, causing `ERR_UNSUPPORTED_DIR_IMPORT` crashes in SSR environments (Vite, TanStack Start, Next.js) where MUI X packages are left external. Fixes by switching to explicit file paths (`…/index.js`), the same resolution the issue reporter and Node's own error message suggest.

Fixes #22984 