### PR TITLE
[code-infra] Reduce release:build concurrency to mitigate tsgo OOM kills

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,7 +230,7 @@ jobs:
           react-version: << parameters.react-version >>
       - run:
           name: Build packages
-          command: pnpm release:build --concurrency 4
+          command: pnpm release:build --concurrency 2
       - run:
           name: Run e2e tests
           command: pnpm test:e2e
@@ -257,7 +257,7 @@ jobs:
           react-version: << parameters.react-version >>
       - run:
           name: Build packages
-          command: pnpm release:build
+          command: pnpm release:build --concurrency 2
       - code-infra/upload-size-snapshot
   test_regressions:
     <<: *default-job


### PR DESCRIPTION
## Summary

- `test_e2e`/`test_e2e_react_18`/`test_package` build packages on a `medium`/`medium.gen2` CircleCI resource class via `pnpm release:build`, which since #22826 emits type declarations with `tsgo` instead of `tsc`.
- When several large packages (`x-charts`, `x-data-grid`, `x-date-pickers`) run their `tsgo` declaration-emit concurrently, combined memory use has been exceeding the container's budget and the OOM killer SIGKILLs one of them -- always `x-charts` in the failures observed so far.
- This shows up intermittently on `master` and various PRs (e.g. https://circleci.com/gh/mui/mui-x/880430 on master, https://circleci.com/gh/mui/mui-x/880470 on a PR), always with the same signature: `Command was killed with SIGKILL (Forced termination)` during `tsgo` declaration emit for `x-charts`.
- This PR lowers `release:build` concurrency from 4 to 2 in `test_e2e` and adds an explicit `--concurrency 2` to `test_package` (previously unbounded) to reduce how many `tsgo` processes run at once, as a first mitigation to test whether it resolves the flakiness.

## Test plan

- [x] Watch `test_e2e`, `test_e2e_react_18`, and `test_package` CI jobs on this PR over several re-runs to confirm the `Build packages` step no longer gets OOM-killed

## Results so far

No OOM kill on the retrigger run with concurrency 2 (all three jobs green). Runtime vs. the concurrency-4 baseline is close, not a clear regression in either direction:

| Job | Concurrency | `Build packages` step | Total job time |
| --- | --- | --- | --- |
| `test_e2e` | 4 (baseline, https://circleci.com/gh/mui/mui-x/879763) | 138.7s | 310.4s |
| `test_e2e` | 2 (this PR, https://circleci.com/gh/mui/mui-x/880697) | 118.2s | 273.5s |
| `test_e2e_react_18` | 4 (baseline, https://circleci.com/gh/mui/mui-x/879818) | 103.4s | 274.8s |
| `test_e2e_react_18` | 2 (this PR, https://circleci.com/gh/mui/mui-x/880699) | 138.9s | 389.9s |
| `test_package` | 4 (baseline, https://circleci.com/gh/mui/mui-x/879764) | 169.8s | 245.9s |
| `test_package` | 2 (this PR, https://circleci.com/gh/mui/mui-x/880693) | 141.3s | 242.1s |

Caveat: one data point per configuration so far, and the OOM was already intermittent at concurrency 4 (it didn't fail every run), so this isn't conclusive proof yet -- more re-runs would help confirm before merging.
