### PR TITLE
[charts] Keep unused plugins out of per-chart bundles

### DIFF
--- a/packages/x-charts/src/BarChart/BarChart.tsx
+++ b/packages/x-charts/src/BarChart/BarChart.tsx
@@ -30,7 +30,7 @@ import type {
   ChartsOverlaySlots,
 } from '../ChartsOverlay/ChartsOverlay';
 import { useBarChartProps } from './useBarChartProps';
-import { ChartsDataProvider } from '../ChartsDataProvider';
+import { ChartDataProviderInternal } from '../ChartsDataProvider/ChartDataProviderInternal';
 import { ChartsSurface } from '../ChartsSurface';
 import { useChartsContainerProps } from '../ChartsContainer/useChartsContainerProps';
 import { ChartsWrapper } from '../ChartsWrapper';
@@ -142,7 +142,7 @@ const BarChart = React.forwardRef(function BarChart(
   const Toolbar = props.slots?.toolbar;
 
   return (
-    <ChartsDataProvider<'bar', BarChartPluginSignatures> {...chartsDataProviderProps}>
+    <ChartDataProviderInternal<'bar', BarChartPluginSignatures> {...chartsDataProviderProps}>
       <ChartsWrapper {...chartsWrapperProps} ref={ref}>
         {props.showToolbar && Toolbar ? <Toolbar {...props.slotProps?.toolbar} /> : null}
         {!props.hideLegend && <ChartsLegend {...legendProps} />}
@@ -160,7 +160,7 @@ const BarChart = React.forwardRef(function BarChart(
         </ChartsSurface>
         {!props.loading && <Tooltip {...props.slotProps?.tooltip} />}
       </ChartsWrapper>
-    </ChartsDataProvider>
+    </ChartDataProviderInternal>
   );
 });
 

--- a/packages/x-charts/src/ChartsContainer/useChartsContainerProps.ts
+++ b/packages/x-charts/src/ChartsContainer/useChartsContainerProps.ts
@@ -3,7 +3,6 @@ import type { ChartsSurfaceProps } from '../ChartsSurface';
 import type { ChartsDataProviderProps } from '../ChartsDataProvider';
 import type { ChartsContainerProps } from './ChartsContainer';
 import type { ChartSeriesType } from '../models/seriesType/config';
-import { DEFAULT_PLUGINS } from '../internals/plugins/allPlugins';
 import type { AllPluginSignatures } from '../internals/plugins/allPlugins';
 import type { ChartAnyPluginSignature } from '../internals/plugins/models/plugin';
 
@@ -109,7 +108,10 @@ export const useChartsContainerProps = <
     onHiddenItemsChange,
     hiddenItems,
     initialHiddenItems,
-    plugins: plugins ?? DEFAULT_PLUGINS,
+    // `plugins` is passed through as-is. Charts always provide their own list;
+    // the generic `ChartsContainer` renders the public `ChartsDataProvider`,
+    // which defaults `plugins` to `DEFAULT_PLUGINS` for standalone usage.
+    plugins,
     slots,
     slotProps,
   } as unknown as ChartsDataProviderProps<SeriesType, TSignatures>;

--- a/packages/x-charts/src/ChartsDataProvider/ChartDataProviderInternal.tsx
+++ b/packages/x-charts/src/ChartsDataProvider/ChartDataProviderInternal.tsx
@@ -1,0 +1,42 @@
+'use client';
+import * as React from 'react';
+import { defaultSlotsMaterial } from '../internals/material';
+import { ChartsSlotsProvider } from '../context/ChartsSlotsContext';
+import { useChartsDataProviderProps } from './useChartsDataProviderProps';
+import { ChartsProvider } from '../context/ChartsProvider';
+import type { ChartSeriesType } from '../models/seriesType/config';
+import type { ChartAnyPluginSignature } from '../internals/plugins/models/plugin';
+import type { AllPluginSignatures } from '../internals/plugins/allPlugins';
+import { ChartsLocalizationProvider } from '../ChartsLocalizationProvider';
+import type { ChartsDataProviderProps } from './ChartsDataProvider';
+
+/**
+ * The data provider logic, without defaulting `plugins` to `DEFAULT_PLUGINS`.
+ *
+ * Chart components render this directly and always pass their own `plugins`
+ * list, so the default plugin set — and everything it references (closest-point,
+ * progressive rendering, ...) — stays out of their bundles. The public
+ * {@link ChartsDataProvider} wraps this and supplies `DEFAULT_PLUGINS` for
+ * standalone/composition usage.
+ */
+export function ChartDataProviderInternal<
+  SeriesType extends ChartSeriesType = ChartSeriesType,
+  TSignatures extends readonly ChartAnyPluginSignature[] = AllPluginSignatures<SeriesType>,
+>(props: ChartsDataProviderProps<SeriesType, TSignatures>) {
+  const { children, localeText, chartProviderProps, slots, slotProps } =
+    useChartsDataProviderProps(props);
+
+  return (
+    <ChartsProvider<SeriesType, TSignatures> {...chartProviderProps}>
+      <ChartsLocalizationProvider localeText={localeText}>
+        <ChartsSlotsProvider
+          slots={slots}
+          slotProps={slotProps}
+          defaultSlots={defaultSlotsMaterial}
+        >
+          {children}
+        </ChartsSlotsProvider>
+      </ChartsLocalizationProvider>
+    </ChartsProvider>
+  );
+}

--- a/packages/x-charts/src/ChartsDataProvider/ChartsDataProvider.tsx
+++ b/packages/x-charts/src/ChartsDataProvider/ChartsDataProvider.tsx
@@ -1,18 +1,13 @@
 'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { defaultSlotsMaterial } from '../internals/material';
 import type { ChartsSlotProps, ChartsSlots } from '../internals/material';
-import { ChartsSlotsProvider } from '../context/ChartsSlotsContext';
-
-import { useChartsDataProviderProps } from './useChartsDataProviderProps';
-import { ChartsProvider } from '../context/ChartsProvider';
+import { ChartDataProviderInternal } from './ChartDataProviderInternal';
 import type { ChartsProviderProps } from '../context/ChartsProvider';
 import type { ChartSeriesType } from '../models/seriesType/config';
 import type { ChartAnyPluginSignature } from '../internals/plugins/models/plugin';
-
+import { DEFAULT_PLUGINS } from '../internals/plugins/allPlugins';
 import type { AllPluginSignatures } from '../internals/plugins/allPlugins';
-import { ChartsLocalizationProvider } from '../ChartsLocalizationProvider';
 import type { ChartsLocalizationProviderProps } from '../ChartsLocalizationProvider';
 
 export interface ChartsDataProviderSlots extends ChartsSlots {}
@@ -68,21 +63,19 @@ function ChartsDataProvider<
   SeriesType extends ChartSeriesType = ChartSeriesType,
   TSignatures extends readonly ChartAnyPluginSignature[] = AllPluginSignatures<SeriesType>,
 >(props: ChartsDataProviderProps<SeriesType, TSignatures>) {
-  const { children, localeText, chartProviderProps, slots, slotProps } =
-    useChartsDataProviderProps(props);
-
+  // Standalone/composition usage doesn't provide a `plugins` list, so default it
+  // here. Chart components render `ChartDataProviderInternal` directly with their
+  // own list, keeping `DEFAULT_PLUGINS` out of their bundles.
   return (
-    <ChartsProvider<SeriesType, TSignatures> {...chartProviderProps}>
-      <ChartsLocalizationProvider localeText={localeText}>
-        <ChartsSlotsProvider
-          slots={slots}
-          slotProps={slotProps}
-          defaultSlots={defaultSlotsMaterial}
-        >
-          {children}
-        </ChartsSlotsProvider>
-      </ChartsLocalizationProvider>
-    </ChartsProvider>
+    <ChartDataProviderInternal<SeriesType, TSignatures>
+      {...props}
+      plugins={
+        (props.plugins ?? DEFAULT_PLUGINS) as ChartsProviderProps<
+          SeriesType,
+          TSignatures
+        >['plugins']
+      }
+    />
   );
 }
 

--- a/packages/x-charts/src/ChartsDataProvider/index.ts
+++ b/packages/x-charts/src/ChartsDataProvider/index.ts
@@ -1,1 +1,2 @@
 export * from './ChartsDataProvider';
+export { ChartDataProviderInternal } from './ChartDataProviderInternal';

--- a/packages/x-charts/src/ChartsDataProvider/useChartsDataProviderProps.ts
+++ b/packages/x-charts/src/ChartsDataProvider/useChartsDataProviderProps.ts
@@ -6,7 +6,6 @@ import { defaultSeriesConfig } from '../internals/plugins/utils/defaultSeriesCon
 import type { ChartAnyPluginSignature, MergeSignaturesProperty } from '../internals/plugins/models';
 import type { ChartSeriesType } from '../models/seriesType/config';
 import type { ChartCorePluginSignatures } from '../internals/plugins/corePlugins';
-import { DEFAULT_PLUGINS } from '../internals/plugins/allPlugins';
 import type { AllPluginSignatures } from '../internals/plugins/allPlugins';
 import type { ChartsLocalizationProviderProps } from '../ChartsLocalizationProvider';
 
@@ -22,7 +21,7 @@ export const useChartsDataProviderProps = <
   const {
     children,
     localeText,
-    plugins = DEFAULT_PLUGINS,
+    plugins,
     slots,
     slotProps,
     seriesConfig = defaultSeriesConfig,

--- a/packages/x-charts/src/LineChart/LineChart.tsx
+++ b/packages/x-charts/src/LineChart/LineChart.tsx
@@ -36,7 +36,7 @@ import type {
 } from '../ChartsOverlay';
 import { useLineChartProps } from './useLineChartProps';
 import { useChartsContainerProps } from '../ChartsContainer/useChartsContainerProps';
-import { ChartsDataProvider } from '../ChartsDataProvider';
+import { ChartDataProviderInternal } from '../ChartsDataProvider/ChartDataProviderInternal';
 import { ChartsSurface } from '../ChartsSurface';
 import { ChartsWrapper } from '../ChartsWrapper';
 import type { LineChartPluginSignatures } from './LineChart.plugins';
@@ -168,7 +168,7 @@ const LineChart = React.forwardRef(function LineChart(
   const Toolbar = props.slots?.toolbar;
 
   return (
-    <ChartsDataProvider<'line', LineChartPluginSignatures> {...chartsDataProviderProps}>
+    <ChartDataProviderInternal<'line', LineChartPluginSignatures> {...chartsDataProviderProps}>
       <ChartsWrapper {...chartsWrapperProps} ref={ref}>
         {props.showToolbar && Toolbar ? <Toolbar {...props.slotProps?.toolbar} /> : null}
         {!props.hideLegend && <ChartsLegend {...legendProps} />}
@@ -192,7 +192,7 @@ const LineChart = React.forwardRef(function LineChart(
         </ChartsSurface>
         {!props.loading && <Tooltip {...props.slotProps?.tooltip} />}
       </ChartsWrapper>
-    </ChartsDataProvider>
+    </ChartDataProviderInternal>
   );
 });
 

--- a/packages/x-charts/src/PieChart/PieChart.tsx
+++ b/packages/x-charts/src/PieChart/PieChart.tsx
@@ -25,7 +25,7 @@ import type {
   ChartsOverlaySlots,
 } from '../ChartsOverlay';
 import { ChartsSurface } from '../ChartsSurface';
-import { ChartsDataProvider } from '../ChartsDataProvider';
+import { ChartDataProviderInternal } from '../ChartsDataProvider/ChartDataProviderInternal';
 import { useChartsContainerProps } from '../ChartsContainer/useChartsContainerProps';
 import { ChartsWrapper } from '../ChartsWrapper';
 import { PIE_CHART_PLUGINS } from './PieChart.plugins';
@@ -144,7 +144,7 @@ const PieChart = React.forwardRef(function PieChart(
   const Toolbar = slots?.toolbar;
 
   return (
-    <ChartsDataProvider<'pie', PieChartPluginSignatures> {...chartsDataProviderProps}>
+    <ChartDataProviderInternal<'pie', PieChartPluginSignatures> {...chartsDataProviderProps}>
       <ChartsWrapper
         legendPosition={slotProps?.legend?.position}
         legendDirection={slotProps?.legend?.direction ?? 'vertical'}
@@ -169,7 +169,7 @@ const PieChart = React.forwardRef(function PieChart(
         </ChartsSurface>
         {!loading && <Tooltip trigger="item" {...slotProps?.tooltip} />}
       </ChartsWrapper>
-    </ChartsDataProvider>
+    </ChartDataProviderInternal>
   );
 });
 

--- a/packages/x-charts/src/RadarChart/RadarDataProvider/RadarDataProvider.tsx
+++ b/packages/x-charts/src/RadarChart/RadarDataProvider/RadarDataProvider.tsx
@@ -9,7 +9,7 @@ import type {
   ChartsRotationAxisProps,
   PolarAxisConfig,
 } from '../../models/axis';
-import { ChartsDataProvider } from '../../ChartsDataProvider';
+import { ChartDataProviderInternal } from '../../ChartsDataProvider/ChartDataProviderInternal';
 import type { ChartsDataProviderProps } from '../../ChartsDataProvider';
 import { defaultizeMargin } from '../../internals/defaultizeMargin';
 import { radarSeriesConfig } from '../seriesConfig';
@@ -109,7 +109,7 @@ function RadarDataProvider<
   );
 
   return (
-    <ChartsDataProvider<'radar', TSignatures>
+    <ChartDataProviderInternal<'radar', TSignatures>
       {...(other as unknown as ChartsDataProviderProps<'radar', TSignatures>)}
       series={defaultizedSeries}
       width={width}
@@ -123,7 +123,7 @@ function RadarDataProvider<
       seriesConfig={RADAR_SERIES_CONFIG}
     >
       {children}
-    </ChartsDataProvider>
+    </ChartDataProviderInternal>
   );
 }
 

--- a/packages/x-charts/src/ScatterChart/ScatterChart.tsx
+++ b/packages/x-charts/src/ScatterChart/ScatterChart.tsx
@@ -32,7 +32,7 @@ import { ChartsGrid } from '../ChartsGrid';
 import type { ChartsGridProps } from '../ChartsGrid';
 import { useScatterChartProps } from './useScatterChartProps';
 import { useChartsContainerProps } from '../ChartsContainer/useChartsContainerProps';
-import { ChartsDataProvider } from '../ChartsDataProvider';
+import { ChartDataProviderInternal } from '../ChartsDataProvider/ChartDataProviderInternal';
 import { ChartsSurface } from '../ChartsSurface';
 import { ChartsWrapper } from '../ChartsWrapper';
 import type { UseChartClosestPointSignature } from '../internals/plugins/featurePlugins/useChartClosestPoint';
@@ -167,7 +167,9 @@ const ScatterChart = React.forwardRef(function ScatterChart(
   const Toolbar = props.slots?.toolbar;
 
   return (
-    <ChartsDataProvider<'scatter', ScatterChartPluginSignatures> {...chartsDataProviderProps}>
+    <ChartDataProviderInternal<'scatter', ScatterChartPluginSignatures>
+      {...chartsDataProviderProps}
+    >
       <ChartsWrapper {...chartsWrapperProps} ref={ref}>
         {props.showToolbar && Toolbar ? <Toolbar {...props.slotProps?.toolbar} /> : null}
         {!props.hideLegend && <ChartsLegend {...legendProps} />}
@@ -185,7 +187,7 @@ const ScatterChart = React.forwardRef(function ScatterChart(
         </ChartsSurface>
         {!props.loading && <Tooltip trigger="item" {...props.slotProps?.tooltip} />}
       </ChartsWrapper>
-    </ChartsDataProvider>
+    </ChartDataProviderInternal>
   );
 });
 

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxisRendering.selectors.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxisRendering.selectors.ts
@@ -37,17 +37,12 @@ import { zoomScaleRange } from './zoom';
 import { getAxisExtrema } from './getAxisExtrema';
 import type { CartesianChartSeriesType } from '../../../../models/seriesType/config';
 import { calculateFinalDomain, computeAxisDomainsMap } from './domain';
-import type { SeriesId } from '../../../../models/seriesType/common';
-import { Flatbush } from '../../../Flatbush';
 import { selectorChartSeriesConfig } from '../../corePlugins/useChartSeriesConfig';
 import type { ChartSeriesConfig } from '../../corePlugins/useChartSeriesConfig';
 import {
   selectorChartXAxisExtrema,
   selectorChartYAxisExtrema,
 } from './useChartAxisExtrema.selectors';
-import { selectorChartZAxis } from '../useChartZAxis';
-import getMarkerSize from '../../../../ScatterChart/seriesConfig/getMarkerSize';
-import type { ScatterSizeGetter } from '../../../../ScatterChart/seriesConfig/getMarkerSize';
 
 export const createZoomMap = (zoom: readonly ZoomData[]) => {
   const zoomItemMap = new Map<AxisId, ZoomData>();
@@ -519,80 +514,4 @@ export const selectorChartDefaultXAxisId = createSelector(
 export const selectorChartDefaultYAxisId = createSelector(
   selectorChartRawYAxis,
   (yAxes) => yAxes![0].id,
-);
-
-export type ScatterFlatbushEntry = {
-  flatbush: Flatbush;
-  /** Per-point marker radius, in pixels. */
-  getItemRadius: number | ((dataIndex: number) => number);
-  /** Largest radius across all points in this series, in pixels. */
-  maxItemRadius: number;
-};
-
-const EMPTY_MAP = new Map<SeriesId, ScatterFlatbushEntry>();
-export const selectorChartSeriesEmptyFlatbushMap = () => EMPTY_MAP;
-
-export const selectorChartSeriesFlatbushMap = createSelectorMemoized(
-  selectorChartSeriesProcessed,
-  selectorChartNormalizedXScales,
-  selectorChartNormalizedYScales,
-  selectorChartDefaultXAxisId,
-  selectorChartDefaultYAxisId,
-  selectorChartZAxis,
-  function selectChartSeriesFlatbushMap(
-    allSeries,
-    xAxesScaleMap,
-    yAxesScaleMap,
-    defaultXAxisId,
-    defaultYAxisId,
-    zAxisState,
-  ) {
-    // FIXME: Do we want to support non-scatter series here?
-    const validSeries = allSeries.scatter;
-    const flatbushMap = new Map<SeriesId, ScatterFlatbushEntry>();
-
-    if (!validSeries) {
-      return flatbushMap;
-    }
-
-    const zAxes = zAxisState?.axis ?? {};
-    const zAxisIds = zAxisState?.axisIds ?? [];
-
-    validSeries.seriesOrder.forEach((seriesId) => {
-      const series = validSeries.series[seriesId];
-      const { data, xAxisId = defaultXAxisId, yAxisId = defaultYAxisId } = series;
-
-      if (data.length === 0) {
-        return;
-      }
-
-      const flatbush = new Flatbush(data.length);
-
-      const sizeAxis = zAxes[series.sizeAxisId ?? zAxisIds[0]];
-
-      const isFixedSize = !sizeAxis || !sizeAxis.sizeScale;
-      const getItemRadius = isFixedSize
-        ? (series.markerSize ?? 0)
-        : getMarkerSize(series, sizeAxis);
-
-      let maxItemRadius = isFixedSize ? (getItemRadius as number) : 0;
-
-      const originalXScale = xAxesScaleMap[xAxisId];
-      const originalYScale = yAxesScaleMap[yAxisId];
-
-      for (let i = 0; i < data.length; i += 1) {
-        if (!isFixedSize) {
-          maxItemRadius = Math.max(maxItemRadius, (getItemRadius as ScatterSizeGetter)(i));
-        }
-        // Add the points using a [0, 1] range so that we don't need to recreate the Flatbush structure when zooming.
-        // This doesn't happen in practice, though, because currently the scales depend on the drawing area.
-        flatbush.add(originalXScale(data[i].x)!, originalYScale(data[i].y)!);
-      }
-
-      flatbush.finish();
-      flatbushMap.set(seriesId, { flatbush, getItemRadius, maxItemRadius });
-    });
-
-    return flatbushMap;
-  },
 );

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartClosestPoint/useChartClosestPoint.selectors.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartClosestPoint/useChartClosestPoint.selectors.ts
@@ -1,10 +1,101 @@
-import { createSelector } from '@mui/x-internals/store';
+import { createSelector, createSelectorMemoized } from '@mui/x-internals/store';
 import type { ChartRootSelector } from '../../utils/selectors';
 import type { UseChartClosestPointSignature } from './useChartClosestPoint.types';
+import type { SeriesId } from '../../../../models/seriesType/common';
+import { Flatbush } from '../../../Flatbush';
+import getMarkerSize from '../../../../ScatterChart/seriesConfig/getMarkerSize';
+import type { ScatterSizeGetter } from '../../../../ScatterChart/seriesConfig/getMarkerSize';
+import { selectorChartSeriesProcessed } from '../../corePlugins/useChartSeries';
+import {
+  selectorChartNormalizedXScales,
+  selectorChartNormalizedYScales,
+  selectorChartDefaultXAxisId,
+  selectorChartDefaultYAxisId,
+} from '../useChartCartesianAxis';
+import { selectorChartZAxis } from '../useChartZAxis';
 
 const selectVoronoi: ChartRootSelector<UseChartClosestPointSignature> = (state) => state.voronoi;
 
 export const selectorChartsIsVoronoiEnabled = createSelector(
   selectVoronoi,
   (voronoi) => voronoi?.isVoronoiEnabled,
+);
+
+export type ScatterFlatbushEntry = {
+  flatbush: Flatbush;
+  /** Per-point marker radius, in pixels. */
+  getItemRadius: number | ((dataIndex: number) => number);
+  /** Largest radius across all points in this series, in pixels. */
+  maxItemRadius: number;
+};
+
+const EMPTY_MAP = new Map<SeriesId, ScatterFlatbushEntry>();
+export const selectorChartSeriesEmptyFlatbushMap = () => EMPTY_MAP;
+
+// Builds a spatial index of scatter points for closest-point detection. It lives
+// in this scatter-only plugin (rather than the shared cartesian-axis selectors)
+// so `Flatbush`/`flatqueue` stay out of charts that don't use closest-point.
+export const selectorChartSeriesFlatbushMap = createSelectorMemoized(
+  selectorChartSeriesProcessed,
+  selectorChartNormalizedXScales,
+  selectorChartNormalizedYScales,
+  selectorChartDefaultXAxisId,
+  selectorChartDefaultYAxisId,
+  selectorChartZAxis,
+  function selectChartSeriesFlatbushMap(
+    allSeries,
+    xAxesScaleMap,
+    yAxesScaleMap,
+    defaultXAxisId,
+    defaultYAxisId,
+    zAxisState,
+  ) {
+    // FIXME: Do we want to support non-scatter series here?
+    const validSeries = allSeries.scatter;
+    const flatbushMap = new Map<SeriesId, ScatterFlatbushEntry>();
+
+    if (!validSeries) {
+      return flatbushMap;
+    }
+
+    const zAxes = zAxisState?.axis ?? {};
+    const zAxisIds = zAxisState?.axisIds ?? [];
+
+    validSeries.seriesOrder.forEach((seriesId) => {
+      const series = validSeries.series[seriesId];
+      const { data, xAxisId = defaultXAxisId, yAxisId = defaultYAxisId } = series;
+
+      if (data.length === 0) {
+        return;
+      }
+
+      const flatbush = new Flatbush(data.length);
+
+      const sizeAxis = zAxes[series.sizeAxisId ?? zAxisIds[0]];
+
+      const isFixedSize = !sizeAxis || !sizeAxis.sizeScale;
+      const getItemRadius = isFixedSize
+        ? (series.markerSize ?? 0)
+        : getMarkerSize(series, sizeAxis);
+
+      let maxItemRadius = isFixedSize ? (getItemRadius as number) : 0;
+
+      const originalXScale = xAxesScaleMap[xAxisId];
+      const originalYScale = yAxesScaleMap[yAxisId];
+
+      for (let i = 0; i < data.length; i += 1) {
+        if (!isFixedSize) {
+          maxItemRadius = Math.max(maxItemRadius, (getItemRadius as ScatterSizeGetter)(i));
+        }
+        // Add the points using a [0, 1] range so that we don't need to recreate the Flatbush structure when zooming.
+        // This doesn't happen in practice, though, because currently the scales depend on the drawing area.
+        flatbush.add(originalXScale(data[i].x)!, originalYScale(data[i].y)!);
+      }
+
+      flatbush.finish();
+      flatbushMap.set(seriesId, { flatbush, getItemRadius, maxItemRadius });
+    });
+
+    return flatbushMap;
+  },
 );

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartClosestPoint/useChartClosestPoint.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartClosestPoint/useChartClosestPoint.ts
@@ -9,12 +9,14 @@ import type { UseChartClosestPointSignature } from './useChartClosestPoint.types
 import { getChartPoint } from '../../../getChartPoint';
 import {
   selectorChartAxisZoomData,
-  selectorChartSeriesEmptyFlatbushMap,
-  selectorChartSeriesFlatbushMap,
   selectorChartXAxis,
   selectorChartYAxis,
   selectorChartZoomIsInteracting,
 } from '../useChartCartesianAxis';
+import {
+  selectorChartSeriesEmptyFlatbushMap,
+  selectorChartSeriesFlatbushMap,
+} from './useChartClosestPoint.selectors';
 import { selectorChartSeriesProcessed } from '../../corePlugins/useChartSeries/useChartSeries.selectors';
 import { findClosestPoints } from './findClosestPoints';
 


### PR DESCRIPTION
WIP not ready for review yet

<!-- Specific charts (Line, Bar, Pie, Scatter, Radar) pass their own plugin list, but they routed through helpers that referenced `DEFAULT_PLUGINS` as a fallback (`plugins ?? DEFAULT_PLUGINS`, `plugins = DEFAULT_PLUGINS`). That static reference forced the full plugin set — including `useChartClosestPoint` and `useProgressiveRendering` — into every chart's bundle even though they never ran.

- Split the data provider into `ChartDataProviderInternal` (requires `plugins`, rendered by chart components) and the public `ChartsDataProvider` wrapper (supplies `DEFAULT_PLUGINS` for standalone/composition usage). Drop the fallback from `useChartsContainerProps`/`useChartsDataProviderProps`.
- Move the scatter-only Flatbush spatial-index selector out of the shared cartesian-axis selectors into the `useChartClosestPoint` plugin, so `Flatbush`/`flatqueue` no longer ship in non-scatter cartesian charts.

Public API is unchanged. Measured on the `LineChart` entrypoint: 87.6 KB → 82.9 KB gzip (-4.7 KB). Similar for Bar/Pie; Scatter keeps closest-point and Flatbush, as it uses them.

 Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
