### PR TITLE
[code-infra] Validate npm publishing through dry run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,25 @@ permissions: {}
 jobs:
   continuous-releases:
     name: Continuous releases
-    uses: mui/mui-public/.github/workflows/ci-base.yml@4e18082e2410a90d523866a414c4e67296b9892c # master
-    with:
-      node-version: '22.22.3'
+    if: ${{ github.repository_owner == 'mui' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "${{ github.actor }}"
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # fetch all tags which are required for `pnpm release:changelog`
+          fetch-depth: 0
+      - name: Set up pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+      - name: Use Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22.22.3'
+          # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
+          cache: 'pnpm'
+      - run: pnpm install
+      - run: pnpm release:build
+      - name: Publish packages to pkg.pr.new and npm dry-run
+        uses: mui/mui-public/.github/actions/ci-publish@963630fef652d2ac707df1af5041d49a7b574889 # master
+        with:
+          npm-dry-run: true

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@mui/internal-babel-plugin-display-name": "1.0.4-canary.20",
     "@mui/internal-babel-plugin-minify-errors": "2.0.8-canary.27",
     "@mui/internal-bundle-size-checker": "1.0.9-canary.83",
-    "@mui/internal-code-infra": "0.0.4-canary.66",
+    "@mui/internal-code-infra": "0.0.4-canary.74",
     "@mui/internal-api-docs-builder": "1.0.4-canary.1",
     "@mui/internal-markdown": "3.0.11-canary.1",
     "@mui/internal-netlify-cache": "0.0.3-canary.5",

--- a/packages/x-charts-premium/package.json
+++ b/packages/x-charts-premium/package.json
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build --flat",
+    "build": "code-infra build",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-charts-pro/package.json
+++ b/packages/x-charts-pro/package.json
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build --flat",
+    "build": "code-infra build",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-charts/package.json
+++ b/packages/x-charts/package.json
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build --flat --ignore 'src/**/*.bench.ts'",
+    "build": "code-infra build --ignore 'src/**/*.bench.ts'",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo",
     "bench:jsdom": "pnpm vitest bench -c ./vitest.config.jsdom.mts",
     "bench:browser": "pnpm vitest bench -c ./vitest.config.browser.mts"

--- a/packages/x-chat-headless/tsconfig.build.json
+++ b/packages/x-chat-headless/tsconfig.build.json
@@ -7,7 +7,7 @@
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,
-    "outDir": "build/esm",
+    "outDir": "build",
     "rootDir": "./src",
     "types": ["../../mui-env.d.ts"]
   },

--- a/packages/x-chat/package.json
+++ b/packages/x-chat/package.json
@@ -37,7 +37,7 @@
   ],
   "scripts": {
     "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build --flat",
+    "build": "code-infra build",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-codemod/package.json
+++ b/packages/x-codemod/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "typescript": "tsc -p tsconfig.json",
     "prebuild": "rimraf build",
-    "build": "code-infra build --flat --bundle cjs --buildTypes false --ignore 'src/types.ts'"
+    "build": "code-infra build --bundle cjs --buildTypes false --ignore 'src/types.ts'"
   },
   "repository": {
     "type": "git",

--- a/packages/x-data-grid-generator/package.json
+++ b/packages/x-data-grid-generator/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build --flat",
+    "build": "code-infra build",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-data-grid-premium/package.json
+++ b/packages/x-data-grid-premium/package.json
@@ -30,7 +30,7 @@
   ],
   "scripts": {
     "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build --flat",
+    "build": "code-infra build",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-data-grid-pro/package.json
+++ b/packages/x-data-grid-pro/package.json
@@ -30,7 +30,7 @@
   ],
   "scripts": {
     "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build --flat",
+    "build": "code-infra build",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-data-grid/package.json
+++ b/packages/x-data-grid/package.json
@@ -34,7 +34,7 @@
   ],
   "scripts": {
     "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build --flat --copy \"src/**/*.css\" --copy \"src/**/*.css:esm\"",
+    "build": "code-infra build --copy \"src/**/*.css\" --copy \"src/**/*.css:esm\"",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-date-pickers-pro/package.json
+++ b/packages/x-date-pickers-pro/package.json
@@ -27,7 +27,7 @@
   ],
   "scripts": {
     "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build --flat",
+    "build": "code-infra build",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-date-pickers/package.json
+++ b/packages/x-date-pickers/package.json
@@ -30,7 +30,7 @@
   ],
   "scripts": {
     "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build --flat",
+    "build": "code-infra build",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-internal-gestures/package.json
+++ b/packages/x-internal-gestures/package.json
@@ -35,7 +35,7 @@
   },
   "scripts": {
     "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build --flat",
+    "build": "code-infra build",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "dependencies": {

--- a/packages/x-internals/package.json
+++ b/packages/x-internals/package.json
@@ -27,7 +27,7 @@
   ],
   "scripts": {
     "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build --flat",
+    "build": "code-infra build",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-license/package.json
+++ b/packages/x-license/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build --flat",
+    "build": "code-infra build",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-scheduler-internals-premium/package.json
+++ b/packages/x-scheduler-internals-premium/package.json
@@ -39,7 +39,7 @@
   ],
   "scripts": {
     "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build --flat --copy \"src/**/*.css\" --copy \"src/**/*.css:esm\"",
+    "build": "code-infra build --copy \"src/**/*.css\" --copy \"src/**/*.css:esm\"",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-scheduler-internals/package.json
+++ b/packages/x-scheduler-internals/package.json
@@ -57,7 +57,7 @@
   ],
   "scripts": {
     "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build --flat --copy \"src/**/*.css\" --copy \"src/**/*.css:esm\"",
+    "build": "code-infra build --copy \"src/**/*.css\" --copy \"src/**/*.css:esm\"",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-scheduler-premium/package.json
+++ b/packages/x-scheduler-premium/package.json
@@ -45,7 +45,7 @@
   ],
   "scripts": {
     "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build --flat --copy \"src/**/*.css\" --copy \"src/**/*.css:esm\"",
+    "build": "code-infra build --copy \"src/**/*.css\" --copy \"src/**/*.css:esm\"",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-scheduler/package.json
+++ b/packages/x-scheduler/package.json
@@ -51,7 +51,7 @@
   ],
   "scripts": {
     "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build --flat --copy \"src/**/*.css\" --copy \"src/**/*.css:esm\"",
+    "build": "code-infra build --copy \"src/**/*.css\" --copy \"src/**/*.css:esm\"",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-telemetry/package.json
+++ b/packages/x-telemetry/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build --flat && pnpm build:update-pkg-json",
+    "build": "code-infra build && pnpm build:update-pkg-json",
     "build:update-pkg-json": "node ./scripts/addPackageScripts.js",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },

--- a/packages/x-tree-view-pro/package.json
+++ b/packages/x-tree-view-pro/package.json
@@ -28,7 +28,7 @@
   ],
   "scripts": {
     "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build --flat",
+    "build": "code-infra build",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-tree-view/package.json
+++ b/packages/x-tree-view/package.json
@@ -28,7 +28,7 @@
   ],
   "scripts": {
     "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build --flat",
+    "build": "code-infra build",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/packages/x-virtualizer/package.json
+++ b/packages/x-virtualizer/package.json
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "typescript": "tsc -p tsconfig.json",
-    "build": "code-infra build --flat",
+    "build": "code-infra build",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
   },
   "repository": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -280,8 +280,8 @@ importers:
         specifier: 1.0.9-canary.83
         version: 1.0.9-canary.83(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(rolldown@1.0.3)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       '@mui/internal-code-infra':
-        specifier: 0.0.4-canary.66
-        version: 0.0.4-canary.66(@next/eslint-plugin-next@16.2.9)(@types/node@22.19.19)(@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(jest-diff@30.2.0)(postcss@8.5.15)(prettier@3.9.3)(stylelint@17.12.0(typescript@6.0.3))(typescript@6.0.3)(vitest@4.1.8)
+        specifier: 0.0.4-canary.74
+        version: 0.0.4-canary.74(@next/eslint-plugin-next@16.2.9)(@types/node@22.19.19)(@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(jest-diff@30.2.0)(postcss@8.5.15)(prettier@3.9.3)(stylelint@17.12.0(typescript@6.0.3))(typescript@6.0.3)(vitest@4.1.8)
       '@mui/internal-core-docs':
         specifier: 'catalog:'
         version: 9.1.2-canary.2(43dcf7d5750ea3513e7b0260e7b1a0ce)
@@ -4284,14 +4284,26 @@ packages:
       '@babel/core': '7'
       '@babel/preset-react': '7'
 
+  '@mui/internal-babel-plugin-display-name@1.0.4-canary.21':
+    resolution: {integrity: sha512-pffrH8KJNBHv+7zSlqZzWluY1/Wc2rfopVgHNdTITQUuNbl8i+2zpGCATjhq69SRe/mhbJLl7RdH3F94KT7BsQ==}
+    peerDependencies:
+      '@babel/core': '7'
+      '@babel/preset-react': '7'
+
   '@mui/internal-babel-plugin-minify-errors@2.0.8-canary.27':
     resolution: {integrity: sha512-nuXX3e0/wN8BwnbZnPeGm4hxLgObNk7qa/5VsRGxbSporvNm3R+AHks1xLLevoEto2/BZjxFjF787q1MXxtrGQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@babel/core': '7'
 
-  '@mui/internal-babel-plugin-resolve-imports@2.0.7-canary.36':
-    resolution: {integrity: sha512-hpaB0I5jkQ9EHxSMkiyJribAmrFRdSl00aP1uZwKIIUv57YJQrK6e9tjNaU8qWBKUXWy3QUXAzSUZFrar+Rx+w==}
+  '@mui/internal-babel-plugin-minify-errors@2.0.8-canary.28':
+    resolution: {integrity: sha512-k/yP/YpZckxSsZ7tvMRo+psCNwlhmdxgwWhf/i+Ty3gN81CUz5oaZ6wiGTxB6e7ZHmS29cJFWWvJ/Vkz5UYKZg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@babel/core': '7'
+
+  '@mui/internal-babel-plugin-resolve-imports@2.0.7-canary.38':
+    resolution: {integrity: sha512-eCI/7caxiBauwEFSBSk1RNXGKV2hnTZ0T/GorLODeu/THwA0lJqiZNx6rhEWnGCdSgyW/bAlpEK+RjkfTjOYYQ==}
     peerDependencies:
       '@babel/core': '7'
 
@@ -4307,8 +4319,8 @@ packages:
     resolution: {integrity: sha512-lmR9P2ITjA1kWgQNafGviA/3k4KLHv+gqvYyZjChzkEIv0dNKpf7pyF1KRzdGfGQwHFIBTIbS07pGXUtgsMm7g==}
     hasBin: true
 
-  '@mui/internal-code-infra@0.0.4-canary.66':
-    resolution: {integrity: sha512-dPm/mwzVzCCeBexrVKtpdcDKWAQk5KW/eII7wl0mIqfq6lcZKPizUJuz57A3rmUUvXKh37UCbj38LbnlQtFrQg==}
+  '@mui/internal-code-infra@0.0.4-canary.74':
+    resolution: {integrity: sha512-dnPV9gKfREE+c/ZjhVAjEI6/0J8t1yRlTUqzMDSfYE98mnnkrkeC4Zcnzj8gCUaNwit2aG+zepb2kl6EshBkIA==}
     hasBin: true
     peerDependencies:
       '@next/eslint-plugin-next': '*'
@@ -6647,9 +6659,9 @@ packages:
     resolution: {integrity: sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA==}
     engines: {node: '>= 0.6'}
 
-  content-type@1.0.5:
-    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
-    engines: {node: '>= 0.6'}
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
 
   conventional-changelog-angular@7.0.0:
     resolution: {integrity: sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==}
@@ -6658,7 +6670,6 @@ packages:
   conventional-changelog-core@5.0.1:
     resolution: {integrity: sha512-Rvi5pH+LvgsqGwZPZ3Cq/tz4ty7mjijhr3qR4m9IBXNbxGGYgTVVO+duXzz9aArmHxFtwZ+LRkrNIMDQzgoY4A==}
     engines: {node: '>=14'}
-    deprecated: Deprecated and no longer maintained. Please use conventional-changelog instead.
 
   conventional-changelog-preset-loader@3.0.0:
     resolution: {integrity: sha512-qy9XbdSLmVnwnvzEisjxdDiLA4OmV3o8db+Zdg4WiFw14fP3B6XNz98X0swPPpkTd/pc1K7+adKgEDM1JCUMiA==}
@@ -13303,6 +13314,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@mui/internal-babel-plugin-display-name@1.0.4-canary.21(@babel/core@7.29.7)(@babel/preset-react@7.28.5(@babel/core@7.29.7))':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/preset-react': 7.28.5(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - supports-color
+
   '@mui/internal-babel-plugin-minify-errors@2.0.8-canary.27(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -13311,7 +13331,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@mui/internal-babel-plugin-resolve-imports@2.0.7-canary.36(@babel/core@7.29.7)':
+  '@mui/internal-babel-plugin-minify-errors@2.0.8-canary.28(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      find-package-json: 1.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@mui/internal-babel-plugin-resolve-imports@2.0.7-canary.38(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       resolve: 1.22.12
@@ -13361,7 +13389,7 @@ snapshots:
       - tsx
       - yaml
 
-  '@mui/internal-code-infra@0.0.4-canary.66(@next/eslint-plugin-next@16.2.9)(@types/node@22.19.19)(@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(jest-diff@30.2.0)(postcss@8.5.15)(prettier@3.9.3)(stylelint@17.12.0(typescript@6.0.3))(typescript@6.0.3)(vitest@4.1.8)':
+  '@mui/internal-code-infra@0.0.4-canary.74(@next/eslint-plugin-next@16.2.9)(@types/node@22.19.19)(@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(jest-diff@30.2.0)(postcss@8.5.15)(prettier@3.9.3)(stylelint@17.12.0(typescript@6.0.3))(typescript@6.0.3)(vitest@4.1.8)':
     dependencies:
       '@argos-ci/core': 6.0.1
       '@babel/cli': 7.29.7(@babel/core@7.29.7)
@@ -13373,14 +13401,13 @@ snapshots:
       '@babel/preset-react': 7.28.5(@babel/core@7.29.7)
       '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
       '@eslint/compat': 2.1.0(eslint@10.4.1(jiti@2.7.0))
-      '@eslint/config-helpers': 0.6.0
       '@eslint/js': 10.0.1(eslint@10.4.1(jiti@2.7.0))
       '@eslint/json': 1.2.0
       '@inquirer/confirm': 6.1.1(@types/node@22.19.19)
       '@inquirer/select': 5.2.1(@types/node@22.19.19)
-      '@mui/internal-babel-plugin-display-name': 1.0.4-canary.20(@babel/core@7.29.7)(@babel/preset-react@7.28.5(@babel/core@7.29.7))
-      '@mui/internal-babel-plugin-minify-errors': 2.0.8-canary.27(@babel/core@7.29.7)
-      '@mui/internal-babel-plugin-resolve-imports': 2.0.7-canary.36(@babel/core@7.29.7)
+      '@mui/internal-babel-plugin-display-name': 1.0.4-canary.21(@babel/core@7.29.7)(@babel/preset-react@7.28.5(@babel/core@7.29.7))
+      '@mui/internal-babel-plugin-minify-errors': 2.0.8-canary.28(@babel/core@7.29.7)
+      '@mui/internal-babel-plugin-resolve-imports': 2.0.7-canary.38(@babel/core@7.29.7)
       '@napi-rs/keyring': 1.3.0
       '@next/eslint-plugin-next': 16.2.9
       '@octokit/auth-action': 6.0.2
@@ -13398,7 +13425,7 @@ snapshots:
       babel-plugin-transform-remove-imports: 1.8.1(@babel/core@7.29.7)
       chalk: 5.6.2
       clipboardy: 5.3.1
-      content-type: 1.0.5
+      content-type: 2.0.0
       env-ci: 11.2.0
       es-toolkit: 1.46.1
       eslint: 10.4.1(jiti@2.7.0)
@@ -15997,7 +16024,7 @@ snapshots:
 
   content-disposition@0.5.2: {}
 
-  content-type@1.0.5: {}
+  content-type@2.0.0: {}
 
   conventional-changelog-angular@7.0.0:
     dependencies:


### PR DESCRIPTION
Ports https://github.com/mui/material-ui/pull/48691 to mui-x.

Validates that npm publishing keeps working over time by running the publish flow in **dry-run mode** during CI.

## Changes

- **CI**: Inline the `continuous-releases` job (previously a call to the `ci-base.yml` reusable workflow) so it can invoke the `ci-publish` action directly with `npm-dry-run: true`. The reusable workflow does not forward the `npm-dry-run` input to the action, which is why material-ui inlined it as well.
- **Bump `@mui/internal-code-infra`** `0.0.4-canary.66` → `0.0.4-canary.74`.
- **Remove the deprecated `--flat` flag** from all `code-infra build` scripts. As of the new code-infra, flat builds are always used and the flag is a no-op scheduled for removal.
- **Fix `x-chat-headless` declaration output dir** (`build/esm` → `build`). It was the only package still emitting types into a nested `esm/` folder; the new code-infra always builds flat, so its composite project reference from `x-chat` broke with `TS6305`. Aligning `outDir` with the flat layout fixes the build.

## Verification

- `pnpm release:build` passes across all packages.
- `code-infra publish --ci --dry-run` runs cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)