### PR TITLE
[code-infra] Avoid OOM in the Netlify docs build and CircleCI lint step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ jobs:
     <<: *default-job
     environment:
       <<: *default-environment
-      NODE_OPTIONS: --max-old-space-size=4096
+      NODE_OPTIONS: --max-old-space-size=3584
     steps:
       - checkout
       - install-deps

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,11 +8,10 @@
 [build.environment]
   NODE_VERSION = "22.22.3"
   PNPM_FLAGS = "--frozen-lockfile"
-  NODE_OPTIONS = "--max-old-space-size=6144"
-  # Cap the Next.js docs build worker count (read by `withDocsInfra`, which
-  # otherwise defaults to `os.availableParallelism()`) to avoid OOM during the
-  # static export build.
-  NEXT_PARALLELISM = "2"
+  # Single-threaded docs build: one large-heap worker fits the ~11 GiB build
+  # container; two multi-GiB workers overflow it (OOM).
+  NODE_OPTIONS = "--max-old-space-size=8192"
+  NEXT_PARALLELISM = "1"
 
 # disabled because of https://github.com/mui/mui-public/issues/809
 # TODO: Re-enable after either:


### PR DESCRIPTION
Two CI out-of-memory fixes. Both are the same class of bug: a Node process is allowed a heap cap at or above its container's RAM, leaving no room for native/young-gen memory, so the kernel OOM-kills it (exit 137 / SIGKILL) instead of a clean V8 abort.

## Netlify docs build (`netlify.toml`)

The docs deploy intermittently fails during the Next.js static export. It surfaced on #23079:

```
Collecting page data using 2 workers ...
[ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL] docs@ build ... Exit status 1
```

No `Reached heap limit ... heap out of memory` line - the worker is kernel-killed. `next build` forks `NEXT_PARALLELISM` page-data workers that each inherit `NODE_OPTIONS`, so at `NEXT_PARALLELISM=2` with `--max-old-space-size=6144` two workers alone are allowed 2 * 6 = 12 GiB of old-space, over the ~11 GiB build container.

Fix: run the export single-threaded with one large-heap worker.

- `NEXT_PARALLELISM` 2 -> 1
- `NODE_OPTIONS` max-old-space-size 6144 -> 8192

One 8 GiB worker plus the parent process and OS fits within ~11 GiB; two multi-GiB workers cannot. Follow-up to #22925 (which reduced parallelism 3 -> 2). Trade-off: the collect + export phases run single-threaded, so the deploy takes a few minutes longer.

## CircleCI `test_lint` (`.circleci/config.yml`)

`test_lint` runs ESLint on the `medium.gen2` container (4096 MB) with `--max-old-space-size=4096` - the full container RAM, no headroom - so under load ESLint's RSS exceeds 4 GiB and the kernel SIGKILLs it (exit 137). Lower the cap to `3584`, matching `test_static` and the `proptypes` / `docs:api` steps on the same container, which already use 3584 precisely to leave headroom so a genuine overflow aborts cleanly (134) instead of being OOM-killed.
