### PR TITLE
[charts][accessibility] Activate onItemClick on Enter / Spacebar

### DIFF
--- a/docs/data/charts/scatter/scatter.md
+++ b/docs/data/charts/scatter/scatter.md
@@ -66,16 +66,19 @@ When `hitAreaRadius` is `"item"`, the user must click directly on the point, and
 
 Otherwise, click behavior matches the [interaction section](#interaction), and the mouse event comes from the SVG container.
 
-When a point is focused with keyboard navigation, <kbd class="key">Enter</kbd> or <kbd class="key">Space</kbd> also calls `onItemClick` with a `KeyboardEvent`.
+A focused point can also be activated with the keyboard.
+To enable keyboard click interaction with <kbd class="key">Enter</kbd> or <kbd class="key">Space</kbd>, provide `experimentalFeatures: { enableKeyboardClickEvents: true }`.
+`onItemClick` is then called with a `KeyboardEvent`.
 
-:::info
-The `event` parameter is typed as `MouseEvent` to avoid a breaking change.
-To also get `KeyboardEvent` in the type, add the following import:
+To get the proper event type, add the following import:
 
 ```ts
 import type {} from '@mui/x-charts/moduleAugmentation/keyboardItemActivation';
 ```
 
+:::info
+Both opt-ins exist to avoid a breaking change.
+Keyboard activation and the wider `event` type become the default in the next major version.
 :::
 
 {{"demo": "ScatterClick.js"}}

--- a/docs/data/charts/scatter/scatter.md
+++ b/docs/data/charts/scatter/scatter.md
@@ -66,6 +66,8 @@ When `hitAreaRadius` is `"item"`, the user must click directly on the point, and
 
 Otherwise, click behavior matches the [interaction section](#interaction), and the mouse event comes from the SVG container.
 
+When a point is focused with keyboard navigation, <kbd class="key">Enter</kbd> or <kbd class="key">Space</kbd> also calls `onItemClick` with a `KeyboardEvent`.
+
 {{"demo": "ScatterClick.js"}}
 
 ## Bubble chart

--- a/docs/data/charts/scatter/scatter.md
+++ b/docs/data/charts/scatter/scatter.md
@@ -68,6 +68,16 @@ Otherwise, click behavior matches the [interaction section](#interaction), and t
 
 When a point is focused with keyboard navigation, <kbd class="key">Enter</kbd> or <kbd class="key">Space</kbd> also calls `onItemClick` with a `KeyboardEvent`.
 
+:::info
+The `event` parameter is typed as `MouseEvent` to avoid a breaking change.
+To also get `KeyboardEvent` in the type, add the following import:
+
+```ts
+import type {} from '@mui/x-charts/moduleAugmentation/keyboardItemActivation';
+```
+
+:::
+
 {{"demo": "ScatterClick.js"}}
 
 ## Bubble chart

--- a/docs/pages/x/api/charts/bar-chart-premium.json
+++ b/docs/pages/x/api/charts/bar-chart-premium.json
@@ -30,7 +30,9 @@
     "desc": { "type": { "name": "string" } },
     "disableAxisListener": { "type": { "name": "bool" }, "default": "false" },
     "disableKeyboardNavigation": { "type": { "name": "bool" } },
-    "experimentalFeatures": { "type": { "name": "object" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ enableKeyboardClickEvents?: bool }" }
+    },
     "grid": {
       "type": { "name": "shape", "description": "{ horizontal?: bool, vertical?: bool }" }
     },

--- a/docs/pages/x/api/charts/bar-chart-pro.json
+++ b/docs/pages/x/api/charts/bar-chart-pro.json
@@ -30,7 +30,9 @@
     "desc": { "type": { "name": "string" } },
     "disableAxisListener": { "type": { "name": "bool" }, "default": "false" },
     "disableKeyboardNavigation": { "type": { "name": "bool" } },
-    "experimentalFeatures": { "type": { "name": "object" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ enableKeyboardClickEvents?: bool }" }
+    },
     "grid": {
       "type": { "name": "shape", "description": "{ horizontal?: bool, vertical?: bool }" }
     },

--- a/docs/pages/x/api/charts/bar-chart.json
+++ b/docs/pages/x/api/charts/bar-chart.json
@@ -30,7 +30,9 @@
     "desc": { "type": { "name": "string" } },
     "disableAxisListener": { "type": { "name": "bool" }, "default": "false" },
     "disableKeyboardNavigation": { "type": { "name": "bool" } },
-    "experimentalFeatures": { "type": { "name": "object" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ enableKeyboardClickEvents?: bool }" }
+    },
     "grid": {
       "type": { "name": "shape", "description": "{ horizontal?: bool, vertical?: bool }" }
     },

--- a/docs/pages/x/api/charts/charts-container.json
+++ b/docs/pages/x/api/charts/charts-container.json
@@ -16,7 +16,9 @@
     "disableAxisListener": { "type": { "name": "bool" }, "default": "false" },
     "disableHitArea": { "type": { "name": "bool" } },
     "disableKeyboardNavigation": { "type": { "name": "bool" } },
-    "experimentalFeatures": { "type": { "name": "any" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ enableKeyboardClickEvents?: bool }" }
+    },
     "height": { "type": { "name": "number" } },
     "hiddenItems": {
       "type": {

--- a/docs/pages/x/api/charts/charts-container.json
+++ b/docs/pages/x/api/charts/charts-container.json
@@ -82,7 +82,7 @@
     "onItemClick": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: MouseEvent | KeyboardEvent, scatterItemIdentifier: ScatterItemIdentifier) => void",
+        "type": "function(event: MouseEvent, scatterItemIdentifier: ScatterItemIdentifier) => void",
         "describedArgs": ["event", "scatterItemIdentifier"]
       }
     },

--- a/docs/pages/x/api/charts/charts-container.json
+++ b/docs/pages/x/api/charts/charts-container.json
@@ -82,7 +82,7 @@
     "onItemClick": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: MouseEvent, scatterItemIdentifier: ScatterItemIdentifier) => void",
+        "type": "function(event: MouseEvent | KeyboardEvent, scatterItemIdentifier: ScatterItemIdentifier) => void",
         "describedArgs": ["event", "scatterItemIdentifier"]
       }
     },

--- a/docs/pages/x/api/charts/charts-data-provider-premium.json
+++ b/docs/pages/x/api/charts/charts-data-provider-premium.json
@@ -5,7 +5,9 @@
       "default": "rainbowSurgePalette"
     },
     "dataset": { "type": { "name": "arrayOf", "description": "Array&lt;object&gt;" } },
-    "experimentalFeatures": { "type": { "name": "any" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ enableKeyboardClickEvents?: bool }" }
+    },
     "height": { "type": { "name": "number" } },
     "id": { "type": { "name": "string" } },
     "localeText": { "type": { "name": "object" } },

--- a/docs/pages/x/api/charts/charts-data-provider-pro.json
+++ b/docs/pages/x/api/charts/charts-data-provider-pro.json
@@ -5,7 +5,9 @@
       "default": "rainbowSurgePalette"
     },
     "dataset": { "type": { "name": "arrayOf", "description": "Array&lt;object&gt;" } },
-    "experimentalFeatures": { "type": { "name": "any" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ enableKeyboardClickEvents?: bool }" }
+    },
     "height": { "type": { "name": "number" } },
     "id": { "type": { "name": "string" } },
     "localeText": { "type": { "name": "object" } },

--- a/docs/pages/x/api/charts/charts-data-provider.json
+++ b/docs/pages/x/api/charts/charts-data-provider.json
@@ -5,7 +5,9 @@
       "default": "rainbowSurgePalette"
     },
     "dataset": { "type": { "name": "arrayOf", "description": "Array&lt;object&gt;" } },
-    "experimentalFeatures": { "type": { "name": "any" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ enableKeyboardClickEvents?: bool }" }
+    },
     "height": { "type": { "name": "number" } },
     "id": { "type": { "name": "string" } },
     "localeText": { "type": { "name": "object" } },

--- a/docs/pages/x/api/charts/charts-geo-data-provider-premium.json
+++ b/docs/pages/x/api/charts/charts-geo-data-provider-premium.json
@@ -5,7 +5,9 @@
       "default": "rainbowSurgePalette"
     },
     "dataset": { "type": { "name": "arrayOf", "description": "Array&lt;object&gt;" } },
-    "experimentalFeatures": { "type": { "name": "any" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ enableKeyboardClickEvents?: bool }" }
+    },
     "height": { "type": { "name": "number" } },
     "id": { "type": { "name": "string" } },
     "localeText": { "type": { "name": "object" } },

--- a/docs/pages/x/api/charts/charts-radial-data-provider-premium.json
+++ b/docs/pages/x/api/charts/charts-radial-data-provider-premium.json
@@ -5,7 +5,9 @@
       "default": "rainbowSurgePalette"
     },
     "dataset": { "type": { "name": "arrayOf", "description": "Array&lt;object&gt;" } },
-    "experimentalFeatures": { "type": { "name": "any" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ enableKeyboardClickEvents?: bool }" }
+    },
     "height": { "type": { "name": "number" } },
     "id": { "type": { "name": "string" } },
     "localeText": { "type": { "name": "object" } },

--- a/docs/pages/x/api/charts/charts-radial-data-provider.json
+++ b/docs/pages/x/api/charts/charts-radial-data-provider.json
@@ -5,7 +5,9 @@
       "default": "rainbowSurgePalette"
     },
     "dataset": { "type": { "name": "arrayOf", "description": "Array&lt;object&gt;" } },
-    "experimentalFeatures": { "type": { "name": "any" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ enableKeyboardClickEvents?: bool }" }
+    },
     "height": { "type": { "name": "number" } },
     "id": { "type": { "name": "string" } },
     "localeText": { "type": { "name": "object" } },

--- a/docs/pages/x/api/charts/funnel-chart.json
+++ b/docs/pages/x/api/charts/funnel-chart.json
@@ -28,7 +28,9 @@
     "desc": { "type": { "name": "string" } },
     "disableAxisListener": { "type": { "name": "bool" }, "default": "false" },
     "disableKeyboardNavigation": { "type": { "name": "bool" } },
