### PR TITLE
[core] Ignore code-infra-renovate[bot] commits in changelog

### DIFF
--- a/scripts/changelogUtils.mjs
+++ b/scripts/changelogUtils.mjs
@@ -21,6 +21,12 @@ import { $ } from 'execa';
 const REPO = 'mui-x';
 
 /**
+ * @type {Set<string>}
+ * Bot logins whose commits are excluded from the changelog and contributor attribution
+ */
+const IGNORED_BOT_LOGINS = new Set(['renovate[bot]', 'code-infra-renovate[bot]']);
+
+/**
  * @type {string[]}
  * Labels to exclude from the changelog
  */
@@ -147,7 +153,7 @@ function getContributors(commits = []) {
   const warnUsers = new Map();
   for (const commitItem of commits) {
     const { author, commit } = commitItem;
-    if (!author || ['renovate[bot]', 'code-infra-renovate[bot]'].includes(author.login)) {
+    if (!author || IGNORED_BOT_LOGINS.has(author.login)) {
       continue;
     }
     if (author.login === 'github-actions[bot]') {
@@ -218,7 +224,7 @@ async function generateChangelog({
       release,
     })
   )
-    .filter((commit) => commit.author?.login !== 'renovate[bot]')
+    .filter((commit) => !IGNORED_BOT_LOGINS.has(commit.author?.login))
     .map((commit) => ({
       ...commit,
       commit: {


### PR DESCRIPTION
The changelog script guarded against the renovate bots inconsistently:

- `getContributors` excluded both `renovate[bot]` and `code-infra-renovate[bot]` (added in #22951).
- The commit filter feeding the changelog body only excluded `renovate[bot]` (narrowed in #21185).

As a result, `code-infra-renovate[bot]` commits (e.g. dependency bumps like #23121) still showed up as changelog entries while being excluded from contributor attribution.

This extracts a shared `IGNORED_BOT_LOGINS` set used by both guards so they can't drift again, and treats `code-infra-renovate[bot]` the same as `renovate[bot]` — excluded from the changelog entirely.