### PR TITLE
[docs] Update Scheduler feedback banner for stable release

### DIFF
--- a/docs/src/modules/components/overview/scheduler/SchedulerFeedbackBanner.tsx
+++ b/docs/src/modules/components/overview/scheduler/SchedulerFeedbackBanner.tsx
@@ -41,7 +41,7 @@ export default function SchedulerFeedbackBanner() {
           ...theme.applyDarkStyles({ color: 'primary.100' }),
         })}
       >
-        🚀 The Scheduler is in beta — we&apos;d love your input.{' '}
+        💬 Got feedback on the Scheduler? We&apos;d love to hear it.{' '}
         <Link
           href={FEEDBACK_FORM_URL}
           target="_blank"


### PR DESCRIPTION
## Summary

The Scheduler is going stable, so the docs overview banner should no longer say it's in beta. This updates the wording to an evergreen feedback message that isn't tied to a specific release stage — feedback is always welcome.

**Before:** 🚀 The Scheduler is in beta — we'd love your input. Share your feedback →
**After:** 💬 Got feedback on the Scheduler? We'd love to hear it. Share your feedback →

The feedback form link is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)