-    "experimentalFeatures": { "type": { "name": "object" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ enableKeyboardClickEvents?: bool }" }
+    },
     "gap": { "type": { "name": "number" }, "default": "0" },
     "height": { "type": { "name": "number" } },
     "hiddenItems": {

--- a/docs/pages/x/api/charts/heatmap-premium.json
+++ b/docs/pages/x/api/charts/heatmap-premium.json
@@ -27,7 +27,9 @@
     "desc": { "type": { "name": "string" } },
     "disableAxisListener": { "type": { "name": "bool" }, "default": "false" },
     "disableKeyboardNavigation": { "type": { "name": "bool" } },
-    "experimentalFeatures": { "type": { "name": "object" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ enableKeyboardClickEvents?: bool }" }
+    },
     "height": { "type": { "name": "number" } },
     "hideLegend": { "type": { "name": "bool" } },
     "highlightedItem": {

--- a/docs/pages/x/api/charts/heatmap.json
+++ b/docs/pages/x/api/charts/heatmap.json
@@ -27,7 +27,9 @@
     "desc": { "type": { "name": "string" } },
     "disableAxisListener": { "type": { "name": "bool" }, "default": "false" },
     "disableKeyboardNavigation": { "type": { "name": "bool" } },
-    "experimentalFeatures": { "type": { "name": "object" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ enableKeyboardClickEvents?: bool }" }
+    },
     "height": { "type": { "name": "number" } },
     "hideLegend": { "type": { "name": "bool" } },
     "highlightedItem": {

--- a/docs/pages/x/api/charts/line-chart-pro.json
+++ b/docs/pages/x/api/charts/line-chart-pro.json
@@ -32,7 +32,10 @@
     "disableKeyboardNavigation": { "type": { "name": "bool" } },
     "disableLineItemHighlight": { "type": { "name": "bool" } },
     "experimentalFeatures": {
-      "type": { "name": "shape", "description": "{ enablePositionBasedPointerInteraction?: bool }" }
+      "type": {
+        "name": "shape",
+        "description": "{ enableKeyboardClickEvents?: bool, enablePositionBasedPointerInteraction?: bool }"
+      }
     },
     "grid": {
       "type": { "name": "shape", "description": "{ horizontal?: bool, vertical?: bool }" }

--- a/docs/pages/x/api/charts/line-chart.json
+++ b/docs/pages/x/api/charts/line-chart.json
@@ -32,7 +32,10 @@
     "disableKeyboardNavigation": { "type": { "name": "bool" } },
     "disableLineItemHighlight": { "type": { "name": "bool" } },
     "experimentalFeatures": {
-      "type": { "name": "shape", "description": "{ enablePositionBasedPointerInteraction?: bool }" }
+      "type": {
+        "name": "shape",
+        "description": "{ enableKeyboardClickEvents?: bool, enablePositionBasedPointerInteraction?: bool }"
+      }
     },
     "grid": {
       "type": { "name": "shape", "description": "{ horizontal?: bool, vertical?: bool }" }

--- a/docs/pages/x/api/charts/pie-chart-pro.json
+++ b/docs/pages/x/api/charts/pie-chart-pro.json
@@ -11,7 +11,9 @@
     "dataset": { "type": { "name": "arrayOf", "description": "Array&lt;object&gt;" } },
     "desc": { "type": { "name": "string" } },
     "disableKeyboardNavigation": { "type": { "name": "bool" } },
-    "experimentalFeatures": { "type": { "name": "object" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ enableKeyboardClickEvents?: bool }" }
+    },
     "height": { "type": { "name": "number" } },
     "hiddenItems": {
       "type": {

--- a/docs/pages/x/api/charts/pie-chart.json
+++ b/docs/pages/x/api/charts/pie-chart.json
@@ -11,7 +11,9 @@
     "dataset": { "type": { "name": "arrayOf", "description": "Array&lt;object&gt;" } },
     "desc": { "type": { "name": "string" } },
     "disableKeyboardNavigation": { "type": { "name": "bool" } },
-    "experimentalFeatures": { "type": { "name": "object" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ enableKeyboardClickEvents?: bool }" }
+    },
     "height": { "type": { "name": "number" } },
     "hiddenItems": {
       "type": {

--- a/docs/pages/x/api/charts/radar-chart-pro.json
+++ b/docs/pages/x/api/charts/radar-chart-pro.json
@@ -20,7 +20,9 @@
     "disableAxisListener": { "type": { "name": "bool" }, "default": "false" },
     "disableKeyboardNavigation": { "type": { "name": "bool" } },
     "divisions": { "type": { "name": "number" }, "default": "5" },
-    "experimentalFeatures": { "type": { "name": "object" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ enableKeyboardClickEvents?: bool }" }
+    },
     "height": { "type": { "name": "number" } },
     "hiddenItems": {
       "type": {

--- a/docs/pages/x/api/charts/radar-chart.json
+++ b/docs/pages/x/api/charts/radar-chart.json
@@ -20,7 +20,9 @@
     "disableAxisListener": { "type": { "name": "bool" }, "default": "false" },
     "disableKeyboardNavigation": { "type": { "name": "bool" } },
     "divisions": { "type": { "name": "number" }, "default": "5" },
-    "experimentalFeatures": { "type": { "name": "object" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ enableKeyboardClickEvents?: bool }" }
+    },
     "height": { "type": { "name": "number" } },
     "hiddenItems": {
       "type": {

--- a/docs/pages/x/api/charts/radial-bar-chart.json
+++ b/docs/pages/x/api/charts/radial-bar-chart.json
@@ -22,7 +22,9 @@
     "dataset": { "type": { "name": "arrayOf", "description": "Array&lt;object&gt;" } },
     "disableAxisListener": { "type": { "name": "bool" }, "default": "false" },
     "disableKeyboardNavigation": { "type": { "name": "bool" } },
-    "experimentalFeatures": { "type": { "name": "object" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ enableKeyboardClickEvents?: bool }" }
+    },
     "grid": { "type": { "name": "shape", "description": "{ radius?: bool, rotation?: bool }" } },
     "height": { "type": { "name": "number" } },
     "hiddenItems": {

--- a/docs/pages/x/api/charts/radial-line-chart.json
+++ b/docs/pages/x/api/charts/radial-line-chart.json
@@ -23,7 +23,9 @@
     "disableAxisListener": { "type": { "name": "bool" }, "default": "false" },
     "disableKeyboardNavigation": { "type": { "name": "bool" } },
     "disableLineItemHighlight": { "type": { "name": "bool" } },
-    "experimentalFeatures": { "type": { "name": "object" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ enableKeyboardClickEvents?: bool }" }
+    },
     "grid": { "type": { "name": "shape", "description": "{ radius?: bool, rotation?: bool }" } },
     "height": { "type": { "name": "number" } },
     "hiddenItems": {

--- a/docs/pages/x/api/charts/sankey-chart.json
+++ b/docs/pages/x/api/charts/sankey-chart.json
@@ -8,7 +8,9 @@
     },
     "desc": { "type": { "name": "string" } },
     "disableKeyboardNavigation": { "type": { "name": "bool" } },
-    "experimentalFeatures": { "type": { "name": "object" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ enableKeyboardClickEvents?: bool }" }
+    },
     "height": { "type": { "name": "number" } },
     "highlightedItem": {
       "type": {

--- a/docs/pages/x/api/charts/sankey-data-provider.json
+++ b/docs/pages/x/api/charts/sankey-data-provider.json
@@ -6,7 +6,9 @@
     },
     "desc": { "type": { "name": "string" } },
     "disableKeyboardNavigation": { "type": { "name": "bool" } },
-    "experimentalFeatures": { "type": { "name": "object" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ enableKeyboardClickEvents?: bool }" }
+    },
     "height": { "type": { "name": "number" } },
     "highlightedItem": {
       "type": {

--- a/docs/pages/x/api/charts/scatter-chart-premium.json
+++ b/docs/pages/x/api/charts/scatter-chart-premium.json
@@ -109,7 +109,7 @@
     "onItemClick": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: MouseEvent | KeyboardEvent, scatterItemIdentifier: ScatterItemIdentifier) => void",
+        "type": "function(event: MouseEvent, scatterItemIdentifier: ScatterItemIdentifier) => void",
         "describedArgs": ["event", "scatterItemIdentifier"]
       }
     },

--- a/docs/pages/x/api/charts/scatter-chart-premium.json
+++ b/docs/pages/x/api/charts/scatter-chart-premium.json
@@ -109,7 +109,7 @@
     "onItemClick": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: MouseEvent, scatterItemIdentifier: ScatterItemIdentifier) => void",
+        "type": "function(event: MouseEvent | KeyboardEvent, scatterItemIdentifier: ScatterItemIdentifier) => void",
         "describedArgs": ["event", "scatterItemIdentifier"]
       }
     },

--- a/docs/pages/x/api/charts/scatter-chart-premium.json
+++ b/docs/pages/x/api/charts/scatter-chart-premium.json
@@ -44,7 +44,10 @@
       "deprecationInfo": "Use <code>disableHitArea</code> instead."
     },
     "experimentalFeatures": {
-      "type": { "name": "shape", "description": "{ progressiveRendering?: bool }" }
+      "type": {
+        "name": "shape",
+        "description": "{ enableKeyboardClickEvents?: bool, progressiveRendering?: bool }"
+      }
     },
     "grid": {
       "type": { "name": "shape", "description": "{ horizontal?: bool, vertical?: bool }" }

--- a/docs/pages/x/api/charts/scatter-chart-pro.json
+++ b/docs/pages/x/api/charts/scatter-chart-pro.json
@@ -109,7 +109,7 @@
     "onItemClick": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: MouseEvent | KeyboardEvent, scatterItemIdentifier: ScatterItemIdentifier) => void",
+        "type": "function(event: MouseEvent, scatterItemIdentifier: ScatterItemIdentifier) => void",
         "describedArgs": ["event", "scatterItemIdentifier"]
       }
     },

--- a/docs/pages/x/api/charts/scatter-chart-pro.json
+++ b/docs/pages/x/api/charts/scatter-chart-pro.json
@@ -109,7 +109,7 @@
     "onItemClick": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: MouseEvent, scatterItemIdentifier: ScatterItemIdentifier) => void",
+        "type": "function(event: MouseEvent | KeyboardEvent, scatterItemIdentifier: ScatterItemIdentifier) => void",
         "describedArgs": ["event", "scatterItemIdentifier"]
       }
     },

--- a/docs/pages/x/api/charts/scatter-chart-pro.json
+++ b/docs/pages/x/api/charts/scatter-chart-pro.json
@@ -44,7 +44,10 @@
       "deprecationInfo": "Use <code>disableHitArea</code> instead."
     },
     "experimentalFeatures": {
-      "type": { "name": "shape", "description": "{ progressiveRendering?: bool }" }
+      "type": {
+        "name": "shape",
+        "description": "{ enableKeyboardClickEvents?: bool, progressiveRendering?: bool }"
+      }
     },
     "grid": {
       "type": { "name": "shape", "description": "{ horizontal?: bool, vertical?: bool }" }

--- a/docs/pages/x/api/charts/scatter-chart.json
+++ b/docs/pages/x/api/charts/scatter-chart.json
@@ -103,7 +103,7 @@
     "onItemClick": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: MouseEvent, scatterItemIdentifier: ScatterItemIdentifier) => void",
+        "type": "function(event: MouseEvent | KeyboardEvent, scatterItemIdentifier: ScatterItemIdentifier) => void",
         "describedArgs": ["event", "scatterItemIdentifier"]
       }
     },

--- a/docs/pages/x/api/charts/scatter-chart.json
+++ b/docs/pages/x/api/charts/scatter-chart.json
@@ -44,7 +44,10 @@
       "deprecationInfo": "Use <code>disableHitArea</code> instead."
     },
     "experimentalFeatures": {
-      "type": { "name": "shape", "description": "{ progressiveRendering?: bool }" }
+      "type": {
+        "name": "shape",
+        "description": "{ enableKeyboardClickEvents?: bool, progressiveRendering?: bool }"
+      }
     },
     "grid": {
       "type": { "name": "shape", "description": "{ horizontal?: bool, vertical?: bool }" }

--- a/docs/pages/x/api/charts/scatter-chart.json
+++ b/docs/pages/x/api/charts/scatter-chart.json
@@ -103,7 +103,7 @@
     "onItemClick": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: MouseEvent | KeyboardEvent, scatterItemIdentifier: ScatterItemIdentifier) => void",
+        "type": "function(event: MouseEvent, scatterItemIdentifier: ScatterItemIdentifier) => void",
         "describedArgs": ["event", "scatterItemIdentifier"]
       }
     },

--- a/docs/pages/x/api/charts/spark-line-chart.json
+++ b/docs/pages/x/api/charts/spark-line-chart.json
@@ -107,7 +107,7 @@
     "onItemClick": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: MouseEvent, scatterItemIdentifier: ScatterItemIdentifier) => void",
+        "type": "function(event: MouseEvent | KeyboardEvent, scatterItemIdentifier: ScatterItemIdentifier) => void",
         "describedArgs": ["event", "scatterItemIdentifier"]
       }
     },

--- a/docs/pages/x/api/charts/spark-line-chart.json
+++ b/docs/pages/x/api/charts/spark-line-chart.json
@@ -107,7 +107,7 @@
     "onItemClick": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: MouseEvent | KeyboardEvent, scatterItemIdentifier: ScatterItemIdentifier) => void",
+        "type": "function(event: MouseEvent, scatterItemIdentifier: ScatterItemIdentifier) => void",
         "describedArgs": ["event", "scatterItemIdentifier"]
       }
     },

