### PR TITLE
[charts] Decouple d3-geo from the universal tooltip

### DIFF
--- a/packages/x-charts-premium/src/Map/seriesConfig/index.ts
+++ b/packages/x-charts-premium/src/Map/seriesConfig/index.ts
@@ -6,7 +6,7 @@ import tooltipGetter from './tooltip';
 import getSeriesWithDefaultValues from './getSeriesWithDefaultValues';
 import descriptionGetter from './descriptionGetter';
 import keyboardFocusHandler from './keyboardFocusHandler';
-import tooltipItemPositionSelector from './tooltipPosition';
+import selectorTooltipItemPosition from './tooltipPosition';
 import identifierSerializer from './identifierSerializer';
 import identifierCleaner from './identifierCleaner';
 import { createIsHighlighted, createIsFaded } from './highlight';
@@ -16,7 +16,7 @@ export const mapShapeSeriesConfig: ChartSeriesTypeConfig<'mapShape'> = {
   colorProcessor: getColor,
   legendGetter,
   tooltipGetter,
-  tooltipItemPositionSelector,
+  tooltipItemPositionSelector: selectorTooltipItemPosition,
   getSeriesWithDefaultValues,
   keyboardFocusHandler,
   identifierSerializer,

--- a/packages/x-charts-premium/src/Map/seriesConfig/index.ts
+++ b/packages/x-charts-premium/src/Map/seriesConfig/index.ts
@@ -16,7 +16,7 @@ export const mapShapeSeriesConfig: ChartSeriesTypeConfig<'mapShape'> = {
   colorProcessor: getColor,
   legendGetter,
   tooltipGetter,
-  tooltipItemPositionSelector: selectorTooltipItemPosition,
+  selectorTooltipItemPosition,
   getSeriesWithDefaultValues,
   keyboardFocusHandler,
   identifierSerializer,

--- a/packages/x-charts-premium/src/Map/seriesConfig/index.ts
+++ b/packages/x-charts-premium/src/Map/seriesConfig/index.ts
@@ -6,7 +6,7 @@ import tooltipGetter from './tooltip';
 import getSeriesWithDefaultValues from './getSeriesWithDefaultValues';
 import descriptionGetter from './descriptionGetter';
 import keyboardFocusHandler from './keyboardFocusHandler';
-import tooltipItemPositionGetter from './tooltipPosition';
+import tooltipItemPositionSelector from './tooltipPosition';
 import identifierSerializer from './identifierSerializer';
 import identifierCleaner from './identifierCleaner';
 import { createIsHighlighted, createIsFaded } from './highlight';
@@ -16,7 +16,7 @@ export const mapShapeSeriesConfig: ChartSeriesTypeConfig<'mapShape'> = {
   colorProcessor: getColor,
   legendGetter,
   tooltipGetter,
-  tooltipItemPositionGetter,
+  tooltipItemPositionSelector,
   getSeriesWithDefaultValues,
   keyboardFocusHandler,
   identifierSerializer,

--- a/packages/x-charts-premium/src/Map/seriesConfig/tooltipPosition.ts
+++ b/packages/x-charts-premium/src/Map/seriesConfig/tooltipPosition.ts
@@ -18,7 +18,7 @@ const tooltipItemPositionGetter: TooltipItemPositionGetter<'mapShape'> = (params
   // so the map series reads it from the store here instead of the core tooltip
   // plugin injecting it for every chart (which would bundle d3-geo everywhere).
   const { projection, geoData, featureIndexesByName } =
-    useGeoProjectionSelectors.selectorGeoTooltipPosition(store.state as any);
+    useGeoProjectionSelectors.selectorGeoTooltipPosition(store.state);
 
   if (projection == null || geoData == null) {
     return null;

--- a/packages/x-charts-premium/src/Map/seriesConfig/tooltipPosition.ts
+++ b/packages/x-charts-premium/src/Map/seriesConfig/tooltipPosition.ts
@@ -1,51 +1,41 @@
 import { geoPath } from '@mui/x-charts-vendor/d3-geo';
-import type { TooltipItemPositionGetter } from '@mui/x-charts/internals';
-import { useGeoProjectionSelectors } from '@mui/x-charts/internals';
+import { createSelectorMemoized } from '@mui/x-internals/store';
+import type { TooltipItemPositionSelector } from '@mui/x-charts/internals';
+import { selectorChartsTooltipItem, useGeoProjectionSelectors } from '@mui/x-charts/internals';
 
-const tooltipItemPositionGetter: TooltipItemPositionGetter<'mapShape'> = (params) => {
-  const { series, identifier, store, placement } = params;
+/**
+ * Positions a map shape tooltip from the geo projection. It lives in the map
+ * series config (rather than the core tooltip plugin) so the geo projection is a
+ * tracked dependency and d3-geo is only bundled with map charts.
+ */
+const tooltipItemPositionSelector: TooltipItemPositionSelector = createSelectorMemoized(
+  selectorChartsTooltipItem,
+  useGeoProjectionSelectors.selectorGeoTooltipPosition,
+  (identifier, { projection, geoData, featureIndexesByName }, position) => {
+    if (identifier?.type !== 'mapShape' || projection == null || geoData == null) {
+      return null;
+    }
 
-  if (!identifier || identifier.name === undefined) {
-    return null;
-  }
-  const itemSeries = series.mapShape?.series[identifier.seriesId];
+    const featureIndex = featureIndexesByName.get(identifier.name)?.[0];
 
-  if (itemSeries == null) {
-    return null;
-  }
+    if (featureIndex === undefined) {
+      return null;
+    }
 
-  // Read the geo projection from the store here rather than through the core
-  // tooltip plugin, so d3-geo is only bundled with map charts.
-  const { projection, geoData, featureIndexesByName } =
-    useGeoProjectionSelectors.selectorGeoTooltipPosition(store.state);
+    const [[x0, y0], [x1, y1]] = geoPath(projection).bounds(geoData.features[featureIndex]);
 
-  if (projection == null || geoData == null) {
-    return null;
-  }
+    switch (position) {
+      case 'right':
+        return { x: x1, y: (y0 + y1) / 2 };
+      case 'bottom':
+        return { x: (x0 + x1) / 2, y: y1 };
+      case 'left':
+        return { x: x0, y: (y0 + y1) / 2 };
+      case 'top':
+      default:
+        return { x: (x0 + x1) / 2, y: y0 };
+    }
+  },
+);
 
-  const featureIndex = featureIndexesByName.get(identifier.name)?.[0];
-
-  if (featureIndex === undefined) {
-    return null;
-  }
-
-  const feature = geoData.features[featureIndex];
-
-  const path = geoPath(projection);
-
-  const [[x0, y0], [x1, y1]] = path.bounds(feature);
-
-  switch (placement) {
-    case 'right':
-      return { x: x1, y: (y0 + y1) / 2 };
-    case 'bottom':
-      return { x: (x0 + x1) / 2, y: y1 };
-    case 'left':
-      return { x: x0, y: (y0 + y1) / 2 };
-    case 'top':
-    default:
-      return { x: (x0 + x1) / 2, y: y0 };
-  }
-};
-
-export default tooltipItemPositionGetter;
+export default tooltipItemPositionSelector;

--- a/packages/x-charts-premium/src/Map/seriesConfig/tooltipPosition.ts
+++ b/packages/x-charts-premium/src/Map/seriesConfig/tooltipPosition.ts
@@ -8,7 +8,7 @@ import { selectorChartsTooltipItem, useGeoProjectionSelectors } from '@mui/x-cha
  * series config (rather than the core tooltip plugin) so the geo projection is a
  * tracked dependency and d3-geo is only bundled with map charts.
  */
-const tooltipItemPositionSelector: TooltipItemPositionSelector = createSelectorMemoized(
+const selectorTooltipItemPosition: TooltipItemPositionSelector = createSelectorMemoized(
   selectorChartsTooltipItem,
   useGeoProjectionSelectors.selectorGeoTooltipPosition,
   // `selectorChartsTooltipItem` is typed with the community series types, which
@@ -48,4 +48,4 @@ const tooltipItemPositionSelector: TooltipItemPositionSelector = createSelectorM
   },
 );
 
-export default tooltipItemPositionSelector;
+export default selectorTooltipItemPosition;

--- a/packages/x-charts-premium/src/Map/seriesConfig/tooltipPosition.ts
+++ b/packages/x-charts-premium/src/Map/seriesConfig/tooltipPosition.ts
@@ -14,9 +14,8 @@ const tooltipItemPositionGetter: TooltipItemPositionGetter<'mapShape'> = (params
     return null;
   }
 
-  // The geo projection lives in a feature plugin only registered by map charts,
-  // so the map series reads it from the store here instead of the core tooltip
-  // plugin injecting it for every chart (which would bundle d3-geo everywhere).
+  // Read the geo projection from the store here rather than through the core
+  // tooltip plugin, so d3-geo is only bundled with map charts.
   const { projection, geoData, featureIndexesByName } =
     useGeoProjectionSelectors.selectorGeoTooltipPosition(store.state);
 

--- a/packages/x-charts-premium/src/Map/seriesConfig/tooltipPosition.ts
+++ b/packages/x-charts-premium/src/Map/seriesConfig/tooltipPosition.ts
@@ -11,8 +11,18 @@ import { selectorChartsTooltipItem, useGeoProjectionSelectors } from '@mui/x-cha
 const tooltipItemPositionSelector: TooltipItemPositionSelector = createSelectorMemoized(
   selectorChartsTooltipItem,
   useGeoProjectionSelectors.selectorGeoTooltipPosition,
-  (identifier, { projection, geoData, featureIndexesByName }, position) => {
-    if (identifier?.type !== 'mapShape' || projection == null || geoData == null) {
+  // `selectorChartsTooltipItem` is typed with the community series types, which
+  // don't include `mapShape`, so the identifier is matched structurally here.
+  (
+    identifier: { type: string; name?: string } | null,
+    { projection, geoData, featureIndexesByName },
+    position: 'top' | 'bottom' | 'left' | 'right' | undefined,
+  ) => {
+    if (identifier?.type !== 'mapShape' || identifier.name === undefined) {
+      return null;
+    }
+
+    if (projection == null || geoData == null) {
       return null;
     }
 

--- a/packages/x-charts-premium/src/Map/seriesConfig/tooltipPosition.ts
+++ b/packages/x-charts-premium/src/Map/seriesConfig/tooltipPosition.ts
@@ -1,8 +1,9 @@
 import { geoPath } from '@mui/x-charts-vendor/d3-geo';
 import type { TooltipItemPositionGetter } from '@mui/x-charts/internals';
+import { useGeoProjectionSelectors } from '@mui/x-charts/internals';
 
 const tooltipItemPositionGetter: TooltipItemPositionGetter<'mapShape'> = (params) => {
-  const { series, identifier, axesConfig, placement } = params;
+  const { series, identifier, store, placement } = params;
 
   if (!identifier || identifier.name === undefined) {
     return null;
@@ -13,11 +14,11 @@ const tooltipItemPositionGetter: TooltipItemPositionGetter<'mapShape'> = (params
     return null;
   }
 
-  if (axesConfig.geo === undefined) {
-    return null;
-  }
-
-  const { projection, geoData, featureIndexesByName } = axesConfig.geo;
+  // The geo projection lives in a feature plugin only registered by map charts,
+  // so the map series reads it from the store here instead of the core tooltip
+  // plugin injecting it for every chart (which would bundle d3-geo everywhere).
+  const { projection, geoData, featureIndexesByName } =
+    useGeoProjectionSelectors.selectorGeoTooltipPosition(store.state as any);
 
   if (projection == null || geoData == null) {
     return null;

--- a/packages/x-charts/src/ChartsTooltip/ChartsTooltipContainer.tsx
+++ b/packages/x-charts/src/ChartsTooltip/ChartsTooltipContainer.tsx
@@ -16,7 +16,7 @@ import type { TriggerOptions } from './utils';
 import { useUtilityClasses } from './chartsTooltipClasses';
 import type { ChartsTooltipClasses } from './chartsTooltipClasses';
 import { useStore } from '../internals/store/useStore';
-import type { ChartStore } from '../internals/plugins/models/chart';
+import type { ChartState, ChartStore } from '../internals/plugins/models/chart';
 import {
   selectorChartsLastInteraction,
   selectorChartsPointerType,
@@ -66,17 +66,30 @@ const defaultAnchorByTrigger = {
   none: 'pointer',
 } as const;
 
+/**
+ * Common shape of the tooltip position selectors. The item selector reads the
+ * extra `store` argument (to let a series type source its own state); the axis
+ * and null selectors simply take fewer parameters, so they remain assignable to
+ * this type without a cast.
+ */
+type TooltipPositionSelector = (
+  state: ChartState<
+    [UseChartCartesianAxisSignature, UseChartInteractionSignature, UseChartTooltipSignature]
+  >,
+  position: ChartsTooltipContainerProps['position'],
+  store: ChartStore,
+) => { x: number; y: number } | null;
+
 const getPositionSelectorByAnchor = (
   anchor: 'pointer' | 'node' | 'chart',
-): typeof selectorChartsTooltipItemPosition => {
+): TooltipPositionSelector => {
   switch (anchor) {
     case 'node':
       return selectorChartsTooltipItemPosition;
     case 'chart':
-      // The axis and null selectors ignore the extra `store` argument.
-      return selectorChartsTooltipAxisPosition as typeof selectorChartsTooltipItemPosition;
+      return selectorChartsTooltipAxisPosition;
     default:
-      return selectorReturnNull as typeof selectorChartsTooltipItemPosition;
+      return selectorReturnNull;
   }
 };
 
@@ -215,7 +228,7 @@ function ChartsTooltipContainer(inProps: ChartsTooltipContainerProps) {
   const itemPosition = store.use(
     getPositionSelectorByAnchor(computedAnchor),
     props.position,
-    store as ChartStore,
+    store,
   );
 
   const isTooltipNodeAnchored = itemPosition !== null;

--- a/packages/x-charts/src/ChartsTooltip/ChartsTooltipContainer.tsx
+++ b/packages/x-charts/src/ChartsTooltip/ChartsTooltipContainer.tsx
@@ -16,12 +16,14 @@ import type { TriggerOptions } from './utils';
 import { useUtilityClasses } from './chartsTooltipClasses';
 import type { ChartsTooltipClasses } from './chartsTooltipClasses';
 import { useStore } from '../internals/store/useStore';
-import type { ChartState, ChartStore } from '../internals/plugins/models/chart';
+import type { TooltipItemPositionSelector } from '../internals/plugins/corePlugins/useChartSeriesConfig';
+import { selectorChartSeriesConfig } from '../internals/plugins/corePlugins/useChartSeriesConfig';
 import {
   selectorChartsLastInteraction,
   selectorChartsPointerType,
 } from '../internals/plugins/featurePlugins/useChartInteraction';
 import {
+  selectorChartsTooltipItem,
   selectorChartsTooltipItemIsDefined,
   selectorChartsTooltipItemPosition,
 } from '../internals/plugins/featurePlugins/useChartTooltip';
@@ -66,24 +68,15 @@ const defaultAnchorByTrigger = {
   none: 'pointer',
 } as const;
 
-/**
- * Shared shape of the tooltip position selectors. The axis and null selectors
- * take fewer parameters than the item selector, so they stay assignable to it.
- */
-type TooltipPositionSelector = (
-  state: ChartState<
-    [UseChartCartesianAxisSignature, UseChartInteractionSignature, UseChartTooltipSignature]
-  >,
-  position: ChartsTooltipContainerProps['position'],
-  store: ChartStore,
-) => { x: number; y: number } | null;
-
+// The axis and null selectors take a state the item selector's state is
+// assignable to, so they all converge to `TooltipItemPositionSelector`.
 const getPositionSelectorByAnchor = (
   anchor: 'pointer' | 'node' | 'chart',
-): TooltipPositionSelector => {
+  itemPositionSelector: TooltipItemPositionSelector,
+): TooltipItemPositionSelector => {
   switch (anchor) {
     case 'node':
-      return selectorChartsTooltipItemPosition;
+      return itemPositionSelector;
     case 'chart':
       return selectorChartsTooltipAxisPosition;
     default:
@@ -223,10 +216,18 @@ function ChartsTooltipContainer(inProps: ChartsTooltipContainerProps) {
   const pointerAnchorUnavailable = lastInteraction === 'keyboard' || pointerType === null;
   const computedAnchor = pointerAnchorUnavailable ? defaultAnchorByTrigger[trigger] : anchor;
 
+  // A series type can override how its item tooltip is positioned (e.g. map
+  // shapes position from the geo projection); otherwise the generic item
+  // selector is used.
+  const tooltipItem = store.use(selectorChartsTooltipItem);
+  const seriesConfig = store.use(selectorChartSeriesConfig);
+  const itemPositionSelector: TooltipItemPositionSelector =
+    (tooltipItem && seriesConfig[tooltipItem.type]?.tooltipItemPositionSelector) ||
+    selectorChartsTooltipItemPosition;
+
   const itemPosition = store.use(
-    getPositionSelectorByAnchor(computedAnchor),
+    getPositionSelectorByAnchor(computedAnchor, itemPositionSelector),
     props.position,
-    store,
   );
 
   const isTooltipNodeAnchored = itemPosition !== null;

--- a/packages/x-charts/src/ChartsTooltip/ChartsTooltipContainer.tsx
+++ b/packages/x-charts/src/ChartsTooltip/ChartsTooltipContainer.tsx
@@ -16,6 +16,7 @@ import type { TriggerOptions } from './utils';
 import { useUtilityClasses } from './chartsTooltipClasses';
 import type { ChartsTooltipClasses } from './chartsTooltipClasses';
 import { useStore } from '../internals/store/useStore';
+import type { ChartStore } from '../internals/plugins/models/chart';
 import {
   selectorChartsLastInteraction,
   selectorChartsPointerType,
@@ -65,14 +66,17 @@ const defaultAnchorByTrigger = {
   none: 'pointer',
 } as const;
 
-const getPositionSelectorByAnchor = (anchor: 'pointer' | 'node' | 'chart') => {
+const getPositionSelectorByAnchor = (
+  anchor: 'pointer' | 'node' | 'chart',
+): typeof selectorChartsTooltipItemPosition => {
   switch (anchor) {
     case 'node':
       return selectorChartsTooltipItemPosition;
     case 'chart':
-      return selectorChartsTooltipAxisPosition;
+      // The axis and null selectors ignore the extra `store` argument.
+      return selectorChartsTooltipAxisPosition as typeof selectorChartsTooltipItemPosition;
     default:
-      return selectorReturnNull;
+      return selectorReturnNull as typeof selectorChartsTooltipItemPosition;
   }
 };
 
@@ -208,7 +212,11 @@ function ChartsTooltipContainer(inProps: ChartsTooltipContainerProps) {
   const pointerAnchorUnavailable = lastInteraction === 'keyboard' || pointerType === null;
   const computedAnchor = pointerAnchorUnavailable ? defaultAnchorByTrigger[trigger] : anchor;
 
-  const itemPosition = store.use(getPositionSelectorByAnchor(computedAnchor), props.position);
+  const itemPosition = store.use(
+    getPositionSelectorByAnchor(computedAnchor),
+    props.position,
+    store as ChartStore,
+  );
 
   const isTooltipNodeAnchored = itemPosition !== null;
 

--- a/packages/x-charts/src/ChartsTooltip/ChartsTooltipContainer.tsx
+++ b/packages/x-charts/src/ChartsTooltip/ChartsTooltipContainer.tsx
@@ -222,7 +222,7 @@ function ChartsTooltipContainer(inProps: ChartsTooltipContainerProps) {
   const tooltipItem = store.use(selectorChartsTooltipItem);
   const seriesConfig = store.use(selectorChartSeriesConfig);
   const selectorItemPosition: TooltipItemPositionSelector =
-    (tooltipItem && seriesConfig[tooltipItem.type]?.tooltipItemPositionSelector) ||
+    (tooltipItem && seriesConfig[tooltipItem.type]?.selectorTooltipItemPosition) ||
     selectorChartsTooltipItemPosition;
 
   const itemPosition = store.use(

--- a/packages/x-charts/src/ChartsTooltip/ChartsTooltipContainer.tsx
+++ b/packages/x-charts/src/ChartsTooltip/ChartsTooltipContainer.tsx
@@ -72,11 +72,11 @@ const defaultAnchorByTrigger = {
 // assignable to, so they all converge to `TooltipItemPositionSelector`.
 const getPositionSelectorByAnchor = (
   anchor: 'pointer' | 'node' | 'chart',
-  itemPositionSelector: TooltipItemPositionSelector,
+  selectorItemPosition: TooltipItemPositionSelector,
 ): TooltipItemPositionSelector => {
   switch (anchor) {
     case 'node':
-      return itemPositionSelector;
+      return selectorItemPosition;
     case 'chart':
       return selectorChartsTooltipAxisPosition;
     default:
@@ -221,12 +221,12 @@ function ChartsTooltipContainer(inProps: ChartsTooltipContainerProps) {
   // selector is used.
   const tooltipItem = store.use(selectorChartsTooltipItem);
   const seriesConfig = store.use(selectorChartSeriesConfig);
-  const itemPositionSelector: TooltipItemPositionSelector =
+  const selectorItemPosition: TooltipItemPositionSelector =
     (tooltipItem && seriesConfig[tooltipItem.type]?.tooltipItemPositionSelector) ||
     selectorChartsTooltipItemPosition;
 
   const itemPosition = store.use(
-    getPositionSelectorByAnchor(computedAnchor, itemPositionSelector),
+    getPositionSelectorByAnchor(computedAnchor, selectorItemPosition),
     props.position,
   );
 

--- a/packages/x-charts/src/ChartsTooltip/ChartsTooltipContainer.tsx
+++ b/packages/x-charts/src/ChartsTooltip/ChartsTooltipContainer.tsx
@@ -67,10 +67,8 @@ const defaultAnchorByTrigger = {
 } as const;
 
 /**
- * Common shape of the tooltip position selectors. The item selector reads the
- * extra `store` argument (to let a series type source its own state); the axis
- * and null selectors simply take fewer parameters, so they remain assignable to
- * this type without a cast.
+ * Shared shape of the tooltip position selectors. The axis and null selectors
+ * take fewer parameters than the item selector, so they stay assignable to it.
  */
 type TooltipPositionSelector = (
   state: ChartState<

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/seriesConfig.types.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/seriesConfig.types.ts
@@ -50,7 +50,7 @@ export type ChartSeriesTypeConfig<SeriesType extends ChartSeriesType> = {
    * whose position depends on state the core tooltip plugin doesn't track.
    * Takes precedence over `tooltipItemPositionGetter`.
    */
-  tooltipItemPositionSelector?: TooltipItemPositionSelector;
+  selectorTooltipItemPosition?: TooltipItemPositionSelector;
   getSeriesWithDefaultValues: GetSeriesWithDefaultValues<SeriesType>;
   keyboardFocusHandler?: KeyboardFocusHandler<SeriesType>;
   /**

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/seriesConfig.types.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/seriesConfig.types.ts
@@ -12,7 +12,10 @@ import type { LegendGetter } from './legendGetter.types';
 import type { AxisTooltipGetter, TooltipGetter } from './tooltipGetter.types';
 import type { PolarExtremumGetter } from './polarExtremumGetter.types';
 import type { GetSeriesWithDefaultValues } from './getSeriesWithDefaultValues.types';
-import type { TooltipItemPositionGetter } from './tooltipItemPositionGetter.types';
+import type {
+  TooltipItemPositionGetter,
+  TooltipItemPositionSelector,
+} from './tooltipItemPositionGetter.types';
 import type { SeriesLayoutGetter } from './seriesLayout.types';
 import type { KeyboardFocusHandler } from '../../../featurePlugins/useChartKeyboardNavigation/keyboardFocusHandler.types';
 import type { IdentifierSerializer } from './identifierSerializer.types';
@@ -42,6 +45,12 @@ export type ChartSeriesTypeConfig<SeriesType extends ChartSeriesType> = {
   tooltipGetter: TooltipGetter<SeriesType>;
   ItemTooltipContent?: React.ComponentType<ItemTooltipContentProps<SeriesType>>;
   tooltipItemPositionGetter?: TooltipItemPositionGetter<SeriesType>;
+  /**
+   * Computes the item tooltip position from the chart state, for series types
+   * whose position depends on state the core tooltip plugin doesn't track.
+   * Takes precedence over `tooltipItemPositionGetter`.
+   */
+  tooltipItemPositionSelector?: TooltipItemPositionSelector;
   getSeriesWithDefaultValues: GetSeriesWithDefaultValues<SeriesType>;
   keyboardFocusHandler?: KeyboardFocusHandler<SeriesType>;
   /**

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/tooltipItemPositionGetter.types.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/tooltipItemPositionGetter.types.ts
@@ -9,7 +9,10 @@ import type {
 import type { ChartDrawingArea } from '../../../../../hooks/useDrawingArea';
 import type { ProcessedSeries, SeriesLayout } from '../../useChartSeries';
 import type { ComputeResult } from '../../../featurePlugins/useChartPolarAxis/computeAxisValue';
-import type { ChartStore } from '../../../models';
+import type { ChartState } from '../../../models';
+import type { UseChartCartesianAxisSignature } from '../../../featurePlugins/useChartCartesianAxis';
+import type { UseChartInteractionSignature } from '../../../featurePlugins/useChartInteraction';
+import type { UseChartTooltipSignature } from '../../../featurePlugins/useChartTooltip';
 
 export interface TooltipPositionGetterAxesConfig {
   x?: ComputedXAxis;
@@ -25,13 +28,25 @@ export type TooltipItemPositionGetter<SeriesType extends ChartSeriesType> = (par
   identifier: SeriesItemIdentifierWithType<SeriesType> | null;
   seriesLayout: SeriesLayout<SeriesType>;
   /**
-   * The chart store, letting a series type read extra state to position its
-   * tooltip (e.g. the geo projection for map series).
-   */
-  store: ChartStore;
-  /**
    * The preferred placement of the tooltip related to the element.
    * @default 'top'
    */
   placement: 'top' | 'bottom' | 'left' | 'right';
 }) => { x: number; y: number } | null;
+
+/**
+ * Computes the anchor position of an item tooltip from the chart state. Series
+ * types whose position depends on state the core tooltip plugin doesn't track
+ * (e.g. the geo projection for map series) provide one of these instead of a
+ * `tooltipItemPositionGetter`, so the dependency is memoized correctly and the
+ * feature-specific code stays out of the core bundle.
+ * @param {ChartState} state The chart state.
+ * @param {'top' | 'bottom' | 'left' | 'right' | undefined} position The preferred placement of the tooltip.
+ * @returns {{ x: number; y: number } | null} The tooltip anchor position, or `null` when it cannot be computed.
+ */
+export type TooltipItemPositionSelector = (
+  state: ChartState<
+    [UseChartCartesianAxisSignature, UseChartInteractionSignature, UseChartTooltipSignature]
+  >,
+  position: 'top' | 'bottom' | 'left' | 'right' | undefined,
+) => { x: number; y: number } | null;

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/tooltipItemPositionGetter.types.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/tooltipItemPositionGetter.types.ts
@@ -1,4 +1,3 @@
-import type { ExtendedFeatureCollection, GeoProjection } from '@mui/x-charts-vendor/d3-geo';
 import type { SeriesItemIdentifierWithType } from '../../../../../models/seriesType';
 import type { ChartSeriesType } from '../../../../../models/seriesType/config';
 import type {
@@ -10,19 +9,13 @@ import type {
 import type { ChartDrawingArea } from '../../../../../hooks/useDrawingArea';
 import type { ProcessedSeries, SeriesLayout } from '../../useChartSeries';
 import type { ComputeResult } from '../../../featurePlugins/useChartPolarAxis/computeAxisValue';
-
-export type GeoTooltipPosition = {
-  geoData: ExtendedFeatureCollection | null;
-  projection: GeoProjection | null;
-  featureIndexesByName: ReadonlyMap<string, number[]>;
-};
+import type { ChartStore } from '../../../models';
 
 export interface TooltipPositionGetterAxesConfig {
   x?: ComputedXAxis;
   y?: ComputedYAxis;
   rotationAxes?: ComputeResult<ChartsRotationAxisProps>;
   radiusAxes?: ComputeResult<ChartsRadiusAxisProps>;
-  geo?: GeoTooltipPosition;
 }
 
 export type TooltipItemPositionGetter<SeriesType extends ChartSeriesType> = (params: {
@@ -31,6 +24,12 @@ export type TooltipItemPositionGetter<SeriesType extends ChartSeriesType> = (par
   drawingArea: ChartDrawingArea;
   identifier: SeriesItemIdentifierWithType<SeriesType> | null;
   seriesLayout: SeriesLayout<SeriesType>;
+  /**
+   * The chart store. Lets a series type read additional state it needs to
+   * position its tooltip (e.g. the geo projection for map series) without the
+   * core tooltip plugin having to depend on feature-specific code.
+   */
+  store: ChartStore;
   /**
    * The preferred placement of the tooltip related to the element.
    * @default 'top'

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/tooltipItemPositionGetter.types.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/tooltipItemPositionGetter.types.ts
@@ -25,9 +25,8 @@ export type TooltipItemPositionGetter<SeriesType extends ChartSeriesType> = (par
   identifier: SeriesItemIdentifierWithType<SeriesType> | null;
   seriesLayout: SeriesLayout<SeriesType>;
   /**
-   * The chart store. Lets a series type read additional state it needs to
-   * position its tooltip (e.g. the geo projection for map series) without the
-   * core tooltip plugin having to depend on feature-specific code.
+   * The chart store, letting a series type read extra state to position its
+   * tooltip (e.g. the geo projection for map series).
    */
   store: ChartStore;
   /**

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartTooltip/useChartTooltip.selectors.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartTooltip/useChartTooltip.selectors.ts
@@ -10,7 +10,6 @@ import { selectorChartSeriesConfig } from '../../corePlugins/useChartSeriesConfi
 import type {
   TooltipPositionGetterAxesConfig,
   ChartSeriesConfig,
-  GeoTooltipPosition,
 } from '../../corePlugins/useChartSeriesConfig';
 import {
   selectorChartXAxis,
@@ -39,7 +38,7 @@ import {
 import type { ComputeResult as ComputePolarResult } from '../useChartPolarAxis/computeAxisValue';
 import type { ChartOptionalRootSelector } from '../../utils/selectors';
 import type { UseChartTooltipSignature } from './useChartTooltip.types';
-import { selectorGeoTooltipPosition } from '../useGeoProjection/useGeoProjection.selectors';
+import type { ChartStore } from '../../models/chart';
 
 const selectTooltip: ChartOptionalRootSelector<UseChartTooltipSignature> = (state) => state.tooltip;
 
@@ -76,7 +75,6 @@ const selectorChartsTooltipAxisConfig = createSelectorMemoized(
   selectorChartRotationAxis,
   selectorChartRadiusAxis,
   selectorChartSeriesProcessed,
-  selectorGeoTooltipPosition,
   function selectorChartsTooltipAxisConfig<SeriesType extends ChartSeriesType>(
     identifier: SeriesItemIdentifierWithType<SeriesType> | null,
     { axis: xAxis, axisIds: xAxisIds }: ComputeResult<ChartsXAxisProps>,
@@ -84,7 +82,6 @@ const selectorChartsTooltipAxisConfig = createSelectorMemoized(
     rotationAxes: ComputePolarResult<ChartsRotationAxisProps>,
     radiusAxes: ComputePolarResult<ChartsRadiusAxisProps>,
     series: ProcessedSeries<SeriesType>,
-    geo: GeoTooltipPosition,
   ) {
     if (!identifier) {
       return {};
@@ -115,9 +112,6 @@ const selectorChartsTooltipAxisConfig = createSelectorMemoized(
     if (yAxisId !== undefined) {
       axesConfig.y = yAxis[yAxisId];
     }
-    if (geo) {
-      axesConfig.geo = geo;
-    }
 
     return axesConfig;
   },
@@ -138,7 +132,8 @@ export const selectorChartsTooltipItemPosition = createSelectorMemoized(
     series: ProcessedSeries<SeriesType>,
     seriesLayout: SeriesLayout<SeriesType>,
     axesConfig: TooltipPositionGetterAxesConfig,
-    placement: 'top' | 'bottom' | 'left' | 'right',
+    placement: 'top' | 'bottom' | 'left' | 'right' | undefined,
+    store: ChartStore,
   ) {
     if (!identifier) {
       return null;
@@ -158,7 +153,8 @@ export const selectorChartsTooltipItemPosition = createSelectorMemoized(
         drawingArea,
         axesConfig,
         identifier,
-        placement,
+        placement: placement ?? 'top',
+        store,
       }) ?? null
     );
   },

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartTooltip/useChartTooltip.selectors.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartTooltip/useChartTooltip.selectors.ts
@@ -38,7 +38,6 @@ import {
 import type { ComputeResult as ComputePolarResult } from '../useChartPolarAxis/computeAxisValue';
 import type { ChartOptionalRootSelector } from '../../utils/selectors';
 import type { UseChartTooltipSignature } from './useChartTooltip.types';
-import type { ChartStore } from '../../models/chart';
 
 const selectTooltip: ChartOptionalRootSelector<UseChartTooltipSignature> = (state) => state.tooltip;
 
@@ -133,7 +132,6 @@ export const selectorChartsTooltipItemPosition = createSelectorMemoized(
     seriesLayout: SeriesLayout<SeriesType>,
     axesConfig: TooltipPositionGetterAxesConfig,
     placement: 'top' | 'bottom' | 'left' | 'right' | undefined,
-    store: ChartStore,
   ) {
     if (!identifier) {
       return null;
@@ -154,7 +152,6 @@ export const selectorChartsTooltipItemPosition = createSelectorMemoized(
         axesConfig,
         identifier,
         placement: placement ?? 'top',
-        store,
       }) ?? null
     );
   },

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useGeoProjection/useGeoProjection.selectors.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useGeoProjection/useGeoProjection.selectors.ts
@@ -9,12 +9,12 @@ import type {
 import type {
   D3NamedProjection,
   GeoProjectionInput,
+  GeoTooltipPosition,
   UseGeoProjectionSignature,
   UseGeoProjectionState,
 } from './useGeoProjection.types';
 import { selectorChartDrawingArea } from '../../corePlugins/useChartDimensions/useChartDimensions.selectors';
 import type { ChartState } from '../../models/chart';
-import type { GeoTooltipPosition } from '../../corePlugins/useChartSeriesConfig';
 
 const isConicProjection = (projection: GeoProjection): projection is GeoConicProjection => {
   return 'parallels' in projection && typeof projection.parallels === 'function';

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useGeoProjection/useGeoProjection.types.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useGeoProjection/useGeoProjection.types.ts
@@ -2,8 +2,8 @@ import type { GeoProjection, ExtendedFeatureCollection } from '@mui/x-charts-ven
 import type { ChartPluginSignature } from '../../models/plugin';
 
 /**
- * The geo data a map series needs to position its tooltip: the resolved
- * projection, the feature collection, and a lookup from feature name to index.
+ * Geo data used to position a map series tooltip: the resolved projection, the
+ * feature collection, and a feature-name-to-index lookup.
  */
 export type GeoTooltipPosition = {
   geoData: ExtendedFeatureCollection | null;

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useGeoProjection/useGeoProjection.types.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useGeoProjection/useGeoProjection.types.ts
@@ -1,6 +1,16 @@
 import type { GeoProjection, ExtendedFeatureCollection } from '@mui/x-charts-vendor/d3-geo';
 import type { ChartPluginSignature } from '../../models/plugin';
 
+/**
+ * The geo data a map series needs to position its tooltip: the resolved
+ * projection, the feature collection, and a lookup from feature name to index.
+ */
+export type GeoTooltipPosition = {
+  geoData: ExtendedFeatureCollection | null;
+  projection: GeoProjection | null;
+  featureIndexesByName: ReadonlyMap<string, number[]>;
+};
+
 export type D3NamedProjection =
   | 'azimuthalEqualArea'
   | 'azimuthalEquidistant'

--- a/packages/x-charts/src/internals/plugins/models/chart.ts
+++ b/packages/x-charts/src/internals/plugins/models/chart.ts
@@ -1,3 +1,4 @@
+import type { Store } from '@mui/x-internals/store';
 import type { ChartAnyPluginSignature } from './plugin';
 import type { MergeSignaturesProperty } from './helpers';
 import type { ChartCorePluginSignatures } from '../corePlugins';
@@ -16,6 +17,12 @@ export type ChartPublicAPI<
   Partial<MergeSignaturesProperty<TOptionalSignatures, 'instance'>>;
 
 export type ChartStateCacheKey = { id: number };
+
+/**
+ * A loosely-typed chart store, accepting any plugin signatures. Useful where a
+ * helper needs the store but should not be coupled to a specific plugin set.
+ */
+export type ChartStore = Store<ChartState<ChartAnyPluginSignature[]>>;
 
 export type ChartState<
   TSignatures extends readonly ChartAnyPluginSignature[],

--- a/packages/x-charts/src/internals/plugins/models/chart.ts
+++ b/packages/x-charts/src/internals/plugins/models/chart.ts
@@ -19,11 +19,9 @@ export type ChartPublicAPI<
 export type ChartStateCacheKey = { id: number };
 
 /**
- * A loosely-typed, read-only view of a chart store, accepting any plugin
- * signatures. Useful where a helper only needs to read state (e.g. a series
- * type sourcing extra state for its tooltip) and should not be coupled to a
- * specific plugin set. Being read-only, a concretely-typed store is assignable
- * to it without a cast.
+ * A loosely-typed, read-only view of a chart store, for helpers that read state
+ * without coupling to a specific plugin set. Being read-only, a concretely-typed
+ * store is assignable to it without a cast.
  */
 export type ChartStore = ReadonlyStore<ChartState<ChartAnyPluginSignature[]>>;
 

--- a/packages/x-charts/src/internals/plugins/models/chart.ts
+++ b/packages/x-charts/src/internals/plugins/models/chart.ts
@@ -1,4 +1,4 @@
-import type { Store } from '@mui/x-internals/store';
+import type { ReadonlyStore } from '@mui/x-internals/store';
 import type { ChartAnyPluginSignature } from './plugin';
 import type { MergeSignaturesProperty } from './helpers';
 import type { ChartCorePluginSignatures } from '../corePlugins';
@@ -19,10 +19,13 @@ export type ChartPublicAPI<
 export type ChartStateCacheKey = { id: number };
 
 /**
- * A loosely-typed chart store, accepting any plugin signatures. Useful where a
- * helper needs the store but should not be coupled to a specific plugin set.
+ * A loosely-typed, read-only view of a chart store, accepting any plugin
+ * signatures. Useful where a helper only needs to read state (e.g. a series
+ * type sourcing extra state for its tooltip) and should not be coupled to a
+ * specific plugin set. Being read-only, a concretely-typed store is assignable
+ * to it without a cast.
  */
-export type ChartStore = Store<ChartState<ChartAnyPluginSignature[]>>;
+export type ChartStore = ReadonlyStore<ChartState<ChartAnyPluginSignature[]>>;
 
 export type ChartState<
   TSignatures extends readonly ChartAnyPluginSignature[],

--- a/packages/x-charts/src/internals/plugins/models/chart.ts
+++ b/packages/x-charts/src/internals/plugins/models/chart.ts
@@ -1,4 +1,3 @@
-import type { ReadonlyStore } from '@mui/x-internals/store';
 import type { ChartAnyPluginSignature } from './plugin';
 import type { MergeSignaturesProperty } from './helpers';
 import type { ChartCorePluginSignatures } from '../corePlugins';
@@ -17,13 +16,6 @@ export type ChartPublicAPI<
   Partial<MergeSignaturesProperty<TOptionalSignatures, 'instance'>>;
 
 export type ChartStateCacheKey = { id: number };
-
-/**
- * A loosely-typed, read-only view of a chart store, for helpers that read state
- * without coupling to a specific plugin set. Being read-only, a concretely-typed
- * store is assignable to it without a cast.
- */
-export type ChartStore = ReadonlyStore<ChartState<ChartAnyPluginSignature[]>>;
 
 export type ChartState<
   TSignatures extends readonly ChartAnyPluginSignature[],


### PR DESCRIPTION
 The core tooltip plugin injected the geo projection (`axesConfig.geo`) for every chart through `selectorGeoTooltipPosition`, which pulls `geoPath` from `@mui/x-charts-vendor/d3-geo` into the community bundle even though only map charts use it.


Asked claude to generate explanation doc by giving it enough inputs. 

https://claude.ai/public/artifacts/c0fde3a8-a451-4315-82d8-60caf403ecd5
 
Just experimenting new way to make it easier for reviewers.

QQ for reviewers: Is doc bit of overkill or genuinely helpful