### PR TITLE
[docs] Update the pickers recommended date library bundle sizes

### DIFF
--- a/docs/data/date-pickers/base-concepts/base-concepts.md
+++ b/docs/data/date-pickers/base-concepts/base-concepts.md
@@ -60,16 +60,16 @@ If you don't have your own requirements or don't manipulate dates outside of MUI
 
 Here is the weight added to your gzipped bundle size by each of these libraries when used inside the Date and Time Pickers:
 
-| Library           | Gzipped size |
-| :---------------- | -----------: |
-| `dayjs@1.11.5`    |      6.77 kB |
-| `date-fns@2.29.3` |     19.39 kB |
-| `luxon@3.0.4`     |     23.26 kB |
-| `moment@2.29.4`   |     20.78 kB |
+| Library          | Gzipped size |
+| :--------------- | -----------: |
+| `dayjs@1.11.21`  |      7.52 kB |
+| `date-fns@4.4.0` |     11.07 kB |
+| `luxon@3.7.2`    |     23.57 kB |
+| `moment@2.30.1`  |     21.45 kB |
 
 :::info
-The results above were obtained in October 2022 with the latest version of each library.
-The bundling of the JavaScript modules was done by a Create React App, and no locale was loaded for any of the libraries.
+The results above were obtained in July 2026 with the latest version of each library, bundled by Vite in production mode.
+Each value is the weight of the corresponding adapter with its date library included; React and Material UI are treated as external because they are already in your bundle, and only the default English locale is loaded.
 
 The results may vary in your application depending on the version of each library, the locale, and the bundler used.
 :::


### PR DESCRIPTION
## Summary

The "Recommended library" section of the pickers base-concepts page (https://mui.com/x/react-date-pickers/base-concepts/#recommended-library) still reported gzipped bundle sizes measured in October 2022, against outdated library versions (notably date-fns v2) and a "bundling done by Create React App" note (CRA is now deprecated).

This refreshes the table with the currently supported versions and freshly re-measured sizes, and rewrites the methodology note. The table is ordered by our recommendation preference (dayjs > date-fns > luxon > moment) rather than by size.

| Library  | Was (Oct 2022)   | Now              |
| -------- | ---------------- | ---------------- |
| dayjs    | 1.11.5, 6.77 kB  | 1.11.21, 7.52 kB |
| date-fns | 2.29.3, 19.39 kB | 4.4.0, 11.07 kB  |
| luxon    | 3.0.4, 23.26 kB  | 3.7.2, 23.57 kB  |
| moment   | 2.29.4, 20.78 kB | 2.30.1, 21.45 kB |

date-fns drops about 43% thanks to v4's modular ESM tree-shaking; dayjs remains the smallest, so the recommendation is unchanged.

## How the numbers were measured

`pnpm size:snapshot` tracks each adapter but externalizes the package's peerDependencies -- which include the date libraries -- so the tracked adapter size excludes the library and is not usable for this table.

Instead, each figure here is the gzipped weight of the built adapter (`build/AdapterX/index.mjs`) with its date library bundled in, and React / Material UI / emotion / `@mui/x-internals` / `@babel/runtime` treated as external (already in your app's bundle). Same Vite production setup as the repo's bundle-size checker, `Z_BEST_COMPRESSION`, SI kB (/1000). Dynamic locale loading is excluded.

One intentional change from the old note: the date-fns figure now includes its required `en-US` locale, because date-fns has no built-in default locale (unlike the others, which ship English in their core). The updated note states this explicitly rather than glossing it as "no locale was loaded".

Generated with [Claude Code](https://claude.com/claude-code)