### PR TITLE
[DataGridPro] Fix in-flight children requests aborted by concurrent root fetches in nested lazy loading

### DIFF
--- a/packages/x-data-grid-premium/src/hooks/features/dataSource/useGridDataSourcePremium.tsx
+++ b/packages/x-data-grid-premium/src/hooks/features/dataSource/useGridDataSourcePremium.tsx
@@ -246,8 +246,20 @@ See [server-side pivoting](https://mui.com/x/react-data-grid/server-side-data/pi
       apiRef.current.setLoading(true);
     }
     stopPolling();
+    // Root fetches don't clear the data source state under the nested lazy loading
+    // strategy — abort the in-flight child requests explicitly since the grouping
+    // model change invalidates the whole tree.
+    apiRef.current.clearDataSourceState();
     debouncedFetchRows();
   }, [apiRef, debouncedFetchRows, stopPolling]);
+
+  const handleFetchParamsModelChange = React.useCallback(() => {
+    // Root fetches don't clear the data source state under the nested lazy loading
+    // strategy — abort the in-flight child requests explicitly since their responses
+    // were computed for the previous aggregation/pivot model.
+    apiRef.current.clearDataSourceState();
+    debouncedFetchRows();
+  }, [apiRef, debouncedFetchRows]);
 
   const privateApi: GridDataSourcePremiumPrivateApi = {
     ...api.private,
@@ -287,21 +299,9 @@ See [server-side pivoting](https://mui.com/x/react-data-grid/server-side-data/pi
     'rowGroupingModelChange',
     runIf(!pivotActive && !!props.dataSource, handleRowGroupingModelChange),
   );
-  useGridEvent(
-    apiRef,
-    'aggregationModelChange',
-    runIf(!pivotActive, () => debouncedFetchRows()),
-  );
-  useGridEvent(
-    apiRef,
-    'pivotModeChange',
-    runIf(!pivotActive, () => debouncedFetchRows()),
-  );
-  useGridEvent(
-    apiRef,
-    'pivotModelChange',
-    runIf(pivotActive, () => debouncedFetchRows()),
-  );
+  useGridEvent(apiRef, 'aggregationModelChange', runIf(!pivotActive, handleFetchParamsModelChange));
+  useGridEvent(apiRef, 'pivotModeChange', runIf(!pivotActive, handleFetchParamsModelChange));
+  useGridEvent(apiRef, 'pivotModelChange', runIf(pivotActive, handleFetchParamsModelChange));
 
   React.useEffect(() => {
     setStrategyAvailability();

--- a/packages/x-data-grid-premium/src/tests/dataSourceRowGrouping.DataGridPremium.test.tsx
+++ b/packages/x-data-grid-premium/src/tests/dataSourceRowGrouping.DataGridPremium.test.tsx
@@ -354,6 +354,88 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Data source row grouping', () =>
       expect(technologyRequest?.groupFields).to.deep.equal(['sector', 'industry']);
     });
 
+    it('should apply the children responses that are in flight when an incremental root fetch happens', async () => {
+      // Root fetches under the nested lazy loading strategy are incremental loads and must
+      // not abort the in-flight children requests (https://github.com/mui/mui-x/issues/22715)
+      type DeferredRequest = { params: GridGetRowsParams; resolve: () => void };
+      const deferredChildrenRequests: DeferredRequest[] = [];
+
+      function TestConcurrentRequests() {
+        apiRef = useGridApiRef();
+
+        const dataSource: GridDataSource = React.useMemo(
+          () => ({
+            getRows: async (params: GridGetRowsParams) => {
+              const groupKeys = params.groupKeys ?? [];
+              const rows = rowsByGroupKeys[JSON.stringify(groupKeys)] ?? [];
+              const start = typeof params.start === 'number' ? params.start : 0;
+              const end = typeof params.end === 'number' ? params.end : rows.length - 1;
+              const response = {
+                rows: rows.slice(start, end + 1),
+                rowCount: rows.length,
+              };
+
+              if (groupKeys.length > 0) {
+                await new Promise<void>((resolve) => {
+                  deferredChildrenRequests.push({ params, resolve });
+                });
+              }
+
+              return response;
+            },
+            getGroupKey: (row) => row.group,
+            getChildrenCount: (row) => row.childrenCount,
+          }),
+          [],
+        );
+
+        return (
+          <div style={{ width: 400, height: 10 * rowHeight + columnHeaderHeight + 2 }}>
+            <DataGridPremium
+              apiRef={apiRef}
+              columns={[
+                { field: 'sector', width: 120 },
+                { field: 'industry', width: 120 },
+                { field: 'company', width: 120 },
+                { field: 'value', width: 80 },
+              ]}
+              dataSource={dataSource}
+              dataSourceCache={null}
+              lazyLoading
+              rowGroupingModel={['sector', 'industry']}
+              defaultGroupingExpansionDepth={1}
+              initialState={{
+                pagination: { paginationModel: { page: 0, pageSize: 10 }, rowCount: 0 },
+              }}
+              rowHeight={rowHeight}
+              columnHeaderHeight={columnHeaderHeight}
+            />
+          </div>
+        );
+      }
+
+      render(<TestConcurrentRequests />);
+
+      // The children requests of both default-expanded groups are in flight
+      await waitFor(() => {
+        const pendingGroupKeys = deferredChildrenRequests.map((request) =>
+          JSON.stringify(request.params.groupKeys),
+        );
+        expect(pendingGroupKeys).to.include('["Technology"]');
+        expect(pendingGroupKeys).to.include('["Finance"]');
+      });
+
+      // An incremental root fetch must not abort the in-flight children requests
+      await act(async () => apiRef.current?.dataSource.fetchRows());
+
+      await waitFor(() => {
+        deferredChildrenRequests.splice(0).forEach((request) => request.resolve());
+        expect(apiRef.current!.getRow('industry-software')).not.to.equal(null);
+        expect(apiRef.current!.getRow('industry-hardware')).not.to.equal(null);
+        expect(apiRef.current!.getRow('industry-banking')).not.to.equal(null);
+      });
+    });
+
     it('should lazy load children for default-expanded row grouping groups', async () => {
       const getRowsSpy = spy();
       render(

--- a/packages/x-data-grid-pro/src/hooks/features/dataSource/models.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/dataSource/models.ts
@@ -96,6 +96,12 @@ export interface GridDataSourcePrivateApiPro {
    */
   resetDataSourceState: () => void;
   /**
+   * Aborts the in-flight child requests and resets the data source state.
+   * To be called when the fetched data is about to be invalidated, so that responses
+   * computed for the outdated parameters are not applied to the updated tree.
+   */
+  clearDataSourceState: () => void;
+  /**
    * Removes the children rows of a parent from the grid.
    * This is used when collapsing a parent row to ensure dynamic data updates work properly.
    * @param {GridRowId} parentId The id of the parent node.

--- a/packages/x-data-grid-pro/src/hooks/features/dataSource/useGridDataSourceBasePro.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/dataSource/useGridDataSourceBasePro.ts
@@ -447,6 +447,7 @@ export const useGridDataSourceBasePro = <Api extends GridPrivateApiPro>(
   const dataSourcePrivateApi: GridDataSourcePrivateApiPro = {
     fetchRowChildren,
     resetDataSourceState,
+    clearDataSourceState,
     removeChildrenRows,
   };
 

--- a/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridDataSourceNestedLazyLoader.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridDataSourceNestedLazyLoader.ts
@@ -1009,6 +1009,10 @@ export const useGridDataSourceNestedLazyLoader = (
       renderedRowsIntervalCache.current = INTERVAL_CACHE_INITIAL_STATE;
       throttledHandleRenderedRowsIntervalChange.clear();
       stopPolling();
+      // Root fetches don't clear the data source state under this strategy — abort the
+      // in-flight child requests explicitly, their responses were computed for the
+      // previous sort model and must not be applied to the rebuilt tree.
+      privateApiRef.current.clearDataSourceState();
       const paginationModel = gridPaginationModelSelector(privateApiRef);
       const filterModel = gridFilterModelSelector(privateApiRef);
 
@@ -1031,6 +1035,10 @@ export const useGridDataSourceNestedLazyLoader = (
       renderedRowsIntervalCache.current = INTERVAL_CACHE_INITIAL_STATE;
       throttledHandleRenderedRowsIntervalChange.clear();
       stopPolling();
+      // Root fetches don't clear the data source state under this strategy — abort the
+      // in-flight child requests explicitly, their responses were computed for the
+      // previous filter model and must not be applied to the rebuilt tree.
+      privateApiRef.current.clearDataSourceState();
 
       const paginationModel = gridPaginationModelSelector(privateApiRef);
       const sortModel = gridSortModelSelector(privateApiRef);

--- a/packages/x-data-grid-pro/src/tests/dataSourceLazyLoader.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/dataSourceLazyLoader.DataGridPro.test.tsx
@@ -1008,6 +1008,217 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
 
       vi.useRealTimers();
     });
+
+    // Root fetches under the nested lazy loading strategy are incremental loads and must
+    // not abort the in-flight children requests (https://github.com/mui/mui-x/issues/22715)
+    describe('concurrent root and children requests', () => {
+      type DeferredRequest = { params: GridGetRowsParams; resolve: () => void };
+      let deferredRequests: DeferredRequest[] = [];
+
+      beforeEach(() => {
+        deferredRequests = [];
+      });
+
+      const resolveDeferredRequests = (
+        predicate: (params: GridGetRowsParams) => boolean = () => true,
+      ) => {
+        const requestsToResolve = deferredRequests.filter((request) => predicate(request.params));
+        deferredRequests = deferredRequests.filter((request) => !predicate(request.params));
+        requestsToResolve.forEach((request) => request.resolve());
+      };
+
+      const deferChildrenRequests = (params: GridGetRowsParams) =>
+        (params.groupKeys ?? []).length > 0;
+
+      const concurrentTreeRows: Record<string, Omit<TreeRow, 'value'>[]> = {
+        '[]': [
+          { id: 'P1', name: 'P1', childrenCount: 2 },
+          { id: 'P2', name: 'P2', childrenCount: 2 },
+          { id: 'R1', name: 'R1', childrenCount: 0 },
+        ],
+        '["P1"]': [
+          { id: 'P1-0', name: 'P1-0', childrenCount: 0 },
+          { id: 'P1-1', name: 'P1-1', childrenCount: 0 },
+        ],
+        '["P2"]': [
+          { id: 'P2-0', name: 'P2-0', childrenCount: 0 },
+          { id: 'P2-1', name: 'P2-1', childrenCount: 0 },
+        ],
+      };
+
+      function TestConcurrentRequests(
+        props: Partial<DataGridProProps> & {
+          onFetchRows?: (params: GridGetRowsParams) => void;
+          deferRequest?: (params: GridGetRowsParams) => boolean;
+        },
+      ) {
+        const { onFetchRows, deferRequest = deferChildrenRequests, ...other } = props;
+        const requestCountRef = React.useRef(0);
+        apiRef = useGridApiRef();
+
+        const dataSource: GridDataSource = React.useMemo(
+          () => ({
+            getRows: async (params: GridGetRowsParams) => {
+              requestCountRef.current += 1;
+              onFetchRows?.(params);
+
+              const groupKeys = params.groupKeys ?? [];
+              const allRows = (concurrentTreeRows[JSON.stringify(groupKeys)] ?? []).map((row) => ({
+                ...row,
+                value: requestCountRef.current,
+              }));
+              const start = typeof params.start === 'number' ? params.start : 0;
+              const end = typeof params.end === 'number' ? params.end : allRows.length - 1;
+              // Snapshot the response before deferring so that it carries the data
+              // from the time the request was made
+              const response = {
+                rows: allRows.slice(start, end + 1),
+                rowCount: allRows.length,
+              };
+
+              if (deferRequest(params)) {
+                await new Promise<void>((resolve) => {
+                  deferredRequests.push({ params, resolve });
+                });
+              }
+
+              return response;
+            },
+            getGroupKey: (row) => row.name,
+            getChildrenCount: (row) => row.childrenCount,
+          }),
+          [onFetchRows, deferRequest],
+        );
+
+        return (
+          <div style={{ width: 300, height: 10 * rowHeight + columnHeaderHeight + 2 }}>
+            <DataGridPro
+              apiRef={apiRef}
+              columns={[
+                { field: 'name', width: 160 },
+                { field: 'value', width: 120 },
+              ]}
+              dataSource={dataSource}
+              dataSourceCache={null}
+              lazyLoading
+              treeData
+              defaultGroupingExpansionDepth={-1}
+              initialState={{
+                pagination: { paginationModel: { page: 0, pageSize: 10 }, rowCount: 0 },
+              }}
+              rowHeight={rowHeight}
+              columnHeaderHeight={columnHeaderHeight}
+              disableVirtualization={false}
+              {...other}
+            />
+          </div>
+        );
+      }
+
+      it('should apply the children responses that are in flight when an incremental root fetch happens', async () => {
+        render(<TestConcurrentRequests />);
+
+        // The children requests of both default-expanded groups are in flight
+        await waitFor(() => {
+          const pendingGroupKeys = deferredRequests.map((request) =>
+            JSON.stringify(request.params.groupKeys),
+          );
+          expect(pendingGroupKeys).to.include('["P1"]');
+          expect(pendingGroupKeys).to.include('["P2"]');
+        });
+
+        // An incremental root fetch must not abort the in-flight children requests
+        await act(async () => apiRef.current?.dataSource.fetchRows());
+
+        await waitFor(() => {
+          resolveDeferredRequests();
+          expect(apiRef.current!.getRow('P1-0')).not.to.equal(null);
+          expect(apiRef.current!.getRow('P1-1')).not.to.equal(null);
+          expect(apiRef.current!.getRow('P2-0')).not.to.equal(null);
+          expect(apiRef.current!.getRow('P2-1')).not.to.equal(null);
+        });
+      });
+
+      it('should apply the children responses that are in flight when the root rows are revalidated', async () => {
+        const localFetchRowsSpy = spy();
+        render(
+          <TestConcurrentRequests dataSourceRevalidateMs={50} onFetchRows={localFetchRowsSpy} />,
+        );
+
+        // The children requests of both default-expanded groups are in flight
+        await waitFor(() => {
+          const pendingGroupKeys = deferredRequests.map((request) =>
+            JSON.stringify(request.params.groupKeys),
+          );
+          expect(pendingGroupKeys).to.include('["P1"]');
+          expect(pendingGroupKeys).to.include('["P2"]');
+        });
+
+        const countRootRequests = () =>
+          localFetchRowsSpy
+            .getCalls()
+            .filter((call) => ((call.firstArg as GridGetRowsParams).groupKeys ?? []).length === 0)
+            .length;
+        const rootRequestsBeforeRevalidation = countRootRequests();
+
+        // A revalidation root fetch goes through while the children requests are in flight
+        await waitFor(() => {
+          expect(countRootRequests()).to.be.greaterThan(rootRequestsBeforeRevalidation);
+        });
+
+        await waitFor(() => {
+          resolveDeferredRequests();
+          expect(apiRef.current!.getRow('P1-0')).not.to.equal(null);
+          expect(apiRef.current!.getRow('P1-1')).not.to.equal(null);
+          expect(apiRef.current!.getRow('P2-0')).not.to.equal(null);
+          expect(apiRef.current!.getRow('P2-1')).not.to.equal(null);
+        });
+      });
+
+      it('should drop the children responses computed for the previous sort model', async () => {
+        const deferChildrenAndSortedRootRequests = (params: GridGetRowsParams) =>
+          (params.groupKeys ?? []).length > 0 || (params.sortModel ?? []).length > 0;
+
+        render(<TestConcurrentRequests deferRequest={deferChildrenAndSortedRootRequests} />);
+
+        // The children requests of both default-expanded groups are in flight
+        await waitFor(() => {
+          const pendingGroupKeys = deferredRequests.map((request) =>
+            JSON.stringify(request.params.groupKeys),
+          );
+          expect(pendingGroupKeys).to.include('["P1"]');
+          expect(pendingGroupKeys).to.include('["P2"]');
+        });
+        const staleRequests = deferredRequests.splice(0);
+
+        // Sorting invalidates the tree. The sorted root request is held back so that the
+        // stale children responses resolve before the tree is rebuilt.
+        await act(async () => apiRef.current?.sortColumn('name', 'desc'));
+        await waitFor(() => {
+          expect(
+            deferredRequests.some((request) => (request.params.groupKeys ?? []).length === 0),
+          ).to.equal(true);
+        });
+
+        // The children responses computed for the previous sort model must be dropped
+        staleRequests.forEach((request) => request.resolve());
+        await act(async () => {
+          await new Promise((resolve) => {
+            setTimeout(resolve, 0);
+          });
+        });
+        expect(apiRef.current!.getRow('P1-0')).to.equal(null);
+        expect(apiRef.current!.getRow('P2-0')).to.equal(null);
+
+        // Release the sorted root request, the rebuilt tree re-fetches the children
+        resolveDeferredRequests((params) => (params.groupKeys ?? []).length === 0);
+        await waitFor(() => {
+          resolveDeferredRequests();
+          expect(apiRef.current!.getRow('P1-0')).not.to.equal(null);
+          expect(apiRef.current!.getRow('P2-0')).not.to.equal(null);
+        });
+      });
+    });
   });
 
   describe('Infinite loading', () => {

--- a/packages/x-data-grid/src/hooks/features/dataSource/useGridDataSourceBase.ts
+++ b/packages/x-data-grid/src/hooks/features/dataSource/useGridDataSourceBase.ts
@@ -85,6 +85,7 @@ export const useGridDataSourceBase = <Api extends GridPrivateApiCommunity>(
 
   const onDataSourceErrorProp = props.onDataSourceError;
   const revalidateMs = props.dataSourceRevalidateMs;
+  const clearDataSourceState = options.clearDataSourceState;
 
   const cacheChunkManager = useLazyRef<CacheChunkManager, void>(() => {
     if (!props.pagination) {
@@ -123,7 +124,21 @@ export const useGridDataSourceBase = <Api extends GridPrivateApiCommunity>(
         return;
       }
 
-      options.clearDataSourceState?.();
+      // For most strategies a root fetch is an invalidating event, so the in-flight
+      // child requests must be aborted along with the rest of the data source state.
+      // The nested lazy loading strategy is the exception: its root fetches are
+      // incremental viewport loads that legitimately run concurrently with child
+      // fetches — clearing here would abort those child requests and leave their
+      // groups stuck as skeleton rows (https://github.com/mui/mui-x/issues/22715).
+      // For that strategy the state is cleared explicitly at the points that
+      // invalidate the whole tree instead (sort/filter model change, `dataSource`
+      // prop change, grouping/aggregation/pivot model change).
+      if (
+        apiRef.current.getActiveStrategy(GridStrategyGroup.DataSource) !==
+        DataSourceRowsUpdateStrategy.LazyLoadedGroupedData
+      ) {
+        clearDataSourceState?.();
+      }
 
       const cacheKeys = cacheChunkManager.getCacheKeys(fetchParams);
       const responses = cacheKeys.map((cacheKey) => cache.get(cacheKey));
@@ -204,6 +219,7 @@ export const useGridDataSourceBase = <Api extends GridPrivateApiCommunity>(
       props.dataSource?.getRows,
       onDataSourceErrorProp,
       options,
+      clearDataSourceState,
       props.signature,
     ],
   );
@@ -459,6 +475,10 @@ export const useGridDataSourceBase = <Api extends GridPrivateApiCommunity>(
         apiRef.current.setRows([]);
       }
       apiRef.current.dataSource.cache.clear();
+      // A new data source invalidates everything in flight. `fetchRows()` clears the
+      // data source state itself for most strategies but intentionally skips it for
+      // nested lazy loading, so the clear is done explicitly here.
+      clearDataSourceState?.();
       apiRef.current.dataSource.fetchRows();
     }
 
@@ -466,7 +486,14 @@ export const useGridDataSourceBase = <Api extends GridPrivateApiCommunity>(
       // ignore the current request on unmount
       lastRequestId.current += 1;
     };
-  }, [apiRef, props.dataSource, props.dataSourceKeepPreviousData, currentStrategy, stopPolling]);
+  }, [
+    apiRef,
+    props.dataSource,
+    props.dataSourceKeepPreviousData,
+    currentStrategy,
+    stopPolling,
+    clearDataSourceState,
+  ]);
 
   React.useEffect(() => {
     // `dataSourceKeepPreviousData` is a no-op for tree data and row grouping: those


### PR DESCRIPTION
Fixes #22715
- Reproduction: https://stackblitz.com/edit/6sut5ruc?file=src%2FDemo.tsx
- Fix: https://stackblitz.com/edit/6sut5ruc-yihmuudo?file=package.json

### The bug

With `dataSource` + `treeData`/row grouping + `lazyLoading`, every root fetch cleared the whole data source state (`nestedDataManager.clear()` + loading/errors reset) in `useGridDataSourceBase.fetchRows` — even for cache-served fetches. Under the nested lazy loading strategy, root fetches are incremental viewport loads that legitimately run while children requests are in flight, so the clear aborted those requests and their responses were then silently discarded by the `RequestStatus.UNKNOWN` guard in `fetchRowChildren`. Nothing re-requests afterwards (the rendered interval doesn't change), so the affected groups stayed as skeleton rows indefinitely.

Most visible with `defaultGroupingExpansionDepth={-1}` (several children fetches in flight right after mount) and with `dataSourceRevalidateMs` (every poll tick cancelled the nested revalidations it had just started). The loader even clobbered itself: `findSkeletonSectionAndFetchRows`/`revalidateRows` dispatch nested fetches synchronously but route the root section through a 0ms-debounced fetch that fired right after and killed them.

The clear-on-root-fetch behavior predates nested lazy loading and is correct for the other strategies, where every root fetch is an invalidating event (mount, sort/filter change, model changes). Nested lazy loading is the first strategy that broke that invariant.

### The fix

State clearing now follows *invalidation* instead of *root fetch*:

- `useGridDataSourceBase.fetchRows` skips the automatic `clearDataSourceState()` when the `LazyLoadedGroupedData` strategy is active. The other strategies (`Default`, `GroupedData`, flat `LazyLoading`) keep the exact same behavior.
- `clearDataSourceState` is exposed on the Pro private API and called explicitly at the points that genuinely invalidate the tree:
  - sort/filter model changes (nested lazy loader, next to the existing `rowsStale` flip, so stale children responses are still dropped)
  - `dataSource` prop changes (base effect)
  - grouping/aggregation/pivot model changes (Premium)

One intended semantic change: `apiRef.current.dataSource.fetchRows()` (no args) under nested lazy loading is now an incremental refresh and no longer aborts sibling children loads — consistent with how its response is applied (incremental `updateLoadedRows` path when the rows aren't stale).

### Tests

New regression tests use deferred `getRows` promises resolved explicitly (no timing sleeps), and were verified to fail without the source changes:

- Pro: in-flight children responses are applied when an incremental root fetch happens, and when revalidation polls the root rows (both fail on `master`); children responses computed for the previous sort model are still dropped (guards the preserved abort semantics).
- Premium: in-flight children responses are applied when an incremental root fetch happens with row grouping (fails on `master`).

Full `dataSource*`/`lazyLoader` suites for community/pro/premium pass in both jsdom and browser modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)