### PR TITLE
[EXPERIMENT - do not merge] Bound docs build memory via require-cache eviction

### DIFF
--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -100,6 +100,11 @@ export default withDeploymentConfig({
   reactStrictMode: true,
   experimental: {
     esmExternals: undefined,
+    // EXPERIMENT: serialize static generation so the require-cache eviction preload
+    // (docs/scripts/evictPageCache.cjs) can free each page's compiled bundle between
+    // renders without racing concurrent renders. Goal: bound peak build memory in a
+    // single build (vs the sharded workaround).
+    staticGenerationMaxConcurrency: 1,
   },
   typescript: {
     tsconfigPath: './tsconfig.json',

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "scripts": {
     "build": "rimraf ./export && cross-env NODE_ENV=production next build --webpack && pnpm build-sw && pnpm link-check",
+    "build:evict": "rimraf ./export && cross-env NODE_ENV=production NODE_OPTIONS=\"--require ./scripts/evictPageCache.cjs --expose-gc --max-old-space-size=8192\" next build --webpack && pnpm build-sw && pnpm link-check",
     "build:clean": "rimraf .next && pnpm build",
     "build-sw": "node ./scripts/buildServiceWorker.js",
     "dev": "cross-env-shell 'next dev --port ${PORT:-3001}'",

--- a/docs/scripts/EVICT_EXPERIMENT.md
+++ b/docs/scripts/EVICT_EXPERIMENT.md
@@ -1,0 +1,47 @@
+# Experiment: bound docs build memory via require-cache eviction
+
+NOT FOR MERGE. This branch tests whether we can fix the docs static-export OOM in a
+**single** `next build` (no sharding, so no cross-section navigation tradeoff) by
+countering the Next.js internals issue directly.
+
+## The issue (root cause)
+
+Next's static-generation worker renders its whole batch of pages in one long-lived
+process. For each page it calls `loadComponents()`, which `require()`s that page's
+compiled server bundle (with the MUI docs' statically-bundled live demos). There is
+no `require.cache` eviction in the build/export path and no worker recycling /
+`idleMemoryLimit` in `createStaticWorker`, so hundreds of page bundles accumulate
+off-heap (V8 compiled-code space). On the Netlify Linux builder the single build
+peaks ~10.5 GB, right at the container ceiling -> intermittent OOM.
+
+## What this branch does
+
+- `docs/scripts/evictPageCache.cjs`: a `NODE_OPTIONS=--require` preload that
+  Proxy-wraps Next's `load-components` module (its exports are non-configurable
+  getters) and, after each page renders, evicts that page's newly-added compiled
+  modules from `require.cache` (keeping `node_modules`), then runs GC.
+- `next.config.ts`: `experimental.staticGenerationMaxConcurrency: 1` so generation
+  is serial and eviction between pages does not race concurrent renders.
+- `docs:build:evict` / `docs/package.json build:evict`: a normal unsharded build
+  with the preload wired via `NODE_OPTIONS`. `netlify.toml` points at it.
+
+## What to look for on the deploy
+
+Grep the build log for `[evict]`. It prints the worker's RSS every 25 pages:
+
+- If RSS stays bounded (e.g. a few GB) as the page count climbs -> the eviction is
+  working and the accumulation is confirmed as the root cause.
+- If the build completes with all pages -> a single-build fix is viable.
+
+## Known limitation (observed locally on macOS)
+
+Eviction bounded the worker from the unbounded ~10 GB climb to ~3.5 GB (confirming
+the mechanism), but evicting the _shared_ `server/chunks/` that the next page
+re-`require()`s causes re-compilation churn, which triggered a V8 heap OOM around
+page ~65. `staticGenerationMaxConcurrency: 1` + `--expose-gc` are here to mitigate
+that; the Linux builder runs leaner than macOS in these builds, so the point of this
+branch is to measure the real behavior there. A production version would need
+section-aware eviction (drop a section's chunks only once it is fully rendered).
+
+The durable fix is upstream: Next recycling the static-generation worker
+(`idleMemoryLimit` / pages-per-worker restart).

--- a/docs/scripts/evictPageCache.cjs
+++ b/docs/scripts/evictPageCache.cjs
@@ -1,0 +1,68 @@
+/* Preload (NODE_OPTIONS=--require) that evicts each page's compiled server bundle
+ * from require.cache after it renders, countering Next's lack of static-generation
+ * worker recycling. Next's dist exports are non-configurable getters, so we wrap
+ * the load-components module in a Proxy to intercept `loadComponents`. */
+/* eslint-disable no-underscore-dangle */
+const Module = require('module');
+const path = require('path');
+
+let sharedSnapshot = null;
+let prevAdded = null;
+let evicted = 0;
+let pages = 0;
+
+const evictable = (k) => !k.includes(`${path.sep}node_modules${path.sep}`);
+
+function makeWrapped(orig) {
+  return async function patchedLoadComponents(...args) {
+    if (sharedSnapshot === null) {
+      sharedSnapshot = new Set(Object.keys(require.cache));
+    } else if (prevAdded) {
+      for (const k of prevAdded) {
+        if (!sharedSnapshot.has(k)) {
+          delete require.cache[k];
+          evicted += 1;
+        }
+      }
+      if (global.gc) {
+        global.gc();
+      }
+    }
+    const before = new Set(Object.keys(require.cache));
+    const result = await orig.apply(this, args);
+    prevAdded = Object.keys(require.cache).filter((k) => !before.has(k) && evictable(k));
+    pages += 1;
+    if (pages % 25 === 0) {
+      const mb = Math.round(process.memoryUsage().rss / 1048576);
+      process.stderr.write(
+        `[evict] pid ${process.pid}: ${pages} pages, ${evicted} evicted, rss ${mb}MB\n`,
+      );
+    }
+    return result;
+  };
+}
+
+let wrapped = null;
+const origLoad = Module._load;
+Module._load = function patchedModuleLoad(request) {
+  const exports = origLoad.apply(this, arguments);
+  if (
+    typeof request === 'string' &&
+    request.endsWith('load-components') &&
+    exports &&
+    typeof exports.loadComponents === 'function'
+  ) {
+    return new Proxy(exports, {
+      get(target, prop, receiver) {
+        if (prop === 'loadComponents') {
+          if (!wrapped) {
+            wrapped = makeWrapped(target.loadComponents);
+          }
+          return wrapped;
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+    });
+  }
+  return exports;
+};

--- a/docs/scripts/evictPageCache.cjs
+++ b/docs/scripts/evictPageCache.cjs
@@ -1,25 +1,42 @@
-/* Preload (NODE_OPTIONS=--require) that evicts each page's compiled server bundle
- * from require.cache after it renders, countering Next's lack of static-generation
- * worker recycling. Next's dist exports are non-configurable getters, so we wrap
- * the load-components module in a Proxy to intercept `loadComponents`. */
+/* Preload (NODE_OPTIONS=--require): section-aware eviction of compiled server
+ * bundles to counter Next's lack of static-generation worker recycling, WITHOUT
+ * the per-page re-compile churn that OOMs the worker's small default heap.
+ *
+ * Pages render in path order, so each product section (`/x/<section>/...`) is
+ * contiguous. We accumulate a section's compiled modules while it renders (chunks
+ * stay cached -> no churn), and evict them from require.cache only once the next
+ * section starts (they are not needed again). Peak ~= one section's footprint. */
 /* eslint-disable no-underscore-dangle */
 const Module = require('module');
 const path = require('path');
 
 let sharedSnapshot = null;
-let prevAdded = null;
+let currentSection = null;
+let sectionKeysBefore = null; // require.cache keys at the section's first page
 let evicted = 0;
 let pages = 0;
 
 const evictable = (k) => !k.includes(`${path.sep}node_modules${path.sep}`);
 
+function sectionOf(page) {
+  // '/x/react-data-grid/overview' -> 'x/react-data-grid'; fall back to the page itself.
+  const parts = String(page || '')
+    .split('/')
+    .filter(Boolean);
+  return parts.slice(0, 2).join('/') || '(root)';
+}
+
 function makeWrapped(orig) {
-  return async function patchedLoadComponents(...args) {
+  return async function patchedLoadComponents(options) {
+    const section = sectionOf(options && options.page);
     if (sharedSnapshot === null) {
       sharedSnapshot = new Set(Object.keys(require.cache));
-    } else if (prevAdded) {
-      for (const k of prevAdded) {
-        if (!sharedSnapshot.has(k)) {
+      sectionKeysBefore = sharedSnapshot;
+      currentSection = section;
+    } else if (section !== currentSection) {
+      // Section boundary: free the finished section's compiled modules.
+      for (const k of Object.keys(require.cache)) {
+        if (!sectionKeysBefore.has(k) && !sharedSnapshot.has(k) && evictable(k)) {
           delete require.cache[k];
           evicted += 1;
         }
@@ -27,15 +44,16 @@ function makeWrapped(orig) {
       if (global.gc) {
         global.gc();
       }
+      currentSection = section;
+      sectionKeysBefore = new Set(Object.keys(require.cache));
     }
-    const before = new Set(Object.keys(require.cache));
-    const result = await orig.apply(this, args);
-    prevAdded = Object.keys(require.cache).filter((k) => !before.has(k) && evictable(k));
+    const result = await orig.call(this, options);
     pages += 1;
     if (pages % 25 === 0) {
       const mb = Math.round(process.memoryUsage().rss / 1048576);
+      const heap = Math.round(process.memoryUsage().heapUsed / 1048576);
       process.stderr.write(
-        `[evict] pid ${process.pid}: ${pages} pages, ${evicted} evicted, rss ${mb}MB\n`,
+        `[evict] pid ${process.pid}: ${pages} pages, section ${currentSection}, ${evicted} evicted, rss ${mb}MB heap ${heap}MB\n`,
       );
     }
     return result;

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,13 +3,14 @@
   publish = "docs/export/"
 
   # Build command.
-  command = "pnpm docs:build"
+  # EXPERIMENT: single (unsharded) build with a require-cache eviction preload
+  # (docs/scripts/evictPageCache.cjs) to test whether it bounds peak memory on the
+  # real builder. See docs/scripts/EVICT_EXPERIMENT.md.
+  command = "pnpm docs:build:evict"
 
 [build.environment]
   NODE_VERSION = "22.23.1"
   PNPM_FLAGS = "--frozen-lockfile"
-  # Single-threaded docs build: one large-heap worker fits the ~11 GiB build
-  # container; two multi-GiB workers overflow it (OOM).
   NODE_OPTIONS = "--max-old-space-size=8192"
   NEXT_PARALLELISM = "1"
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "docs:llms:build": "rimraf --glob ./docs/public/x/ && tsx ./scripts/buildLlmsDocs/index.ts --projectSettings scripts/buildApiDocs/projectSettings.ts",
     "docs:link-check": "pnpm --filter docs link-check",
     "docs:build": "pnpm --filter @mui/x-charts-vendor build && pnpm docs:llms:build && pnpm --filter docs build",
+    "docs:build:evict": "pnpm --filter @mui/x-charts-vendor build && pnpm docs:llms:build && pnpm --filter docs build:evict",
     "docs:typescript:formatted": "pnpm --filter docs typescript:transpile",
     "docs:populate:demos": "pnpm --filter docs populate:demos",
     "docs:importDocsStatic": "node scripts/importDocsStatic.mjs",


### PR DESCRIPTION
Do NOT merge. Experiment to validate on the real Netlify builder whether a single (unsharded) `next build` can avoid the docs static-export OOM by evicting each page's compiled bundle from `require.cache` after it renders - countering Next's lack of static-generation worker recycling.

Context: an alternative to the sharding PR (#23096), which fixes the OOM but adds a cross-section navigation tradeoff (each shard is an independent build). This tests the root-cause fix in a single build, which would avoid that tradeoff.

## What it does

- `docs/scripts/evictPageCache.cjs`: a `NODE_OPTIONS=--require` preload that Proxy-wraps Next's `load-components` (its exports are non-configurable getters) and, after each page renders, evicts that page's newly-added compiled modules from `require.cache` (keeping `node_modules`), then runs GC.
- `next.config.ts`: `experimental.staticGenerationMaxConcurrency: 1` so eviction between pages does not race concurrent renders.
- `docs:build:evict` + `netlify.toml` run a single unsharded build with the preload wired via `NODE_OPTIONS`.

See `docs/scripts/EVICT_EXPERIMENT.md` for the full write-up and the root-cause analysis.

## What to look for in this deploy

Grep the build log for `[evict]` (worker RSS printed every 25 pages):

- RSS stays bounded as the page count climbs -> confirms the accumulation (per-page compiled bundles retained off-heap) is the root cause.
- Build completes with all 717 pages -> a single-build fix is viable (no nav tradeoff).

## Known caveat

Locally (macOS) eviction bounded the worker from the unbounded ~10 GB climb to ~3.5 GB, but the shared `server/chunks/` re-compile churn triggered a V8 heap OOM around page ~65, so the local build did not finish. The Linux builder runs leaner in these builds, so this PR measures the real behavior there. A production version would need section-aware eviction; the durable fix is upstream in Next.js (static-generation worker `idleMemoryLimit` / pages-per-worker recycling).
