### PR TITLE
[code-infra] Group @atlaskit/pragmatic-drag-and-drop renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,10 @@
       "matchPackageNames": ["@base-ui/**"]
     },
     {
+      "groupName": "pragmatic-drag-and-drop",
+      "matchSourceUrls": ["https://github.com/atlassian/pragmatic-drag-and-drop"]
+    },
+    {
       "groupName": "bundling fixtures",
       "matchFileNames": ["test/bundling/fixtures/**/package.json"],
       "schedule": "* * 1 1,7 *"


### PR DESCRIPTION
Add a Renovate group so all `@atlaskit/pragmatic-drag-and-drop*` packages are bumped together in a single PR.

## Why

The `pragmatic-drag-and-drop` packages are versioned independently but are meant to be used at compatible versions. Renovate was raising them one at a time (for example https://github.com/mui/mui-x/pull/23085 bumped only the core `@atlaskit/pragmatic-drag-and-drop` to v2), while `@atlaskit/pragmatic-drag-and-drop-auto-scroll` has its own new major (v3) waiting as a separate update. Grouping keeps the family in lockstep and avoids partial upgrades landing on their own.

## Notes for reviewers

- The glob `@atlaskit/pragmatic-drag-and-drop*` matches the bare core package plus every suffixed variant (currently `-auto-scroll`, and any future `-hitbox`, `-react-drop-indicator`, etc.), consistent with the existing `d3-*` rule.
- No `matchUpdateTypes` restriction, so all update types move together, same as the D3 / react-spring / Base UI / Tanstack groups.
- Mirrors the existing `[infra] Group Base UI renovate updates` (https://github.com/mui/mui-x/pull/22590) rule directly above it.
- Validated locally with `renovate-config-validator` (passes).

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
