### PR TITLE
[l10n] Improve German (de-DE) locale

### DIFF
--- a/packages/x-scheduler/src/locales/deDE.ts
+++ b/packages/x-scheduler/src/locales/deDE.ts
@@ -103,7 +103,7 @@ const deDECalendar: Partial<Omit<EventCalendarLocaleText, keyof EventDialogLocal
   // weekdaySaturday: 'Saturday',
 
   // WeekView
-  allDay: 'Ganztägig',
+  allDay: 'ganztags',
   hiddenEvents: (hiddenEventsCount) => `${hiddenEventsCount} weitere..`,
   nextTimeSpan: (timeSpan) => `Nächste(r) ${timeSpan}`,
   previousTimeSpan: (timeSpan) => `Vorherige(r) ${timeSpan}`,


### PR DESCRIPTION
Both forms "Ganztägig" and "Ganztags" are in use in German.

See https://www.duden.de/rechtschreibung/ganztaegig and https://www.duden.de/rechtschreibung/ganztags.

"Ganztägig" is unfortunately too long for the standard weekday column containing all the labels and will wrap, whereas the slightly shorter "Ganztags" will render in one line.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
