### PR TITLE
[scheduler] Revert docs stable-release prep

### DIFF
--- a/docs/data/pages.ts
+++ b/docs/data/pages.ts
@@ -11,7 +11,7 @@ const schedulerPages: MuiPage[] = [
   {
     pathname: '/x/react-scheduler-group',
     title: 'Scheduler',
-    newFeature: true,
+    unstable: true,
     children: [
       { pathname: '/x/react-scheduler', title: 'Overview' },
       { pathname: '/x/react-scheduler/quickstart' },

--- a/docs/src/modules/components/overview/scheduler/SchedulerFeedbackBanner.tsx
+++ b/docs/src/modules/components/overview/scheduler/SchedulerFeedbackBanner.tsx
@@ -41,7 +41,7 @@ export default function SchedulerFeedbackBanner() {
           ...theme.applyDarkStyles({ color: 'primary.100' }),
         })}
       >
-        💬 Got feedback on the Scheduler? We&apos;d love to hear it.{' '}
+        🚀 The Scheduler is in beta — we&apos;d love your input.{' '}
         <Link
           href={FEEDBACK_FORM_URL}
           target="_blank"


### PR DESCRIPTION
Reverts the Scheduler docs changes that prepared for the stable release, since the stable release is no longer happening now.

Reverts:
- #23054 — "[scheduler] Replace docs \"Preview\" label with \"New\"" (restores \`unstable: true\` on the Scheduler pages)
- #23050 — "[docs] Update Scheduler feedback banner for stable release" (restores the beta feedback banner copy)

