### PR TITLE
[scheduler-premium] Dependencies - Render the FS arrow

### DIFF
--- a/docs/data/scheduler/experiments/TimelineDependencyArrows.js
+++ b/docs/data/scheduler/experiments/TimelineDependencyArrows.js
@@ -1,0 +1,158 @@
+import * as React from 'react';
+
+import { eventTimelinePremiumClasses } from '@mui/x-scheduler-premium/event-timeline-premium';
+import {
+  EventTimelinePremiumContent,
+  EventTimelinePremiumStyledContext,
+} from '@mui/x-scheduler-premium/internals';
+import { useEventTimelinePremium } from '@mui/x-scheduler-internals-premium/use-event-timeline-premium';
+
+import { SchedulerStoreContext } from '@mui/x-scheduler-internals/use-scheduler-store-context';
+import {
+  EventDialogStyledContext,
+  SharedComponentsStyledContext,
+  EVENT_TIMELINE_DEFAULT_LOCALE_TEXT,
+} from '@mui/x-scheduler/internals';
+
+const resources = [
+  { id: 'backend', title: 'Backend' },
+  { id: 'frontend', title: 'Frontend' },
+  { id: 'qa', title: 'QA' },
+  { id: 'docs', title: 'Docs' },
+];
+
+// One event pair per arrow shape: same-row straight, cross-row elbow (with an event
+// blocking the default turn), adjacent events, and backward S routes.
+// Early hours so every arrow is inside the initial viewport without scrolling.
+const initialEvents = [
+  {
+    id: 'api',
+    title: 'API design',
+    start: '2025-07-03T01:00:00',
+    end: '2025-07-03T03:00:00',
+    resource: 'backend',
+  },
+  {
+    id: 'impl',
+    title: 'Implementation',
+    start: '2025-07-03T07:00:00',
+    end: '2025-07-03T09:30:00',
+    resource: 'frontend',
+  },
+  {
+    id: 'test',
+    title: 'Testing',
+    start: '2025-07-03T10:00:00',
+    end: '2025-07-03T11:00:00',
+    resource: 'qa',
+  },
+  {
+    id: 'draft',
+    title: 'Docs draft',
+    start: '2025-07-03T01:00:00',
+    end: '2025-07-03T02:00:00',
+    resource: 'docs',
+  },
+  {
+    id: 'review',
+    title: 'Docs review',
+    start: '2025-07-03T03:00:00',
+    end: '2025-07-03T04:00:00',
+    resource: 'docs',
+  },
+  {
+    id: 'publish',
+    title: 'Publish',
+    start: '2025-07-03T04:00:00',
+    end: '2025-07-03T05:00:00',
+    resource: 'docs',
+  },
+  {
+    id: 'hotfix',
+    title: 'Hotfix',
+    start: '2025-07-03T07:00:00',
+    end: '2025-07-03T09:00:00',
+    resource: 'backend',
+  },
+  {
+    id: 'retro',
+    title: 'Retro notes',
+    start: '2025-07-03T02:00:00',
+    end: '2025-07-03T03:00:00',
+    resource: 'qa',
+  },
+  {
+    id: 'spike',
+    title: 'Spike',
+    start: '2025-07-03T02:00:00',
+    end: '2025-07-03T06:30:00',
+    resource: 'frontend',
+  },
+];
+
+const initialDependencies = [
+  { id: 'd1', source: 'api', target: 'impl', type: 'FinishToStart' },
+  { id: 'd2', source: 'impl', target: 'test', type: 'FinishToStart' },
+  { id: 'd3', source: 'draft', target: 'review', type: 'FinishToStart' },
+  { id: 'd4', source: 'review', target: 'publish', type: 'FinishToStart' },
+  { id: 'd5', source: 'hotfix', target: 'retro', type: 'FinishToStart' },
+  { id: 'd6', source: 'spike', target: 'impl', type: 'FinishToStart' },
+];
+
+const styledContextValue = {
+  schedulerId: 'experiment-dependency-arrows',
+  classes: eventTimelinePremiumClasses,
+  localeText: EVENT_TIMELINE_DEFAULT_LOCALE_TEXT,
+};
+const sharedStyledContextValue = { classes: eventTimelinePremiumClasses };
+
+export default function TimelineDependencyArrows() {
+  const [events, setEvents] = React.useState(initialEvents);
+  const [dependencies, setDependencies] = React.useState(initialDependencies);
+
+  // `dependencies` has no public API yet (#22855), so instead of `<EventTimelinePremium />`
+  // this experiment feeds the internal store parameters to the same hook the component
+  // uses and renders its content inside the same providers.
+  const parameters = {
+    events,
+    onEventsChange: setEvents,
+    resources,
+    dependencies,
+    onDependenciesChange: setDependencies,
+    defaultVisibleDate: new Date('2025-07-03T00:00:00'),
+    defaultPreset: 'dayAndHour',
+    areEventsDraggable: true,
+    areEventsResizable: true,
+  };
+  const store = useEventTimelinePremium(parameters);
+
+  return (
+    /* Mimics the layout, font-size and box-sizing reset the `EventTimelinePremium`
+       root provides to the content (the row-height CSS resolves against them). */
+    <div
+      className="experiment-dependency-arrows-host"
+      style={{
+        height: 420,
+        width: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        fontSize: '0.875rem',
+      }}
+    >
+      <style>
+        {
+          '.experiment-dependency-arrows-host, .experiment-dependency-arrows-host * { box-sizing: border-box; }'
+        }
+      </style>
+      <SchedulerStoreContext.Provider value={store}>
+        <EventTimelinePremiumStyledContext.Provider value={styledContextValue}>
+          <EventDialogStyledContext.Provider value={styledContextValue}>
+            <SharedComponentsStyledContext.Provider value={sharedStyledContextValue}>
+              <EventTimelinePremiumContent />
+            </SharedComponentsStyledContext.Provider>
+          </EventDialogStyledContext.Provider>
+        </EventTimelinePremiumStyledContext.Provider>
+      </SchedulerStoreContext.Provider>
+    </div>
+  );
+}

--- a/docs/data/scheduler/experiments/TimelineDependencyArrows.js
+++ b/docs/data/scheduler/experiments/TimelineDependencyArrows.js
@@ -21,8 +21,8 @@ const resources = [
   { id: 'docs', title: 'Docs' },
 ];
 
-// One event pair per arrow shape: same-row straight, cross-row elbow (with an event
-// blocking the default turn), adjacent events, and backward S routes.
+// The dataset covers every arrow shape: same-row straight, cross-row elbow (with an
+// event blocking the default turn), adjacent events, and backward S routes.
 // Early hours so every arrow is inside the initial viewport without scrolling.
 const initialEvents = [
   {
@@ -125,6 +125,9 @@ export default function TimelineDependencyArrows() {
     areEventsResizable: true,
   };
   const store = useEventTimelinePremium(parameters);
+  // The context is typed on the base scheduler state and the store generic is
+  // invariant, so the premium store (extra state slices) needs the cast.
+  const storeContextValue = store;
 
   return (
     /* Mimics the layout, font-size and box-sizing reset the `EventTimelinePremium`
@@ -144,7 +147,7 @@ export default function TimelineDependencyArrows() {
           '.experiment-dependency-arrows-host, .experiment-dependency-arrows-host * { box-sizing: border-box; }'
         }
       </style>
-      <SchedulerStoreContext.Provider value={store}>
+      <SchedulerStoreContext.Provider value={storeContextValue}>
         <EventTimelinePremiumStyledContext.Provider value={styledContextValue}>
           <EventDialogStyledContext.Provider value={styledContextValue}>
             <SharedComponentsStyledContext.Provider value={sharedStyledContextValue}>

--- a/docs/data/scheduler/experiments/TimelineDependencyArrows.tsx
+++ b/docs/data/scheduler/experiments/TimelineDependencyArrows.tsx
@@ -24,8 +24,8 @@ const resources: SchedulerResource[] = [
   { id: 'docs', title: 'Docs' },
 ];
 
-// One event pair per arrow shape: same-row straight, cross-row elbow (with an event
-// blocking the default turn), adjacent events, and backward S routes.
+// The dataset covers every arrow shape: same-row straight, cross-row elbow (with an
+// event blocking the default turn), adjacent events, and backward S routes.
 // Early hours so every arrow is inside the initial viewport without scrolling.
 const initialEvents: SchedulerEvent[] = [
   {
@@ -133,6 +133,9 @@ export default function TimelineDependencyArrows() {
     areEventsResizable: true,
   };
   const store = useEventTimelinePremium(parameters);
+  // The context is typed on the base scheduler state and the store generic is
+  // invariant, so the premium store (extra state slices) needs the cast.
+  const storeContextValue = store as any;
 
   return (
     /* Mimics the layout, font-size and box-sizing reset the `EventTimelinePremium`
@@ -152,7 +155,7 @@ export default function TimelineDependencyArrows() {
           '.experiment-dependency-arrows-host, .experiment-dependency-arrows-host * { box-sizing: border-box; }'
         }
       </style>
-      <SchedulerStoreContext.Provider value={store as any}>
+      <SchedulerStoreContext.Provider value={storeContextValue}>
         <EventTimelinePremiumStyledContext.Provider value={styledContextValue}>
           <EventDialogStyledContext.Provider value={styledContextValue}>
             <SharedComponentsStyledContext.Provider value={sharedStyledContextValue}>

--- a/docs/data/scheduler/experiments/TimelineDependencyArrows.tsx
+++ b/docs/data/scheduler/experiments/TimelineDependencyArrows.tsx
@@ -1,0 +1,166 @@
+import * as React from 'react';
+import { SchedulerEvent, SchedulerResource } from '@mui/x-scheduler/models';
+import { eventTimelinePremiumClasses } from '@mui/x-scheduler-premium/event-timeline-premium';
+import {
+  EventTimelinePremiumContent,
+  EventTimelinePremiumStyledContext,
+} from '@mui/x-scheduler-premium/internals';
+import {
+  useEventTimelinePremium,
+  EventTimelinePremiumStoreParameters,
+} from '@mui/x-scheduler-internals-premium/use-event-timeline-premium';
+import { SchedulerDependency } from '@mui/x-scheduler-internals-premium/models';
+import { SchedulerStoreContext } from '@mui/x-scheduler-internals/use-scheduler-store-context';
+import {
+  EventDialogStyledContext,
+  SharedComponentsStyledContext,
+  EVENT_TIMELINE_DEFAULT_LOCALE_TEXT,
+} from '@mui/x-scheduler/internals';
+
+const resources: SchedulerResource[] = [
+  { id: 'backend', title: 'Backend' },
+  { id: 'frontend', title: 'Frontend' },
+  { id: 'qa', title: 'QA' },
+  { id: 'docs', title: 'Docs' },
+];
+
+// One event pair per arrow shape: same-row straight, cross-row elbow (with an event
+// blocking the default turn), adjacent events, and backward S routes.
+// Early hours so every arrow is inside the initial viewport without scrolling.
+const initialEvents: SchedulerEvent[] = [
+  {
+    id: 'api',
+    title: 'API design',
+    start: '2025-07-03T01:00:00',
+    end: '2025-07-03T03:00:00',
+    resource: 'backend',
+  },
+  {
+    id: 'impl',
+    title: 'Implementation',
+    start: '2025-07-03T07:00:00',
+    end: '2025-07-03T09:30:00',
+    resource: 'frontend',
+  },
+  {
+    id: 'test',
+    title: 'Testing',
+    start: '2025-07-03T10:00:00',
+    end: '2025-07-03T11:00:00',
+    resource: 'qa',
+  },
+  {
+    id: 'draft',
+    title: 'Docs draft',
+    start: '2025-07-03T01:00:00',
+    end: '2025-07-03T02:00:00',
+    resource: 'docs',
+  },
+  {
+    id: 'review',
+    title: 'Docs review',
+    start: '2025-07-03T03:00:00',
+    end: '2025-07-03T04:00:00',
+    resource: 'docs',
+  },
+  {
+    id: 'publish',
+    title: 'Publish',
+    start: '2025-07-03T04:00:00',
+    end: '2025-07-03T05:00:00',
+    resource: 'docs',
+  },
+  {
+    id: 'hotfix',
+    title: 'Hotfix',
+    start: '2025-07-03T07:00:00',
+    end: '2025-07-03T09:00:00',
+    resource: 'backend',
+  },
+  {
+    id: 'retro',
+    title: 'Retro notes',
+    start: '2025-07-03T02:00:00',
+    end: '2025-07-03T03:00:00',
+    resource: 'qa',
+  },
+  {
+    id: 'spike',
+    title: 'Spike',
+    start: '2025-07-03T02:00:00',
+    end: '2025-07-03T06:30:00',
+    resource: 'frontend',
+  },
+];
+
+const initialDependencies: SchedulerDependency[] = [
+  { id: 'd1', source: 'api', target: 'impl', type: 'FinishToStart' },
+  { id: 'd2', source: 'impl', target: 'test', type: 'FinishToStart' },
+  { id: 'd3', source: 'draft', target: 'review', type: 'FinishToStart' },
+  { id: 'd4', source: 'review', target: 'publish', type: 'FinishToStart' },
+  { id: 'd5', source: 'hotfix', target: 'retro', type: 'FinishToStart' },
+  { id: 'd6', source: 'spike', target: 'impl', type: 'FinishToStart' },
+];
+
+const styledContextValue = {
+  schedulerId: 'experiment-dependency-arrows',
+  classes: eventTimelinePremiumClasses,
+  localeText: EVENT_TIMELINE_DEFAULT_LOCALE_TEXT,
+};
+const sharedStyledContextValue = { classes: eventTimelinePremiumClasses };
+
+export default function TimelineDependencyArrows() {
+  const [events, setEvents] = React.useState(initialEvents);
+  const [dependencies, setDependencies] = React.useState<
+    readonly SchedulerDependency[] | undefined
+  >(initialDependencies);
+
+  // `dependencies` has no public API yet (#22855), so instead of `<EventTimelinePremium />`
+  // this experiment feeds the internal store parameters to the same hook the component
+  // uses and renders its content inside the same providers.
+  const parameters: EventTimelinePremiumStoreParameters<
+    SchedulerEvent,
+    SchedulerResource
+  > = {
+    events,
+    onEventsChange: setEvents,
+    resources,
+    dependencies,
+    onDependenciesChange: setDependencies,
+    defaultVisibleDate: new Date('2025-07-03T00:00:00'),
+    defaultPreset: 'dayAndHour',
+    areEventsDraggable: true,
+    areEventsResizable: true,
+  };
+  const store = useEventTimelinePremium(parameters);
+
+  return (
+    /* Mimics the layout, font-size and box-sizing reset the `EventTimelinePremium`
+       root provides to the content (the row-height CSS resolves against them). */
+    <div
+      className="experiment-dependency-arrows-host"
+      style={{
+        height: 420,
+        width: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        fontSize: '0.875rem',
+      }}
+    >
+      <style>
+        {
+          '.experiment-dependency-arrows-host, .experiment-dependency-arrows-host * { box-sizing: border-box; }'
+        }
+      </style>
+      <SchedulerStoreContext.Provider value={store as any}>
+        <EventTimelinePremiumStyledContext.Provider value={styledContextValue}>
+          <EventDialogStyledContext.Provider value={styledContextValue}>
+            <SharedComponentsStyledContext.Provider value={sharedStyledContextValue}>
+              <EventTimelinePremiumContent />
+            </SharedComponentsStyledContext.Provider>
+          </EventDialogStyledContext.Provider>
+        </EventTimelinePremiumStyledContext.Provider>
+      </SchedulerStoreContext.Provider>
+    </div>
+  );
+}

--- a/docs/data/scheduler/experiments/TimelineDependencyArrows.tsx.preview
+++ b/docs/data/scheduler/experiments/TimelineDependencyArrows.tsx.preview
@@ -1,0 +1,14 @@
+<style>
+  {
+    '.experiment-dependency-arrows-host, .experiment-dependency-arrows-host * { box-sizing: border-box; }'
+  }
+</style>
+<SchedulerStoreContext.Provider value={store as any}>
+  <EventTimelinePremiumStyledContext.Provider value={styledContextValue}>
+    <EventDialogStyledContext.Provider value={styledContextValue}>
+      <SharedComponentsStyledContext.Provider value={sharedStyledContextValue}>
+        <EventTimelinePremiumContent />
+      </SharedComponentsStyledContext.Provider>
+    </EventDialogStyledContext.Provider>
+  </EventTimelinePremiumStyledContext.Provider>
+</SchedulerStoreContext.Provider>

--- a/docs/data/scheduler/experiments/TimelineDependencyArrows.tsx.preview
+++ b/docs/data/scheduler/experiments/TimelineDependencyArrows.tsx.preview
@@ -3,7 +3,7 @@
     '.experiment-dependency-arrows-host, .experiment-dependency-arrows-host * { box-sizing: border-box; }'
   }
 </style>
-<SchedulerStoreContext.Provider value={store as any}>
+<SchedulerStoreContext.Provider value={storeContextValue}>
   <EventTimelinePremiumStyledContext.Provider value={styledContextValue}>
     <EventDialogStyledContext.Provider value={styledContextValue}>
       <SharedComponentsStyledContext.Provider value={sharedStyledContextValue}>

--- a/docs/data/scheduler/experiments/experiments.md
+++ b/docs/data/scheduler/experiments/experiments.md
@@ -14,6 +14,12 @@ components: StandaloneCompactDayView, StandaloneCompactThreeDayView, StandaloneC
 
 {{"demo": "RecurringEventDurations.js", "bg": "inline", "defaultCodeOpen": false}}
 
+## Timeline dependency arrows (#22855)
+
+Finish-to-Start dependencies rendered as arrows on the timeline. The dataset covers every route shape: a straight arrow on the same lane, an elbow across rows that turns right before its target to avoid crossing other events, a short arrow between adjacent events, and S routes for successors starting before their predecessor ends. Drag or resize an event to see its arrows follow. The feature has no public API yet, so the demo feeds the internal store parameters.
+
+{{"demo": "TimelineDependencyArrows.js", "bg": "inline", "defaultCodeOpen": false}}
+
 ## Month view multi-day overflow
 
 ### Continuation after overflow (#22735)

--- a/packages/x-scheduler-internals-premium/src/event-timeline-premium-selectors/eventTimelinePremiumDependencySelectors.test.ts
+++ b/packages/x-scheduler-internals-premium/src/event-timeline-premium-selectors/eventTimelinePremiumDependencySelectors.test.ts
@@ -125,6 +125,48 @@ describe('eventTimelinePremiumDependencySelectors', () => {
     expect(first).to.equal(second);
   });
 
