### PR TITLE
[test] Fix flaky "should render only the pageSize" Data Grid virtualization test

### DIFF
--- a/packages/x-data-grid-pro/src/tests/rows.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/rows.DataGridPro.test.tsx
@@ -603,9 +603,15 @@ describe('<DataGridPro /> - Rows', () => {
         // scroll to the bottom
         await act(async () => virtualScroller.scrollTo({ top: 2000 }));
 
+        // `scrollTo` updates `scrollTop` synchronously but the browser dispatches the native
+        // `scroll` event asynchronously, and the render context only updates from that event.
+        // Poll until the bottom window is rendered to avoid a flaky race.
+        await waitFor(() => {
+          const lastCell = $$('[role="row"]:last-child [role="gridcell"]')[0];
+          expect(lastCell).to.have.text('31');
+        });
+
         const dimensions = apiRef.current!.state.dimensions;
-        const lastCell = $$('[role="row"]:last-child [role="gridcell"]')[0];
-        expect(lastCell).to.have.text('31');
         expect(virtualScroller.scrollHeight).to.equal(
           dimensions.headerHeight + nbRows * rowHeight + dimensions.scrollbarSize,
         );


### PR DESCRIPTION
## Problem

The browser test `<DataGridPro /> - Rows > virtualization > Pagination > should render only the pageSize` fails intermittently in CI (for example CircleCI build https://circleci.com/gh/mui/mui-x/877236, which surfaced on the unrelated Renovate PR https://github.com/mui/mui-x/pull/23083 that only bumps `@tanstack/query` in the docs):

```
AssertionError: expected div.MuiDataGrid-cell...[title="7"] to have text '31', but the text was '7'
```

## Cause

The test scrolls the virtual scroller to the bottom and then asserts the last rendered cell synchronously, with no `waitFor`:

```js
await act(async () => virtualScroller.scrollTo({ top: 2000 }));
const lastCell = ...;
expect(lastCell).to.have.text('31');
```

`scrollTo` updates `scrollTop` synchronously, but the browser dispatches the native `scroll` event asynchronously. The grid updates its render context only from that event (`handleScroll` -> `triggerUpdateRenderContext` -> `ReactDOM.flushSync`). When the assertion runs before the scroll event fires, the DOM still shows the initial top window, so the last cell reads its initial value (`7`) instead of the expected `31`. Under CI load the event is sometimes late, hence the flake.

The sibling test `should not virtualize the last page if smaller than viewport` is not affected: its last page fits within the viewport, so the scroll is clamped to 0 and no re-render is needed.

## Fix

Wrap the assertion in `waitFor`, matching the convention already used by every other scroll test in this file.

## Test plan

Ran the browser test suite for the file locally; the target test and the full `rows.DataGridPro.test.tsx` (47 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
