### PR TITLE
[charts] Set aria-hidden on accessibility proxy divs at initialization

### DIFF
--- a/packages/x-charts/src/internals/components/ChartsAccessibilityProxy/ChartsAccessibilityProxy.test.tsx
+++ b/packages/x-charts/src/internals/components/ChartsAccessibilityProxy/ChartsAccessibilityProxy.test.tsx
@@ -1,0 +1,54 @@
+import { isJSDOM } from 'test/utils/skipIf';
+import { createRenderer } from '@mui/internal-test-utils/createRenderer';
+import { BarChart } from '@mui/x-charts/BarChart';
+
+describe('<ChartsAccessibilityProxy />', () => {
+  const { render } = createRenderer();
+
+  const PROXY_SELECTOR = 'div[role="img"][aria-labelledby^="voiceover-"]';
+
+  it('should set aria-hidden="true" on proxy divs before keyboard focus', async () => {
+    const { container } = render(
+      <BarChart
+        height={100}
+        width={100}
+        skipAnimation
+        margin={0}
+        series={[{ id: 'A', data: [50, 100] }]}
+      />,
+    );
+
+    const proxyDivs = container.querySelectorAll<HTMLElement>(PROXY_SELECTOR);
+    expect(proxyDivs.length).to.equal(2);
+
+    for (const div of proxyDivs) {
+      expect(div.getAttribute('aria-hidden')).to.equal('true');
+    }
+  });
+
+  it.skipIf(isJSDOM)(
+    'should set aria-hidden="false" on the active proxy div after keyboard focus',
+    async () => {
+      const { container, user } = render(
+        <BarChart
+          height={100}
+          width={100}
+          skipAnimation
+          margin={0}
+          series={[{ id: 'A', data: [50, 100] }]}
+        />,
+      );
+
+      await user.keyboard('{Tab}');
+      await user.keyboard('[ArrowRight]');
+
+      const proxyDivs = container.querySelectorAll<HTMLElement>(PROXY_SELECTOR);
+
+      const ariaHiddenValues = Array.from(proxyDivs).map((div) => div.getAttribute('aria-hidden'));
+
+      // One proxy should be visible (active), one hidden (inactive)
+      expect(ariaHiddenValues).to.include('false');
+      expect(ariaHiddenValues).to.include('true');
+    },
+  );
+});

--- a/packages/x-charts/src/internals/components/ChartsAccessibilityProxy/ChartsAccessibilityProxy.tsx
+++ b/packages/x-charts/src/internals/components/ChartsAccessibilityProxy/ChartsAccessibilityProxy.tsx
@@ -56,6 +56,7 @@ export function ChartsAccessibilityProxy() {
           div.setAttribute('tabindex', '0');
         }
         div.setAttribute('role', 'img');
+        div.setAttribute('aria-hidden', 'true');
         div.setAttribute(
           'aria-labelledby',
           i === 0 ? `voiceover-${chartId}-1` : `voiceover-${chartId}-2`,


### PR DESCRIPTION
## Summary

Fixes #23185

`ChartsAccessibilityProxy` creates two `div[role="img"]` elements whose `aria-labelledby` targets are empty until a chart item receives keyboard focus. Without `aria-hidden`, these divs appear in the accessibility tree as images with no accessible name, violating WCAG 1.1.1 (Non-text Content).

Accessibility tools flag this as:

> This DIV (role=img) does not have a mechanism that allows an accessible name value to be calculated.

## Changes

**One-line fix:** add `div.setAttribute('aria-hidden', 'true')` when the proxy divs are created during initialization (line 59 of `ChartsAccessibilityProxy.tsx`).

The existing focus handler already manages `aria-hidden` correctly on subsequent interactions:
- Line 89: `activeDiv.setAttribute('aria-hidden', 'false')` — reveals the active buffer
- Line 98: `inactiveDiv.setAttribute('aria-hidden', 'true')` — hides the inactive buffer

The initial `aria-hidden="true"` fills the gap between creation and first keyboard focus.

## Test plan

Added two browser tests in `ChartsAccessibilityProxy.test.tsx`:
1. Verifies proxy divs have `aria-hidden="true"` on initial render (before keyboard interaction)
2. Verifies `aria-hidden="false"` is set on the active proxy div after keyboard navigation

All existing `useChartKeyboardNavigation` tests pass (22/22).

**Reproduced on:** `@mui/x-charts` 9.10.0 (latest) and 9.8.0.