+  it('should group the source event titles by target event id', () => {
+    const state = getState();
+
+    const titlesByTarget =
+      eventTimelinePremiumDependencySelectors.activeSourceTitlesByTarget(state);
+
+    expect(titlesByTarget.get('event-b')).to.deep.equal([eventA.title]);
+    expect(titlesByTarget.get('event-a')).to.equal(undefined);
+  });
+
+  it('should return the source titles of all the active dependencies targeting the event', () => {
+    const eventC = EventBuilder.new().id('event-c').title('Event C').build();
+    const state = getEventTimelinePremiumStateFromParameters({
+      resources: TEST_RESOURCES,
+      events: [eventA, eventB, eventC],
+      dependencies: [
+        DEP_1,
+        { id: 'dep-c', source: 'event-c', target: 'event-b', type: 'FinishToStart' },
+      ],
+    });
+
+    expect(
+      eventTimelinePremiumDependencySelectors.activeSourceTitlesForTarget(state, 'event-b'),
+    ).to.deep.equal([eventA.title, 'Event C']);
+  });
+
+  it('should return the same empty instance for every event without predecessors', () => {
+    const state = getState();
+
+    const first = eventTimelinePremiumDependencySelectors.activeSourceTitlesForTarget(
+      state,
+      'event-a',
+    );
+    const second = eventTimelinePremiumDependencySelectors.activeSourceTitlesForTarget(
+      state,
+      'event-r',
+    );
+
+    expect(first).to.deep.equal([]);
+    expect(first).to.equal(second);
+  });
+
   it('should keep only the last dependency when two of them share the same id', () => {
     const firstDependency: SchedulerDependency = {
       id: 'dup-1',

--- a/packages/x-scheduler-internals-premium/src/event-timeline-premium-selectors/eventTimelinePremiumDependencySelectors.ts
+++ b/packages/x-scheduler-internals-premium/src/event-timeline-premium-selectors/eventTimelinePremiumDependencySelectors.ts
@@ -27,6 +27,8 @@ function groupByEventId(
   return groups;
 }
 
+const EMPTY_TITLES: readonly string[] = [];
+
 const activeModelListSelector = createSelectorMemoized(
   (state: State) => state.dependencyModelLookup,
   (state: State) => state.processedEventLookup,
@@ -38,6 +40,25 @@ const activeModelListSelector = createSelectorMemoized(
         (eventId) => classifyDependencyEvent(processedEventLookup, eventId) === 'ok',
       ),
     ),
+);
+
+const activeSourceTitlesByTargetSelector = createSelectorMemoized(
+  activeModelListSelector,
+  (state: State) => state.processedEventLookup,
+  (dependencies, processedEventLookup) => {
+    const titlesByTarget = new Map<SchedulerEventId, string[]>();
+    for (const dependency of dependencies) {
+      // Active dependencies always resolve: their events exist in the lookup.
+      const title = processedEventLookup.get(dependency.source)!.title;
+      const titles = titlesByTarget.get(dependency.target);
+      if (titles) {
+        titles.push(title);
+      } else {
+        titlesByTarget.set(dependency.target, [title]);
+      }
+    }
+    return titlesByTarget;
+  },
 );
 
 export const eventTimelinePremiumDependencySelectors = {
@@ -58,5 +79,14 @@ export const eventTimelinePremiumDependencySelectors = {
   ),
   activeModelListByTarget: createSelectorMemoized(activeModelListSelector, (dependencies) =>
     groupByEventId(dependencies, 'target'),
+  ),
+  /**
+   * Titles of the source events of the active dependencies, grouped by target event id.
+   * Used to describe an event with the events it depends on.
+   */
+  activeSourceTitlesByTarget: activeSourceTitlesByTargetSelector,
+  activeSourceTitlesForTarget: createSelector(
+    activeSourceTitlesByTargetSelector,
+    (titlesByTarget, eventId: SchedulerEventId) => titlesByTarget.get(eventId) ?? EMPTY_TITLES,
   ),
 };

--- a/packages/x-scheduler-internals-premium/src/event-timeline-premium-selectors/eventTimelinePremiumDependencySelectors.ts
+++ b/packages/x-scheduler-internals-premium/src/event-timeline-premium-selectors/eventTimelinePremiumDependencySelectors.ts
@@ -1,4 +1,5 @@
 import { createSelector, createSelectorMemoized } from '@base-ui/utils/store';
+import { EMPTY_ARRAY } from '@base-ui/utils/empty';
 import type { SchedulerEventId } from '@mui/x-scheduler-internals/models';
 import type { SchedulerState } from '@mui/x-scheduler-internals/internals';
 import type {
@@ -26,8 +27,6 @@ function groupByEventId(
   }
   return groups;
 }
-
-const EMPTY_TITLES: readonly string[] = [];
 
 const activeModelListSelector = createSelectorMemoized(
   (state: State) => state.dependencyModelLookup,
@@ -87,6 +86,7 @@ export const eventTimelinePremiumDependencySelectors = {
   activeSourceTitlesByTarget: activeSourceTitlesByTargetSelector,
   activeSourceTitlesForTarget: createSelector(
     activeSourceTitlesByTargetSelector,
-    (titlesByTarget, eventId: SchedulerEventId) => titlesByTarget.get(eventId) ?? EMPTY_TITLES,
+    (titlesByTarget, eventId: SchedulerEventId): readonly string[] =>
+      titlesByTarget.get(eventId) ?? EMPTY_ARRAY,
   ),
 };

--- a/packages/x-scheduler-internals/src/internals/utils/useElementPositionInCollection.ts
+++ b/packages/x-scheduler-internals/src/internals/utils/useElementPositionInCollection.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { useAdapterContext } from '../../use-adapter-context';
+import type { Adapter } from '../../use-adapter/useAdapter.types';
 import type { SchedulerProcessedDate, TemporalSupportedObject } from '../../models';
 
 // Default visual window: the full 24h day (visual time, not real-time duration)
@@ -19,52 +20,80 @@ export function useElementPositionInCollection(
 
   const adapter = useAdapterContext();
 
-  return React.useMemo(() => {
-    // Number of minutes displayed per day. With the default window this is the full day (1440).
-    const dayMinutes = Math.max(1, dayEndMinute - dayStartMinute);
+  return React.useMemo(
+    () =>
+      computeElementPositionInCollection(adapter, {
+        start,
+        end,
+        collectionStart,
+        collectionEnd,
+        dayStartMinute,
+        dayEndMinute,
+      }),
+    [adapter, start, end, collectionStart, collectionEnd, dayStartMinute, dayEndMinute],
+  );
+}
 
-    const startDayIndex = adapter.differenceInDays(
-      adapter.startOfDay(start.value),
+/**
+ * Pure helper behind `useElementPositionInCollection`, callable outside React.
+ */
+export function computeElementPositionInCollection(
+  adapter: Adapter,
+  parameters: useElementPositionInCollection.Parameters,
+): useElementPositionInCollection.ReturnValue {
+  const {
+    start,
+    end,
+    collectionStart,
+    collectionEnd,
+    dayStartMinute = 0,
+    dayEndMinute = FIXED_24H_GRID_MINUTES,
+  } = parameters;
+
+  // Number of minutes displayed per day. With the default window this is the full day (1440).
+  const dayMinutes = Math.max(1, dayEndMinute - dayStartMinute);
+
+  const startDayIndex = adapter.differenceInDays(
+    adapter.startOfDay(start.value),
+    adapter.startOfDay(collectionStart),
+  );
+
+  const endDayIndex = adapter.differenceInDays(
+    adapter.startOfDay(end.value),
+    adapter.startOfDay(collectionStart),
+  );
+
+  const startIndexMinutes = startDayIndex * dayMinutes + (start.minutesInDay - dayStartMinute);
+
+  let endIndexMinutes = endDayIndex * dayMinutes + (end.minutesInDay - dayStartMinute);
+
+  // If the event ends before it starts, it means it spans over midnight(s)
+  if (endIndexMinutes < startIndexMinutes) {
+    endIndexMinutes += dayMinutes;
+  }
+
+  const totalDays =
+    adapter.differenceInDays(
+      adapter.startOfDay(collectionEnd),
       adapter.startOfDay(collectionStart),
-    );
+    ) + 1;
 
-    const endDayIndex = adapter.differenceInDays(
-      adapter.startOfDay(end.value),
-      adapter.startOfDay(collectionStart),
-    );
+  const totalMinutes = Math.max(1, totalDays * dayMinutes);
 
-    const startIndexMinutes = startDayIndex * dayMinutes + (start.minutesInDay - dayStartMinute);
+  const clampToTimeline = (value: number) => Math.min(Math.max(value, 0), totalMinutes);
 
-    let endIndexMinutes = endDayIndex * dayMinutes + (end.minutesInDay - dayStartMinute);
+  const clampedStartMinutes = clampToTimeline(startIndexMinutes);
+  const clampedEndMinutes = clampToTimeline(endIndexMinutes);
 
-    // If the event ends before it starts, it means it spans over midnight(s)
-    if (endIndexMinutes < startIndexMinutes) {
-      endIndexMinutes += dayMinutes;
-    }
+  const startingBeforeEdge = startIndexMinutes < 0;
+  const endingAfterEdge = endIndexMinutes > totalMinutes;
 
-    const totalDays =
-      adapter.differenceInDays(
-        adapter.startOfDay(collectionEnd),
-        adapter.startOfDay(collectionStart),
-      ) + 1;
-
-    const totalMinutes = Math.max(1, totalDays * dayMinutes);
-
-    const clampToTimeline = (value: number) => Math.min(Math.max(value, 0), totalMinutes);
-
-    const clampedStartMinutes = clampToTimeline(startIndexMinutes);
-    const clampedEndMinutes = clampToTimeline(endIndexMinutes);
-
-    const startingBeforeEdge = startIndexMinutes < 0;
-    const endingAfterEdge = endIndexMinutes > totalMinutes;
-
-    return {
-      position: clampedStartMinutes / totalMinutes,
-      duration: Math.max(0, clampedEndMinutes - clampedStartMinutes) / totalMinutes,
-      startingBeforeEdge,
-      endingAfterEdge,
-    };
-  }, [adapter, start, end, collectionStart, collectionEnd, dayStartMinute, dayEndMinute]);
+  return {
+    position: clampedStartMinutes / totalMinutes,
+    duration: Math.max(0, clampedEndMinutes - clampedStartMinutes) / totalMinutes,
+    startingBeforeEdge,
+    endingAfterEdge,
+  };
 }
 
 namespace useElementPositionInCollection {

--- a/packages/x-scheduler-internals/src/use-event-occurrences-with-timeline-position/useEventOccurrencesWithTimelinePosition.test.ts
+++ b/packages/x-scheduler-internals/src/use-event-occurrences-with-timeline-position/useEventOccurrencesWithTimelinePosition.test.ts
@@ -2,7 +2,10 @@ import { adapter, EventBuilder } from 'test/utils/scheduler';
 import { renderHook } from '@mui/internal-test-utils';
 import type { SchedulerProcessedEvent } from '@mui/x-scheduler-internals/models';
 import { getOccurrencesFromEvents } from '@mui/x-scheduler-internals/internals';
-import { useEventOccurrencesWithTimelinePosition } from './useEventOccurrencesWithTimelinePosition';
+import {
+  computeOccurrencesFirstIndexLookup,
+  useEventOccurrencesWithTimelinePosition,
+} from './useEventOccurrencesWithTimelinePosition';
 
 describe('useDayListEventOccurrencesWithPosition', () => {
   const collectionStart = adapter.date('2024-01-15', 'default');
@@ -213,5 +216,33 @@ describe('useDayListEventOccurrencesWithPosition', () => {
     expect(result.occurrences[1].position).to.deep.equal({ firstIndex: 2, lastIndex: 2 });
     expect(result.occurrences[2].id).to.equal('C');
     expect(result.occurrences[2].position).to.deep.equal({ firstIndex: 1, lastIndex: 1 });
+  });
+
+  describe('computeOccurrencesFirstIndexLookup', () => {
+    it('should return the same firstIndex as the hook for overlapping occurrences', () => {
+      const events = [
+        EventBuilder.new().id('A').singleDay('2024-01-15T10:00:00Z', 120).toProcessed(),
+        EventBuilder.new().id('B').singleDay('2024-01-15T10:00:00Z').toProcessed(),
+        EventBuilder.new().id('C').singleDay('2024-01-15T10:30:00Z', 240).toProcessed(),
+        EventBuilder.new().id('D').singleDay('2024-01-15T13:00:00Z').toProcessed(),
+      ];
+      const result = testHook(events, 1);
+
+      const occurrences = getOccurrencesFromEvents({
+        adapter,
+        start: collectionStart,
+        end: collectionEnd,
+        events,
+        displayTimezone: 'default',
+        visibleResources: {},
+        recurringEventsPlugin: null,
+      });
+      const lookup = computeOccurrencesFirstIndexLookup(adapter, occurrences);
+
+      expect(Object.keys(lookup)).to.have.length(result.occurrences.length);
+      for (const occurrence of result.occurrences) {
+        expect(lookup[occurrence.key]).to.equal(occurrence.position.firstIndex);
+      }
+    });
   });
 });

--- a/packages/x-scheduler-internals/src/use-event-occurrences-with-timeline-position/useEventOccurrencesWithTimelinePosition.ts
+++ b/packages/x-scheduler-internals/src/use-event-occurrences-with-timeline-position/useEventOccurrencesWithTimelinePosition.ts
@@ -47,6 +47,20 @@ export function computeOccurrencesMaxIndex(
   return buildFirstIndexLookup(conflicts).maxIndex;
 }
 
+/**
+ * Pure helper that returns the 1-based lane (`firstIndex`) of each occurrence, keyed by
+ * occurrence key. With `maxSpan: 1` this matches the `position.firstIndex` the hook returns,
+ * so it can be used to locate occurrences in rows that are not mounted.
+ */
+export function computeOccurrencesFirstIndexLookup(
+  adapter: Adapter,
+  occurrences: readonly SchedulerEventOccurrence[],
+): { [occurrenceKey: string]: number } {
+  const sortedOccurrences = sortEventOccurrences(occurrences);
+  const conflicts = buildOccurrenceConflicts(adapter, sortedOccurrences);
+  return buildFirstIndexLookup(conflicts).firstIndexLookup;
+}
+
 export namespace useEventOccurrencesWithTimelinePosition {
   export interface Parameters {
     /**

--- a/packages/x-scheduler-internals/src/use-event-occurrences-with-timeline-position/useEventOccurrencesWithTimelinePosition.ts
+++ b/packages/x-scheduler-internals/src/use-event-occurrences-with-timeline-position/useEventOccurrencesWithTimelinePosition.ts
@@ -49,8 +49,8 @@ export function computeOccurrencesMaxIndex(
 
 /**
  * Pure helper that returns the 1-based lane (`firstIndex`) of each occurrence, keyed by
- * occurrence key. With `maxSpan: 1` this matches the `position.firstIndex` the hook returns,
- * so it can be used to locate occurrences in rows that are not mounted.
+ * occurrence key. Matches the `position.firstIndex` the hook returns, so it can be used
+ * to locate occurrences in rows that are not mounted.
  */
 export function computeOccurrencesFirstIndexLookup(
   adapter: Adapter,

--- a/packages/x-scheduler-premium/src/event-timeline-premium/content/EventTimelinePremiumContent.tsx
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/content/EventTimelinePremiumContent.tsx
@@ -1,6 +1,5 @@
 'use client';
 import * as React from 'react';
-import type { Theme } from '@mui/material/styles';
 import { styled, useTheme } from '@mui/material/styles';
 import { useMergedRefs } from '@base-ui/utils/useMergedRefs';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
@@ -31,7 +30,10 @@ import {
   useEventDialogContext,
   getCellFocusBackground,
 } from '@mui/x-scheduler/internals';
-import { useTimelineDragAutoScroll } from '@mui/x-scheduler-internals/internals';
+import {
+  computeElementPositionInCollection,
+  useTimelineDragAutoScroll,
+} from '@mui/x-scheduler-internals/internals';
 import { PREMIUM_EVENT_DIALOG_OPTIONAL_RENDERERS } from '../../internals/eventDialogOptionalRenderers';
 import { EventTimelinePremiumHeader } from './timeline-header';
 import type { EventTimelinePremiumContentProps } from './EventTimelinePremiumContent.types';
@@ -50,6 +52,8 @@ import {
 } from './useTitleColumnWidth';
 import { useTitleScrollSync } from './useTitleScrollSync';
 import { useEventTabNavigation } from './useEventTabNavigation';
+import { getRowHeightForLaneCount } from './rowGeometry';
+import { EventTimelinePremiumDependencyArrows } from './timeline-dependency-arrows';
 
 const EventTimelinePremiumContentRoot = styled('section', {
   name: 'MuiEventTimeline',
@@ -467,9 +471,6 @@ function FillerRow() {
   );
 }
 
-// Fixed 24h grid (must match useElementPositionInCollection)
-const FIXED_24H_GRID_MINUTES = 24 * 60;
-
 /**
  * Renders only the events that intersect the virtualizer's visible column range.
  * Isolated into its own component so that scrolling (which updates `renderContext`)
@@ -489,44 +490,24 @@ function EventList({
   const renderContext = virtualizerStore.use(Virtualization.selectors.renderContext);
 
   // Precompute position fractions for all occurrences (recomputed only when occurrences or preset changes)
-  const occurrencesWithFraction = React.useMemo(() => {
-    const collectionStart = presetConfig.start;
-    const collectionEnd = presetConfig.end;
+  const occurrencesWithFraction = React.useMemo(
+    () =>
+      occurrences.map((occurrence) => {
+        const { position, duration } = computeElementPositionInCollection(adapter, {
+          start: occurrence.displayTimezone.start,
+          end: occurrence.displayTimezone.end,
+          collectionStart: presetConfig.start,
+          collectionEnd: presetConfig.end,
+        });
 
-    const totalDays =
-      adapter.differenceInDays(
-        adapter.startOfDay(collectionEnd),
-        adapter.startOfDay(collectionStart),
-      ) + 1;
-    const totalMinutes = Math.max(1, totalDays * FIXED_24H_GRID_MINUTES);
-    const clamp = (v: number) => Math.min(Math.max(v, 0), totalMinutes);
-
-    return occurrences.map((occurrence) => {
-      const start = occurrence.displayTimezone.start;
-      const end = occurrence.displayTimezone.end;
-
-      const startDayIndex = adapter.differenceInDays(
-        adapter.startOfDay(start.value),
-        adapter.startOfDay(collectionStart),
-      );
-      const endDayIndex = adapter.differenceInDays(
-        adapter.startOfDay(end.value),
-        adapter.startOfDay(collectionStart),
-      );
-
-      const startMinutes = startDayIndex * FIXED_24H_GRID_MINUTES + start.minutesInDay;
-      let endMinutes = endDayIndex * FIXED_24H_GRID_MINUTES + end.minutesInDay;
-      if (endMinutes < startMinutes) {
-        endMinutes += FIXED_24H_GRID_MINUTES;
-      }
-
-      return {
-        occurrence,
-        fractionStart: clamp(startMinutes) / totalMinutes,
-        fractionEnd: clamp(endMinutes) / totalMinutes,
-      };
-    });
-  }, [adapter, occurrences, presetConfig.start, presetConfig.end]);
+        return {
+          occurrence,
+          fractionStart: position,
+          fractionEnd: position + duration,
+        };
+      }),
+    [adapter, occurrences, presetConfig.start, presetConfig.end],
+  );
 
   // Convert virtualizer column range to fraction range
   const { tickCount } = presetConfig;
@@ -891,6 +872,7 @@ export const EventTimelinePremiumContent = React.forwardRef(function EventTimeli
                         aria-hidden
                       />
                     )}
+                    <EventTimelinePremiumDependencyArrows />
                   </RowContainer>
                   <FillerRow />
                 </EventTimelinePremiumViewport>
@@ -933,36 +915,3 @@ export const EventTimelinePremiumContent = React.forwardRef(function EventTimeli
     </EventTimelinePremiumContentRoot>
   );
 });
-
-// `EventsCell` is the tallest in-flow child of the body row and therefore drives
-// its rendered height. These helpers mirror the CSS so the virtualizer's
-// `getRowHeight` returns the same value the browser will lay out.
-//
-// CSS for EventsCell:
-//   padding: theme.spacing(2, 0);
-//   grid-template-rows: repeat(var(--lane-count, 1),
-//                              minmax(calc(${body2.lineHeight}em + ${theme.spacing(1.125)}), auto));
-//   row-gap: theme.spacing(0.5);
-//   border-bottom: 1px solid divider;
-//
-// `em` in the grid track resolves against the EventsCell's font-size, which
-// inherits `theme.typography.body2.fontSize` from the Content root.
-export function getEventsCellLaneMinHeight(theme: Theme): number {
-  const fontSizeRem = parseFloat(String(theme.typography.body2.fontSize));
-  const fontSize =
-    Number.isFinite(fontSizeRem) && fontSizeRem > 0
-      ? fontSizeRem * (theme.typography.htmlFontSize ?? 16)
-      : 14;
-  const lineHeight = Number(theme.typography.body2.lineHeight) || 1.43;
-  const extra = parseFloat(theme.spacing(1.125)) || 9;
-  return lineHeight * fontSize + extra;
-}
-
-export function getRowHeightForLaneCount(theme: Theme, laneCount: number): number {
-  const padding = parseFloat(theme.spacing(2)) || 16;
-  const gap = parseFloat(theme.spacing(0.5)) || 4;
-  const laneMin = getEventsCellLaneMinHeight(theme);
-  const lanes = Math.max(1, laneCount);
-  // 2 paddings + N lanes + (N-1) row-gaps + bottom border.
-  return 2 * padding + lanes * laneMin + (lanes - 1) * gap + 1;
-}

--- a/packages/x-scheduler-premium/src/event-timeline-premium/content/EventTimelinePremiumContent.tsx
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/content/EventTimelinePremiumContent.tsx
@@ -53,6 +53,7 @@ import {
 import { useTitleScrollSync } from './useTitleScrollSync';
 import { useEventTabNavigation } from './useEventTabNavigation';
 import { getRowHeightForLaneCount } from './rowGeometry';
+import { getVisibleFractionRange } from './getVisibleFractionRange';
 import { EventTimelinePremiumDependencyArrows } from './timeline-dependency-arrows';
 
 const EventTimelinePremiumContentRoot = styled('section', {
@@ -510,9 +511,10 @@ function EventList({
   );
 
   // Convert virtualizer column range to fraction range
-  const { tickCount } = presetConfig;
-  const visibleStart = Math.max(0, renderContext.firstColumnIndex - 1) / tickCount;
-  const visibleEnd = Math.max(0, renderContext.lastColumnIndex - 1) / tickCount;
+  const { start: visibleStart, end: visibleEnd } = getVisibleFractionRange(
+    renderContext,
+    presetConfig.tickCount,
+  );
 
   return (
     <React.Fragment>

--- a/packages/x-scheduler-premium/src/event-timeline-premium/content/getRowHeightForLaneCount.test.ts
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/content/getRowHeightForLaneCount.test.ts
@@ -1,8 +1,5 @@
 import { createTheme } from '@mui/material/styles';
-import {
-  getEventsCellLaneMinHeight,
-  getRowHeightForLaneCount,
-} from './EventTimelinePremiumContent';
+import { getEventsCellLaneMinHeight, getRowHeightForLaneCount } from './rowGeometry';
 
 // These helpers mirror the EventsCell CSS in JS so the virtualizer can reserve the
 // correct vertical space per row. The two paths must agree to the pixel — if either

--- a/packages/x-scheduler-premium/src/event-timeline-premium/content/getVisibleFractionRange.test.ts
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/content/getVisibleFractionRange.test.ts
@@ -1,0 +1,17 @@
+import { getVisibleFractionRange } from './getVisibleFractionRange';
+
+describe('getVisibleFractionRange', () => {
+  it('should offset the rendered columns by the title column when converting to fractions', () => {
+    // Columns 5–13 render ticks 4–12 out of 24.
+    expect(getVisibleFractionRange({ firstColumnIndex: 5, lastColumnIndex: 13 }, 24)).to.deep.equal(
+      { start: 4 / 24, end: 12 / 24 },
+    );
+  });
+
+  it('should clamp the range start when the title column is the first rendered column', () => {
+    expect(getVisibleFractionRange({ firstColumnIndex: 0, lastColumnIndex: 9 }, 24)).to.deep.equal({
+      start: 0,
+      end: 8 / 24,
+    });
+  });
+});

--- a/packages/x-scheduler-premium/src/event-timeline-premium/content/getVisibleFractionRange.ts
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/content/getVisibleFractionRange.ts
@@ -1,0 +1,14 @@
+/**
+ * Converts the virtualizer's rendered column range into a fraction range of the events
+ * area. The virtualizer's column 0 is the pinned title column, so tick `n` renders in
+ * column `n + 1`.
+ */
+export function getVisibleFractionRange(
+  renderContext: { firstColumnIndex: number; lastColumnIndex: number },
+  tickCount: number,
+): { start: number; end: number } {
+  return {
+    start: Math.max(0, renderContext.firstColumnIndex - 1) / tickCount,
+    end: Math.max(0, renderContext.lastColumnIndex - 1) / tickCount,
+  };
+}

--- a/packages/x-scheduler-premium/src/event-timeline-premium/content/rowGeometry.ts
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/content/rowGeometry.ts
@@ -12,7 +12,7 @@ import type { Theme } from '@mui/material/styles';
 //   border-bottom: 1px solid divider;
 //
 // `em` in the grid track resolves against the EventsCell's font-size, which
-// inherits `theme.typography.body2.fontSize` from the Content root.
+// inherits `theme.typography.body2.fontSize` from the `EventTimelinePremium` root.
 export function getEventsCellLaneMinHeight(theme: Theme): number {
   const fontSizeRem = parseFloat(String(theme.typography.body2.fontSize));
   const fontSize =

--- a/packages/x-scheduler-premium/src/event-timeline-premium/content/rowGeometry.ts
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/content/rowGeometry.ts
@@ -1,0 +1,58 @@
+import type { Theme } from '@mui/material/styles';
+
+// `EventsCell` is the tallest in-flow child of the body row and therefore drives
+// its rendered height. These helpers mirror the CSS so the virtualizer's
+// `getRowHeight` returns the same value the browser will lay out.
+//
+// CSS for EventsCell:
+//   padding: theme.spacing(2, 0);
+//   grid-template-rows: repeat(var(--lane-count, 1),
+//                              minmax(calc(${body2.lineHeight}em + ${theme.spacing(1.125)}), auto));
+//   row-gap: theme.spacing(0.5);
+//   border-bottom: 1px solid divider;
+//
+// `em` in the grid track resolves against the EventsCell's font-size, which
+// inherits `theme.typography.body2.fontSize` from the Content root.
+export function getEventsCellLaneMinHeight(theme: Theme): number {
+  const fontSizeRem = parseFloat(String(theme.typography.body2.fontSize));
+  const fontSize =
+    Number.isFinite(fontSizeRem) && fontSizeRem > 0
+      ? fontSizeRem * (theme.typography.htmlFontSize ?? 16)
+      : 14;
+  const lineHeight = Number(theme.typography.body2.lineHeight) || 1.43;
+  const extra = parseFloat(theme.spacing(1.125)) || 9;
+  return lineHeight * fontSize + extra;
+}
+
+export function getRowHeightForLaneCount(theme: Theme, laneCount: number): number {
+  const { topPadding, laneMinHeight, laneGap } = getEventsCellLaneMetrics(theme);
+  const lanes = Math.max(1, laneCount);
+  // 2 paddings + N lanes + (N-1) row-gaps + bottom border.
+  return 2 * topPadding + lanes * laneMinHeight + (lanes - 1) * laneGap + 1;
+}
+
+export interface EventsCellLaneMetrics {
+  /**
+   * The `EventsCell` vertical padding, above the first lane.
+   */
+  topPadding: number;
+  /**
+   * The minimum height of one lane (one grid track).
+   */
+  laneMinHeight: number;
+  /**
+   * The gap between two consecutive lanes.
+   */
+  laneGap: number;
+}
+
+/**
+ * The vertical metrics of the lanes inside an `EventsCell`, mirroring its CSS.
+ */
+export function getEventsCellLaneMetrics(theme: Theme): EventsCellLaneMetrics {
+  return {
+    topPadding: parseFloat(theme.spacing(2)) || 16,
+    laneMinHeight: getEventsCellLaneMinHeight(theme),
+    laneGap: parseFloat(theme.spacing(0.5)) || 4,
+  };
+}

--- a/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-dependency-arrows/EventTimelinePremiumDependencyArrows.tsx
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-dependency-arrows/EventTimelinePremiumDependencyArrows.tsx
@@ -30,6 +30,10 @@ const DependencyArrowsSvg = styled('svg', {
   top: 0,
   left: 'var(--title-column-width)',
   pointerEvents: 'none',
+  // The entry and exit stubs reach a few px outside the viewBox when an anchor sits at
+  // the timeline edge; the SVG root clips them by default. The pinned title column and
+  // the header row paint above the overlay, so the spill never shows over them.
+  overflow: 'visible',
   // Same layer as the current time indicator: above the events cells, below the pinned
   // title column, which covers the arrows on horizontal scroll.
   zIndex: 2,

--- a/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-dependency-arrows/EventTimelinePremiumDependencyArrows.tsx
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-dependency-arrows/EventTimelinePremiumDependencyArrows.tsx
@@ -14,6 +14,7 @@ import type { SchedulerDependency } from '@mui/x-scheduler-internals-premium/mod
 import { useEventTimelinePremiumStyledContext } from '../../EventTimelinePremiumStyledContext';
 import { useEventTimelinePremiumVirtualizerStore } from '../EventTimelinePremiumVirtualizerContext';
 import { getEventsCellLaneMetrics } from '../rowGeometry';
+import { getVisibleFractionRange } from '../getVisibleFractionRange';
 import { computeDependencyArrows, DEPENDENCY_ARROWHEAD_SIZE } from './dependencyArrowGeometry';
 
 const DEPENDENCY_ARROW_STROKE_WIDTH = 1;
@@ -105,10 +106,10 @@ function DependencyArrowsLayer({ dependencies }: { dependencies: readonly Schedu
   // Only render the arrows intersecting the visible range. Row-range overlap (rather
   // than endpoint visibility) keeps an arrow whose vertical segment crosses the
   // viewport even when both of its endpoints are scrolled out.
-  const visibleStartFraction =
-    Math.max(0, renderContext.firstColumnIndex - 1) / presetConfig.tickCount;
-  const visibleEndFraction =
-    Math.max(0, renderContext.lastColumnIndex - 1) / presetConfig.tickCount;
+  const { start: visibleStartFraction, end: visibleEndFraction } = getVisibleFractionRange(
+    renderContext,
+    presetConfig.tickCount,
+  );
   const visibleArrows = arrows.filter(
     (arrow) =>
       arrow.maxXFraction > visibleStartFraction &&

--- a/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-dependency-arrows/EventTimelinePremiumDependencyArrows.tsx
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-dependency-arrows/EventTimelinePremiumDependencyArrows.tsx
@@ -30,10 +30,6 @@ const DependencyArrowsSvg = styled('svg', {
   top: 0,
   left: 'var(--title-column-width)',
   pointerEvents: 'none',
-  // The entry and exit stubs reach a few px outside the viewBox when an anchor sits at
-  // the timeline edge; the SVG root clips them by default. The pinned title column and
-  // the header row paint above the overlay, so the spill never shows over them.
-  overflow: 'visible',
   // Same layer as the current time indicator: above the events cells, below the pinned
   // title column, which covers the arrows on horizontal scroll.
   zIndex: 2,

--- a/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-dependency-arrows/EventTimelinePremiumDependencyArrows.tsx
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-dependency-arrows/EventTimelinePremiumDependencyArrows.tsx
@@ -158,7 +158,7 @@ function DependencyArrowsLayer({ dependencies }: { dependencies: readonly Schedu
       </defs>
       {visibleArrows.map((arrow) => (
         <path
-          key={String(arrow.id)}
+          key={arrow.key}
           data-dependency-id={String(arrow.id)}
           d={arrow.d}
           fill="none"

--- a/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-dependency-arrows/EventTimelinePremiumDependencyArrows.tsx
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-dependency-arrows/EventTimelinePremiumDependencyArrows.tsx
@@ -1,0 +1,171 @@
+'use client';
+import * as React from 'react';
+import { styled, useTheme } from '@mui/material/styles';
+import { useStore } from '@base-ui/utils/store';
+import { Dimensions, Virtualization } from '@mui/x-virtualizer';
+import { useAdapterContext } from '@mui/x-scheduler-internals/use-adapter-context';
+import { schedulerOccurrenceSelectors } from '@mui/x-scheduler-internals/scheduler-selectors';
+import { useEventTimelinePremiumStoreContext } from '@mui/x-scheduler-internals-premium/use-event-timeline-premium-store-context';
+import {
+  eventTimelinePremiumDependencySelectors,
+  eventTimelinePremiumPresetSelectors,
+} from '@mui/x-scheduler-internals-premium/event-timeline-premium-selectors';
+import type { SchedulerDependency } from '@mui/x-scheduler-internals-premium/models';
+import { useEventTimelinePremiumStyledContext } from '../../EventTimelinePremiumStyledContext';
+import { useEventTimelinePremiumVirtualizerStore } from '../EventTimelinePremiumVirtualizerContext';
+import { getEventsCellLaneMetrics } from '../rowGeometry';
+import { computeDependencyArrows, DEPENDENCY_ARROWHEAD_SIZE } from './dependencyArrowGeometry';
+
+const DEPENDENCY_ARROW_STROKE_WIDTH = 1;
+
+// TODO(dependencies public flip): add a `dependencyArrows` utility class and assert the
+// slot in the theme augmentation. The overlay only carries data attributes while the
+// feature has no public API.
+const DependencyArrowsSvg = styled('svg', {
+  name: 'MuiEventTimeline',
+  slot: 'DependencyArrows',
+})(({ theme }) => ({
+  position: 'absolute',
+  top: 0,
+  left: 'var(--title-column-width)',
+  pointerEvents: 'none',
+  // Same layer as the current time indicator: above the events cells, below the pinned
+  // title column, which covers the arrows on horizontal scroll.
+  zIndex: 2,
+  color: (theme.vars || theme).palette.grey[400],
+  ...theme.applyStyles('dark', {
+    color: (theme.vars || theme).palette.grey[600],
+  }),
+}));
+
+/**
+ * Renders the arrows of the active dependencies over the timeline rows.
+ * Rendering-only: it subscribes to the dependencies state slice and never mutates it.
+ */
+export function EventTimelinePremiumDependencyArrows() {
+  const store = useEventTimelinePremiumStoreContext();
+  const dependencies = useStore(store, eventTimelinePremiumDependencySelectors.activeModelList);
+
+  if (dependencies.length === 0) {
+    return null;
+  }
+
+  return <DependencyArrowsLayer dependencies={dependencies} />;
+}
+
+/**
+ * Isolated like `EventList` so that scrolling (which updates `renderContext`) only
+ * re-renders this subtree. Arrow paths are computed from the data model — never from
+ * the DOM — so they can anchor on events the virtualizer did not mount, and they only
+ * change when an event or dependency changes, not on scroll.
+ */
+function DependencyArrowsLayer({ dependencies }: { dependencies: readonly SchedulerDependency[] }) {
+  const adapter = useAdapterContext();
+  const theme = useTheme();
+  const store = useEventTimelinePremiumStoreContext();
+  const virtualizerStore = useEventTimelinePremiumVirtualizerStore();
+  const { schedulerId } = useEventTimelinePremiumStyledContext();
+
+  const presetConfig = useStore(store, eventTimelinePremiumPresetSelectors.config);
+  const resources = useStore(
+    store,
+    schedulerOccurrenceSelectors.groupedByResourceList,
+    presetConfig.start,
+    presetConfig.end,
+  );
+  const rowsMeta = virtualizerStore.use(Dimensions.selectors.rowsMeta);
+  const renderContext = virtualizerStore.use(Virtualization.selectors.renderContext);
+
+  const eventsWidth = presetConfig.tickCount * presetConfig.tickWidth;
+
+  const arrows = React.useMemo(
+    () =>
+      computeDependencyArrows({
+        adapter,
+        dependencies,
+        resources,
+        rowPositions: rowsMeta.positions,
+        collectionStart: presetConfig.start,
+        collectionEnd: presetConfig.end,
+        eventsWidth,
+        laneMetrics: getEventsCellLaneMetrics(theme),
+      }),
+    [
+      adapter,
+      dependencies,
+      resources,
+      rowsMeta.positions,
+      presetConfig.start,
+      presetConfig.end,
+      eventsWidth,
+      theme,
+    ],
+  );
+
+  // Only render the arrows intersecting the visible range. Row-range overlap (rather
+  // than endpoint visibility) keeps an arrow whose vertical segment crosses the
+  // viewport even when both of its endpoints are scrolled out.
+  const visibleStartFraction =
+    Math.max(0, renderContext.firstColumnIndex - 1) / presetConfig.tickCount;
+  const visibleEndFraction =
+    Math.max(0, renderContext.lastColumnIndex - 1) / presetConfig.tickCount;
+  const visibleArrows = arrows.filter(
+    (arrow) =>
+      arrow.maxXFraction > visibleStartFraction &&
+      arrow.minXFraction < visibleEndFraction &&
+      arrow.maxRowIndex >= renderContext.firstRowIndex &&
+      arrow.minRowIndex <= renderContext.lastRowIndex,
+  );
+
+  // The overlay's y = 0 is the top of the first rendered row (the positioner offsets
+  // the row container), while the paths are in absolute row-space. The viewBox maps
+  // one to the other and clips the arrows reaching off-screen anchors.
+  const offsetTop = rowsMeta.positions[renderContext.firstRowIndex] ?? 0;
+  const height = rowsMeta.currentPageTotalHeight - offsetTop;
+
+  if (visibleArrows.length === 0 || eventsWidth <= 0 || height <= 0) {
+    return null;
+  }
+
+  const arrowheadId = `${schedulerId}-dependency-arrowhead`;
+
+  return (
+    <DependencyArrowsSvg
+      aria-hidden
+      data-dependency-arrows=""
+      width={eventsWidth}
+      height={height}
+      viewBox={`0 ${offsetTop} ${eventsWidth} ${height}`}
+    >
+      <defs>
+        <marker
+          id={arrowheadId}
+          viewBox={`0 0 ${DEPENDENCY_ARROWHEAD_SIZE} ${DEPENDENCY_ARROWHEAD_SIZE}`}
+          markerWidth={DEPENDENCY_ARROWHEAD_SIZE}
+          markerHeight={DEPENDENCY_ARROWHEAD_SIZE}
+          markerUnits="userSpaceOnUse"
+          refX={DEPENDENCY_ARROWHEAD_SIZE}
+          refY={DEPENDENCY_ARROWHEAD_SIZE / 2}
+          orient="auto"
+        >
+          <path
+            d={`M 0 0 L ${DEPENDENCY_ARROWHEAD_SIZE} ${DEPENDENCY_ARROWHEAD_SIZE / 2} L 0 ${DEPENDENCY_ARROWHEAD_SIZE} Z`}
+            fill="currentColor"
+            stroke="none"
+          />
+        </marker>
+      </defs>
+      {visibleArrows.map((arrow) => (
+        <path
+          key={String(arrow.id)}
+          data-dependency-id={String(arrow.id)}
+          d={arrow.d}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={DEPENDENCY_ARROW_STROKE_WIDTH}
+          markerEnd={`url(#${arrowheadId})`}
+        />
+      ))}
+    </DependencyArrowsSvg>
+  );
+}

--- a/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-dependency-arrows/dependencyArrowGeometry.test.ts
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-dependency-arrows/dependencyArrowGeometry.test.ts
@@ -94,7 +94,12 @@ describe('dependencyArrowGeometry', () => {
 
   describe('buildDependencyArrowRoutes', () => {
     it('should return a straight segment when the anchors share the same height and the target is forward', () => {
-      const [points] = buildDependencyArrowRoutes({ x: 10, y: 5 }, { x: 50, y: 5 }, DETOUR_OFFSET);
+      const [points] = buildDependencyArrowRoutes(
+        { x: 10, y: 5 },
+        { x: 50, y: 5 },
+        DETOUR_OFFSET,
+        EVENTS_WIDTH,
+      );
 
       expect(points).to.deep.equal([
         { x: 10, y: 5 },
@@ -103,7 +108,12 @@ describe('dependencyArrowGeometry', () => {
     });
 
     it('should return a two-corner elbow for a forward arrow between different heights', () => {
-      const [points] = buildDependencyArrowRoutes({ x: 10, y: 5 }, { x: 50, y: 40 }, DETOUR_OFFSET);
+      const [points] = buildDependencyArrowRoutes(
+        { x: 10, y: 5 },
+        { x: 50, y: 40 },
+        DETOUR_OFFSET,
+        EVENTS_WIDTH,
+      );
 
       expect(points).to.deep.equal([
         { x: 10, y: 5 },
@@ -114,47 +124,67 @@ describe('dependencyArrowGeometry', () => {
     });
 
     it('should route the S detour below the source when the target starts before the source ends', () => {
-      const [points] = buildDependencyArrowRoutes({ x: 50, y: 5 }, { x: 10, y: 40 }, DETOUR_OFFSET);
+      const [points] = buildDependencyArrowRoutes(
+        { x: 50, y: 5 },
+        { x: 20, y: 40 },
+        DETOUR_OFFSET,
+        EVENTS_WIDTH,
+      );
 
       expect(points).to.deep.equal([
         { x: 50, y: 5 },
         { x: 58, y: 5 },
         { x: 58, y: 5 + DETOUR_OFFSET },
-        { x: -2, y: 5 + DETOUR_OFFSET },
-        { x: -2, y: 40 },
-        { x: 10, y: 40 },
+        { x: 8, y: 5 + DETOUR_OFFSET },
+        { x: 8, y: 40 },
+        { x: 20, y: 40 },
       ]);
     });
 
     it('should route the S detour above the source when the target is higher', () => {
-      const [points] = buildDependencyArrowRoutes({ x: 50, y: 40 }, { x: 10, y: 5 }, DETOUR_OFFSET);
+      const [points] = buildDependencyArrowRoutes(
+        { x: 50, y: 40 },
+        { x: 20, y: 5 },
+        DETOUR_OFFSET,
+        EVENTS_WIDTH,
+      );
 
       expect(points).to.deep.equal([
         { x: 50, y: 40 },
         { x: 58, y: 40 },
         { x: 58, y: 40 - DETOUR_OFFSET },
-        { x: -2, y: 40 - DETOUR_OFFSET },
-        { x: -2, y: 5 },
-        { x: 10, y: 5 },
+        { x: 8, y: 40 - DETOUR_OFFSET },
+        { x: 8, y: 5 },
+        { x: 20, y: 5 },
       ]);
     });
 
     it('should route the S detour below the events when the anchors share the same height', () => {
-      const [points] = buildDependencyArrowRoutes({ x: 50, y: 5 }, { x: 10, y: 5 }, DETOUR_OFFSET);
+      const [points] = buildDependencyArrowRoutes(
+        { x: 50, y: 5 },
+        { x: 20, y: 5 },
+        DETOUR_OFFSET,
+        EVENTS_WIDTH,
+      );
 
       expect(points).to.deep.equal([
         { x: 50, y: 5 },
         { x: 58, y: 5 },
         { x: 58, y: 5 + DETOUR_OFFSET },
-        { x: -2, y: 5 + DETOUR_OFFSET },
-        { x: -2, y: 5 },
-        { x: 10, y: 5 },
+        { x: 8, y: 5 + DETOUR_OFFSET },
+        { x: 8, y: 5 },
+        { x: 20, y: 5 },
       ]);
     });
 
     it('should route the S detour when the target starts too close after the source ends', () => {
       // forwardX = 5: forward, but the stub and the entry clearance do not fit.
-      const [points] = buildDependencyArrowRoutes({ x: 50, y: 5 }, { x: 55, y: 40 }, DETOUR_OFFSET);
+      const [points] = buildDependencyArrowRoutes(
+        { x: 50, y: 5 },
+        { x: 55, y: 40 },
+        DETOUR_OFFSET,
+        EVENTS_WIDTH,
+      );
 
       expect(points).to.deep.equal([
         { x: 50, y: 5 },
@@ -167,7 +197,12 @@ describe('dependencyArrowGeometry', () => {
     });
 
     it('should render a short straight arrow overlapping the predecessor between two adjacent events', () => {
-      const [points] = buildDependencyArrowRoutes({ x: 50, y: 5 }, { x: 50, y: 5 }, DETOUR_OFFSET);
+      const [points] = buildDependencyArrowRoutes(
+        { x: 50, y: 5 },
+        { x: 50, y: 5 },
+        DETOUR_OFFSET,
+        EVENTS_WIDTH,
+      );
 
       expect(points).to.deep.equal([
         { x: 34, y: 5 },
@@ -176,7 +211,12 @@ describe('dependencyArrowGeometry', () => {
     });
 
     it('should return a second elbow candidate turning right before the target', () => {
-      const routes = buildDependencyArrowRoutes({ x: 10, y: 5 }, { x: 50, y: 40 }, DETOUR_OFFSET);
+      const routes = buildDependencyArrowRoutes(
+        { x: 10, y: 5 },
+        { x: 50, y: 40 },
+        DETOUR_OFFSET,
+        EVENTS_WIDTH,
+      );
 
       expect(routes).to.have.length(2);
       expect(routes[1]).to.deep.equal([
@@ -187,10 +227,67 @@ describe('dependencyArrowGeometry', () => {
       ]);
     });
 
+    it('should ride the entry onto the target when it starts too close to the timeline start', () => {
+      // The entry elbow would land at x = -7, under the pinned title column: the
+      // vertical clamps to x = 0 and the arrowhead rides over the target's start.
+      const [points] = buildDependencyArrowRoutes(
+        { x: 50, y: 5 },
+        { x: 5, y: 40 },
+        DETOUR_OFFSET,
+        EVENTS_WIDTH,
+      );
+
+      expect(points).to.deep.equal([
+        { x: 50, y: 5 },
+        { x: 58, y: 5 },
+        { x: 58, y: 5 + DETOUR_OFFSET },
+        { x: 0, y: 5 + DETOUR_OFFSET },
+        { x: 0, y: 40 },
+        { x: 12, y: 40 },
+      ]);
+    });
+
+    it('should ride the exit onto the source when it ends at the timeline end', () => {
+      const [points] = buildDependencyArrowRoutes(
+        { x: EVENTS_WIDTH, y: 5 },
+        { x: 30, y: 40 },
+        DETOUR_OFFSET,
+        EVENTS_WIDTH,
+      );
+
+      expect(points).to.deep.equal([
+        { x: 1432, y: 5 },
+        { x: 1440, y: 5 },
+        { x: 1440, y: 5 + DETOUR_OFFSET },
+        { x: 18, y: 5 + DETOUR_OFFSET },
+        { x: 18, y: 40 },
+        { x: 30, y: 40 },
+      ]);
+    });
+
+    it('should clamp the short adjacent arrow at the timeline start', () => {
+      const [points] = buildDependencyArrowRoutes(
+        { x: 10, y: 5 },
+        { x: 10, y: 5 },
+        DETOUR_OFFSET,
+        EVENTS_WIDTH,
+      );
+
+      expect(points).to.deep.equal([
+        { x: 0, y: 5 },
+        { x: 10, y: 5 },
+      ]);
+    });
+
     it('should return a single elbow candidate when both turns collapse to the same x', () => {
       // forwardX = 20: the early turn (source + stub) and the late turn (target −
       // clearance) land on the same vertical.
-      const routes = buildDependencyArrowRoutes({ x: 10, y: 5 }, { x: 30, y: 40 }, DETOUR_OFFSET);
+      const routes = buildDependencyArrowRoutes(
+        { x: 10, y: 5 },
+        { x: 30, y: 40 },
+        DETOUR_OFFSET,
+        EVENTS_WIDTH,
+      );
 
       expect(routes).to.have.length(1);
       expect(routes[0]).to.deep.equal([
@@ -388,7 +485,7 @@ describe('dependencyArrowGeometry', () => {
       expect(arrows[0].maxRowIndex).to.equal(0);
     });
 
-    it('should clamp the route to the events area when an anchor sits at a timeline edge', () => {
+    it('should keep the route inside the events area when an anchor sits at a timeline edge', () => {
       // Ends at 24:00 → end x = 1440, the exit stub would leave the events area.
       const lateEvent = EventBuilder.new()
         .id('event-late')
@@ -416,9 +513,10 @@ describe('dependencyArrowGeometry', () => {
       });
 
       expect(arrows).to.have.length(1);
-      // The exit stub collapses on the right edge and the entry elbow hugs x = 0.
+      // Both stubs ride over their event: the exit starts 8px before the source's end
+      // edge and the arrowhead lands 12px past the target's start edge.
       expect(arrows[0].d).to.equal(
-        'M 1440 31 L 1440 48 Q 1440 52 1436 52 L 4 52 Q 0 52 0 56 L 0 90.5 Q 0 93 2.5 93 L 5 93',
+        'M 1432 31 L 1436 31 Q 1440 31 1440 35 L 1440 48 Q 1440 52 1436 52 L 4 52 Q 0 52 0 56 L 0 89 Q 0 93 4 93 L 12 93',
       );
       expect(arrows[0].minXFraction).to.equal(0);
       expect(arrows[0].maxXFraction).to.equal(1);

--- a/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-dependency-arrows/dependencyArrowGeometry.test.ts
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-dependency-arrows/dependencyArrowGeometry.test.ts
@@ -152,6 +152,20 @@ describe('dependencyArrowGeometry', () => {
       ]);
     });
 
+    it('should route the S detour when the target starts too close after the source ends', () => {
+      // forwardX = 5: forward, but the stub and the entry clearance do not fit.
+      const [points] = buildDependencyArrowRoutes({ x: 50, y: 5 }, { x: 55, y: 40 }, DETOUR_OFFSET);
+
+      expect(points).to.deep.equal([
+        { x: 50, y: 5 },
+        { x: 58, y: 5 },
+        { x: 58, y: 5 + DETOUR_OFFSET },
+        { x: 43, y: 5 + DETOUR_OFFSET },
+        { x: 43, y: 40 },
+        { x: 55, y: 40 },
+      ]);
+    });
+
     it('should render a short straight arrow overlapping the predecessor between two adjacent events', () => {
       const [points] = buildDependencyArrowRoutes({ x: 50, y: 5 }, { x: 50, y: 5 }, DETOUR_OFFSET);
 
@@ -170,6 +184,20 @@ describe('dependencyArrowGeometry', () => {
         { x: 38, y: 5 },
         { x: 38, y: 40 },
         { x: 50, y: 40 },
+      ]);
+    });
+
+    it('should return a single elbow candidate when both turns collapse to the same x', () => {
+      // forwardX = 20: the early turn (source + stub) and the late turn (target −
+      // clearance) land on the same vertical.
+      const routes = buildDependencyArrowRoutes({ x: 10, y: 5 }, { x: 30, y: 40 }, DETOUR_OFFSET);
+
+      expect(routes).to.have.length(1);
+      expect(routes[0]).to.deep.equal([
+        { x: 10, y: 5 },
+        { x: 18, y: 5 },
+        { x: 18, y: 40 },
+        { x: 30, y: 40 },
       ]);
     });
   });
@@ -358,6 +386,21 @@ describe('dependencyArrowGeometry', () => {
 
       expect(arrows).to.have.length(1);
       expect(arrows[0].maxRowIndex).to.equal(0);
+    });
+
+    it('should return no arrow when the events area has no width', () => {
+      const arrows = computeDependencyArrows({
+        adapter,
+        dependencies: [buildDependency('dep-1', 'event-a', 'event-b')],
+        resources: [{ resource: RESOURCE_1, occurrences: getOccurrences([eventA, eventB]) }],
+        rowPositions: [0],
+        collectionStart,
+        collectionEnd,
+        eventsWidth: 0,
+        laneMetrics: LANE_METRICS,
+      });
+
+      expect(arrows).to.deep.equal([]);
     });
 
     it('should return no arrow when there is no dependency', () => {

--- a/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-dependency-arrows/dependencyArrowGeometry.test.ts
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-dependency-arrows/dependencyArrowGeometry.test.ts
@@ -464,7 +464,7 @@ describe('dependencyArrowGeometry', () => {
       expect(arrows.map((arrow) => arrow.id)).to.deep.equal(['dep-1']);
     });
 
-    it('should anchor an event rendered in several rows on its first row', () => {
+    it('should render an arrow to every row appearance of the target event', () => {
       const occurrencesB = getOccurrences([eventB]);
 
       const arrows = computeDependencyArrows({
@@ -481,8 +481,35 @@ describe('dependencyArrowGeometry', () => {
         laneMetrics: LANE_METRICS,
       });
 
-      expect(arrows).to.have.length(1);
-      expect(arrows[0].maxRowIndex).to.equal(0);
+      expect(arrows.map((arrow) => arrow.id)).to.deep.equal(['dep-1', 'dep-1']);
+      expect(arrows.map((arrow) => arrow.key)).to.deep.equal(['dep-1:0:0', 'dep-1:0:1']);
+      expect(arrows.map((arrow) => arrow.maxRowIndex)).to.deep.equal([0, 1]);
+    });
+
+    it('should render an arrow for every pair of appearances when both events span several rows', () => {
+      const occurrencesA = getOccurrences([eventA]);
+      const occurrencesB = getOccurrences([eventB]);
+
+      const arrows = computeDependencyArrows({
+        adapter,
+        dependencies: [buildDependency('dep-1', 'event-a', 'event-b')],
+        resources: [
+          { resource: RESOURCE_1, occurrences: [...occurrencesA, ...occurrencesB] },
+          { resource: RESOURCE_2, occurrences: [...occurrencesA, ...occurrencesB] },
+        ],
+        rowPositions: [0, 62],
+        collectionStart,
+        collectionEnd,
+        eventsWidth: EVENTS_WIDTH,
+        laneMetrics: LANE_METRICS,
+      });
+
+      expect(arrows.map((arrow) => arrow.key)).to.deep.equal([
+        'dep-1:0:0',
+        'dep-1:0:1',
+        'dep-1:1:0',
+        'dep-1:1:1',
+      ]);
     });
 
     it('should keep the route inside the events area when an anchor sits at a timeline edge', () => {

--- a/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-dependency-arrows/dependencyArrowGeometry.test.ts
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-dependency-arrows/dependencyArrowGeometry.test.ts
@@ -1,0 +1,378 @@
+import { adapter, EventBuilder, ResourceBuilder } from 'test/utils/scheduler';
+import type { SchedulerProcessedEvent } from '@mui/x-scheduler-internals/models';
+import { getOccurrencesFromEvents } from '@mui/x-scheduler-internals/internals';
+import type { SchedulerDependency } from '@mui/x-scheduler-internals-premium/models';
+import {
+  buildDependencyArrowRoutes,
+  buildRoundedOrthogonalPath,
+  computeDependencyArrows,
+} from './dependencyArrowGeometry';
+
+const collectionStart = adapter.date('2024-01-15', 'default');
+const collectionEnd = adapter.endOfDay(collectionStart);
+
+// 1440 minutes in the collection and eventsWidth = 1440 → 1px per minute.
+const EVENTS_WIDTH = 1440;
+const LANE_METRICS = { topPadding: 16, laneMinHeight: 30, laneGap: 4 };
+// Offset the S route detours below same-height anchors (laneMinHeight / 2 + clearance).
+const DETOUR_OFFSET = 21;
+// One-lane rows: the anchor sits at rowPosition + topPadding + laneMinHeight / 2.
+const LANE_1_CENTER = LANE_METRICS.topPadding + LANE_METRICS.laneMinHeight / 2;
+
+const RESOURCE_1 = ResourceBuilder.new().id('r1').title('Resource 1').build();
+const RESOURCE_2 = ResourceBuilder.new().id('r2').title('Resource 2').build();
+
+function getOccurrences(events: SchedulerProcessedEvent[]) {
+  return getOccurrencesFromEvents({
+    adapter,
+    start: collectionStart,
+    end: collectionEnd,
+    events,
+    displayTimezone: 'default',
+    visibleResources: {},
+    recurringEventsPlugin: null,
+  });
+}
+
+function buildDependency(id: string, source: string, target: string): SchedulerDependency {
+  return { id, source, target, type: 'FinishToStart' };
+}
+
+describe('dependencyArrowGeometry', () => {
+  describe('buildRoundedOrthogonalPath', () => {
+    it('should return a straight path for two points', () => {
+      expect(
+        buildRoundedOrthogonalPath(
+          [
+            { x: 0, y: 0 },
+            { x: 10, y: 0 },
+          ],
+          4,
+        ),
+      ).to.equal('M 0 0 L 10 0');
+    });
+
+    it('should soften a corner with a quadratic curve', () => {
+      expect(
+        buildRoundedOrthogonalPath(
+          [
+            { x: 0, y: 0 },
+            { x: 10, y: 0 },
+            { x: 10, y: 20 },
+          ],
+          4,
+        ),
+      ).to.equal('M 0 0 L 6 0 Q 10 0 10 4 L 10 20');
+    });
+
+    it('should clamp the corner radius to half of the shortest adjacent segment', () => {
+      expect(
+        buildRoundedOrthogonalPath(
+          [
+            { x: 0, y: 0 },
+            { x: 2, y: 0 },
+            { x: 2, y: 10 },
+          ],
+          4,
+        ),
+      ).to.equal('M 0 0 L 1 0 Q 2 0 2 1 L 2 10');
+    });
+
+    it('should collapse consecutive duplicated points', () => {
+      expect(
+        buildRoundedOrthogonalPath(
+          [
+            { x: 0, y: 0 },
+            { x: 0, y: 0 },
+            { x: 5, y: 0 },
+          ],
+          4,
+        ),
+      ).to.equal('M 0 0 L 5 0');
+    });
+  });
+
+  describe('buildDependencyArrowRoutes', () => {
+    it('should return a straight segment when the anchors share the same height and the target is forward', () => {
+      const [points] = buildDependencyArrowRoutes({ x: 10, y: 5 }, { x: 50, y: 5 }, DETOUR_OFFSET);
+
+      expect(points).to.deep.equal([
+        { x: 10, y: 5 },
+        { x: 50, y: 5 },
+      ]);
+    });
+
+    it('should return a two-corner elbow for a forward arrow between different heights', () => {
+      const [points] = buildDependencyArrowRoutes({ x: 10, y: 5 }, { x: 50, y: 40 }, DETOUR_OFFSET);
+
+      expect(points).to.deep.equal([
+        { x: 10, y: 5 },
+        { x: 18, y: 5 },
+        { x: 18, y: 40 },
+        { x: 50, y: 40 },
+      ]);
+    });
+
+    it('should route the S detour below the source when the target starts before the source ends', () => {
+      const [points] = buildDependencyArrowRoutes({ x: 50, y: 5 }, { x: 10, y: 40 }, DETOUR_OFFSET);
+
+      expect(points).to.deep.equal([
+        { x: 50, y: 5 },
+        { x: 58, y: 5 },
+        { x: 58, y: 5 + DETOUR_OFFSET },
+        { x: -2, y: 5 + DETOUR_OFFSET },
+        { x: -2, y: 40 },
+        { x: 10, y: 40 },
+      ]);
+    });
+
+    it('should route the S detour above the source when the target is higher', () => {
+      const [points] = buildDependencyArrowRoutes({ x: 50, y: 40 }, { x: 10, y: 5 }, DETOUR_OFFSET);
+
+      expect(points).to.deep.equal([
+        { x: 50, y: 40 },
+        { x: 58, y: 40 },
+        { x: 58, y: 40 - DETOUR_OFFSET },
+        { x: -2, y: 40 - DETOUR_OFFSET },
+        { x: -2, y: 5 },
+        { x: 10, y: 5 },
+      ]);
+    });
+
+    it('should route the S detour below the events when the anchors share the same height', () => {
+      const [points] = buildDependencyArrowRoutes({ x: 50, y: 5 }, { x: 10, y: 5 }, DETOUR_OFFSET);
+
+      expect(points).to.deep.equal([
+        { x: 50, y: 5 },
+        { x: 58, y: 5 },
+        { x: 58, y: 5 + DETOUR_OFFSET },
+        { x: -2, y: 5 + DETOUR_OFFSET },
+        { x: -2, y: 5 },
+        { x: 10, y: 5 },
+      ]);
+    });
+
+    it('should render a short straight arrow overlapping the predecessor between two adjacent events', () => {
+      const [points] = buildDependencyArrowRoutes({ x: 50, y: 5 }, { x: 50, y: 5 }, DETOUR_OFFSET);
+
+      expect(points).to.deep.equal([
+        { x: 34, y: 5 },
+        { x: 50, y: 5 },
+      ]);
+    });
+
+    it('should return a second elbow candidate turning right before the target', () => {
+      const routes = buildDependencyArrowRoutes({ x: 10, y: 5 }, { x: 50, y: 40 }, DETOUR_OFFSET);
+
+      expect(routes).to.have.length(2);
+      expect(routes[1]).to.deep.equal([
+        { x: 10, y: 5 },
+        { x: 38, y: 5 },
+        { x: 38, y: 40 },
+        { x: 50, y: 40 },
+      ]);
+    });
+  });
+
+  describe('computeDependencyArrows', () => {
+    // 10:00–12:00 UTC → end x = 720. 13:00–14:00 UTC → start x = 780.
+    const eventA = EventBuilder.new()
+      .id('event-a')
+      .singleDay('2024-01-15T10:00:00Z', 120)
+      .toProcessed();
+    const eventB = EventBuilder.new().id('event-b').singleDay('2024-01-15T13:00:00Z').toProcessed();
+    const eventC = EventBuilder.new().id('event-c').singleDay('2024-01-15T13:00:00Z').toProcessed();
+
+    it('should return a straight arrow between two events in the same row and lane', () => {
+      const arrows = computeDependencyArrows({
+        adapter,
+        dependencies: [buildDependency('dep-1', 'event-a', 'event-b')],
+        resources: [{ resource: RESOURCE_1, occurrences: getOccurrences([eventA, eventB]) }],
+        rowPositions: [0],
+        collectionStart,
+        collectionEnd,
+        eventsWidth: EVENTS_WIDTH,
+        laneMetrics: LANE_METRICS,
+      });
+
+      expect(arrows).to.have.length(1);
+      expect(arrows[0].d).to.equal(`M 720 ${LANE_1_CENTER} L 780 ${LANE_1_CENTER}`);
+      expect(arrows[0].minXFraction).to.equal(720 / EVENTS_WIDTH);
+      expect(arrows[0].maxXFraction).to.equal(780 / EVENTS_WIDTH);
+      expect(arrows[0].minRowIndex).to.equal(0);
+      expect(arrows[0].maxRowIndex).to.equal(0);
+    });
+
+    it('should route an orthogonal elbow between two rows using the row positions', () => {
+      const arrows = computeDependencyArrows({
+        adapter,
+        dependencies: [buildDependency('dep-1', 'event-a', 'event-c')],
+        resources: [
+          { resource: RESOURCE_1, occurrences: getOccurrences([eventA]) },
+          { resource: RESOURCE_2, occurrences: getOccurrences([eventC]) },
+        ],
+        rowPositions: [0, 62],
+        collectionStart,
+        collectionEnd,
+        eventsWidth: EVENTS_WIDTH,
+        laneMetrics: LANE_METRICS,
+      });
+
+      expect(arrows).to.have.length(1);
+      // Source y = 31 (row 0), target y = 62 + 31 = 93 (row 1), turn at x = 720 + 8.
+      expect(arrows[0].d).to.equal(
+        'M 720 31 L 724 31 Q 728 31 728 35 L 728 89 Q 728 93 732 93 L 780 93',
+      );
+      expect(arrows[0].minRowIndex).to.equal(0);
+      expect(arrows[0].maxRowIndex).to.equal(1);
+    });
+
+    it('should place an event overlapping another one in its lane', () => {
+      // event-d overlaps event-a → lane 2 of row 0.
+      const eventD = EventBuilder.new()
+        .id('event-d')
+        .singleDay('2024-01-15T11:00:00Z', 240)
+        .toProcessed();
+
+      const arrows = computeDependencyArrows({
+        adapter,
+        dependencies: [buildDependency('dep-1', 'event-a', 'event-d')],
+        resources: [{ resource: RESOURCE_1, occurrences: getOccurrences([eventA, eventD]) }],
+        rowPositions: [0],
+        collectionStart,
+        collectionEnd,
+        eventsWidth: EVENTS_WIDTH,
+        laneMetrics: LANE_METRICS,
+      });
+
+      expect(arrows).to.have.length(1);
+      // Backward S route: source (720, 31, lane 1) → target (660, 65, lane 2), detour
+      // hugging the source at y = 31 + 21.
+      expect(arrows[0].d).to.equal(
+        'M 720 31 L 724 31 Q 728 31 728 35 L 728 48 Q 728 52 724 52 L 652 52 Q 648 52 648 56 L 648 61 Q 648 65 652 65 L 660 65',
+      );
+      // The bounding box includes the stub and entry-clearance overhangs.
+      expect(arrows[0].minXFraction).to.equal(648 / EVENTS_WIDTH);
+      expect(arrows[0].maxXFraction).to.equal(728 / EVENTS_WIDTH);
+    });
+
+    it('should turn before the target when the default elbow crosses an event', () => {
+      // The obstacle (11:30–13:15) sits on the default vertical at x = 728; the late
+      // turn at x = 840 − 12 avoids it.
+      const obstacle = EventBuilder.new()
+        .id('event-o')
+        .singleDay('2024-01-15T11:30:00Z', 105)
+        .toProcessed();
+      const eventT = EventBuilder.new()
+        .id('event-t')
+        .singleDay('2024-01-15T14:00:00Z')
+        .toProcessed();
+
+      const arrows = computeDependencyArrows({
+        adapter,
+        dependencies: [buildDependency('dep-1', 'event-a', 'event-t')],
+        resources: [
+          { resource: RESOURCE_1, occurrences: getOccurrences([eventA]) },
+          { resource: RESOURCE_2, occurrences: getOccurrences([obstacle, eventT]) },
+        ],
+        rowPositions: [0, 62],
+        collectionStart,
+        collectionEnd,
+        eventsWidth: EVENTS_WIDTH,
+        laneMetrics: LANE_METRICS,
+      });
+
+      expect(arrows).to.have.length(1);
+      expect(arrows[0].d).to.equal(
+        'M 720 31 L 824 31 Q 828 31 828 35 L 828 89 Q 828 93 832 93 L 840 93',
+      );
+    });
+
+    it('should keep the default turn when every candidate crosses an event', () => {
+      // The obstacle (9:00–15:00) covers both candidate verticals.
+      const obstacle = EventBuilder.new()
+        .id('event-o')
+        .singleDay('2024-01-15T09:00:00Z', 360)
+        .toProcessed();
+      const eventT = EventBuilder.new()
+        .id('event-t')
+        .singleDay('2024-01-15T14:00:00Z')
+        .toProcessed();
+      const resource3 = ResourceBuilder.new().id('r3').title('Resource 3').build();
+
+      const arrows = computeDependencyArrows({
+        adapter,
+        dependencies: [buildDependency('dep-1', 'event-a', 'event-t')],
+        resources: [
+          { resource: RESOURCE_1, occurrences: getOccurrences([eventA]) },
+          { resource: RESOURCE_2, occurrences: getOccurrences([obstacle]) },
+          { resource: resource3, occurrences: getOccurrences([eventT]) },
+        ],
+        rowPositions: [0, 62, 124],
+        collectionStart,
+        collectionEnd,
+        eventsWidth: EVENTS_WIDTH,
+        laneMetrics: LANE_METRICS,
+      });
+
+      expect(arrows).to.have.length(1);
+      expect(arrows[0].d).to.equal(
+        'M 720 31 L 724 31 Q 728 31 728 35 L 728 151 Q 728 155 732 155 L 840 155',
+      );
+    });
+
+    it('should skip a dependency when one of its events has no occurrence in any row', () => {
+      const arrows = computeDependencyArrows({
+        adapter,
+        dependencies: [
+          buildDependency('dep-1', 'event-a', 'event-b'),
+          buildDependency('dep-2', 'event-a', 'event-x'),
+        ],
+        resources: [{ resource: RESOURCE_1, occurrences: getOccurrences([eventA, eventB]) }],
+        rowPositions: [0],
+        collectionStart,
+        collectionEnd,
+        eventsWidth: EVENTS_WIDTH,
+        laneMetrics: LANE_METRICS,
+      });
+
+      expect(arrows.map((arrow) => arrow.id)).to.deep.equal(['dep-1']);
+    });
+
+    it('should anchor an event rendered in several rows on its first row', () => {
+      const occurrencesB = getOccurrences([eventB]);
+
+      const arrows = computeDependencyArrows({
+        adapter,
+        dependencies: [buildDependency('dep-1', 'event-a', 'event-b')],
+        resources: [
+          { resource: RESOURCE_1, occurrences: [...getOccurrences([eventA]), ...occurrencesB] },
+          { resource: RESOURCE_2, occurrences: occurrencesB },
+        ],
+        rowPositions: [0, 62],
+        collectionStart,
+        collectionEnd,
+        eventsWidth: EVENTS_WIDTH,
+        laneMetrics: LANE_METRICS,
+      });
+
+      expect(arrows).to.have.length(1);
+      expect(arrows[0].maxRowIndex).to.equal(0);
+    });
+
+    it('should return no arrow when there is no dependency', () => {
+      const arrows = computeDependencyArrows({
+        adapter,
+        dependencies: [],
+        resources: [{ resource: RESOURCE_1, occurrences: getOccurrences([eventA]) }],
+        rowPositions: [0],
+        collectionStart,
+        collectionEnd,
+        eventsWidth: EVENTS_WIDTH,
+        laneMetrics: LANE_METRICS,
+      });
+
+      expect(arrows).to.deep.equal([]);
+    });
+  });
+});

--- a/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-dependency-arrows/dependencyArrowGeometry.test.ts
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-dependency-arrows/dependencyArrowGeometry.test.ts
@@ -388,6 +388,42 @@ describe('dependencyArrowGeometry', () => {
       expect(arrows[0].maxRowIndex).to.equal(0);
     });
 
+    it('should clamp the route to the events area when an anchor sits at a timeline edge', () => {
+      // Ends at 24:00 → end x = 1440, the exit stub would leave the events area.
+      const lateEvent = EventBuilder.new()
+        .id('event-late')
+        .singleDay('2024-01-15T23:00:00Z', 60)
+        .toProcessed();
+      // Starts at 00:05 → start x = 5, the entry elbow would land at x = -7, under
+      // the pinned title column.
+      const earlyEvent = EventBuilder.new()
+        .id('event-early')
+        .singleDay('2024-01-15T00:05:00Z', 55)
+        .toProcessed();
+
+      const arrows = computeDependencyArrows({
+        adapter,
+        dependencies: [buildDependency('dep-1', 'event-late', 'event-early')],
+        resources: [
+          { resource: RESOURCE_1, occurrences: getOccurrences([lateEvent]) },
+          { resource: RESOURCE_2, occurrences: getOccurrences([earlyEvent]) },
+        ],
+        rowPositions: [0, 62],
+        collectionStart,
+        collectionEnd,
+        eventsWidth: EVENTS_WIDTH,
+        laneMetrics: LANE_METRICS,
+      });
+
+      expect(arrows).to.have.length(1);
+      // The exit stub collapses on the right edge and the entry elbow hugs x = 0.
+      expect(arrows[0].d).to.equal(
+        'M 1440 31 L 1440 48 Q 1440 52 1436 52 L 4 52 Q 0 52 0 56 L 0 90.5 Q 0 93 2.5 93 L 5 93',
+      );
+      expect(arrows[0].minXFraction).to.equal(0);
+      expect(arrows[0].maxXFraction).to.equal(1);
+    });
+
     it('should return no arrow when the events area has no width', () => {
       const arrows = computeDependencyArrows({
         adapter,

--- a/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-dependency-arrows/dependencyArrowGeometry.ts
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-dependency-arrows/dependencyArrowGeometry.ts
@@ -209,6 +209,8 @@ export function computeDependencyArrows(
       continue;
     }
 
+    const minRowIndex = Math.min(sourceAnchor.rowIndex, targetAnchor.rowIndex);
+    const maxRowIndex = Math.max(sourceAnchor.rowIndex, targetAnchor.rowIndex);
     const sourcePosition = getPosition(sourceAnchor.occurrence);
     const targetPosition = getPosition(targetAnchor.occurrence);
 
@@ -227,8 +229,6 @@ export function computeDependencyArrows(
     // a tie). Best-effort avoidance, not full pathfinding.
     let points = routes[0];
     if (routes.length > 1) {
-      const minRowIndex = Math.min(sourceAnchor.rowIndex, targetAnchor.rowIndex);
-      const maxRowIndex = Math.max(sourceAnchor.rowIndex, targetAnchor.rowIndex);
       const obstacles: DependencyArrowObstacle[] = [];
       for (let rowIndex = minRowIndex; rowIndex <= maxRowIndex; rowIndex += 1) {
         for (const obstacle of getRowObstacles(rowIndex)) {
@@ -263,8 +263,8 @@ export function computeDependencyArrows(
       d: buildRoundedOrthogonalPath(points, DEPENDENCY_ARROW_CORNER_RADIUS),
       minXFraction: minX / eventsWidth,
       maxXFraction: maxX / eventsWidth,
-      minRowIndex: Math.min(sourceAnchor.rowIndex, targetAnchor.rowIndex),
-      maxRowIndex: Math.max(sourceAnchor.rowIndex, targetAnchor.rowIndex),
+      minRowIndex,
+      maxRowIndex,
     });
   }
 

--- a/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-dependency-arrows/dependencyArrowGeometry.ts
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-dependency-arrows/dependencyArrowGeometry.ts
@@ -221,7 +221,7 @@ export function computeDependencyArrows(
       y: getY(targetAnchor),
     };
 
-    const routes = buildDependencyArrowRoutes(source, target, detourOffset);
+    const routes = buildDependencyArrowRoutes(source, target, detourOffset, eventsWidth);
 
     // With several candidates, keep the one crossing the fewest events (first wins on
     // a tie). Best-effort avoidance, not full pathfinding.
@@ -251,14 +251,6 @@ export function computeDependencyArrows(
       }
     }
 
-    // Keep the route inside the events area: x < 0 sits under the pinned title column
-    // and x > eventsWidth is past the last tick, so the elbow of an anchor sitting at
-    // the timeline edge would never be visible there.
-    points = points.map((point) => ({
-      x: Math.min(Math.max(point.x, 0), eventsWidth),
-      y: point.y,
-    }));
-
     let minX = Infinity;
     let maxX = -Infinity;
     for (const point of points) {
@@ -287,11 +279,14 @@ export function computeDependencyArrows(
  * `detourOffset` is how far from the source anchor the S route runs its horizontal
  * detour — it must clear the event's edge, otherwise the route overlaps the events and
  * reads as a knot instead of a detour.
+ * Routes stay inside `[0, eventsWidth]`: at a timeline edge the stubs ride over the
+ * event instead of leaving the visible area.
  */
 export function buildDependencyArrowRoutes(
   source: DependencyArrowPoint,
   target: DependencyArrowPoint,
   detourOffset: number,
+  eventsWidth: number,
 ): DependencyArrowPoint[][] {
   const forwardX = target.x - source.x;
 
@@ -304,7 +299,7 @@ export function buildDependencyArrowRoutes(
     // Adjacent events (two same-lane events never overlap in time, so a same-height
     // gap is always forward): a short straight arrow slightly overlapping the
     // predecessor's tail reads better than a detour around the junction.
-    return [[{ x: target.x - 2 * DEPENDENCY_ARROW_STUB, y: target.y }, target]];
+    return [[{ x: Math.max(0, target.x - 2 * DEPENDENCY_ARROW_STUB), y: target.y }, target]];
   }
 
   if (forwardX >= DEPENDENCY_ARROW_STUB + DEPENDENCY_ARROW_TARGET_CLEARANCE) {
@@ -326,17 +321,20 @@ export function buildDependencyArrowRoutes(
   // above when the target is higher) and comes back before entering the target. An
   // arbitrary height between the two anchors could land exactly on a row border and
   // read as part of the grid.
+  // The verticals clamp to the events area (x < 0 sits under the pinned title column)
+  // and the fixed-length stubs then ride over the event — the same overlap trade-off
+  // as the short arrow between two adjacent events.
   const detourY = target.y >= source.y ? source.y + detourOffset : source.y - detourOffset;
-  const exitX = source.x + DEPENDENCY_ARROW_STUB;
-  const entryX = target.x - DEPENDENCY_ARROW_TARGET_CLEARANCE;
+  const exitX = Math.min(eventsWidth, source.x + DEPENDENCY_ARROW_STUB);
+  const entryX = Math.max(0, target.x - DEPENDENCY_ARROW_TARGET_CLEARANCE);
   return [
     [
-      source,
+      { x: exitX - DEPENDENCY_ARROW_STUB, y: source.y },
       { x: exitX, y: source.y },
       { x: exitX, y: detourY },
       { x: entryX, y: detourY },
       { x: entryX, y: target.y },
-      target,
+      { x: entryX + DEPENDENCY_ARROW_TARGET_CLEARANCE, y: target.y },
     ],
   ];
 }

--- a/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-dependency-arrows/dependencyArrowGeometry.ts
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-dependency-arrows/dependencyArrowGeometry.ts
@@ -251,6 +251,14 @@ export function computeDependencyArrows(
       }
     }
 
+    // Keep the route inside the events area: x < 0 sits under the pinned title column
+    // and x > eventsWidth is past the last tick, so the elbow of an anchor sitting at
+    // the timeline edge would never be visible there.
+    points = points.map((point) => ({
+      x: Math.min(Math.max(point.x, 0), eventsWidth),
+      y: point.y,
+    }));
+
     let minX = Infinity;
     let maxX = -Infinity;
     for (const point of points) {

--- a/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-dependency-arrows/dependencyArrowGeometry.ts
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-dependency-arrows/dependencyArrowGeometry.ts
@@ -1,0 +1,449 @@
+import type { Adapter } from '@mui/x-scheduler-internals/use-adapter';
+import type {
+  SchedulerEventId,
+  SchedulerEventOccurrence,
+  SchedulerResource,
+  TemporalSupportedObject,
+} from '@mui/x-scheduler-internals/models';
+import { computeElementPositionInCollection } from '@mui/x-scheduler-internals/internals';
+import { computeOccurrencesFirstIndexLookup } from '@mui/x-scheduler-internals/use-event-occurrences-with-timeline-position';
+import type {
+  SchedulerDependency,
+  SchedulerDependencyId,
+} from '@mui/x-scheduler-internals-premium/models';
+import type { EventsCellLaneMetrics } from '../rowGeometry';
+
+/**
+ * Minimum horizontal segment when leaving the predecessor's end edge and when
+ * entering the successor's start edge.
+ */
+export const DEPENDENCY_ARROW_STUB = 8;
+/**
+ * Radius used to soften the corners of the orthogonal route.
+ */
+export const DEPENDENCY_ARROW_CORNER_RADIUS = 4;
+/**
+ * Size of the arrowhead marker at the successor's start edge.
+ */
+export const DEPENDENCY_ARROWHEAD_SIZE = 7;
+/**
+ * Minimum length of the final segment entering the target: the softened corner plus the
+ * arrowhead must fit on it, otherwise the arrowhead overlaps the curve.
+ */
+const DEPENDENCY_ARROW_TARGET_CLEARANCE =
+  DEPENDENCY_ARROW_CORNER_RADIUS + DEPENDENCY_ARROWHEAD_SIZE + 1;
+/**
+ * Vertical clearance between the edge of the source event and the S route detour that
+ * hugs it.
+ */
+export const DEPENDENCY_ARROW_DETOUR_CLEARANCE = 6;
+
+export interface DependencyArrowPoint {
+  x: number;
+  y: number;
+}
+
+export interface DependencyArrow {
+  id: SchedulerDependencyId;
+  /**
+   * The SVG path of the arrow, in absolute row-space pixels (y = 0 is the top of the
+   * first row), so it does not depend on the scroll position.
+   */
+  d: string;
+  /**
+   * Horizontal bounding box of the arrow, as fractions of the events area width.
+   */
+  minXFraction: number;
+  maxXFraction: number;
+  /**
+   * Vertical bounding box of the arrow, as row indexes.
+   */
+  minRowIndex: number;
+  maxRowIndex: number;
+}
+
+export interface ComputeDependencyArrowsParameters {
+  adapter: Adapter;
+  /**
+   * The active dependencies (both events exist and are not recurring).
+   */
+  dependencies: readonly SchedulerDependency[];
+  /**
+   * The visible resources with their occurrences, in row render order.
+   */
+  resources: readonly { resource: SchedulerResource; occurrences: SchedulerEventOccurrence[] }[];
+  /**
+   * The y offset of each row in pixels, in the same order as `resources`.
+   */
+  rowPositions: readonly number[];
+  collectionStart: TemporalSupportedObject;
+  collectionEnd: TemporalSupportedObject;
+  /**
+   * The width of the events area in pixels (tick count × tick width).
+   */
+  eventsWidth: number;
+  laneMetrics: EventsCellLaneMetrics;
+}
+
+interface DependencyArrowAnchor {
+  rowIndex: number;
+  occurrence: SchedulerEventOccurrence;
+}
+
+/**
+ * Computes the arrow of each renderable dependency, connecting the end edge of the
+ * source event to the start edge of the target event.
+ * Anchors are derived from the data model (not measured on the DOM) so arrows can
+ * reach events that the virtualizer did not mount.
+ */
+export function computeDependencyArrows(
+  parameters: ComputeDependencyArrowsParameters,
+): DependencyArrow[] {
+  const {
+    adapter,
+    dependencies,
+    resources,
+    rowPositions,
+    collectionStart,
+    collectionEnd,
+    eventsWidth,
+    laneMetrics,
+  } = parameters;
+
+  if (dependencies.length === 0 || eventsWidth <= 0) {
+    return [];
+  }
+
+  const endpointIds = new Set<SchedulerEventId>();
+  for (const dependency of dependencies) {
+    endpointIds.add(dependency.source);
+    endpointIds.add(dependency.target);
+  }
+
+  // An event assigned to several resources appears in several rows: anchor it on the
+  // first row in render order.
+  const anchorLookup = new Map<SchedulerEventId, DependencyArrowAnchor>();
+  for (let rowIndex = 0; rowIndex < resources.length; rowIndex += 1) {
+    for (const occurrence of resources[rowIndex].occurrences) {
+      if (endpointIds.has(occurrence.id) && !anchorLookup.has(occurrence.id)) {
+        anchorLookup.set(occurrence.id, { rowIndex, occurrence });
+      }
+    }
+  }
+
+  // Lane assignment of a row, computed on demand and only once per involved row.
+  const laneLookupByRow = new Map<number, { [occurrenceKey: string]: number }>();
+  const getLaneLookup = (rowIndex: number): { [occurrenceKey: string]: number } => {
+    let laneLookup = laneLookupByRow.get(rowIndex);
+    if (laneLookup == null) {
+      laneLookup = computeOccurrencesFirstIndexLookup(adapter, resources[rowIndex].occurrences);
+      laneLookupByRow.set(rowIndex, laneLookup);
+    }
+    return laneLookup;
+  };
+
+  const positionByOccurrenceKey = new Map<
+    string,
+    ReturnType<typeof computeElementPositionInCollection>
+  >();
+  const getPosition = (occurrence: SchedulerEventOccurrence) => {
+    let position = positionByOccurrenceKey.get(occurrence.key);
+    if (position == null) {
+      position = computeElementPositionInCollection(adapter, {
+        start: occurrence.displayTimezone.start,
+        end: occurrence.displayTimezone.end,
+        collectionStart,
+        collectionEnd,
+      });
+      positionByOccurrenceKey.set(occurrence.key, position);
+    }
+    return position;
+  };
+
+  const laneStep = laneMetrics.laneMinHeight + laneMetrics.laneGap;
+  const getLaneTop = (rowIndex: number, lane: number): number =>
+    rowPositions[rowIndex] + laneMetrics.topPadding + (lane - 1) * laneStep;
+  const getY = (anchor: DependencyArrowAnchor): number =>
+    getLaneTop(anchor.rowIndex, getLaneLookup(anchor.rowIndex)[anchor.occurrence.key]) +
+    laneMetrics.laneMinHeight / 2;
+
+  // The event boxes of a row, used to pick the elbow candidate crossing the fewest
+  // events. Computed on demand and only once per row an arrow spans.
+  const obstaclesByRow = new Map<number, DependencyArrowObstacle[]>();
+  const getRowObstacles = (rowIndex: number): DependencyArrowObstacle[] => {
+    let obstacles = obstaclesByRow.get(rowIndex);
+    if (obstacles == null) {
+      const laneLookup = getLaneLookup(rowIndex);
+      obstacles = resources[rowIndex].occurrences.map((occurrence) => {
+        const position = getPosition(occurrence);
+        const laneTop = getLaneTop(rowIndex, laneLookup[occurrence.key]);
+        return {
+          occurrenceKey: occurrence.key,
+          x1: position.position * eventsWidth,
+          x2: (position.position + position.duration) * eventsWidth,
+          y1: laneTop,
+          y2: laneTop + laneMetrics.laneMinHeight,
+        };
+      });
+      obstaclesByRow.set(rowIndex, obstacles);
+    }
+    return obstacles;
+  };
+
+  const detourOffset = laneMetrics.laneMinHeight / 2 + DEPENDENCY_ARROW_DETOUR_CLEARANCE;
+
+  const arrows: DependencyArrow[] = [];
+  for (const dependency of dependencies) {
+    const sourceAnchor = anchorLookup.get(dependency.source);
+    const targetAnchor = anchorLookup.get(dependency.target);
+
+    // An endpoint without an anchor is not rendered in the timeline: its event has no
+    // resource, is outside the collection range, or its row is hidden. The dependency
+    // stays in the data, it just has no arrow.
+    if (
+      sourceAnchor == null ||
+      targetAnchor == null ||
+      rowPositions[sourceAnchor.rowIndex] == null ||
+      rowPositions[targetAnchor.rowIndex] == null
+    ) {
+      continue;
+    }
+
+    const sourcePosition = getPosition(sourceAnchor.occurrence);
+    const targetPosition = getPosition(targetAnchor.occurrence);
+
+    const source: DependencyArrowPoint = {
+      x: (sourcePosition.position + sourcePosition.duration) * eventsWidth,
+      y: getY(sourceAnchor),
+    };
+    const target: DependencyArrowPoint = {
+      x: targetPosition.position * eventsWidth,
+      y: getY(targetAnchor),
+    };
+
+    const routes = buildDependencyArrowRoutes(source, target, detourOffset);
+
+    // With several candidates, keep the one crossing the fewest events (first wins on
+    // a tie). Best-effort avoidance, not full pathfinding.
+    let points = routes[0];
+    if (routes.length > 1) {
+      const minRowIndex = Math.min(sourceAnchor.rowIndex, targetAnchor.rowIndex);
+      const maxRowIndex = Math.max(sourceAnchor.rowIndex, targetAnchor.rowIndex);
+      const obstacles: DependencyArrowObstacle[] = [];
+      for (let rowIndex = minRowIndex; rowIndex <= maxRowIndex; rowIndex += 1) {
+        for (const obstacle of getRowObstacles(rowIndex)) {
+          if (
+            obstacle.occurrenceKey !== sourceAnchor.occurrence.key &&
+            obstacle.occurrenceKey !== targetAnchor.occurrence.key
+          ) {
+            obstacles.push(obstacle);
+          }
+        }
+      }
+
+      let bestCollisions = countRouteCollisions(points, obstacles);
+      for (let index = 1; index < routes.length && bestCollisions > 0; index += 1) {
+        const collisions = countRouteCollisions(routes[index], obstacles);
+        if (collisions < bestCollisions) {
+          bestCollisions = collisions;
+          points = routes[index];
+        }
+      }
+    }
+
+    let minX = Infinity;
+    let maxX = -Infinity;
+    for (const point of points) {
+      minX = Math.min(minX, point.x);
+      maxX = Math.max(maxX, point.x);
+    }
+
+    arrows.push({
+      id: dependency.id,
+      d: buildRoundedOrthogonalPath(points, DEPENDENCY_ARROW_CORNER_RADIUS),
+      minXFraction: minX / eventsWidth,
+      maxXFraction: maxX / eventsWidth,
+      minRowIndex: Math.min(sourceAnchor.rowIndex, targetAnchor.rowIndex),
+      maxRowIndex: Math.max(sourceAnchor.rowIndex, targetAnchor.rowIndex),
+    });
+  }
+
+  return arrows;
+}
+
+/**
+ * Builds the candidate orthogonal routes from the source anchor (end edge of the
+ * predecessor) to the target anchor (start edge of the successor), best first.
+ * The forward elbow returns two candidates (turn right after the source, or right
+ * before the target) so the caller can pick the one crossing the fewest events.
+ * `detourOffset` is how far from the source anchor the S route runs its horizontal
+ * detour — it must clear the event's edge, otherwise the route overlaps the events and
+ * reads as a knot instead of a detour.
+ */
+export function buildDependencyArrowRoutes(
+  source: DependencyArrowPoint,
+  target: DependencyArrowPoint,
+  detourOffset: number,
+): DependencyArrowPoint[][] {
+  const forwardX = target.x - source.x;
+
+  if (source.y === target.y && forwardX >= 0) {
+    if (forwardX >= 2 * DEPENDENCY_ARROW_STUB) {
+      // Straight segment between two anchors at the same height.
+      return [[source, target]];
+    }
+
+    // Adjacent events (two same-lane events never overlap in time, so a same-height
+    // gap is always forward): a short straight arrow slightly overlapping the
+    // predecessor's tail reads better than a detour around the junction.
+    return [[{ x: target.x - 2 * DEPENDENCY_ARROW_STUB, y: target.y }, target]];
+  }
+
+  if (forwardX >= DEPENDENCY_ARROW_STUB + DEPENDENCY_ARROW_TARGET_CLEARANCE) {
+    // Forward elbow: right off the source, vertical, then right into the target — or
+    // the mirrored turn right before the target.
+    const earlyTurnX = source.x + DEPENDENCY_ARROW_STUB;
+    const lateTurnX = target.x - DEPENDENCY_ARROW_TARGET_CLEARANCE;
+    const routes = [
+      [source, { x: earlyTurnX, y: source.y }, { x: earlyTurnX, y: target.y }, target],
+    ];
+    if (lateTurnX > earlyTurnX) {
+      routes.push([source, { x: lateTurnX, y: source.y }, { x: lateTurnX, y: target.y }, target]);
+    }
+    return routes;
+  }
+
+  // S route: the successor starts before (or too close to) the predecessor's end, so
+  // the arrow exits right, detours horizontally hugging the source event (below it, or
+  // above when the target is higher) and comes back before entering the target. An
+  // arbitrary height between the two anchors could land exactly on a row border and
+  // read as part of the grid.
+  const detourY = target.y >= source.y ? source.y + detourOffset : source.y - detourOffset;
+  const exitX = source.x + DEPENDENCY_ARROW_STUB;
+  const entryX = target.x - DEPENDENCY_ARROW_TARGET_CLEARANCE;
+  return [
+    [
+      source,
+      { x: exitX, y: source.y },
+      { x: exitX, y: detourY },
+      { x: entryX, y: detourY },
+      { x: entryX, y: target.y },
+      target,
+    ],
+  ];
+}
+
+/**
+ * How much a route segment must overlap an event to count as crossing it — anchors
+ * touching their own event's edge must not count.
+ */
+const COLLISION_EPSILON = 0.5;
+
+interface DependencyArrowObstacle {
+  occurrenceKey: string;
+  x1: number;
+  x2: number;
+  y1: number;
+  y2: number;
+}
+
+function segmentCrossesObstacle(
+  a: DependencyArrowPoint,
+  b: DependencyArrowPoint,
+  obstacle: DependencyArrowObstacle,
+): boolean {
+  // Vertical segment: x strictly inside the obstacle, y ranges overlapping.
+  if (a.x === b.x) {
+    return (
+      a.x > obstacle.x1 + COLLISION_EPSILON &&
+      a.x < obstacle.x2 - COLLISION_EPSILON &&
+      Math.min(Math.max(a.y, b.y), obstacle.y2) - Math.max(Math.min(a.y, b.y), obstacle.y1) >
+        COLLISION_EPSILON
+    );
+  }
+  // Horizontal segment: y strictly inside the obstacle, x ranges overlapping.
+  if (a.y === b.y) {
+    return (
+      a.y > obstacle.y1 + COLLISION_EPSILON &&
+      a.y < obstacle.y2 - COLLISION_EPSILON &&
+      Math.min(Math.max(a.x, b.x), obstacle.x2) - Math.max(Math.min(a.x, b.x), obstacle.x1) >
+        COLLISION_EPSILON
+    );
+  }
+  // Routes only have horizontal and vertical segments.
+  return false;
+}
+
+/**
+ * Number of obstacles a route crosses. Each obstacle counts once, no matter how many
+ * segments cross it.
+ */
+function countRouteCollisions(
+  points: readonly DependencyArrowPoint[],
+  obstacles: readonly DependencyArrowObstacle[],
+): number {
+  let count = 0;
+  for (const obstacle of obstacles) {
+    for (let index = 0; index < points.length - 1; index += 1) {
+      if (segmentCrossesObstacle(points[index], points[index + 1], obstacle)) {
+        count += 1;
+        break;
+      }
+    }
+  }
+  return count;
+}
+
+function formatCoordinate(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+/**
+ * Builds an SVG path following the provided points with horizontal/vertical segments,
+ * softening each corner with a quadratic curve. The radius is clamped so two corners
+ * never overlap, and zero-length segments collapse their corner.
+ */
+export function buildRoundedOrthogonalPath(
+  points: readonly DependencyArrowPoint[],
+  radius: number,
+): string {
+  // Drop consecutive duplicated points so degenerate segments don't produce corners.
+  const cleanPoints = points.filter(
+    (point, index) =>
+      index === 0 || point.x !== points[index - 1].x || point.y !== points[index - 1].y,
+  );
+
+  if (cleanPoints.length < 2) {
+    return '';
+  }
+
+  let d = `M ${formatCoordinate(cleanPoints[0].x)} ${formatCoordinate(cleanPoints[0].y)}`;
+
+  for (let index = 1; index < cleanPoints.length - 1; index += 1) {
+    const previous = cleanPoints[index - 1];
+    const corner = cleanPoints[index];
+    const next = cleanPoints[index + 1];
+
+    const inLength = Math.hypot(corner.x - previous.x, corner.y - previous.y);
+    const outLength = Math.hypot(next.x - corner.x, next.y - corner.y);
+    const cornerRadius = Math.min(radius, inLength / 2, outLength / 2);
+
+    if (cornerRadius <= 0) {
+      d += ` L ${formatCoordinate(corner.x)} ${formatCoordinate(corner.y)}`;
+      continue;
+    }
+
+    const inX = corner.x - ((corner.x - previous.x) / inLength) * cornerRadius;
+    const inY = corner.y - ((corner.y - previous.y) / inLength) * cornerRadius;
+    const outX = corner.x + ((next.x - corner.x) / outLength) * cornerRadius;
+    const outY = corner.y + ((next.y - corner.y) / outLength) * cornerRadius;
+
+    d += ` L ${formatCoordinate(inX)} ${formatCoordinate(inY)}`;
+    d += ` Q ${formatCoordinate(corner.x)} ${formatCoordinate(corner.y)} ${formatCoordinate(outX)} ${formatCoordinate(outY)}`;
+  }
+
+  const last = cleanPoints[cleanPoints.length - 1];
+  d += ` L ${formatCoordinate(last.x)} ${formatCoordinate(last.y)}`;
+
+  return d;
+}

--- a/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-dependency-arrows/dependencyArrowGeometry.ts
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-dependency-arrows/dependencyArrowGeometry.ts
@@ -44,6 +44,11 @@ export interface DependencyArrowPoint {
 }
 
 export interface DependencyArrow {
+  /**
+   * Unique key of the arrow: a dependency renders one arrow per pair of row
+   * appearances of its events.
+   */
+  key: string;
   id: SchedulerDependencyId;
   /**
    * The SVG path of the arrow, in absolute row-space pixels (y = 0 is the top of the
@@ -120,13 +125,18 @@ export function computeDependencyArrows(
     endpointIds.add(dependency.target);
   }
 
-  // An event assigned to several resources appears in several rows: anchor it on the
-  // first row in render order.
-  const anchorLookup = new Map<SchedulerEventId, DependencyArrowAnchor>();
+  // An event assigned to several resources appears once in each of its rows: collect
+  // every appearance so each one gets its own arrows.
+  const anchorsLookup = new Map<SchedulerEventId, DependencyArrowAnchor[]>();
   for (let rowIndex = 0; rowIndex < resources.length; rowIndex += 1) {
     for (const occurrence of resources[rowIndex].occurrences) {
-      if (endpointIds.has(occurrence.id) && !anchorLookup.has(occurrence.id)) {
-        anchorLookup.set(occurrence.id, { rowIndex, occurrence });
+      if (endpointIds.has(occurrence.id)) {
+        const anchors = anchorsLookup.get(occurrence.id);
+        if (anchors) {
+          anchors.push({ rowIndex, occurrence });
+        } else {
+          anchorsLookup.set(occurrence.id, [{ rowIndex, occurrence }]);
+        }
       }
     }
   }
@@ -192,21 +202,18 @@ export function computeDependencyArrows(
 
   const detourOffset = laneMetrics.laneMinHeight / 2 + DEPENDENCY_ARROW_DETOUR_CLEARANCE;
 
-  const arrows: DependencyArrow[] = [];
-  for (const dependency of dependencies) {
-    const sourceAnchor = anchorLookup.get(dependency.source);
-    const targetAnchor = anchorLookup.get(dependency.target);
-
-    // An endpoint without an anchor is not rendered in the timeline: its event has no
-    // resource, is outside the collection range, or its row is hidden. The dependency
-    // stays in the data, it just has no arrow.
+  const buildArrow = (
+    dependency: SchedulerDependency,
+    sourceAnchor: DependencyArrowAnchor,
+    targetAnchor: DependencyArrowAnchor,
+  ): DependencyArrow | null => {
+    // A row without a position is not laid out yet (see the transient resources /
+    // rowsMeta desync): skip the pair for this frame.
     if (
-      sourceAnchor == null ||
-      targetAnchor == null ||
       rowPositions[sourceAnchor.rowIndex] == null ||
       rowPositions[targetAnchor.rowIndex] == null
     ) {
-      continue;
+      return null;
     }
 
     const minRowIndex = Math.min(sourceAnchor.rowIndex, targetAnchor.rowIndex);
@@ -258,14 +265,39 @@ export function computeDependencyArrows(
       maxX = Math.max(maxX, point.x);
     }
 
-    arrows.push({
+    return {
+      key: `${String(dependency.id)}:${sourceAnchor.rowIndex}:${targetAnchor.rowIndex}`,
       id: dependency.id,
       d: buildRoundedOrthogonalPath(points, DEPENDENCY_ARROW_CORNER_RADIUS),
       minXFraction: minX / eventsWidth,
       maxXFraction: maxX / eventsWidth,
       minRowIndex,
       maxRowIndex,
-    });
+    };
+  };
+
+  const arrows: DependencyArrow[] = [];
+  for (const dependency of dependencies) {
+    const sourceAnchors = anchorsLookup.get(dependency.source);
+    const targetAnchors = anchorsLookup.get(dependency.target);
+
+    // An endpoint without an anchor is not rendered in the timeline: its event has no
+    // resource or is outside the collection range. The dependency stays in the data,
+    // it just has no arrow.
+    if (sourceAnchors == null || targetAnchors == null) {
+      continue;
+    }
+
+    // One arrow per pair of appearances: an event assigned to several resources shows
+    // the dependency in each of its rows.
+    for (const sourceAnchor of sourceAnchors) {
+      for (const targetAnchor of targetAnchors) {
+        const arrow = buildArrow(dependency, sourceAnchor, targetAnchor);
+        if (arrow != null) {
+          arrows.push(arrow);
+        }
+      }
+    }
   }
 
   return arrows;

--- a/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-dependency-arrows/dependencyArrowGeometry.ts
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-dependency-arrows/dependencyArrowGeometry.ts
@@ -17,11 +17,11 @@ import type { EventsCellLaneMetrics } from '../rowGeometry';
  * Minimum horizontal segment when leaving the predecessor's end edge and when
  * entering the successor's start edge.
  */
-export const DEPENDENCY_ARROW_STUB = 8;
+const DEPENDENCY_ARROW_STUB = 8;
 /**
  * Radius used to soften the corners of the orthogonal route.
  */
-export const DEPENDENCY_ARROW_CORNER_RADIUS = 4;
+const DEPENDENCY_ARROW_CORNER_RADIUS = 4;
 /**
  * Size of the arrowhead marker at the successor's start edge.
  */
@@ -36,7 +36,7 @@ const DEPENDENCY_ARROW_TARGET_CLEARANCE =
  * Vertical clearance between the edge of the source event and the S route detour that
  * hugs it.
  */
-export const DEPENDENCY_ARROW_DETOUR_CLEARANCE = 6;
+const DEPENDENCY_ARROW_DETOUR_CLEARANCE = 6;
 
 export interface DependencyArrowPoint {
   x: number;

--- a/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-dependency-arrows/dependencyArrowGeometry.ts
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-dependency-arrows/dependencyArrowGeometry.ts
@@ -282,8 +282,8 @@ export function computeDependencyArrows(
     const targetAnchors = anchorsLookup.get(dependency.target);
 
     // An endpoint without an anchor is not rendered in the timeline: its event has no
-    // resource or is outside the collection range. The dependency stays in the data,
-    // it just has no arrow.
+    // resource, is outside the collection range, or its row is hidden. The dependency
+    // stays in the data, it just has no arrow.
     if (sourceAnchors == null || targetAnchors == null) {
       continue;
     }

--- a/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-dependency-arrows/index.ts
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-dependency-arrows/index.ts
@@ -1,0 +1,1 @@
+export { EventTimelinePremiumDependencyArrows } from './EventTimelinePremiumDependencyArrows';

--- a/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-event/EventTimelinePremiumEvent.tsx
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-event/EventTimelinePremiumEvent.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
 import clsx from 'clsx';
 import { styled } from '@mui/material/styles';
+import visuallyHidden from '@mui/utils/visuallyHidden';
 import { useStore } from '@base-ui/utils/store';
 import { useId } from '@base-ui/utils/useId';
 import RepeatRounded from '@mui/icons-material/RepeatRounded';
 import { TimelineGrid } from '@mui/x-scheduler-internals-premium/timeline-grid';
 import { schedulerEventSelectors } from '@mui/x-scheduler-internals/scheduler-selectors';
+import { eventTimelinePremiumDependencySelectors } from '@mui/x-scheduler-internals-premium/event-timeline-premium-selectors';
 import { useEventTimelinePremiumStoreContext } from '@mui/x-scheduler-internals-premium/use-event-timeline-premium-store-context';
 import { EventDragPreview, getPaletteVariants } from '@mui/x-scheduler/internals';
 import type { EventTimelinePremiumEventProps } from './EventTimelinePremiumEvent.types';
@@ -146,6 +148,11 @@ export const EventTimelinePremiumEvent = React.forwardRef(function EventTimeline
   const isEndResizable = useStore(store, schedulerEventSelectors.isResizable, occurrence.id, 'end');
   const color = useStore(store, schedulerEventSelectors.color, occurrence.id);
   const isRecurring = useStore(store, schedulerEventSelectors.isRecurring, occurrence.id);
+  const dependsOnTitles = useStore(
+    store,
+    eventTimelinePremiumDependencySelectors.activeSourceTitlesForTarget,
+    occurrence.id,
+  );
 
   // Feature hooks
   const id = useId(idProp);
@@ -194,6 +201,7 @@ export const EventTimelinePremiumEvent = React.forwardRef(function EventTimeline
       occurrenceKey={occurrence.key}
       renderDragPreview={(parameters) => <EventDragPreview {...parameters} />}
       {...sharedProps}
+      aria-describedby={dependsOnTitles.length > 0 ? `${id}-dependencies` : undefined}
       className={clsx(sharedProps.className, classes.event)}
     >
       {isStartResizable && (
@@ -205,6 +213,13 @@ export const EventTimelinePremiumEvent = React.forwardRef(function EventTimeline
       <EventTimelinePremiumEventLinesClamp className={classes.eventLinesClamp}>
         {occurrence.title}
       </EventTimelinePremiumEventLinesClamp>
+      {dependsOnTitles.length > 0 && (
+        <span id={`${id}-dependencies`} style={visuallyHidden}>
+          {/* TODO(dependencies public flip): move to localeText. Hardcoded while the
+              feature has no public API. */}
+          Depends on {dependsOnTitles.join(', ')}
+        </span>
+      )}
       {isRecurring && (
         <EventTimelinePremiumEventRecurringIcon
           className={classes.eventRecurringIcon}

--- a/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-event/EventTimelinePremiumEvent.tsx
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/content/timeline-event/EventTimelinePremiumEvent.tsx
@@ -214,7 +214,10 @@ export const EventTimelinePremiumEvent = React.forwardRef(function EventTimeline
         {occurrence.title}
       </EventTimelinePremiumEventLinesClamp>
       {dependsOnTitles.length > 0 && (
-        <span id={`${id}-dependencies`} style={visuallyHidden}>
+        // `aria-hidden` keeps the description out of the name-from-content computed
+        // through the self-referential `aria-labelledby`; the `aria-describedby`
+        // reference still picks it up.
+        <span id={`${id}-dependencies`} style={visuallyHidden} aria-hidden>
           {/* TODO(dependencies public flip): move to localeText. Hardcoded while the
               feature has no public API. */}
           Depends on {dependsOnTitles.join(', ')}

--- a/packages/x-scheduler-premium/src/event-timeline-premium/tests/dependencyArrows.EventTimelinePremium.test.tsx
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/tests/dependencyArrows.EventTimelinePremium.test.tsx
@@ -96,9 +96,12 @@ describe('<EventTimelinePremium /> dependency arrows', () => {
     React.useEffect(() => {
       onStoreReady(store);
     }, [onStoreReady, store]);
+    // The context is typed on the base scheduler state and the store generic is
+    // invariant, so the premium store (extra state slices) needs the cast.
+    const storeContextValue = store as any;
 
     return (
-      <SchedulerStoreContext.Provider value={store as any}>
+      <SchedulerStoreContext.Provider value={storeContextValue}>
         <EventTimelinePremiumStyledContext.Provider value={styledContextValue}>
           <EventDialogStyledContext.Provider value={styledContextValue}>
             <SharedComponentsStyledContext.Provider value={sharedStyledContextValue}>

--- a/packages/x-scheduler-premium/src/event-timeline-premium/tests/dependencyArrows.EventTimelinePremium.test.tsx
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/tests/dependencyArrows.EventTimelinePremium.test.tsx
@@ -225,6 +225,25 @@ describe('<EventTimelinePremium /> dependency arrows', () => {
     expect(d.match(/Q /g)).to.have.length(4);
   });
 
+  it('should render one arrow per row appearance of a multi-resource event', () => {
+    const multiResourceEvent = EventBuilder.new()
+      .id('event-multi')
+      .title('Event multi')
+      .singleDay('2025-07-03T11:00:00Z')
+      .resources([resource1, resource2])
+      .build();
+
+    renderTimeline({
+      events: [eventA, multiResourceEvent],
+      dependencies: [buildDependency('dep-1', 'event-a', 'event-multi')],
+    });
+
+    expect(getArrowPaths().map((path) => path.getAttribute('data-dependency-id'))).to.deep.equal([
+      'dep-1',
+      'dep-1',
+    ]);
+  });
+
   it('should not render an arrow when an endpoint event has no resource', () => {
     const unresourcedEvent = EventBuilder.new()
       .id('event-unresourced')

--- a/packages/x-scheduler-premium/src/event-timeline-premium/tests/dependencyArrows.EventTimelinePremium.test.tsx
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/tests/dependencyArrows.EventTimelinePremium.test.tsx
@@ -304,18 +304,6 @@ describe('<EventTimelinePremium /> dependency arrows', () => {
     expect(document.querySelector('[data-dependency-arrows]')).to.equal(null);
   });
 
-  it('should let the arrows paint outside the overlay near the timeline edges', () => {
-    renderTimeline({
-      events: [eventA, eventB],
-      dependencies: [buildDependency('dep-1', 'event-a', 'event-b')],
-    });
-
-    // The entry and exit stubs reach outside the viewBox at the timeline edges; the
-    // SVG root's default `overflow: hidden` would clip them.
-    const svg = document.querySelector('[data-dependency-arrows]')!;
-    expect(getComputedStyle(svg).overflow).to.equal('visible');
-  });
-
   it('should hide the arrows overlay from assistive technology', () => {
     renderTimeline({
       events: [eventA, eventB],

--- a/packages/x-scheduler-premium/src/event-timeline-premium/tests/dependencyArrows.EventTimelinePremium.test.tsx
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/tests/dependencyArrows.EventTimelinePremium.test.tsx
@@ -339,12 +339,20 @@ describe('<EventTimelinePremium /> dependency arrows', () => {
       });
 
       const successor = getEventElement('Event B');
-      const descriptionId = successor.getAttribute('aria-describedby')!;
 
-      expect(descriptionId).not.to.equal(null);
-      expect(document.getElementById(descriptionId)!.textContent).to.equal(
-        'Depends on Event A, Event C',
-      );
+      expect(successor).toHaveAccessibleDescription('Depends on Event A, Event C');
+    });
+
+    it('should keep the predecessor titles out of the successor accessible name', () => {
+      renderTimeline({
+        events: [eventA, eventB, eventC],
+        dependencies: [
+          buildDependency('dep-1', 'event-a', 'event-b'),
+          buildDependency('dep-2', 'event-c', 'event-b'),
+        ],
+      });
+
+      expect(getEventElement('Event B')).toHaveAccessibleName('Resource 1 Event B');
     });
 
     it('should not describe an event without predecessors', () => {

--- a/packages/x-scheduler-premium/src/event-timeline-premium/tests/dependencyArrows.EventTimelinePremium.test.tsx
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/tests/dependencyArrows.EventTimelinePremium.test.tsx
@@ -153,6 +153,10 @@ describe('<EventTimelinePremium /> dependency arrows', () => {
     return Array.from(document.querySelectorAll<SVGPathElement>('[data-dependency-id]'));
   }
 
+  function getEventElement(title: string) {
+    return screen.getByText(title).closest('[data-occurrence-key]')!;
+  }
+
   it('should render one arrow per active dependency', () => {
     renderTimeline({
       events: [eventA, eventB, eventC],
@@ -313,10 +317,6 @@ describe('<EventTimelinePremium /> dependency arrows', () => {
   });
 
   describe('successor accessible description', () => {
-    function getEventElement(title: string) {
-      return screen.getByText(title).closest('[data-occurrence-key]')!;
-    }
-
     it('should describe the successor event with its predecessor titles', () => {
       renderTimeline({
         events: [eventA, eventB, eventC],
@@ -342,6 +342,30 @@ describe('<EventTimelinePremium /> dependency arrows', () => {
       });
 
       expect(getEventElement('Event A').getAttribute('aria-describedby')).to.equal(null);
+    });
+  });
+
+  // Anchors are computed from `getEventsCellLaneMetrics`, which mirrors the EventsCell
+  // CSS in JS: this pins the mirror against the layout the browser actually produces.
+  describe.skipIf(isJSDOM)('anchor alignment', () => {
+    it('should anchor the straight arrow on the vertical center of the source event', async () => {
+      renderTimeline({
+        events: [eventA, eventB],
+        dependencies: [buildDependency('dep-1', 'event-a', 'event-b')],
+      });
+
+      await waitFor(() => {
+        expect(getArrowPaths()).to.have.length(1);
+      });
+
+      const svg = document.querySelector<SVGSVGElement>('[data-dependency-arrows]')!;
+      const d = getArrowPaths()[0].getAttribute('d')!;
+      const pathY = parseFloat(d.match(/^M [\d.]+ ([\d.]+) /)![1]);
+      // The path is in absolute row-space; the viewBox y offset maps it to the overlay.
+      const arrowScreenY = svg.getBoundingClientRect().top + (pathY - svg.viewBox.baseVal.y);
+
+      const sourceRect = getEventElement('Event A').getBoundingClientRect();
+      expect(arrowScreenY).to.be.closeTo(sourceRect.top + sourceRect.height / 2, 1);
     });
   });
 

--- a/packages/x-scheduler-premium/src/event-timeline-premium/tests/dependencyArrows.EventTimelinePremium.test.tsx
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/tests/dependencyArrows.EventTimelinePremium.test.tsx
@@ -269,7 +269,8 @@ describe('<EventTimelinePremium /> dependency arrows', () => {
       dependencies: [buildDependency('dep-1', 'event-a', 'event-b')],
     });
 
-    const initialD = getArrowPaths()[0].getAttribute('d')!;
+    const straightPath = /^M ([\d.]+) ([\d.]+) L ([\d.]+) ([\d.]+)$/;
+    const initialMatch = getArrowPaths()[0].getAttribute('d')!.match(straightPath)!;
 
     act(() => {
       store.updateEvent({
@@ -279,8 +280,12 @@ describe('<EventTimelinePremium /> dependency arrows', () => {
       });
     });
 
-    const updatedD = getArrowPaths()[0].getAttribute('d')!;
-    expect(updatedD).not.to.equal(initialD);
+    const updatedMatch = getArrowPaths()[0].getAttribute('d')!.match(straightPath)!;
+    // The arrow's start follows the predecessor's end edge, moved 30 minutes later;
+    // the successor did not move, so the entry point and the height stay put.
+    expect(parseFloat(updatedMatch[1])).to.be.greaterThan(parseFloat(initialMatch[1]));
+    expect(updatedMatch[3]).to.equal(initialMatch[3]);
+    expect(updatedMatch[2]).to.equal(initialMatch[2]);
   });
 
   it('should remove the arrow when the dependency is deleted', () => {
@@ -297,6 +302,18 @@ describe('<EventTimelinePremium /> dependency arrows', () => {
 
     expect(getArrowPaths()).to.have.length(0);
     expect(document.querySelector('[data-dependency-arrows]')).to.equal(null);
+  });
+
+  it('should let the arrows paint outside the overlay near the timeline edges', () => {
+    renderTimeline({
+      events: [eventA, eventB],
+      dependencies: [buildDependency('dep-1', 'event-a', 'event-b')],
+    });
+
+    // The entry and exit stubs reach outside the viewBox at the timeline edges; the
+    // SVG root's default `overflow: hidden` would clip them.
+    const svg = document.querySelector('[data-dependency-arrows]')!;
+    expect(getComputedStyle(svg).overflow).to.equal('visible');
   });
 
   it('should hide the arrows overlay from assistive technology', () => {

--- a/packages/x-scheduler-premium/src/event-timeline-premium/tests/dependencyArrows.EventTimelinePremium.test.tsx
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/tests/dependencyArrows.EventTimelinePremium.test.tsx
@@ -1,0 +1,452 @@
+import * as React from 'react';
+import { act, screen, waitFor } from '@mui/internal-test-utils';
+import { isJSDOM } from 'test/utils/skipIf';
+import { SchedulerStoreContext } from '@mui/x-scheduler-internals/use-scheduler-store-context';
+import { useEventTimelinePremium } from '@mui/x-scheduler-internals-premium/use-event-timeline-premium';
+import type {
+  EventTimelinePremiumStore,
+  EventTimelinePremiumStoreParameters,
+} from '@mui/x-scheduler-internals-premium/use-event-timeline-premium';
+import type { SchedulerDependency } from '@mui/x-scheduler-internals-premium/models';
+import type { SchedulerEvent, SchedulerResource } from '@mui/x-scheduler-internals/models';
+import {
+  EventDialogStyledContext,
+  EVENT_TIMELINE_DEFAULT_LOCALE_TEXT,
+  SharedComponentsStyledContext,
+} from '@mui/x-scheduler/internals';
+import {
+  adapter,
+  createSchedulerRenderer,
+  DEFAULT_TESTING_VISIBLE_DATE,
+  DEFAULT_TESTING_VISIBLE_DATE_STR,
+  EventBuilder,
+  ResourceBuilder,
+} from 'test/utils/scheduler';
+import { EventTimelinePremiumContent } from '../content';
+import { EventTimelinePremiumStyledContext } from '../EventTimelinePremiumStyledContext';
+import { eventTimelinePremiumClasses } from '../eventTimelinePremiumClasses';
+
+const resource1 = ResourceBuilder.new().id('r1').title('Resource 1').build();
+const resource2 = ResourceBuilder.new().id('r2').title('Resource 2').build();
+
+const eventA = EventBuilder.new()
+  .id('event-a')
+  .title('Event A')
+  .singleDay('2025-07-03T09:00:00Z')
+  .resource(resource1)
+  .build();
+const eventB = EventBuilder.new()
+  .id('event-b')
+  .title('Event B')
+  .singleDay('2025-07-03T11:00:00Z')
+  .resource(resource1)
+  .build();
+const eventC = EventBuilder.new()
+  .id('event-c')
+  .title('Event C')
+  .singleDay('2025-07-03T11:00:00Z')
+  .resource(resource2)
+  .build();
+
+function buildDependency(id: string, source: string, target: string): SchedulerDependency {
+  return { id, source, target, type: 'FinishToStart' };
+}
+
+const styledContextValue = {
+  schedulerId: 'test-timeline',
+  classes: eventTimelinePremiumClasses,
+  localeText: EVENT_TIMELINE_DEFAULT_LOCALE_TEXT,
+};
+
+const sharedStyledContextValue = { classes: eventTimelinePremiumClasses };
+
+describe('<EventTimelinePremium /> dependency arrows', () => {
+  const { render } = createSchedulerRenderer({
+    clockConfig: new Date(DEFAULT_TESTING_VISIBLE_DATE_STR),
+  });
+
+  // `dependencies` is not a public prop yet, so the harness feeds the internal store
+  // parameters to the same hook the component uses, and closes the controlled loop
+  // (`onEventsChange` / `onDependenciesChange` → new parameter values) like a consumer.
+  function TestTimeline({
+    events: initialEvents,
+    resources,
+    dependencies: initialDependencies,
+    onStoreReady,
+  }: {
+    events: SchedulerEvent[];
+    resources: SchedulerResource[];
+    dependencies?: SchedulerDependency[];
+    onStoreReady: (store: EventTimelinePremiumStore<any, any>) => void;
+  }) {
+    const [events, setEvents] = React.useState(initialEvents);
+    const [dependencies, setDependencies] = React.useState(initialDependencies);
+
+    const parameters: EventTimelinePremiumStoreParameters<SchedulerEvent, SchedulerResource> = {
+      events,
+      resources,
+      dependencies,
+      onEventsChange: setEvents,
+      onDependenciesChange: setDependencies,
+      visibleDate: DEFAULT_TESTING_VISIBLE_DATE,
+      preset: 'dayAndHour',
+      presets: ['dayAndHour'],
+    };
+    const store = useEventTimelinePremium(parameters);
+    React.useEffect(() => {
+      onStoreReady(store);
+    }, [onStoreReady, store]);
+
+    return (
+      <SchedulerStoreContext.Provider value={store as any}>
+        <EventTimelinePremiumStyledContext.Provider value={styledContextValue}>
+          <EventDialogStyledContext.Provider value={styledContextValue}>
+            <SharedComponentsStyledContext.Provider value={sharedStyledContextValue}>
+              <EventTimelinePremiumContent />
+            </SharedComponentsStyledContext.Provider>
+          </EventDialogStyledContext.Provider>
+        </EventTimelinePremiumStyledContext.Provider>
+      </SchedulerStoreContext.Provider>
+    );
+  }
+
+  function renderTimeline({
+    events,
+    resources = [resource1, resource2],
+    dependencies,
+  }: {
+    events: SchedulerEvent[];
+    resources?: SchedulerResource[];
+    dependencies?: SchedulerDependency[];
+  }) {
+    let store!: EventTimelinePremiumStore<any, any>;
+
+    const view = render(
+      // Mimics the layout, font-size and box-sizing reset the `EventTimelinePremium`
+      // root provides to the content (the row-height CSS resolves against them).
+      <div
+        className="test-timeline-host"
+        style={{
+          width: 1200,
+          height: 600,
+          display: 'flex',
+          flexDirection: 'column',
+          fontSize: '0.875rem',
+        }}
+      >
+        <style>{'.test-timeline-host, .test-timeline-host * { box-sizing: border-box; }'}</style>
+        <TestTimeline
+          events={events}
+          resources={resources}
+          dependencies={dependencies}
+          onStoreReady={(mountedStore) => {
+            store = mountedStore;
+          }}
+        />
+      </div>,
+    );
+
+    return { store, ...view };
+  }
+
+  function getArrowPaths() {
+    return Array.from(document.querySelectorAll<SVGPathElement>('[data-dependency-id]'));
+  }
+
+  it('should render one arrow per active dependency', () => {
+    renderTimeline({
+      events: [eventA, eventB, eventC],
+      dependencies: [
+        buildDependency('dep-1', 'event-a', 'event-b'),
+        buildDependency('dep-2', 'event-a', 'event-c'),
+      ],
+    });
+
+    expect(getArrowPaths().map((path) => path.getAttribute('data-dependency-id'))).to.deep.equal([
+      'dep-1',
+      'dep-2',
+    ]);
+  });
+
+  it('should render a straight horizontal path between two events in the same row and lane', () => {
+    renderTimeline({
+      events: [eventA, eventB],
+      dependencies: [buildDependency('dep-1', 'event-a', 'event-b')],
+    });
+
+    const d = getArrowPaths()[0].getAttribute('d')!;
+    const match = d.match(/^M ([\d.]+) ([\d.]+) L ([\d.]+) ([\d.]+)$/);
+
+    expect(match).not.to.equal(null);
+    // Same height on both ends, pointing forward.
+    expect(match![2]).to.equal(match![4]);
+    expect(parseFloat(match![3])).to.be.greaterThan(parseFloat(match![1]));
+  });
+
+  it('should render an orthogonal path with softened corners between two rows', () => {
+    renderTimeline({
+      events: [eventA, eventC],
+      dependencies: [buildDependency('dep-1', 'event-a', 'event-c')],
+    });
+
+    const d = getArrowPaths()[0].getAttribute('d')!;
+
+    // Forward elbow: two softened corners.
+    expect(d.match(/Q /g)).to.have.length(2);
+
+    // The path ends lower than it starts (row 1 is below row 0).
+    const coordinates = d.match(/[\d.]+/g)!.map(parseFloat);
+    expect(coordinates[coordinates.length - 1]).to.be.greaterThan(coordinates[1]);
+  });
+
+  it('should render an S route when the successor starts before the predecessor ends', () => {
+    const earlyEvent = EventBuilder.new()
+      .id('event-early')
+      .title('Event early')
+      .singleDay('2025-07-03T08:00:00Z')
+      .resource(resource2)
+      .build();
+
+    renderTimeline({
+      events: [eventA, earlyEvent],
+      dependencies: [buildDependency('dep-1', 'event-a', 'event-early')],
+    });
+
+    const d = getArrowPaths()[0].getAttribute('d')!;
+
+    // S route: four softened corners.
+    expect(d.match(/Q /g)).to.have.length(4);
+  });
+
+  it('should not render an arrow when an endpoint event has no resource', () => {
+    const unresourcedEvent = EventBuilder.new()
+      .id('event-unresourced')
+      .title('Event unresourced')
+      .singleDay('2025-07-03T11:00:00Z')
+      .build();
+
+    renderTimeline({
+      events: [eventA, eventB, unresourcedEvent],
+      dependencies: [
+        buildDependency('dep-1', 'event-a', 'event-unresourced'),
+        buildDependency('dep-2', 'event-a', 'event-b'),
+      ],
+    });
+
+    expect(getArrowPaths().map((path) => path.getAttribute('data-dependency-id'))).to.deep.equal([
+      'dep-2',
+    ]);
+  });
+
+  it('should not render an arrow when an endpoint event is outside the visible range', () => {
+    const outOfRangeEvent = EventBuilder.new()
+      .id('event-out-of-range')
+      .title('Event out of range')
+      .singleDay('2050-07-03T11:00:00Z')
+      .resource(resource2)
+      .build();
+
+    renderTimeline({
+      events: [eventA, eventB, outOfRangeEvent],
+      dependencies: [
+        buildDependency('dep-1', 'event-a', 'event-out-of-range'),
+        buildDependency('dep-2', 'event-a', 'event-b'),
+      ],
+    });
+
+    expect(getArrowPaths().map((path) => path.getAttribute('data-dependency-id'))).to.deep.equal([
+      'dep-2',
+    ]);
+  });
+
+  it('should update the arrow when the predecessor event moves', () => {
+    const { store } = renderTimeline({
+      events: [eventA, eventB],
+      dependencies: [buildDependency('dep-1', 'event-a', 'event-b')],
+    });
+
+    const initialD = getArrowPaths()[0].getAttribute('d')!;
+
+    act(() => {
+      store.updateEvent({
+        id: 'event-a',
+        start: adapter.date('2025-07-03T09:30:00Z', 'default'),
+        end: adapter.date('2025-07-03T10:30:00Z', 'default'),
+      });
+    });
+
+    const updatedD = getArrowPaths()[0].getAttribute('d')!;
+    expect(updatedD).not.to.equal(initialD);
+  });
+
+  it('should remove the arrow when the dependency is deleted', () => {
+    const { store } = renderTimeline({
+      events: [eventA, eventB],
+      dependencies: [buildDependency('dep-1', 'event-a', 'event-b')],
+    });
+
+    expect(getArrowPaths()).to.have.length(1);
+
+    act(() => {
+      store.deleteDependency('dep-1');
+    });
+
+    expect(getArrowPaths()).to.have.length(0);
+    expect(document.querySelector('[data-dependency-arrows]')).to.equal(null);
+  });
+
+  it('should hide the arrows overlay from assistive technology', () => {
+    renderTimeline({
+      events: [eventA, eventB],
+      dependencies: [buildDependency('dep-1', 'event-a', 'event-b')],
+    });
+
+    expect(
+      document.querySelector('[data-dependency-arrows]')!.getAttribute('aria-hidden'),
+    ).to.equal('true');
+  });
+
+  it('should render no overlay when there is no dependency', () => {
+    renderTimeline({ events: [eventA, eventB] });
+
+    expect(document.querySelector('[data-dependency-arrows]')).to.equal(null);
+  });
+
+  describe('successor accessible description', () => {
+    function getEventElement(title: string) {
+      return screen.getByText(title).closest('[data-occurrence-key]')!;
+    }
+
+    it('should describe the successor event with its predecessor titles', () => {
+      renderTimeline({
+        events: [eventA, eventB, eventC],
+        dependencies: [
+          buildDependency('dep-1', 'event-a', 'event-b'),
+          buildDependency('dep-2', 'event-c', 'event-b'),
+        ],
+      });
+
+      const successor = getEventElement('Event B');
+      const descriptionId = successor.getAttribute('aria-describedby')!;
+
+      expect(descriptionId).not.to.equal(null);
+      expect(document.getElementById(descriptionId)!.textContent).to.equal(
+        'Depends on Event A, Event C',
+      );
+    });
+
+    it('should not describe an event without predecessors', () => {
+      renderTimeline({
+        events: [eventA, eventB],
+        dependencies: [buildDependency('dep-1', 'event-a', 'event-b')],
+      });
+
+      expect(getEventElement('Event A').getAttribute('aria-describedby')).to.equal(null);
+    });
+  });
+
+  describe.skipIf(isJSDOM)('virtualization', () => {
+    function getGrid() {
+      return document.querySelector<HTMLElement>(`.${eventTimelinePremiumClasses.grid}`)!;
+    }
+
+    it('should cull an arrow outside the visible column range and restore it on scroll', async () => {
+      // Both events sit on the third day: outside the initial viewport of the
+      // dayAndHour preset (64px per hour, 1200px wide host).
+      const laterEventA = EventBuilder.new()
+        .id('event-later-a')
+        .title('Event later A')
+        .singleDay('2025-07-05T09:00:00Z')
+        .resource(resource1)
+        .build();
+      const laterEventB = EventBuilder.new()
+        .id('event-later-b')
+        .title('Event later B')
+        .singleDay('2025-07-05T11:00:00Z')
+        .resource(resource1)
+        .build();
+
+      renderTimeline({
+        events: [laterEventA, laterEventB],
+        dependencies: [buildDependency('dep-1', 'event-later-a', 'event-later-b')],
+      });
+
+      await waitFor(() => {
+        expect(getArrowPaths().length).to.equal(0);
+      });
+
+      // Scroll to the third day (2 days × 24h × 64px).
+      act(() => {
+        getGrid().scrollLeft = 2 * 24 * 64;
+      });
+      await waitFor(() => {
+        expect(getArrowPaths().length).to.equal(1);
+      });
+
+      act(() => {
+        getGrid().scrollLeft = 0;
+      });
+      await waitFor(() => {
+        expect(getArrowPaths().length).to.equal(0);
+      });
+    });
+
+    it('should keep an arrow crossing the viewport when both endpoint rows are scrolled out', async () => {
+      const manyResources = Array.from({ length: 30 }, (_, index) =>
+        ResourceBuilder.new()
+          .id(`resource-${String(index).padStart(2, '0')}`)
+          .title(`Resource ${String(index).padStart(2, '0')}`)
+          .build(),
+      );
+      const firstRowEvent = EventBuilder.new()
+        .id('event-first-row')
+        .title('Event first row')
+        .singleDay('2025-07-03T09:00:00Z')
+        .resource(manyResources[0])
+        .build();
+      const lastRowEvent = EventBuilder.new()
+        .id('event-last-row')
+        .title('Event last row')
+        .singleDay('2025-07-03T11:00:00Z')
+        .resource(manyResources[29])
+        .build();
+
+      renderTimeline({
+        events: [firstRowEvent, lastRowEvent],
+        resources: manyResources,
+        dependencies: [buildDependency('dep-1', 'event-first-row', 'event-last-row')],
+      });
+
+      await waitFor(() => {
+        expect(getArrowPaths().length).to.equal(1);
+      });
+      await waitFor(() => {
+        expect(getGrid().scrollHeight).to.be.greaterThan(getGrid().clientHeight);
+      });
+
+      // Scroll vertically to the middle of the rows: both endpoints leave the viewport
+      // but the arrow's vertical segment still crosses it.
+      act(() => {
+        getGrid().scrollTop = 900;
+      });
+      await waitFor(() => {
+        expect(getGrid().scrollTop).to.be.greaterThan(0);
+      });
+      expect(getArrowPaths().length).to.equal(1);
+    });
+
+    it('should not catch pointer events on the overlay', async () => {
+      renderTimeline({
+        events: [eventA, eventB],
+        dependencies: [buildDependency('dep-1', 'event-a', 'event-b')],
+      });
+
+      await waitFor(() => {
+        expect(document.querySelector('[data-dependency-arrows]')).not.to.equal(null);
+      });
+      expect(
+        getComputedStyle(document.querySelector('[data-dependency-arrows]')!).pointerEvents,
+      ).to.equal('none');
+    });
+  });
+});

--- a/packages/x-scheduler-premium/src/event-timeline-premium/tests/dependencyArrows.EventTimelinePremium.test.tsx
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/tests/dependencyArrows.EventTimelinePremium.test.tsx
@@ -225,24 +225,9 @@ describe('<EventTimelinePremium /> dependency arrows', () => {
     expect(d.match(/Q /g)).to.have.length(4);
   });
 
-  it('should render one arrow per row appearance of a multi-resource event', () => {
-    const multiResourceEvent = EventBuilder.new()
-      .id('event-multi')
-      .title('Event multi')
-      .singleDay('2025-07-03T11:00:00Z')
-      .resources([resource1, resource2])
-      .build();
-
-    renderTimeline({
-      events: [eventA, multiResourceEvent],
-      dependencies: [buildDependency('dep-1', 'event-a', 'event-multi')],
-    });
-
-    expect(getArrowPaths().map((path) => path.getAttribute('data-dependency-id'))).to.deep.equal([
-      'dep-1',
-      'dep-1',
-    ]);
-  });
+  // TODO(multi-resource rendering): add an integration test rendering one arrow per
+  // row appearance of a multi-resource event once the rendering support lands. The
+  // per-appearance fan-out is covered by the `computeDependencyArrows` unit tests.
 
   it('should not render an arrow when an endpoint event has no resource', () => {
     const unresourcedEvent = EventBuilder.new()

--- a/packages/x-scheduler-premium/src/internals/index.ts
+++ b/packages/x-scheduler-premium/src/internals/index.ts
@@ -1,3 +1,7 @@
 export { RecurrenceTab } from './components/event-dialog/RecurrenceTab';
 export { RecurringScopeDialog } from './components/recurring-scope-dialog/RecurringScopeDialog';
 export { PREMIUM_EVENT_DIALOG_OPTIONAL_RENDERERS } from './eventDialogOptionalRenderers';
+// Seam for the docs experiments while the dependencies feature has no public API:
+// lets an experiment recreate the timeline with the internal store parameters.
+export { EventTimelinePremiumContent } from '../event-timeline-premium/content';
+export { EventTimelinePremiumStyledContext } from '../event-timeline-premium/EventTimelinePremiumStyledContext';

--- a/scripts/buildApiDocs/schedulerSettings/index.ts
+++ b/scripts/buildApiDocs/schedulerSettings/index.ts
@@ -109,6 +109,7 @@ export default schedulerApiPages;
       'x-scheduler-premium/src/event-timeline-premium/content/timeline-event/EventTimelinePremiumEvent.tsx',
       'x-scheduler-premium/src/event-timeline-premium/content/timeline-title-cell/EventTimelinePremiumTitleCell.tsx',
       'x-scheduler-premium/src/event-timeline-premium/content/timeline-header/EventTimelinePremiumHeader.tsx',
+      'x-scheduler-premium/src/event-timeline-premium/content/timeline-dependency-arrows/EventTimelinePremiumDependencyArrows.tsx',
       'x-scheduler-premium/src/event-timeline-premium/error-container/EventTimelinePremiumErrorContainer.tsx',
     ].some((invalidPath) => filename.endsWith(invalidPath));
   },


### PR DESCRIPTION
Part of #22853. Closes #22855.

Renders the Finish-to-Start dependency arrows in the timeline. Pure rendering: no validation, no rescheduling, no interaction (#22856–#22858).

- Anchors computed from the data model (time fraction × width, row offsets from the virtualizer, lane), never measured on the DOM, so arrows work under virtualization on both axes and follow moves/resizes through store subscriptions alone.
- Orthogonal routing with softened corners: straight segment on the same lane, elbow across rows with two turn candidates keeping the one crossing the fewest events (best-effort avoidance, not full pathfinding), Bryntum-style short overlapping arrow between adjacent events, and S routes hugging the source event for backward links (so the detour never lands on a row border).
- Viewport culling from the render context using precomputed bounding boxes; off-screen anchors are clipped by the overlay's viewBox.
- A11y: the overlay is `aria-hidden`; successor events expose a visually hidden "Depends on X" description through `aria-describedby`.
- Zero public API: the overlay reads the internal dependencies slice (#23117), which cannot be populated through the public component yet. `pnpm proptypes` + `pnpm docs:api` produce no changes.

## How to review

- Open the [deploy preview](https://deploy-preview-23162--material-ui-x.netlify.app/x/react-scheduler/experiments/) — the "Timeline dependency arrows" section showcases every route shape with draggable events. The demo feeds the internal store parameters through a seam exported from the premium internals.
- Suggested reading order: the pure extractions (`computeElementPositionInCollection`, `computeOccurrencesFirstIndexLookup`) → `rowGeometry.ts` → `dependencyArrowGeometry.ts` with its tests → the overlay component → the a11y increment.
- Heads-up: on machines where scrollbars take layout space (Windows/Linux, or macOS with a mouse connected) the event pills themselves drift off the model grid — that is the pre-existing #23167, which the model-anchored arrows expose; it is not introduced here.

## Flagged for review

- Multi-resource endpoint events anchor on their first row in render order (the issue is silent on this case).
- Visual constants (`grey[400]`/`grey[600]`, 1px stroke, 7px filled arrowhead, radius 4, stub 8) are isolated as module constants pending design review.
- Hardcoded English a11y string ("Depends on X") with a TODO to move into localeText at the public flip. At that point the wording should become one parametrized key per dependency type ("Cannot start until X finishes" for FS, "Cannot start until X starts" for SS, etc.) — the short "Depends on" form is deliberate in v1 to keep screen reader verbosity low with multiple predecessors.
- The S route does not participate in obstacle avoidance yet.