--- a/docs/pages/x/api/charts/spark-line-chart.json
+++ b/docs/pages/x/api/charts/spark-line-chart.json
@@ -38,7 +38,7 @@
     "experimentalFeatures": {
       "type": {
         "name": "shape",
-        "description": "{ enablePositionBasedPointerInteraction?: bool, progressiveRendering?: bool }"
+        "description": "{ enableKeyboardClickEvents?: bool, enablePositionBasedPointerInteraction?: bool, progressiveRendering?: bool }"
       }
     },
     "height": { "type": { "name": "number" } },

--- a/docs/translations/api-docs/charts/charts-container/charts-container.json
+++ b/docs/translations/api-docs/charts/charts-container/charts-container.json
@@ -87,7 +87,7 @@
       }
     },
     "onItemClick": {
-      "description": "Callback fired when an item is activated. This is only available for scatter plot for now.",
+      "description": "Callback fired when clicking close to an item, or when it is activated with the Enter or Space keys. This is only available for scatter plot for now.",
       "typeDescriptions": {
         "event": {
           "name": "event",

--- a/docs/translations/api-docs/charts/charts-container/charts-container.json
+++ b/docs/translations/api-docs/charts/charts-container/charts-container.json
@@ -87,9 +87,12 @@
       }
     },
     "onItemClick": {
-      "description": "Callback fired when clicking close to an item. This is only available for scatter plot for now.",
+      "description": "Callback fired when an item is activated. This is only available for scatter plot for now.",
       "typeDescriptions": {
-        "event": { "name": "event", "description": "Mouse event caught at the svg level" },
+        "event": {
+          "name": "event",
+          "description": "The pointer or keyboard event that activated the item."
+        },
         "scatterItemIdentifier": {
           "name": "scatterItemIdentifier",
           "description": "Identify which item got clicked"

--- a/docs/translations/api-docs/charts/charts-container/charts-container.json
+++ b/docs/translations/api-docs/charts/charts-container/charts-container.json
@@ -91,7 +91,7 @@
       "typeDescriptions": {
         "event": {
           "name": "event",
-          "description": "The pointer or keyboard event that activated the item."
+          "description": "The event that activated the item. It is a <code>KeyboardEvent</code> on Enter or Space activation. Import <code>@mui/x-charts/moduleAugmentation/keyboardItemActivation</code> for correct typing."
         },
         "scatterItemIdentifier": {
           "name": "scatterItemIdentifier",

--- a/docs/translations/api-docs/charts/charts-container/charts-container.json
+++ b/docs/translations/api-docs/charts/charts-container/charts-container.json
@@ -87,7 +87,7 @@
       }
     },
     "onItemClick": {
-      "description": "Callback fired when clicking close to an item, or when it is activated with the Enter or Space keys. This is only available for scatter plot for now.",
+      "description": "Callback fired when clicking close to an item, or when it is activated with the Enter or Space keys. This is only available for scatter plot for now. Activation with the Enter and Space keys requires the <code>enableKeyboardClickEvents</code> experimental feature.",
       "typeDescriptions": {
         "event": {
           "name": "event",

--- a/docs/translations/api-docs/charts/scatter-chart-premium/scatter-chart-premium.json
+++ b/docs/translations/api-docs/charts/scatter-chart-premium/scatter-chart-premium.json
@@ -98,7 +98,7 @@
       "typeDescriptions": {
         "event": {
           "name": "event",
-          "description": "The event that activated the item. This is a mouse event for pointer interaction and a keyboard event for Enter or Space activation."
+          "description": "The event that activated the item. It is a <code>KeyboardEvent</code> on Enter or Space activation. Import <code>@mui/x-charts/moduleAugmentation/keyboardItemActivation</code> for correct typing."
         },
         "scatterItemIdentifier": {
           "name": "scatterItemIdentifier",

--- a/docs/translations/api-docs/charts/scatter-chart-premium/scatter-chart-premium.json
+++ b/docs/translations/api-docs/charts/scatter-chart-premium/scatter-chart-premium.json
@@ -94,7 +94,7 @@
       }
     },
     "onItemClick": {
-      "description": "Callback fired when a scatter item is activated.",
+      "description": "Callback fired when a scatter item is activated. Activation with the Enter and Space keys requires the <code>enableKeyboardClickEvents</code> experimental feature.",
       "typeDescriptions": {
         "event": {
           "name": "event",

--- a/docs/translations/api-docs/charts/scatter-chart-premium/scatter-chart-premium.json
+++ b/docs/translations/api-docs/charts/scatter-chart-premium/scatter-chart-premium.json
@@ -94,11 +94,11 @@
       }
     },
     "onItemClick": {
-      "description": "Callback fired when clicking on a scatter item.",
+      "description": "Callback fired when a scatter item is activated.",
       "typeDescriptions": {
         "event": {
           "name": "event",
-          "description": "The mouse event recorded on the <code>&lt;svg/&gt;</code> element if using hit area interaction. Or the Mouse event from the scatter element, when <code>disableHitArea=true</code>."
+          "description": "The event that activated the item. This is a mouse event for pointer interaction and a keyboard event for Enter or Space activation."
         },
         "scatterItemIdentifier": {
           "name": "scatterItemIdentifier",

--- a/docs/translations/api-docs/charts/scatter-chart-pro/scatter-chart-pro.json
+++ b/docs/translations/api-docs/charts/scatter-chart-pro/scatter-chart-pro.json
@@ -98,7 +98,7 @@
       "typeDescriptions": {
         "event": {
           "name": "event",
-          "description": "The event that activated the item. This is a mouse event for pointer interaction and a keyboard event for Enter or Space activation."
+          "description": "The event that activated the item. It is a <code>KeyboardEvent</code> on Enter or Space activation. Import <code>@mui/x-charts/moduleAugmentation/keyboardItemActivation</code> for correct typing."
         },
         "scatterItemIdentifier": {
           "name": "scatterItemIdentifier",

--- a/docs/translations/api-docs/charts/scatter-chart-pro/scatter-chart-pro.json
+++ b/docs/translations/api-docs/charts/scatter-chart-pro/scatter-chart-pro.json
@@ -94,7 +94,7 @@
       }
     },
     "onItemClick": {
-      "description": "Callback fired when a scatter item is activated.",
+      "description": "Callback fired when a scatter item is activated. Activation with the Enter and Space keys requires the <code>enableKeyboardClickEvents</code> experimental feature.",
       "typeDescriptions": {
         "event": {
           "name": "event",

--- a/docs/translations/api-docs/charts/scatter-chart-pro/scatter-chart-pro.json
+++ b/docs/translations/api-docs/charts/scatter-chart-pro/scatter-chart-pro.json
@@ -94,11 +94,11 @@
       }
     },
     "onItemClick": {
-      "description": "Callback fired when clicking on a scatter item.",
+      "description": "Callback fired when a scatter item is activated.",
       "typeDescriptions": {
         "event": {
           "name": "event",
-          "description": "The mouse event recorded on the <code>&lt;svg/&gt;</code> element if using hit area interaction. Or the Mouse event from the scatter element, when <code>disableHitArea=true</code>."
+          "description": "The event that activated the item. This is a mouse event for pointer interaction and a keyboard event for Enter or Space activation."
         },
         "scatterItemIdentifier": {
           "name": "scatterItemIdentifier",

--- a/docs/translations/api-docs/charts/scatter-chart/scatter-chart.json
+++ b/docs/translations/api-docs/charts/scatter-chart/scatter-chart.json
@@ -91,11 +91,11 @@
       }
     },
     "onItemClick": {
-      "description": "Callback fired when clicking on a scatter item.",
+      "description": "Callback fired when a scatter item is activated.",
       "typeDescriptions": {
         "event": {
           "name": "event",
-          "description": "The mouse event recorded on the <code>&lt;svg/&gt;</code> element if using hit area interaction. Or the Mouse event from the scatter element, when <code>disableHitArea=true</code>."
+          "description": "The event that activated the item. This is a mouse event for pointer interaction and a keyboard event for Enter or Space activation."
         },
         "scatterItemIdentifier": {
           "name": "scatterItemIdentifier",

--- a/docs/translations/api-docs/charts/scatter-chart/scatter-chart.json
+++ b/docs/translations/api-docs/charts/scatter-chart/scatter-chart.json
@@ -91,7 +91,7 @@
       }
     },
     "onItemClick": {
-      "description": "Callback fired when a scatter item is activated.",
+      "description": "Callback fired when a scatter item is activated. Activation with the Enter and Space keys requires the <code>enableKeyboardClickEvents</code> experimental feature.",
       "typeDescriptions": {
         "event": {
           "name": "event",

--- a/docs/translations/api-docs/charts/scatter-chart/scatter-chart.json
+++ b/docs/translations/api-docs/charts/scatter-chart/scatter-chart.json
@@ -95,7 +95,7 @@
       "typeDescriptions": {
         "event": {
           "name": "event",
-          "description": "The event that activated the item. This is a mouse event for pointer interaction and a keyboard event for Enter or Space activation."
+          "description": "The event that activated the item. It is a <code>KeyboardEvent</code> on Enter or Space activation. Import <code>@mui/x-charts/moduleAugmentation/keyboardItemActivation</code> for correct typing."
         },
         "scatterItemIdentifier": {
           "name": "scatterItemIdentifier",

--- a/docs/translations/api-docs/charts/spark-line-chart/spark-line-chart.json
+++ b/docs/translations/api-docs/charts/spark-line-chart/spark-line-chart.json
@@ -97,7 +97,7 @@
       }
     },
     "onItemClick": {
-      "description": "Callback fired when clicking close to an item, or when it is activated with the Enter or Space keys. This is only available for scatter plot for now.",
+      "description": "Callback fired when clicking close to an item, or when it is activated with the Enter or Space keys. This is only available for scatter plot for now. Activation with the Enter and Space keys requires the <code>enableKeyboardClickEvents</code> experimental feature.",
       "typeDescriptions": {
         "event": {
           "name": "event",

--- a/docs/translations/api-docs/charts/spark-line-chart/spark-line-chart.json
+++ b/docs/translations/api-docs/charts/spark-line-chart/spark-line-chart.json
@@ -97,9 +97,12 @@
       }
     },
     "onItemClick": {
-      "description": "Callback fired when clicking close to an item. This is only available for scatter plot for now.",
+      "description": "Callback fired when an item is activated. This is only available for scatter plot for now.",
       "typeDescriptions": {
-        "event": { "name": "event", "description": "Mouse event caught at the svg level" },
+        "event": {
+          "name": "event",
+          "description": "The pointer or keyboard event that activated the item."
+        },
         "scatterItemIdentifier": {
           "name": "scatterItemIdentifier",
           "description": "Identify which item got clicked"

--- a/docs/translations/api-docs/charts/spark-line-chart/spark-line-chart.json
+++ b/docs/translations/api-docs/charts/spark-line-chart/spark-line-chart.json
@@ -101,7 +101,7 @@
       "typeDescriptions": {
         "event": {
           "name": "event",
-          "description": "The pointer or keyboard event that activated the item."
+          "description": "The event that activated the item. It is a <code>KeyboardEvent</code> on Enter or Space activation. Import <code>@mui/x-charts/moduleAugmentation/keyboardItemActivation</code> for correct typing."
         },
         "scatterItemIdentifier": {
           "name": "scatterItemIdentifier",

--- a/docs/translations/api-docs/charts/spark-line-chart/spark-line-chart.json
+++ b/docs/translations/api-docs/charts/spark-line-chart/spark-line-chart.json
@@ -97,7 +97,7 @@
       }
     },
     "onItemClick": {
-      "description": "Callback fired when an item is activated. This is only available for scatter plot for now.",
+      "description": "Callback fired when clicking close to an item, or when it is activated with the Enter or Space keys. This is only available for scatter plot for now.",
       "typeDescriptions": {
         "event": {
           "name": "event",

--- a/packages/x-charts-premium/src/BarChartPremium/BarChartPremium.tsx
+++ b/packages/x-charts-premium/src/BarChartPremium/BarChartPremium.tsx
@@ -241,7 +241,9 @@ BarChartPremium.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.object,
+  experimentalFeatures: PropTypes.shape({
+    enableKeyboardClickEvents: PropTypes.bool,
+  }),
   /**
    * Option to display a cartesian grid in the background.
    */

--- a/packages/x-charts-premium/src/ChartsDataProviderPremium/ChartsDataProviderPremium.tsx
+++ b/packages/x-charts-premium/src/ChartsDataProviderPremium/ChartsDataProviderPremium.tsx
@@ -131,7 +131,9 @@ ChartsDataProviderPremium.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.any,
+  experimentalFeatures: PropTypes.shape({
+    enableKeyboardClickEvents: PropTypes.bool,
+  }),
   /**
    * The height of the chart in px. If not defined, it takes the height of the parent element.
    */

--- a/packages/x-charts-premium/src/ChartsGeoDataProviderPremium/ChartsGeoDataProviderPremium.tsx
+++ b/packages/x-charts-premium/src/ChartsGeoDataProviderPremium/ChartsGeoDataProviderPremium.tsx
@@ -105,7 +105,9 @@ ChartsGeoDataProviderPremium.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.any,
+  experimentalFeatures: PropTypes.shape({
+    enableKeyboardClickEvents: PropTypes.bool,
+  }),
   /**
    * The height of the chart in px. If not defined, it takes the height of the parent element.
    */

--- a/packages/x-charts-premium/src/ChartsRadialDataProviderPremium/ChartsRadialDataProviderPremium.tsx
+++ b/packages/x-charts-premium/src/ChartsRadialDataProviderPremium/ChartsRadialDataProviderPremium.tsx
@@ -112,7 +112,9 @@ ChartsRadialDataProviderPremium.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.any,
+  experimentalFeatures: PropTypes.shape({
+    enableKeyboardClickEvents: PropTypes.bool,
+  }),
   /**
    * The height of the chart in px. If not defined, it takes the height of the parent element.
    */

--- a/packages/x-charts-premium/src/HeatmapPremium/HeatmapPremium.tsx
+++ b/packages/x-charts-premium/src/HeatmapPremium/HeatmapPremium.tsx
@@ -139,7 +139,9 @@ HeatmapPremium.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.object,
+  experimentalFeatures: PropTypes.shape({
+    enableKeyboardClickEvents: PropTypes.bool,
+  }),
   /**
    * The height of the chart in px. If not defined, it takes the height of the parent element.
    */

--- a/packages/x-charts-premium/src/RadialBarChart/RadialBarChart.tsx
+++ b/packages/x-charts-premium/src/RadialBarChart/RadialBarChart.tsx
@@ -203,7 +203,9 @@ RadialBarChart.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.object,
+  experimentalFeatures: PropTypes.shape({
+    enableKeyboardClickEvents: PropTypes.bool,
+  }),
   /**
    * Option to display a radial grid in the background.
    */

--- a/packages/x-charts-premium/src/RadialLineChart/RadialLineChart.tsx
+++ b/packages/x-charts-premium/src/RadialLineChart/RadialLineChart.tsx
@@ -220,7 +220,9 @@ RadialLineChart.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.object,
+  experimentalFeatures: PropTypes.shape({
+    enableKeyboardClickEvents: PropTypes.bool,
+  }),
   /**
    * Option to display a radial grid in the background.
    */

--- a/packages/x-charts-premium/src/ScatterChartPremium/ScatterChartPremium.tsx
+++ b/packages/x-charts-premium/src/ScatterChartPremium/ScatterChartPremium.tsx
@@ -443,8 +443,8 @@ ScatterChartPremium.propTypes /* remove-proptypes */ = {
    */
   onHighlightChange: PropTypes.func,
   /**
-   * Callback fired when clicking on a scatter item.
-   * @param {MouseEvent} event The mouse event recorded on the `<svg/>` element if using hit area interaction. Or the Mouse event from the scatter element, when `disableHitArea=true`.
+   * Callback fired when a scatter item is activated.
+   * @param {MouseEvent | KeyboardEvent} event The event that activated the item. This is a mouse event for pointer interaction and a keyboard event for Enter or Space activation.
    * @param {ScatterItemIdentifier} scatterItemIdentifier The scatter item identifier.
    */
   onItemClick: PropTypes.func,

--- a/packages/x-charts-premium/src/ScatterChartPremium/ScatterChartPremium.tsx
+++ b/packages/x-charts-premium/src/ScatterChartPremium/ScatterChartPremium.tsx
@@ -445,6 +445,7 @@ ScatterChartPremium.propTypes /* remove-proptypes */ = {
   onHighlightChange: PropTypes.func,
   /**
    * Callback fired when a scatter item is activated.
+   * Activation with the Enter and Space keys requires the `enableKeyboardClickEvents` experimental feature.
    * @param {MouseEvent} event The event that activated the item. It is a `KeyboardEvent` on Enter or Space activation. Import `@mui/x-charts/moduleAugmentation/keyboardItemActivation` for correct typing.
    * @param {ScatterItemIdentifier} scatterItemIdentifier The scatter item identifier.
    */

--- a/packages/x-charts-premium/src/ScatterChartPremium/ScatterChartPremium.tsx
+++ b/packages/x-charts-premium/src/ScatterChartPremium/ScatterChartPremium.tsx
@@ -444,7 +444,7 @@ ScatterChartPremium.propTypes /* remove-proptypes */ = {
   onHighlightChange: PropTypes.func,
   /**
    * Callback fired when a scatter item is activated.
-   * @param {MouseEvent | KeyboardEvent} event The event that activated the item. This is a mouse event for pointer interaction and a keyboard event for Enter or Space activation.
+   * @param {MouseEvent} event The event that activated the item. It is a `KeyboardEvent` on Enter or Space activation. Import `@mui/x-charts/moduleAugmentation/keyboardItemActivation` for correct typing.
    * @param {ScatterItemIdentifier} scatterItemIdentifier The scatter item identifier.
    */
   onItemClick: PropTypes.func,

--- a/packages/x-charts-premium/src/ScatterChartPremium/ScatterChartPremium.tsx
+++ b/packages/x-charts-premium/src/ScatterChartPremium/ScatterChartPremium.tsx
@@ -250,6 +250,7 @@ ScatterChartPremium.propTypes /* remove-proptypes */ = {
    * Options to enable features planned for the next major.
    */
   experimentalFeatures: PropTypes.shape({
+    enableKeyboardClickEvents: PropTypes.bool,
     progressiveRendering: PropTypes.bool,
   }),
   /**

--- a/packages/x-charts-pro/src/BarChartPro/BarChartPro.tsx
+++ b/packages/x-charts-pro/src/BarChartPro/BarChartPro.tsx
@@ -206,7 +206,9 @@ BarChartPro.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.object,
+  experimentalFeatures: PropTypes.shape({
+    enableKeyboardClickEvents: PropTypes.bool,
+  }),
   /**
    * Option to display a cartesian grid in the background.
    */

--- a/packages/x-charts-pro/src/ChartsDataProviderPro/ChartsDataProviderPro.tsx
+++ b/packages/x-charts-pro/src/ChartsDataProviderPro/ChartsDataProviderPro.tsx
@@ -128,7 +128,9 @@ ChartsDataProviderPro.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.any,
+  experimentalFeatures: PropTypes.shape({
+    enableKeyboardClickEvents: PropTypes.bool,
+  }),
   /**
    * The height of the chart in px. If not defined, it takes the height of the parent element.
    */

--- a/packages/x-charts-pro/src/FunnelChart/FunnelChart.tsx
+++ b/packages/x-charts-pro/src/FunnelChart/FunnelChart.tsx
@@ -259,7 +259,9 @@ FunnelChart.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.object,
+  experimentalFeatures: PropTypes.shape({
+    enableKeyboardClickEvents: PropTypes.bool,
+  }),
   /**
    * The gap, in pixels, between funnel sections.
    * @default 0

--- a/packages/x-charts-pro/src/Heatmap/Heatmap.tsx
+++ b/packages/x-charts-pro/src/Heatmap/Heatmap.tsx
@@ -233,7 +233,9 @@ Heatmap.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.object,
+  experimentalFeatures: PropTypes.shape({
+    enableKeyboardClickEvents: PropTypes.bool,
+  }),
   /**
    * The height of the chart in px. If not defined, it takes the height of the parent element.
    */

--- a/packages/x-charts-pro/src/Heatmap/seriesConfig/keyboardFocusHandler.test.ts
+++ b/packages/x-charts-pro/src/Heatmap/seriesConfig/keyboardFocusHandler.test.ts
@@ -73,9 +73,11 @@ function test(
   direction: 'ArrowRight' | 'ArrowLeft' | 'ArrowUp' | 'ArrowDown',
   initialFocus: FocusedItemIdentifier<'heatmap'> | null,
 ) {
-  return {
-    ...keyboardFocusHandler({ key: direction } as KeyboardEvent)?.(initialFocus, state),
-  };
+  const keyboardHandlerResult = keyboardFocusHandler({ key: direction } as KeyboardEvent);
+
+  return typeof keyboardHandlerResult === 'function'
+    ? { ...keyboardHandlerResult(initialFocus, state) }
+    : keyboardHandlerResult;
 }
 
 describe('<Heatmap /> - keyboard navigation', () => {

--- a/packages/x-charts-pro/src/LineChartPro/LineChartPro.tsx
+++ b/packages/x-charts-pro/src/LineChartPro/LineChartPro.tsx
@@ -221,6 +221,7 @@ LineChartPro.propTypes /* remove-proptypes */ = {
    * Options to enable features planned for the next major.
    */
   experimentalFeatures: PropTypes.shape({
+    enableKeyboardClickEvents: PropTypes.bool,
     enablePositionBasedPointerInteraction: PropTypes.bool,
   }),
   /**

--- a/packages/x-charts-pro/src/PieChartPro/PieChartPro.tsx
+++ b/packages/x-charts-pro/src/PieChartPro/PieChartPro.tsx
@@ -157,7 +157,9 @@ PieChartPro.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.object,
+  experimentalFeatures: PropTypes.shape({
+    enableKeyboardClickEvents: PropTypes.bool,
+  }),
   /**
    * The height of the chart in px. If not defined, it takes the height of the parent element.
    */

--- a/packages/x-charts-pro/src/RadarChartPro/RadarChartPro.tsx
+++ b/packages/x-charts-pro/src/RadarChartPro/RadarChartPro.tsx
@@ -155,7 +155,9 @@ RadarChartPro.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.object,
+  experimentalFeatures: PropTypes.shape({
+    enableKeyboardClickEvents: PropTypes.bool,
+  }),
   /**
    * The height of the chart in px. If not defined, it takes the height of the parent element.
    */

--- a/packages/x-charts-pro/src/SankeyChart/SankeyChart.tsx
+++ b/packages/x-charts-pro/src/SankeyChart/SankeyChart.tsx
@@ -116,7 +116,9 @@ SankeyChart.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.object,
+  experimentalFeatures: PropTypes.shape({
+    enableKeyboardClickEvents: PropTypes.bool,
+  }),
   /**
    * The height of the chart in px. If not defined, it takes the height of the parent element.
    */

--- a/packages/x-charts-pro/src/SankeyChart/SankeyDataProvider.tsx
+++ b/packages/x-charts-pro/src/SankeyChart/SankeyDataProvider.tsx
@@ -67,7 +67,9 @@ SankeyDataProvider.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.object,
+  experimentalFeatures: PropTypes.shape({
+    enableKeyboardClickEvents: PropTypes.bool,
+  }),
   /**
    * The height of the chart in px. If not defined, it takes the height of the parent element.
    */

--- a/packages/x-charts-pro/src/SankeyChart/seriesConfig/keyboardFocusHandler.test.ts
+++ b/packages/x-charts-pro/src/SankeyChart/seriesConfig/keyboardFocusHandler.test.ts
@@ -80,7 +80,11 @@ function test(
   initialFocus: FocusedItemIdentifier<'sankey'> | null,
   align: 'left' | 'justify' = 'left',
 ) {
-  return keyboardFocusHandler({ key: direction } as KeyboardEvent)?.(initialFocus, state(align));
+  const keyboardHandlerResult = keyboardFocusHandler({ key: direction } as KeyboardEvent);
+
+  return typeof keyboardHandlerResult === 'function'
+    ? keyboardHandlerResult(initialFocus, state(align))
+    : keyboardHandlerResult;
 }
 
 describe('<Sankey /> - keyboard navigation', () => {

--- a/packages/x-charts-pro/src/ScatterChartPro/ScatterChartPro.tsx
+++ b/packages/x-charts-pro/src/ScatterChartPro/ScatterChartPro.tsx
@@ -225,6 +225,7 @@ ScatterChartPro.propTypes /* remove-proptypes */ = {
    * Options to enable features planned for the next major.
    */
   experimentalFeatures: PropTypes.shape({
+    enableKeyboardClickEvents: PropTypes.bool,
     progressiveRendering: PropTypes.bool,
   }),
   /**

--- a/packages/x-charts-pro/src/ScatterChartPro/ScatterChartPro.tsx
+++ b/packages/x-charts-pro/src/ScatterChartPro/ScatterChartPro.tsx
@@ -420,6 +420,7 @@ ScatterChartPro.propTypes /* remove-proptypes */ = {
   onHighlightChange: PropTypes.func,
   /**
    * Callback fired when a scatter item is activated.
+   * Activation with the Enter and Space keys requires the `enableKeyboardClickEvents` experimental feature.
    * @param {MouseEvent} event The event that activated the item. It is a `KeyboardEvent` on Enter or Space activation. Import `@mui/x-charts/moduleAugmentation/keyboardItemActivation` for correct typing.
    * @param {ScatterItemIdentifier} scatterItemIdentifier The scatter item identifier.
    */

--- a/packages/x-charts-pro/src/ScatterChartPro/ScatterChartPro.tsx
+++ b/packages/x-charts-pro/src/ScatterChartPro/ScatterChartPro.tsx
@@ -418,8 +418,8 @@ ScatterChartPro.propTypes /* remove-proptypes */ = {
    */
   onHighlightChange: PropTypes.func,
   /**
-   * Callback fired when clicking on a scatter item.
-   * @param {MouseEvent} event The mouse event recorded on the `<svg/>` element if using hit area interaction. Or the Mouse event from the scatter element, when `disableHitArea=true`.
+   * Callback fired when a scatter item is activated.
+   * @param {MouseEvent | KeyboardEvent} event The event that activated the item. This is a mouse event for pointer interaction and a keyboard event for Enter or Space activation.
    * @param {ScatterItemIdentifier} scatterItemIdentifier The scatter item identifier.
    */
   onItemClick: PropTypes.func,

--- a/packages/x-charts-pro/src/ScatterChartPro/ScatterChartPro.tsx
+++ b/packages/x-charts-pro/src/ScatterChartPro/ScatterChartPro.tsx
@@ -419,7 +419,7 @@ ScatterChartPro.propTypes /* remove-proptypes */ = {
   onHighlightChange: PropTypes.func,
   /**
    * Callback fired when a scatter item is activated.
-   * @param {MouseEvent | KeyboardEvent} event The event that activated the item. This is a mouse event for pointer interaction and a keyboard event for Enter or Space activation.
+   * @param {MouseEvent} event The event that activated the item. It is a `KeyboardEvent` on Enter or Space activation. Import `@mui/x-charts/moduleAugmentation/keyboardItemActivation` for correct typing.
    * @param {ScatterItemIdentifier} scatterItemIdentifier The scatter item identifier.
    */
   onItemClick: PropTypes.func,

--- a/packages/x-charts/src/BarChart/BarChart.tsx
+++ b/packages/x-charts/src/BarChart/BarChart.tsx
@@ -228,7 +228,9 @@ BarChart.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.object,
+  experimentalFeatures: PropTypes.shape({
+    enableKeyboardClickEvents: PropTypes.bool,
+  }),
   /**
    * Option to display a cartesian grid in the background.
    */

--- a/packages/x-charts/src/ChartsContainer/ChartsContainer.tsx
+++ b/packages/x-charts/src/ChartsContainer/ChartsContainer.tsx
@@ -123,7 +123,9 @@ ChartsContainer.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.any,
+  experimentalFeatures: PropTypes.shape({
+    enableKeyboardClickEvents: PropTypes.bool,
+  }),
   /**
    * The height of the chart in px. If not defined, it takes the height of the parent element.
    */
@@ -279,7 +281,7 @@ ChartsContainer.propTypes /* remove-proptypes */ = {
    */
   onHighlightedAxisChange: PropTypes.func,
   /**
-   * Callback fired when an item is activated.
+   * Callback fired when clicking close to an item, or when it is activated with the Enter or Space keys.
    * This is only available for scatter plot for now.
    * @param {MouseEvent} event The event that activated the item. It is a `KeyboardEvent` on Enter or Space activation. Import `@mui/x-charts/moduleAugmentation/keyboardItemActivation` for correct typing.
    * @param {ScatterItemIdentifier} scatterItemIdentifier Identify which item got clicked

--- a/packages/x-charts/src/ChartsContainer/ChartsContainer.tsx
+++ b/packages/x-charts/src/ChartsContainer/ChartsContainer.tsx
@@ -283,6 +283,7 @@ ChartsContainer.propTypes /* remove-proptypes */ = {
   /**
    * Callback fired when clicking close to an item, or when it is activated with the Enter or Space keys.
    * This is only available for scatter plot for now.
+   * Activation with the Enter and Space keys requires the `enableKeyboardClickEvents` experimental feature.
    * @param {MouseEvent} event The event that activated the item. It is a `KeyboardEvent` on Enter or Space activation. Import `@mui/x-charts/moduleAugmentation/keyboardItemActivation` for correct typing.
    * @param {ScatterItemIdentifier} scatterItemIdentifier Identify which item got clicked
    */

--- a/packages/x-charts/src/ChartsContainer/ChartsContainer.tsx
+++ b/packages/x-charts/src/ChartsContainer/ChartsContainer.tsx
@@ -279,9 +279,9 @@ ChartsContainer.propTypes /* remove-proptypes */ = {
    */
   onHighlightedAxisChange: PropTypes.func,
   /**
-   * Callback fired when clicking close to an item.
+   * Callback fired when an item is activated.
    * This is only available for scatter plot for now.
-   * @param {MouseEvent} event Mouse event caught at the svg level
+   * @param {MouseEvent | KeyboardEvent} event The pointer or keyboard event that activated the item.
    * @param {ScatterItemIdentifier} scatterItemIdentifier Identify which item got clicked
    */
   onItemClick: PropTypes.func,

--- a/packages/x-charts/src/ChartsContainer/ChartsContainer.tsx
+++ b/packages/x-charts/src/ChartsContainer/ChartsContainer.tsx
@@ -281,7 +281,7 @@ ChartsContainer.propTypes /* remove-proptypes */ = {
   /**
    * Callback fired when an item is activated.
    * This is only available for scatter plot for now.
-   * @param {MouseEvent | KeyboardEvent} event The pointer or keyboard event that activated the item.
+   * @param {MouseEvent} event The event that activated the item. It is a `KeyboardEvent` on Enter or Space activation. Import `@mui/x-charts/moduleAugmentation/keyboardItemActivation` for correct typing.
    * @param {ScatterItemIdentifier} scatterItemIdentifier Identify which item got clicked
    */
   onItemClick: PropTypes.func,

--- a/packages/x-charts/src/ChartsDataProvider/ChartsDataProvider.tsx
+++ b/packages/x-charts/src/ChartsDataProvider/ChartsDataProvider.tsx
@@ -106,7 +106,9 @@ ChartsDataProvider.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.any,
+  experimentalFeatures: PropTypes.shape({
+    enableKeyboardClickEvents: PropTypes.bool,
+  }),
   /**
    * The height of the chart in px. If not defined, it takes the height of the parent element.
    */

--- a/packages/x-charts/src/ChartsRadialDataProvider/ChartsRadialDataProvider.tsx
+++ b/packages/x-charts/src/ChartsRadialDataProvider/ChartsRadialDataProvider.tsx
@@ -91,7 +91,9 @@ ChartsRadialDataProvider.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.any,
+  experimentalFeatures: PropTypes.shape({
+    enableKeyboardClickEvents: PropTypes.bool,
+  }),
   /**
    * The height of the chart in px. If not defined, it takes the height of the parent element.
    */

--- a/packages/x-charts/src/LineChart/LineChart.tsx
+++ b/packages/x-charts/src/LineChart/LineChart.tsx
@@ -260,6 +260,7 @@ LineChart.propTypes /* remove-proptypes */ = {
    * Options to enable features planned for the next major.
    */
   experimentalFeatures: PropTypes.shape({
+    enableKeyboardClickEvents: PropTypes.bool,
     enablePositionBasedPointerInteraction: PropTypes.bool,
   }),
   /**

--- a/packages/x-charts/src/PieChart/PieChart.tsx
+++ b/packages/x-charts/src/PieChart/PieChart.tsx
@@ -204,7 +204,9 @@ PieChart.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.object,
+  experimentalFeatures: PropTypes.shape({
+    enableKeyboardClickEvents: PropTypes.bool,
+  }),
   /**
    * The height of the chart in px. If not defined, it takes the height of the parent element.
    */

--- a/packages/x-charts/src/RadarChart/RadarChart.tsx
+++ b/packages/x-charts/src/RadarChart/RadarChart.tsx
@@ -168,7 +168,9 @@ RadarChart.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.object,
+  experimentalFeatures: PropTypes.shape({
+    enableKeyboardClickEvents: PropTypes.bool,
+  }),
   /**
    * The height of the chart in px. If not defined, it takes the height of the parent element.
    */

--- a/packages/x-charts/src/ScatterChart/ScatterChart.tsx
+++ b/packages/x-charts/src/ScatterChart/ScatterChart.tsx
@@ -268,6 +268,7 @@ ScatterChart.propTypes /* remove-proptypes */ = {
    * Options to enable features planned for the next major.
    */
   experimentalFeatures: PropTypes.shape({
+    enableKeyboardClickEvents: PropTypes.bool,
     progressiveRendering: PropTypes.bool,
   }),
   /**

--- a/packages/x-charts/src/ScatterChart/ScatterChart.tsx
+++ b/packages/x-charts/src/ScatterChart/ScatterChart.tsx
@@ -128,8 +128,8 @@ export interface ScatterChartProps
    */
   slotProps?: ScatterChartSlotProps;
   /**
-   * Callback fired when clicking on a scatter item.
-   * @param {MouseEvent} event The mouse event recorded on the `<svg/>` element if using hit area interaction. Or the Mouse event from the scatter element, when `disableHitArea=true`.
+   * Callback fired when a scatter item is activated.
+   * @param {MouseEvent | KeyboardEvent} event The event that activated the item. This is a mouse event for pointer interaction and a keyboard event for Enter or Space activation.
    * @param {ScatterItemIdentifier} scatterItemIdentifier The scatter item identifier.
    */
   onItemClick?:
@@ -423,8 +423,8 @@ ScatterChart.propTypes /* remove-proptypes */ = {
    */
   onHighlightChange: PropTypes.func,
   /**
-   * Callback fired when clicking on a scatter item.
-   * @param {MouseEvent} event The mouse event recorded on the `<svg/>` element if using hit area interaction. Or the Mouse event from the scatter element, when `disableHitArea=true`.
+   * Callback fired when a scatter item is activated.
+   * @param {MouseEvent | KeyboardEvent} event The event that activated the item. This is a mouse event for pointer interaction and a keyboard event for Enter or Space activation.
    * @param {ScatterItemIdentifier} scatterItemIdentifier The scatter item identifier.
    */
   onItemClick: PropTypes.func,

--- a/packages/x-charts/src/ScatterChart/ScatterChart.tsx
+++ b/packages/x-charts/src/ScatterChart/ScatterChart.tsx
@@ -129,7 +129,7 @@ export interface ScatterChartProps
   slotProps?: ScatterChartSlotProps;
   /**
    * Callback fired when a scatter item is activated.
-   * @param {MouseEvent | KeyboardEvent} event The event that activated the item. This is a mouse event for pointer interaction and a keyboard event for Enter or Space activation.
+   * @param {MouseEvent} event The event that activated the item. It is a `KeyboardEvent` on Enter or Space activation. Import `@mui/x-charts/moduleAugmentation/keyboardItemActivation` for correct typing.
    * @param {ScatterItemIdentifier} scatterItemIdentifier The scatter item identifier.
    */
   onItemClick?:
@@ -424,7 +424,7 @@ ScatterChart.propTypes /* remove-proptypes */ = {
   onHighlightChange: PropTypes.func,
   /**
    * Callback fired when a scatter item is activated.
-   * @param {MouseEvent | KeyboardEvent} event The event that activated the item. This is a mouse event for pointer interaction and a keyboard event for Enter or Space activation.
+   * @param {MouseEvent} event The event that activated the item. It is a `KeyboardEvent` on Enter or Space activation. Import `@mui/x-charts/moduleAugmentation/keyboardItemActivation` for correct typing.
    * @param {ScatterItemIdentifier} scatterItemIdentifier The scatter item identifier.
    */
   onItemClick: PropTypes.func,

--- a/packages/x-charts/src/ScatterChart/ScatterChart.tsx
+++ b/packages/x-charts/src/ScatterChart/ScatterChart.tsx
@@ -129,6 +129,7 @@ export interface ScatterChartProps
   slotProps?: ScatterChartSlotProps;
   /**
    * Callback fired when a scatter item is activated.
+   * Activation with the Enter and Space keys requires the `enableKeyboardClickEvents` experimental feature.
    * @param {MouseEvent} event The event that activated the item. It is a `KeyboardEvent` on Enter or Space activation. Import `@mui/x-charts/moduleAugmentation/keyboardItemActivation` for correct typing.
    * @param {ScatterItemIdentifier} scatterItemIdentifier The scatter item identifier.
    */
@@ -425,6 +426,7 @@ ScatterChart.propTypes /* remove-proptypes */ = {
   onHighlightChange: PropTypes.func,
   /**
    * Callback fired when a scatter item is activated.
+   * Activation with the Enter and Space keys requires the `enableKeyboardClickEvents` experimental feature.
    * @param {MouseEvent} event The event that activated the item. It is a `KeyboardEvent` on Enter or Space activation. Import `@mui/x-charts/moduleAugmentation/keyboardItemActivation` for correct typing.
    * @param {ScatterItemIdentifier} scatterItemIdentifier The scatter item identifier.
    */

--- a/packages/x-charts/src/ScatterChart/checkClickEvent.test.tsx
+++ b/packages/x-charts/src/ScatterChart/checkClickEvent.test.tsx
@@ -1,4 +1,4 @@
-import { createRenderer } from '@mui/internal-test-utils';
+import { createRenderer, fireEvent } from '@mui/internal-test-utils';
 import { vi } from 'vitest';
 import { ScatterChart } from '@mui/x-charts/ScatterChart';
 import { isJSDOM } from 'test/utils/skipIf';
@@ -212,6 +212,30 @@ describe('ScatterChart - click event', () => {
         dataIndex: 0,
         seriesId: 's1',
       });
+    });
+
+    it('should fire onItemClick once while the key is held down', async () => {
+      const onItemClick = vi.fn();
+      const { user } = render(
+        <ScatterChart
+          {...config}
+          series={[{ id: 's1', data: config.dataset }]}
+          onItemClick={onItemClick}
+          experimentalFeatures={{ enableKeyboardClickEvents: true }}
+        />,
+      );
+
+      await user.keyboard('{Tab}{ArrowRight}');
+
+      const target = document.activeElement!;
+      const repeated = fireEvent.keyDown(target, { key: ' ', repeat: true });
+
+      expect(onItemClick.mock.calls).to.have.length(0);
+      expect(repeated).to.equal(false); // default prevented, so the page does not scroll
+
+      fireEvent.keyDown(target, { key: ' ' });
+
+      expect(onItemClick.mock.calls).to.have.length(1);
     });
 
     it('should not call onItemClick without the experimental feature enabled', async () => {

--- a/packages/x-charts/src/ScatterChart/checkClickEvent.test.tsx
+++ b/packages/x-charts/src/ScatterChart/checkClickEvent.test.tsx
@@ -197,6 +197,7 @@ describe('ScatterChart - click event', () => {
           {...config}
           series={[{ id: 's1', data: config.dataset }]}
           onItemClick={onItemClick}
+          experimentalFeatures={{ enableKeyboardClickEvents: true }}
         />,
       );
 
@@ -213,6 +214,22 @@ describe('ScatterChart - click event', () => {
       });
     });
 
+    it('should not call onItemClick without the experimental feature enabled', async () => {
+      const onItemClick = vi.fn();
+      const { user } = render(
+        <ScatterChart
+          {...config}
+          series={[{ id: 's1', data: config.dataset }]}
+          onItemClick={onItemClick}
+        />,
+      );
+
+      await user.keyboard('{Tab}{ArrowRight}{Enter}');
+      await user.keyboard(' ');
+
+      expect(onItemClick.mock.calls).to.have.length(0);
+    });
+
     it('should activate the focused item when hit area interaction is disabled', async () => {
       const onItemClick = vi.fn();
       const { user } = render(
@@ -221,6 +238,7 @@ describe('ScatterChart - click event', () => {
           series={[{ id: 's1', data: config.dataset }]}
           onItemClick={onItemClick}
           disableHitArea
+          experimentalFeatures={{ enableKeyboardClickEvents: true }}
         />,
       );
 

--- a/packages/x-charts/src/ScatterChart/checkClickEvent.test.tsx
+++ b/packages/x-charts/src/ScatterChart/checkClickEvent.test.tsx
@@ -188,4 +188,49 @@ describe('ScatterChart - click event', () => {
       expect(onItemClick.mock.calls.length).to.equal(1); // Make sure voronoi + item click does not duplicate event triggering
     });
   });
+
+  describe('onItemClick - keyboard activation', () => {
+    it('should provide the focused item when pressing Enter or Space', async () => {
+      const onItemClick = vi.fn();
+      const { user } = render(
+        <ScatterChart
+          {...config}
+          series={[{ id: 's1', data: config.dataset }]}
+          onItemClick={onItemClick}
+        />,
+      );
+
+      await user.keyboard('{Tab}{ArrowRight}{Enter}');
+      await user.keyboard(' ');
+
+      expect(onItemClick.mock.calls).to.have.length(2);
+      expect(onItemClick.mock.calls[0][0]).to.have.property('key', 'Enter');
+      expect(onItemClick.mock.calls[1][0]).to.have.property('key', ' ');
+      expect(onItemClick.mock.calls[1][1]).to.deep.equal({
+        type: 'scatter',
+        dataIndex: 0,
+        seriesId: 's1',
+      });
+    });
+
+    it('should activate the focused item when hit area interaction is disabled', async () => {
+      const onItemClick = vi.fn();
+      const { user } = render(
+        <ScatterChart
+          {...config}
+          series={[{ id: 's1', data: config.dataset }]}
+          onItemClick={onItemClick}
+          disableHitArea
+        />,
+      );
+
+      await user.keyboard('{Tab}{ArrowRight}{Enter}');
+
+      expect(onItemClick.mock.lastCall?.[1]).to.deep.equal({
+        type: 'scatter',
+        dataIndex: 0,
+        seriesId: 's1',
+      });
+    });
+  });
 });

--- a/packages/x-charts/src/ScatterChart/seriesConfig/keyboardFocusHandler.ts
+++ b/packages/x-charts/src/ScatterChart/seriesConfig/keyboardFocusHandler.ts
@@ -1,9 +1,9 @@
-import { createCommonKeyboardFocusHandler } from '../../internals/createCommonKeyboardFocusHandler';
+import { createActivatingKeyboardFocusHandler } from '../../internals/createActivatingKeyboardFocusHandler';
 import type { KeyboardFocusHandler } from '../../internals/plugins/featurePlugins/useChartKeyboardNavigation/keyboardFocusHandler.types';
 import { composableCartesianSeriesTypes } from '../../models/seriesType/composition';
 import type { ComposableCartesianChartSeriesType } from '../../models/seriesType/composition';
 
 const keyboardFocusHandler: KeyboardFocusHandler<'scatter', ComposableCartesianChartSeriesType> =
-  createCommonKeyboardFocusHandler(composableCartesianSeriesTypes);
+  createActivatingKeyboardFocusHandler(composableCartesianSeriesTypes);
 
 export default keyboardFocusHandler;

--- a/packages/x-charts/src/ScatterChart/useScatterChartProps.ts
+++ b/packages/x-charts/src/ScatterChart/useScatterChartProps.ts
@@ -73,9 +73,9 @@ export const useScatterChartProps = (props: ScatterChartProps) => {
     onHighlightChange,
     disableHitArea,
     hitAreaRadius,
-    onItemClick: useVoronoiOnItemClick
-      ? (onItemClick as UseChartClosestPointSignature['params']['onItemClick'])
-      : undefined,
+    // Keep this callback available to keyboard navigation even when pointer clicks are handled
+    // directly by the marker because `disableHitArea` is enabled.
+    onItemClick: onItemClick as UseChartClosestPointSignature['params']['onItemClick'],
     plugins: SCATTER_CHART_PLUGINS,
     slots,
     slotProps,

--- a/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
+++ b/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
@@ -692,6 +692,7 @@ SparkLineChart.propTypes /* remove-proptypes */ = {
   /**
    * Callback fired when clicking close to an item, or when it is activated with the Enter or Space keys.
    * This is only available for scatter plot for now.
+   * Activation with the Enter and Space keys requires the `enableKeyboardClickEvents` experimental feature.
    * @param {MouseEvent} event The event that activated the item. It is a `KeyboardEvent` on Enter or Space activation. Import `@mui/x-charts/moduleAugmentation/keyboardItemActivation` for correct typing.
    * @param {ScatterItemIdentifier} scatterItemIdentifier Identify which item got clicked
    */

--- a/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
+++ b/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
@@ -690,7 +690,7 @@ SparkLineChart.propTypes /* remove-proptypes */ = {
    */
   onHighlightedAxisChange: PropTypes.func,
   /**
-   * Callback fired when an item is activated.
+   * Callback fired when clicking close to an item, or when it is activated with the Enter or Space keys.
    * This is only available for scatter plot for now.
    * @param {MouseEvent} event The event that activated the item. It is a `KeyboardEvent` on Enter or Space activation. Import `@mui/x-charts/moduleAugmentation/keyboardItemActivation` for correct typing.
    * @param {ScatterItemIdentifier} scatterItemIdentifier Identify which item got clicked

--- a/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
+++ b/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
@@ -691,7 +691,7 @@ SparkLineChart.propTypes /* remove-proptypes */ = {
   /**
    * Callback fired when an item is activated.
    * This is only available for scatter plot for now.
-   * @param {MouseEvent | KeyboardEvent} event The pointer or keyboard event that activated the item.
+   * @param {MouseEvent} event The event that activated the item. It is a `KeyboardEvent` on Enter or Space activation. Import `@mui/x-charts/moduleAugmentation/keyboardItemActivation` for correct typing.
    * @param {ScatterItemIdentifier} scatterItemIdentifier Identify which item got clicked
    */
   onItemClick: PropTypes.func,

--- a/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
+++ b/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
@@ -689,9 +689,9 @@ SparkLineChart.propTypes /* remove-proptypes */ = {
    */
   onHighlightedAxisChange: PropTypes.func,
   /**
-   * Callback fired when clicking close to an item.
+   * Callback fired when an item is activated.
    * This is only available for scatter plot for now.
-   * @param {MouseEvent} event Mouse event caught at the svg level
+   * @param {MouseEvent | KeyboardEvent} event The pointer or keyboard event that activated the item.
    * @param {ScatterItemIdentifier} scatterItemIdentifier Identify which item got clicked
    */
   onItemClick: PropTypes.func,

--- a/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
+++ b/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
@@ -430,6 +430,7 @@ SparkLineChart.propTypes /* remove-proptypes */ = {
    * Options to enable features planned for the next major.
    */
   experimentalFeatures: PropTypes.shape({
+    enableKeyboardClickEvents: PropTypes.bool,
     enablePositionBasedPointerInteraction: PropTypes.bool,
     progressiveRendering: PropTypes.bool,
   }),

--- a/packages/x-charts/src/internals/createActivatingKeyboardFocusHandler.ts
+++ b/packages/x-charts/src/internals/createActivatingKeyboardFocusHandler.ts
@@ -1,0 +1,26 @@
+import type { ChartSeriesType } from '../models/seriesType/config';
+import { createCommonKeyboardFocusHandler } from './createCommonKeyboardFocusHandler';
+
+/**
+ * Create a keyboard focus handler for common use cases where focused items are defined by series ID and data index.
+ */
+export function createActivatingKeyboardFocusHandler<
+  SeriesType extends Exclude<ChartSeriesType, 'sankey' | 'heatmap'>,
+  TInputSeriesType extends Exclude<ChartSeriesType, 'sankey' | 'heatmap'> = SeriesType,
+>(outSeriesTypes: Set<SeriesType>, allowCycles?: boolean, useCurrentSeriesMaxLength?: boolean) {
+  const commonHandler = createCommonKeyboardFocusHandler<SeriesType, TInputSeriesType>(
+    outSeriesTypes,
+    allowCycles,
+    useCurrentSeriesMaxLength,
+  );
+
+  const keyboardFocusHandler = (event: KeyboardEvent) => {
+    if (!event.repeat && (event.key === ' ' || event.key === 'Enter')) {
+      return 'activate' as const;
+    }
+
+    return commonHandler(event);
+  };
+
+  return keyboardFocusHandler;
+}

--- a/packages/x-charts/src/internals/createActivatingKeyboardFocusHandler.ts
+++ b/packages/x-charts/src/internals/createActivatingKeyboardFocusHandler.ts
@@ -15,7 +15,9 @@ export function createActivatingKeyboardFocusHandler<
   );
 
   const keyboardFocusHandler = (event: KeyboardEvent) => {
-    if (!event.repeat && (event.key === ' ' || event.key === 'Enter')) {
+    // Repeats are reported as activations too, so the caller can keep preventing the default
+    // scroll while the key is held. It is up to the caller to only fire the callback once.
+    if (event.key === ' ' || event.key === 'Enter') {
       return 'activate' as const;
     }
 

--- a/packages/x-charts/src/internals/index.ts
+++ b/packages/x-charts/src/internals/index.ts
@@ -91,6 +91,7 @@ export * from './scaleGuards';
 export * from './findMinMax';
 export * from './commonNextFocusItem';
 export { createCommonKeyboardFocusHandler } from './createCommonKeyboardFocusHandler';
+export { createActivatingKeyboardFocusHandler } from './createActivatingKeyboardFocusHandler';
 export { getSeriesColorFn } from './getSeriesColorFn';
 export { resolveColorProcessor } from './resolveColorProcessor';
 export { processLineLikeSeries } from './processLineLikeSeries';

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartExperimentalFeature/useChartExperimentalFeature.types.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartExperimentalFeature/useChartExperimentalFeature.types.ts
@@ -1,6 +1,19 @@
 import type { ChartPluginSignature } from '../../models';
 import type { ChartSeriesType } from '../../../../models/seriesType/config';
 
+interface CommonExperimentalFeatures {
+  /**
+   * Enables activating the focused item with the Enter and Space keys, which calls `onItemClick`
+   * with a `KeyboardEvent`.
+   *
+   * Import `@mui/x-charts/moduleAugmentation/keyboardItemActivation` to widen the `onItemClick`
+   * event type accordingly.
+   *
+   * This behavior will become the default in the next major version.
+   */
+  enableKeyboardClickEvents?: boolean;
+}
+
 interface LineExperimentalFeatures {
   /**
    * Enables pointer-based interaction detection for line and area series.
@@ -28,20 +41,11 @@ interface ScatterExperimentalFeatures {
    * This behavior will become the default in the next major version.
    */
   progressiveRendering?: boolean;
-  /**
-   * Enables activating the focused item with the Enter and Space keys, which calls `onItemClick`
-   * with a `KeyboardEvent`.
-   *
-   * Import `@mui/x-charts/moduleAugmentation/keyboardItemActivation` to widen the `onItemClick`
-   * event type accordingly.
-   *
-   * This behavior will become the default in the next major version.
-   */
-  enableKeyboardClickEvents?: boolean;
 }
 
 export type ChartExperimentalFeatures<SeriesType extends ChartSeriesType = ChartSeriesType> =
-  ('line' extends SeriesType ? LineExperimentalFeatures : {}) &
+  CommonExperimentalFeatures &
+    ('line' extends SeriesType ? LineExperimentalFeatures : {}) &
     ('scatter' extends SeriesType ? ScatterExperimentalFeatures : {});
 
 export interface UseChartExperimentalFeaturesParameters<

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartExperimentalFeature/useChartExperimentalFeature.types.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartExperimentalFeature/useChartExperimentalFeature.types.ts
@@ -28,6 +28,16 @@ interface ScatterExperimentalFeatures {
    * This behavior will become the default in the next major version.
    */
   progressiveRendering?: boolean;
+  /**
+   * Enables activating the focused item with the Enter and Space keys, which calls `onItemClick`
+   * with a `KeyboardEvent`.
+   *
+   * Import `@mui/x-charts/moduleAugmentation/keyboardItemActivation` to widen the `onItemClick`
+   * event type accordingly.
+   *
+   * This behavior will become the default in the next major version.
+   */
+  enableKeyboardClickEvents?: boolean;
 }
 
 export type ChartExperimentalFeatures<SeriesType extends ChartSeriesType = ChartSeriesType> =

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartClosestPoint/useChartClosestPoint.types.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartClosestPoint/useChartClosestPoint.types.ts
@@ -41,12 +41,15 @@ export interface UseChartVoronoiParameters {
    */
   hitAreaRadius?: 'item' | number | undefined;
   /**
-   * Callback fired when clicking close to an item.
+   * Callback fired when clicking close to an item, or it is activated via keyboard Enter or Space.
    * This is only available for scatter plot for now.
-   * @param {MouseEvent} event Mouse event caught at the svg level
+   * @param {MouseEvent | KeyboardEvent} event The pointer or keyboard event that activated the item.
    * @param {ScatterItemIdentifier} scatterItemIdentifier Identify which item got clicked
    */
-  onItemClick?: (event: MouseEvent, scatterItemIdentifier: ScatterItemIdentifier) => void;
+  onItemClick?: (
+    event: MouseEvent | KeyboardEvent,
+    scatterItemIdentifier: ScatterItemIdentifier,
+  ) => void;
 }
 
 export type UseChartVoronoiDefaultizedParameters = Pick<

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartClosestPoint/useChartClosestPoint.types.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartClosestPoint/useChartClosestPoint.types.ts
@@ -44,6 +44,7 @@ export interface UseChartVoronoiParameters {
   /**
    * Callback fired when clicking close to an item, or when it is activated with the Enter or Space keys.
    * This is only available for scatter plot for now.
+   * Activation with the Enter and Space keys requires the `enableKeyboardClickEvents` experimental feature.
    * @param {MouseEvent} event The event that activated the item. It is a `KeyboardEvent` on Enter or Space activation. Import `@mui/x-charts/moduleAugmentation/keyboardItemActivation` for correct typing.
    * @param {ScatterItemIdentifier} scatterItemIdentifier Identify which item got clicked
    */

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartClosestPoint/useChartClosestPoint.types.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartClosestPoint/useChartClosestPoint.types.ts
@@ -1,3 +1,4 @@
+import type { ItemActivationEvent } from '../../../../models/featureFlags';
 import type { ScatterItemIdentifier } from '../../../../models/seriesType';
 import type { ChartSeriesType } from '../../../../models/seriesType/config';
 import type { UseChartSeriesSignature } from '../../corePlugins/useChartSeries';
@@ -41,15 +42,12 @@ export interface UseChartVoronoiParameters {
    */
   hitAreaRadius?: 'item' | number | undefined;
   /**
-   * Callback fired when clicking close to an item, or it is activated via keyboard Enter or Space.
+   * Callback fired when clicking close to an item, or when it is activated with the Enter or Space keys.
    * This is only available for scatter plot for now.
-   * @param {MouseEvent | KeyboardEvent} event The pointer or keyboard event that activated the item.
+   * @param {MouseEvent} event The event that activated the item. It is a `KeyboardEvent` on Enter or Space activation. Import `@mui/x-charts/moduleAugmentation/keyboardItemActivation` for correct typing.
    * @param {ScatterItemIdentifier} scatterItemIdentifier Identify which item got clicked
    */
-  onItemClick?: (
-    event: MouseEvent | KeyboardEvent,
-    scatterItemIdentifier: ScatterItemIdentifier,
-  ) => void;
+  onItemClick?: (event: ItemActivationEvent, scatterItemIdentifier: ScatterItemIdentifier) => void;
 }
 
 export type UseChartVoronoiDefaultizedParameters = Pick<

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/keyboardFocusHandler.types.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/keyboardFocusHandler.types.ts
@@ -24,14 +24,18 @@ export type FocusedItemUpdater<
     : Pick<ChartState<[UseChartKeyboardNavigationSignature], [], SeriesType>, 'series'>,
 ) => FocusedItemIdentifier<OutputSeriesType> | null;
 
+export type KeyboardActivation = 'activate';
+
 /**
  * Get the next focusable item in the chart.
  * @param {SeriesItemIdentifierWithType<SeriesType> | null} currentItem The current focused item.
  * @param {KeyboardEvent} event The keyboard event that triggered the navigation.
  * @param {ChartState<[UseChartKeyboardNavigationSignature], []>} state The current chart state.
- * @returns {SeriesItemIdentifierWithType<ChartSeriesType> | null} The next focusable item or null if none found.
+ * @returns {FocusedItemUpdater<ChartSeriesType> | KeyboardActivation | null} The next focusable item updater, an activation request, or null if none found.
  */
 export type KeyboardFocusHandler<
   SeriesType extends ChartSeriesType,
   OutputSeriesType extends ChartSeriesType = ChartSeriesType,
-> = (event: KeyboardEvent) => FocusedItemUpdater<SeriesType, OutputSeriesType> | null;
+> = (
+  event: KeyboardEvent,
+) => FocusedItemUpdater<SeriesType, OutputSeriesType> | KeyboardActivation | null;

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.test.tsx
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.test.tsx
@@ -1,3 +1,4 @@
+import { spy } from 'sinon';
 import { isJSDOM } from 'test/utils/skipIf';
 import { createRenderer, act } from '@mui/internal-test-utils/createRenderer';
 import { BarChart, barClasses } from '@mui/x-charts/BarChart';
@@ -310,6 +311,52 @@ describe('useChartKeyboardNavigation', () => {
       expect(container.querySelector(FOCUSED_BAR_SELECTOR)).not.to.equal(null);
       expect(secondBar!.getAttribute('data-highlighted')).to.equal('true');
       expect(firstBar!.getAttribute('data-highlighted')).to.equal(null);
+    },
+  );
+
+  it.skipIf(isJSDOM)(
+    'should call onItemClick when pressing Enter or Space on a focused item',
+    async () => {
+      const onItemClick = spy();
+      const { user } = render(
+        <ScatterChart
+          height={200}
+          width={200}
+          skipAnimation
+          margin={0}
+          onItemClick={onItemClick}
+          series={[
+            {
+              id: 'A',
+              data: [
+                { id: 'a1', x: 1, y: 1 },
+                { id: 'a2', x: 2, y: 2 },
+              ],
+              highlightScope: { highlight: 'item' },
+            },
+          ]}
+        />,
+      );
+
+      await user.keyboard('{Tab}');
+      await user.keyboard('[ArrowRight]');
+      await user.keyboard('[Enter]');
+
+      expect(onItemClick.callCount).to.equal(1);
+      expect(onItemClick.lastCall.args[1]).to.deep.equal({
+        type: 'scatter',
+        seriesId: 'A',
+        dataIndex: 0,
+      });
+
+      await user.keyboard('[Space]');
+
+      expect(onItemClick.callCount).to.equal(2);
+      expect(onItemClick.lastCall.args[1]).to.deep.equal({
+        type: 'scatter',
+        seriesId: 'A',
+        dataIndex: 0,
+      });
     },
   );
 });

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.test.tsx
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.test.tsx
@@ -325,6 +325,7 @@ describe('useChartKeyboardNavigation', () => {
           skipAnimation
           margin={0}
           onItemClick={onItemClick}
+          experimentalFeatures={{ enableKeyboardClickEvents: true }}
           series={[
             {
               id: 'A',

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.ts
@@ -3,6 +3,7 @@ import * as React from 'react';
 import useEnhancedEffect from '@mui/utils/useEnhancedEffect';
 import { selectorChartDefaultizedSeries } from '../../corePlugins/useChartSeries/useChartSeries.selectors';
 import { selectorChartSeriesConfig } from '../../corePlugins/useChartSeriesConfig';
+import { selectorChartExperimentalFeaturesState } from '../../corePlugins/useChartExperimentalFeature';
 import type { ChartPlugin } from '../../models';
 import type { UseChartKeyboardNavigationSignature } from './useChartKeyboardNavigation.types';
 import type { ChartSeriesType } from '../../../../models/seriesType/config';
@@ -86,7 +87,11 @@ export const useChartKeyboardNavigation: ChartPlugin<UseChartKeyboardNavigationS
       }
 
       if (keyboardHandlerResult === 'activate') {
-        if (store.state.keyboardNavigation.isFocused && newFocusedItem?.type === 'scatter') {
+        if (
+          selectorChartExperimentalFeaturesState(store.state, 'enableKeyboardClickEvents') &&
+          store.state.keyboardNavigation.isFocused &&
+          newFocusedItem?.type === 'scatter'
+        ) {
           event.preventDefault();
           // `onItemClick` is typed with `MouseEvent` until the consumer opts into the
           // `keyboardItemActivation` module augmentation.

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.ts
@@ -7,6 +7,12 @@ import type { ChartPlugin } from '../../models';
 import type { UseChartKeyboardNavigationSignature } from './useChartKeyboardNavigation.types';
 import type { ChartSeriesType } from '../../../../models/seriesType/config';
 import type { FocusedItemUpdater, KeyboardActivation } from './keyboardFocusHandler.types';
+import type { ScatterItemIdentifier } from '../../../../models/seriesType';
+
+type KeyboardActivationHandler = (
+  event: KeyboardEvent,
+  scatterItemIdentifier: ScatterItemIdentifier,
+) => void;
 
 export const useChartKeyboardNavigation: ChartPlugin<UseChartKeyboardNavigationSignature> = ({
   params,
@@ -82,7 +88,9 @@ export const useChartKeyboardNavigation: ChartPlugin<UseChartKeyboardNavigationS
       if (keyboardHandlerResult === 'activate') {
         if (store.state.keyboardNavigation.isFocused && newFocusedItem?.type === 'scatter') {
           event.preventDefault();
-          onItemClick?.(event, newFocusedItem);
+          // `onItemClick` is typed with `MouseEvent` until the consumer opts into the
+          // `keyboardItemActivation` module augmentation.
+          (onItemClick as KeyboardActivationHandler | undefined)?.(event, newFocusedItem);
         }
         return;
       }

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.ts
@@ -6,7 +6,7 @@ import { selectorChartSeriesConfig } from '../../corePlugins/useChartSeriesConfi
 import type { ChartPlugin } from '../../models';
 import type { UseChartKeyboardNavigationSignature } from './useChartKeyboardNavigation.types';
 import type { ChartSeriesType } from '../../../../models/seriesType/config';
-import type { FocusedItemUpdater } from './keyboardFocusHandler.types';
+import type { FocusedItemUpdater, KeyboardActivation } from './keyboardFocusHandler.types';
 
 export const useChartKeyboardNavigation: ChartPlugin<UseChartKeyboardNavigationSignature> = ({
   params,
@@ -14,11 +14,12 @@ export const useChartKeyboardNavigation: ChartPlugin<UseChartKeyboardNavigationS
   instance,
 }) => {
   const { chartsLayerContainerRef } = instance;
+  const { disableKeyboardNavigation, onItemClick } = params;
 
   React.useEffect(() => {
     const element = chartsLayerContainerRef.current;
 
-    if (!element || params.disableKeyboardNavigation) {
+    if (!element || disableKeyboardNavigation) {
       return undefined;
     }
 
@@ -71,14 +72,22 @@ export const useChartKeyboardNavigation: ChartPlugin<UseChartKeyboardNavigationS
         }
       }
 
-      const calculateFocusedItem = seriesConfig[seriesType]?.keyboardFocusHandler?.(event) as
-        FocusedItemUpdater<typeof seriesType> | undefined;
+      const keyboardHandlerResult = seriesConfig[seriesType]?.keyboardFocusHandler?.(event) as
+        FocusedItemUpdater<typeof seriesType> | KeyboardActivation | undefined;
 
-      if (!calculateFocusedItem) {
+      if (!keyboardHandlerResult) {
         return;
       }
 
-      newFocusedItem = calculateFocusedItem(newFocusedItem, store.state);
+      if (keyboardHandlerResult === 'activate') {
+        if (store.state.keyboardNavigation.isFocused && newFocusedItem?.type === 'scatter') {
+          event.preventDefault();
+          onItemClick?.(event, newFocusedItem);
+        }
+        return;
+      }
+
+      newFocusedItem = keyboardHandlerResult(newFocusedItem, store.state);
 
       if (newFocusedItem !== store.state.keyboardNavigation.item) {
         event.preventDefault();
@@ -106,14 +115,14 @@ export const useChartKeyboardNavigation: ChartPlugin<UseChartKeyboardNavigationS
       element.removeEventListener('focusout', removeFocus);
       element.removeEventListener('focusin', restoreFocus);
     };
-  }, [chartsLayerContainerRef, params.disableKeyboardNavigation, store]);
+  }, [chartsLayerContainerRef, disableKeyboardNavigation, onItemClick, store]);
 
   useEnhancedEffect(() => {
     store.set('keyboardNavigation', {
       ...store.state.keyboardNavigation,
-      enabled: !params.disableKeyboardNavigation,
+      enabled: !disableKeyboardNavigation,
     });
-  }, [store, params.disableKeyboardNavigation]);
+  }, [store, disableKeyboardNavigation]);
 
   return {};
 };

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.ts
@@ -93,9 +93,12 @@ export const useChartKeyboardNavigation: ChartPlugin<UseChartKeyboardNavigationS
           newFocusedItem?.type === 'scatter'
         ) {
           event.preventDefault();
-          // `onItemClick` is typed with `MouseEvent` until the consumer opts into the
-          // `keyboardItemActivation` module augmentation.
-          (onItemClick as KeyboardActivationHandler | undefined)?.(event, newFocusedItem);
+
+          if (!event.repeat) {
+            // `onItemClick` is typed with `MouseEvent` until the consumer opts into the
+            // `keyboardItemActivation` module augmentation.
+            (onItemClick as KeyboardActivationHandler | undefined)?.(event, newFocusedItem);
+          }
         }
         return;
       }

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.types.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.types.ts
@@ -2,6 +2,7 @@ import type { ChartPluginSignature } from '../../models';
 import type { UseChartInteractionSignature } from '../useChartInteraction';
 import type { UseChartCartesianAxisSignature } from '../useChartCartesianAxis';
 import type { UseChartHighlightSignature } from '../useChartHighlight';
+import type { UseChartClosestPointSignature } from '../useChartClosestPoint';
 import type { FocusedItemIdentifier } from '../../../../models/seriesType';
 import type { ChartSeriesType } from '../../../../models/seriesType/config';
 
@@ -40,5 +41,6 @@ export type UseChartKeyboardNavigationSignature = ChartPluginSignature<{
     UseChartInteractionSignature,
     UseChartHighlightSignature<ChartSeriesType>,
     UseChartCartesianAxisSignature,
+    UseChartClosestPointSignature,
   ];
 }>;

--- a/packages/x-charts/src/models/featureFlags.ts
+++ b/packages/x-charts/src/models/featureFlags.ts
@@ -1,1 +1,15 @@
+import type { HasProperty } from '@mui/x-internals/types';
+
 export interface ChartsTypeFeatureFlags {}
+
+/**
+ * The event that activated an item.
+ * Defaults to `MouseEvent`. Import `@mui/x-charts/moduleAugmentation/keyboardItemActivation`
+ * to widen it to `MouseEvent | KeyboardEvent`, which is what is received at runtime since items
+ * can also be activated with the Enter and Space keys.
+ */
+export type ItemActivationEvent =
+  HasProperty<ChartsTypeFeatureFlags, 'itemActivationEvent'> extends true
+    ? // @ts-ignore this property is added through module augmentation
+      ChartsTypeFeatureFlags['itemActivationEvent']
+    : MouseEvent;

--- a/packages/x-charts/src/moduleAugmentation/keyboardItemActivation.ts
+++ b/packages/x-charts/src/moduleAugmentation/keyboardItemActivation.ts
@@ -1,0 +1,8 @@
+declare module '@mui/x-charts/models' {
+  interface ChartsTypeFeatureFlags {
+    itemActivationEvent: MouseEvent | KeyboardEvent;
+  }
+}
+
+// Required to make this file into a module
+export default {};

--- a/scripts/x-charts-premium.exports.json
+++ b/scripts/x-charts-premium.exports.json
@@ -418,6 +418,7 @@
   { "name": "HighlightOptions", "kind": "TypeAlias" },
   { "name": "HighlightScope", "kind": "TypeAlias" },
   { "name": "HighlightState", "kind": "TypeAlias" },
+  { "name": "ItemActivationEvent", "kind": "TypeAlias" },
   { "name": "ItemTooltip", "kind": "Interface" },
   { "name": "labelClasses", "kind": "Variable" },
   { "name": "labelGradientClasses", "kind": "Variable" },

--- a/scripts/x-charts-pro.exports.json
+++ b/scripts/x-charts-pro.exports.json
@@ -376,6 +376,7 @@
   { "name": "HighlightOptions", "kind": "TypeAlias" },
   { "name": "HighlightScope", "kind": "TypeAlias" },
   { "name": "HighlightState", "kind": "TypeAlias" },
+  { "name": "ItemActivationEvent", "kind": "TypeAlias" },
   { "name": "ItemTooltip", "kind": "Interface" },
   { "name": "labelClasses", "kind": "Variable" },
   { "name": "labelGradientClasses", "kind": "Variable" },

--- a/scripts/x-charts.exports.json
+++ b/scripts/x-charts.exports.json
@@ -280,6 +280,7 @@
   { "name": "HighlightOptions", "kind": "TypeAlias" },
   { "name": "HighlightScope", "kind": "TypeAlias" },
   { "name": "HighlightState", "kind": "TypeAlias" },
+  { "name": "ItemActivationEvent", "kind": "TypeAlias" },
   { "name": "ItemTooltip", "kind": "Interface" },
   { "name": "labelClasses", "kind": "Variable" },
   { "name": "labelGradientClasses", "kind": "Variable" },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui/mui-x/issues/23148.

Involves augmenting the type in `onItemClick` since now it can also receive a KeyboardEvent.

Whenever an Enter or Space is detected in the keyboard handler, we return an `'activate'` string instead of function to get the next item. In `useChartKeyboardNavigation` when we receive this, we call `onItemClick`.