### PR TITLE
[DateRangeCalendar] Fix auto month-switch across the year boundary

### DIFF
--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.test.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.test.tsx
@@ -645,6 +645,31 @@ describe('<DateRangeCalendar />', () => {
       });
     });
 
+    it('should not switch the visible months when the requested month is already visible across a year boundary', async () => {
+      const { setProps } = render(
+        <DateRangeCalendar
+          value={[adapterToUse.date('2023-12-01'), adapterToUse.date('2023-12-01')]}
+        />,
+      );
+
+      // The two calendars initially show December 2023 and January 2024.
+      expect(screen.getByRole('grid', { name: 'December 2023' })).not.to.equal(null);
+      expect(screen.getByRole('grid', { name: 'January 2024' })).not.to.equal(null);
+
+      // Move the start to a day already visible in the second calendar (January 2024).
+      setProps({
+        value: [adapterToUse.date('2024-01-15'), adapterToUse.date('2024-01-15')],
+      });
+
+      // The new start is now selected, confirming the auto month-switch effect ran.
+      await screen.findByRole('gridcell', { name: '15', selected: true });
+
+      // The visible months must not jump: December 2023 and January 2024 stay, February 2024 does not appear.
+      expect(screen.getByRole('grid', { name: 'December 2023' })).not.to.equal(null);
+      expect(screen.getByRole('grid', { name: 'January 2024' })).not.to.equal(null);
+      expect(screen.queryByRole('grid', { name: 'February 2024' })).to.equal(null);
+    });
+
     describe('prop: currentMonthCalendarPosition', () => {
       it('should switch to the selected month when changing value from the outside', async () => {
         const { setProps } = render(

--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
@@ -417,11 +417,13 @@ const DateRangeCalendar = React.forwardRef(function DateRangeCalendar(
     }
 
     const displayingMonthRange = calendars - currentMonthCalendarPosition;
-    const currentMonthNumber = adapter.getMonth(calendarState.currentMonth);
-    const requestedMonthNumber = adapter.getMonth(date);
+    // Use absolute months (year * 12 + month) so the comparison stays correct across year boundaries.
+    const currentMonthNumber =
+      adapter.getYear(calendarState.currentMonth) * 12 +
+      adapter.getMonth(calendarState.currentMonth);
+    const requestedMonthNumber = adapter.getYear(date) * 12 + adapter.getMonth(date);
 
     if (
-      !adapter.isSameYear(calendarState.currentMonth, date) ||
       requestedMonthNumber < currentMonthNumber ||
       requestedMonthNumber > currentMonthNumber + displayingMonthRange
     ) {


### PR DESCRIPTION
Fixes inconsistent auto month-switching in `DateRangeCalendar` across the year boundary.

When the value changes from the outside, an effect scrolls the visible months so the changed date stays visible. The decision compared 0–11 month indices and added a blanket `!isSameYear` trigger, so a date already visible in the second calendar scrolled unnecessarily across a December to January boundary, but not in the equivalent same-year case (the 0–11 indices also wrap at the year boundary).

The fix compares absolute months (`year * 12 + month`) and drops the `!isSameYear` clause. Behavior is unchanged for same-year scenarios; only the broken cross-year cases change.

Closes #22980

## Change summary

`DateRangeCalendar` no longer scrolls the visible months unnecessarily when a date that is already visible is set from the outside across a year boundary.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
