### PR TITLE
[l10n] Improve Japanese (ja-JP) locale

### DIFF
--- a/docs/data/data-grid/localization/data.json
+++ b/docs/data/data-grid/localization/data.json
@@ -179,7 +179,7 @@
     "languageTag": "ja-JP",
     "importName": "jaJP",
     "localeName": "Japanese",
-    "missingKeysCount": 74,
+    "missingKeysCount": 70,
     "totalKeysCount": 223,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/locales/jaJP.ts"
   },

--- a/packages/x-data-grid/src/locales/jaJP.ts
+++ b/packages/x-data-grid/src/locales/jaJP.ts
@@ -8,8 +8,8 @@ const jaJPGrid: Partial<GridLocaleText> = {
   // Root
   noRowsLabel: '行がありません。',
   noResultsOverlayLabel: '結果がありません。',
-  // noColumnsOverlayLabel: 'No columns',
-  // noColumnsOverlayManageColumns: 'Manage columns',
+  noColumnsOverlayLabel: '列がありません。',
+  noColumnsOverlayManageColumns: '列管理',
   // emptyPivotOverlayLabel: 'Add fields to rows, columns, and values to create a pivot table',
 
   // Density selector toolbar button text
@@ -60,7 +60,7 @@ const jaJPGrid: Partial<GridLocaleText> = {
   columnsManagementNoColumns: 'カラムなし',
   columnsManagementShowHideAllText: 'すべて表示/非表示',
   columnsManagementReset: 'リセット',
-  // columnsManagementDeleteIconLabel: 'Clear',
+  columnsManagementDeleteIconLabel: 'クリア',
 
   // Filter panel text
   filterPanelAddFilter: 'フィルター追加',
@@ -128,7 +128,7 @@ const jaJPGrid: Partial<GridLocaleText> = {
 
   // Column menu text
   columnMenuLabel: 'メニュー',
-  // columnMenuAriaLabel: (columnName: string) => `${columnName} column menu`,
+  columnMenuAriaLabel: (columnName: string) => `${columnName} 列メニュー`,
   columnMenuShowColumns: '列表示',
   columnMenuManageColumns: '列管理',
   columnMenuFilter: 'フィルター',


### PR DESCRIPTION
These four keys are already translated in the `zhCN` and `koKR` locales but were never filled in for `jaJP`, so a Japanese app still shows the English defaults for them.

- `noColumnsOverlayLabel` and `noColumnsOverlayManageColumns` were added with the "No columns" overlay in #16543. Their `jaJP` lines have stayed commented out since then, while `zhCN` and `koKR` got translated afterwards.
- `columnsManagementDeleteIconLabel` ("Clear") is the clear button of the columns management search field. I used クリア to match the existing `toolbarQuickFilterDeleteIconLabel`, which is the same "Clear" action.
- `columnMenuAriaLabel` was added in #16796. I used `${columnName} 列メニュー`, consistent with the existing column menu wording (`columnMenuShowColumns`: 列表示, `columnMenuManageColumns`: 列管理).

`noColumnsOverlayLabel` ends with 。 to match `noRowsLabel` and `noResultsOverlayLabel` in the same file.
