### PR TITLE
[DateRangePicker] Fix broken active range position underline in single input range fields

### DIFF
--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.test.tsx
@@ -1,6 +1,6 @@
 import type { DateRangePickerProps } from '@mui/x-date-pickers-pro/DateRangePicker';
 import { DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker';
-import { screen, waitFor } from '@mui/internal-test-utils';
+import { screen, waitFor, within } from '@mui/internal-test-utils';
 import { spy } from 'sinon';
 import {
   adapterToUse,
@@ -124,8 +124,11 @@ describe('<DateRangePicker />', () => {
   });
 
   // The active range position underline (`activeBar`) is measured from the rendered
-  // section widths (`offsetWidth`), which is always `0` in jsdom, so this runs in the browser.
+  // section widths (`offsetWidth`), which is always `0` in jsdom, so these run in the browser.
   describe('active range position underline (single input)', () => {
+    const getPickerDay = (name: string, picker = 'January 2018') =>
+      within(screen.getByRole('grid', { name: picker })).getByRole('gridcell', { name });
+
     it.skipIf(isJSDOM)(
       'should render the active bar with a non-zero width for the focused range position',
       async () => {
@@ -153,33 +156,37 @@ describe('<DateRangePicker />', () => {
     );
 
     it.skipIf(isJSDOM)(
-      'should move the active bar to the end range position when editing the end date',
+      'should move the active bar to the end range position after selecting the start date',
       async () => {
         stubMatchMedia(true);
-        const view = renderWithProps({
-          rangePosition: 'start',
-          defaultValue: [adapterToUse.date('2022-04-17'), adapterToUse.date('2022-04-21')],
+        const { user } = renderWithProps({
+          defaultValue: [adapterToUse.date('2018-01-01'), adapterToUse.date('2018-01-06')],
         });
-        await openPicker(view.user, {
+        await openPicker(user, {
           type: 'date-range',
           initialFocus: 'start',
           fieldType: 'single-input',
         });
 
-        const activeBar = document.querySelector<HTMLElement>(
-          `.${pickersInputBaseClasses.activeBar}`,
-        )!;
+        const activeBarSelector = `.${pickersInputBaseClasses.activeBar}`;
         let startLeft = 0;
         await waitFor(() => {
+          const activeBar = document.querySelector<HTMLElement>(activeBarSelector)!;
           expect(activeBar.offsetWidth).to.be.greaterThan(0);
           startLeft = activeBar.offsetLeft;
         });
 
-        view.setProps({ rangePosition: 'end' });
+        // Selecting the start date advances the picker to the end range position.
+        await user.click(getPickerDay('3'));
 
         await waitFor(() => {
+          expect(document.querySelector('[data-active-range-position]')).to.have.attribute(
+            'data-active-range-position',
+            'end',
+          );
           // The bar now sits under the end date sections, well to the right of the start
           // sections (observed gap is ~100px; 40px keeps the assertion comfortably robust).
+          const activeBar = document.querySelector<HTMLElement>(activeBarSelector)!;
           expect(activeBar.offsetLeft).to.be.greaterThan(startLeft + 40);
         });
       },

--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.test.tsx
@@ -151,5 +151,38 @@ describe('<DateRangePicker />', () => {
         });
       },
     );
+
+    it.skipIf(isJSDOM)(
+      'should move the active bar to the end range position when editing the end date',
+      async () => {
+        stubMatchMedia(true);
+        const view = renderWithProps({
+          rangePosition: 'start',
+          defaultValue: [adapterToUse.date('2022-04-17'), adapterToUse.date('2022-04-21')],
+        });
+        await openPicker(view.user, {
+          type: 'date-range',
+          initialFocus: 'start',
+          fieldType: 'single-input',
+        });
+
+        const activeBar = document.querySelector<HTMLElement>(
+          `.${pickersInputBaseClasses.activeBar}`,
+        )!;
+        let startLeft = 0;
+        await waitFor(() => {
+          expect(activeBar.offsetWidth).to.be.greaterThan(0);
+          startLeft = activeBar.offsetLeft;
+        });
+
+        view.setProps({ rangePosition: 'end' });
+
+        await waitFor(() => {
+          // The bar now sits under the end date sections, well to the right of the start
+          // sections (observed gap is ~100px; 40px keeps the assertion comfortably robust).
+          expect(activeBar.offsetLeft).to.be.greaterThan(startLeft + 40);
+        });
+      },
+    );
   });
 });

--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.test.tsx
@@ -1,14 +1,17 @@
 import type { DateRangePickerProps } from '@mui/x-date-pickers-pro/DateRangePicker';
 import { DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker';
-import { screen } from '@mui/internal-test-utils/createRenderer';
+import { screen, waitFor } from '@mui/internal-test-utils';
 import { spy } from 'sinon';
 import {
+  adapterToUse,
   buildFieldInteractions,
   createPickerRenderer,
   openPicker,
   stubMatchMedia,
 } from 'test/utils/pickers';
 import { pickerPopperClasses } from '@mui/x-date-pickers/internals';
+import { pickersInputBaseClasses } from '@mui/x-date-pickers/PickersTextField';
+import { isJSDOM } from 'test/utils/skipIf';
 import { MultiInputDateRangeField } from '../MultiInputDateRangeField';
 
 describe('<DateRangePicker />', () => {
@@ -118,5 +121,35 @@ describe('<DateRangePicker />', () => {
 
       expect(handleSubmit.callCount).to.equal(0);
     });
+  });
+
+  // The active range position underline (`activeBar`) is measured from the rendered
+  // section widths (`offsetWidth`), which is always `0` in jsdom, so this runs in the browser.
+  describe('active range position underline (single input)', () => {
+    it.skipIf(isJSDOM)(
+      'should render the active bar with a non-zero width for the focused range position',
+      async () => {
+        stubMatchMedia(true);
+        const { user } = renderWithProps({
+          defaultValue: [adapterToUse.date('2022-04-17'), adapterToUse.date('2022-04-21')],
+        });
+        await openPicker(user, {
+          type: 'date-range',
+          initialFocus: 'start',
+          fieldType: 'single-input',
+        });
+
+        const fieldRoot = document.querySelector<HTMLElement>('[data-active-range-position]');
+        expect(fieldRoot).to.have.attribute('data-active-range-position', 'start');
+
+        const activeBar = document.querySelector<HTMLElement>(
+          `.${pickersInputBaseClasses.activeBar}`,
+        );
+        expect(activeBar).not.to.equal(null);
+        await waitFor(() => {
+          expect(activeBar!.offsetWidth).to.be.greaterThan(0);
+        });
+      },
+    );
   });
 });

--- a/packages/x-date-pickers/src/PickersTextField/PickersInputBase/PickersInputBase.tsx
+++ b/packages/x-date-pickers/src/PickersTextField/PickersInputBase/PickersInputBase.tsx
@@ -267,8 +267,7 @@ function resolveSectionElementWidth(
   index: number,
   dateRangePosition: 'start' | 'end',
 ) {
-  // Only measure sections that belong to a range date. This used to check `content.id`, but
-  // that was removed in https://github.com/mui/mui-x/pull/19523, which silently zeroed the bar.
+  // Only measure sections that belong to a range date.
   if (sectionElement.content['data-range-position']) {
     const activeSectionElements = rootRef.current?.querySelectorAll<HTMLSpanElement>(
       `[data-sectionindex="${index}"] [data-range-position="${dateRangePosition}"]`,

--- a/packages/x-date-pickers/src/PickersTextField/PickersInputBase/PickersInputBase.tsx
+++ b/packages/x-date-pickers/src/PickersTextField/PickersInputBase/PickersInputBase.tsx
@@ -267,7 +267,9 @@ function resolveSectionElementWidth(
   index: number,
   dateRangePosition: 'start' | 'end',
 ) {
-  if (sectionElement.content.id) {
+  // Only measure sections that belong to a range date. This used to check `content.id`, but
+  // that was removed in https://github.com/mui/mui-x/pull/19523, which silently zeroed the bar.
+  if (sectionElement.content['data-range-position']) {
     const activeSectionElements = rootRef.current?.querySelectorAll<HTMLSpanElement>(
       `[data-sectionindex="${index}"] [data-range-position="${dateRangePosition}"]`,
     );

--- a/packages/x-date-pickers/src/PickersTextField/PickersInputBase/PickersInputBase.tsx
+++ b/packages/x-date-pickers/src/PickersTextField/PickersInputBase/PickersInputBase.tsx
@@ -268,7 +268,7 @@ function resolveSectionElementWidth(
   dateRangePosition: 'start' | 'end',
 ) {
   // Only measure sections that belong to a range date.
-  if (sectionElement.content['data-range-position']) {
+  if (sectionElement.content['data-range-position'] !== undefined) {
     const activeSectionElements = rootRef.current?.querySelectorAll<HTMLSpanElement>(
       `[data-sectionindex="${index}"] [data-range-position="${dateRangePosition}"]`,
     );


### PR DESCRIPTION
## Summary

The active range position underline (`activeBar`) that marks the range side currently being selected in a **single input** range field is visually broken -- it renders but is invisible.

## Root cause

The bar's width is computed in `resolveSectionElementWidth` (`PickersInputBase.tsx`), which is gated on `if (sectionElement.content.id)`. When the `activeBar` was introduced in https://github.com/mui/mui-x/pull/16938 every section's content object carried an `id` (`${id}-${section.type}`), so that guard was effectively always true. https://github.com/mui/mui-x/pull/19523 later removed that `id` from the section content props as redundant, which silently turned the guard into a permanent short-circuit: `resolveSectionElementWidth` now always returns `0`, so `activeBarWidth` is always `0` and the bar renders at `width: 0px`.

`display` still toggles and `left` still positions correctly -- only the width was zeroed, which is why the bar was invisible rather than mispositioned.

## Fix

Guard on `content['data-range-position']` instead of the removed `content.id`. It is the typed `'start' | 'end'` signal that is still present on every range section and already drives `isSingleInputRange` in the same file, so it is the natural, intent-revealing replacement.

## Testing

There were previously zero tests referencing the `activeBar`, which is why the regression slipped through. This adds two browser-only tests (`DateRangePicker.test.tsx`): one asserting the bar has a non-zero width once a single-input desktop range picker is open, and one asserting the bar's `left` shifts to the end date sections after the start date is selected (which advances the picker to the end position). They are `skipIf(isJSDOM)` because `offsetWidth` / `offsetLeft` are always `0` in jsdom. Verified the width test fails on the old guard and passes with the fix.

## Visual comparison

| Before | After |
|--------|--------|
| <img width="908" height="606" alt="Screenshot 2026-07-20 at 15 51 11" src="https://github.com/user-attachments/assets/f995c6be-bb2a-419f-8ceb-ea0d8efb14b4" /> | <img width="898" height="602" alt="Screenshot 2026-07-20 at 15 51 34" src="https://github.com/user-attachments/assets/7d0db6a9-ac96-4f72-8b76-8cfa3cb64237" /> | 
