### PR TITLE
[docs] Fix broken social preview image on shared docs links

### DIFF
--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -255,6 +255,8 @@ const CSB_CONFIG = {
 
 const DOCS_CONFIG: DocsConfig = {
   ...DEFAULT_DOCS_CONFIG,
+  // Absolute origin for canonical and social-preview URLs (og:url, og:image).
+  hostUrl: 'https://mui.com',
 };
 
 function useThemeWrapper() {


### PR DESCRIPTION
Added `hostUrl: 'https://mui.com'` to `DOCS_CONFIG` in `docs/pages/_app.tsx` to specify the absolute origin for canonical and social-preview URLs (og:url, og:image).

Before and after 

<img width="1225" height="1500" alt="Screenshot_20260704_002419_WhatsApp" src="https://github.com/user-attachments/assets/92034047-37db-43f2-8210-6e21d707e7cd" />
