### PR TITLE
[chat] Normalize message part link URLs

### DIFF
--- a/packages/x-chat-headless/src/message/defaultMessagePartRenderers.tsx
+++ b/packages/x-chat-headless/src/message/defaultMessagePartRenderers.tsx
@@ -12,7 +12,7 @@ import type {
   ChatToolMessagePart,
 } from '../types/chat-message-parts';
 import type { ChatPartRenderer } from '../renderers/chatPartRenderer';
-import { safeUri } from './parts/partUtils';
+import { safeFileUri, safeUri } from './parts/partUtils';
 
 function JsonBlock(props: { value: unknown }) {
   const { value } = props;
@@ -62,7 +62,7 @@ export const renderDefaultFilePart: ChatPartRenderer<ChatFileMessagePart> = ({ p
     return <img alt={part.filename ?? ''} src={part.url} />;
   }
 
-  return <a href={safeUri(part.url) || undefined}>{part.filename ?? part.url}</a>;
+  return <a href={safeFileUri(part.url) || undefined}>{part.filename ?? part.url}</a>;
 };
 
 export const renderDefaultSourceUrlPart: ChatPartRenderer<ChatSourceUrlMessagePart> = ({

--- a/packages/x-chat-headless/src/message/defaultMessagePartRenderers.tsx
+++ b/packages/x-chat-headless/src/message/defaultMessagePartRenderers.tsx
@@ -12,6 +12,7 @@ import type {
   ChatToolMessagePart,
 } from '../types/chat-message-parts';
 import type { ChatPartRenderer } from '../renderers/chatPartRenderer';
+import { safeUri } from './parts/partUtils';
 
 function JsonBlock(props: { value: unknown }) {
   const { value } = props;
@@ -61,12 +62,12 @@ export const renderDefaultFilePart: ChatPartRenderer<ChatFileMessagePart> = ({ p
     return <img alt={part.filename ?? ''} src={part.url} />;
   }
 
-  return <a href={part.url}>{part.filename ?? part.url}</a>;
+  return <a href={safeUri(part.url) || undefined}>{part.filename ?? part.url}</a>;
 };
 
 export const renderDefaultSourceUrlPart: ChatPartRenderer<ChatSourceUrlMessagePart> = ({
   part,
-}) => <a href={part.url}>{part.title ?? part.url}</a>;
+}) => <a href={safeUri(part.url) || undefined}>{part.title ?? part.url}</a>;
 
 export const renderDefaultSourceDocumentPart: ChatPartRenderer<ChatSourceDocumentMessagePart> = ({
   part,

--- a/packages/x-chat-headless/src/message/parts/FilePart.tsx
+++ b/packages/x-chat-headless/src/message/parts/FilePart.tsx
@@ -6,7 +6,7 @@ import type { ChatFileMessagePart } from '../../types/chat-message-parts';
 import type { ChatPartRenderer, ChatPartRendererProps } from '../../renderers/chatPartRenderer';
 import type { ChatRole } from '../../types/chat-entities';
 import { useMessageContentTabIndex } from '../../message-list/internals/MessageRovingContext';
-import { safeUri } from './partUtils';
+import { safeFileUri } from './partUtils';
 
 export interface FilePartOwnerState {
   image: boolean;
@@ -115,7 +115,7 @@ export const FilePart = React.forwardRef(function FilePart(
   return (
     <Root {...rootProps}>
       <LinkSlot
-        href={safeUri(part.url) || undefined}
+        href={safeFileUri(part.url) || undefined}
         rel="noreferrer noopener"
         target="_blank"
         {...linkProps}

--- a/packages/x-chat-headless/src/message/parts/FilePart.tsx
+++ b/packages/x-chat-headless/src/message/parts/FilePart.tsx
@@ -6,6 +6,7 @@ import type { ChatFileMessagePart } from '../../types/chat-message-parts';
 import type { ChatPartRenderer, ChatPartRendererProps } from '../../renderers/chatPartRenderer';
 import type { ChatRole } from '../../types/chat-entities';
 import { useMessageContentTabIndex } from '../../message-list/internals/MessageRovingContext';
+import { safeUri } from './partUtils';
 
 export interface FilePartOwnerState {
   image: boolean;
@@ -113,7 +114,12 @@ export const FilePart = React.forwardRef(function FilePart(
 
   return (
     <Root {...rootProps}>
-      <LinkSlot href={part.url} rel="noreferrer noopener" target="_blank" {...linkProps}>
+      <LinkSlot
+        href={safeUri(part.url) || undefined}
+        rel="noreferrer noopener"
+        target="_blank"
+        {...linkProps}
+      >
         {ownerState.image ? (
           <Preview alt={part.filename ?? ''} src={part.url} {...previewProps} />
         ) : (

--- a/packages/x-chat-headless/src/message/parts/MessageParts.test.tsx
+++ b/packages/x-chat-headless/src/message/parts/MessageParts.test.tsx
@@ -229,6 +229,25 @@ describe('FilePart', () => {
     );
   });
 
+  it('preserves a same-origin blob URL as the link target', () => {
+    const blobUrl = `blob:${window.location.origin}/attachment`;
+
+    renderWithMessage({
+      id: 'm1',
+      role: 'assistant',
+      parts: [
+        {
+          type: 'file',
+          mediaType: 'application/pdf',
+          url: blobUrl,
+          filename: 'doc.pdf',
+        },
+      ],
+    });
+
+    expect(screen.getByText('doc.pdf').closest('a')).to.have.attribute('href', blobUrl);
+  });
+
   it('falls back to URL when no filename', () => {
     renderWithMessage({
       id: 'm1',
@@ -371,6 +390,21 @@ describe('SourceDocumentPart', () => {
 });
 
 describe('defaultMessagePartRenderers', () => {
+  it('renderDefaultFilePart preserves a same-origin blob URL as the link target', () => {
+    const blobUrl = `blob:${window.location.origin}/attachment`;
+    const part = {
+      type: 'file' as const,
+      mediaType: 'application/pdf',
+      url: blobUrl,
+      filename: 'doc.pdf',
+    };
+    const message: ChatMessage = { id: 'm1', role: 'assistant', parts: [part] };
+
+    render(<React.Fragment>{renderDefaultFilePart({ part, message, index: 0 })}</React.Fragment>);
+
+    expect(screen.getByText('doc.pdf').closest('a')).to.have.attribute('href', blobUrl);
+  });
+
   it('renderDefaultFilePart does not expose an unsafe URL as the link target', () => {
     const part = {
       type: 'file' as const,

--- a/packages/x-chat-headless/src/message/parts/MessageParts.test.tsx
+++ b/packages/x-chat-headless/src/message/parts/MessageParts.test.tsx
@@ -20,6 +20,8 @@ import { MessageContent } from '../MessageContent';
 import { MessageRoot } from '../MessageRoot';
 
 const { render } = createRenderer();
+// eslint-disable-next-line no-script-url
+const unsafeUrl = 'javascript:alert(document.domain)';
 
 function createAdapter(): ChatAdapter {
   return {
@@ -221,7 +223,10 @@ describe('FilePart', () => {
       ],
     });
 
-    expect(screen.getByText('doc.pdf')).not.to.equal(null);
+    expect(screen.getByText('doc.pdf').closest('a')).to.have.attribute(
+      'href',
+      'https://example.com/doc.pdf',
+    );
   });
 
   it('falls back to URL when no filename', () => {
@@ -238,6 +243,23 @@ describe('FilePart', () => {
     });
 
     expect(screen.getByText('https://example.com/doc.pdf')).not.to.equal(null);
+  });
+
+  it('does not expose an unsafe URL as the link target', () => {
+    renderWithMessage({
+      id: 'm1',
+      role: 'assistant',
+      parts: [
+        {
+          type: 'file',
+          mediaType: 'application/pdf',
+          url: unsafeUrl,
+          filename: 'doc.pdf',
+        },
+      ],
+    });
+
+    expect(screen.getByText('doc.pdf').closest('a')!.getAttribute('href')).to.equal(null);
   });
 });
 
@@ -258,6 +280,7 @@ describe('SourceUrlPart', () => {
 
     const link = screen.getByText('MUI Docs');
 
+    expect(link.closest('a')).to.have.attribute('href', 'https://mui.com');
     expect(link.closest('a')).to.have.attribute('target', '_blank');
     expect(link.closest('a')).to.have.attribute('rel', 'noreferrer noopener');
   });
@@ -276,6 +299,23 @@ describe('SourceUrlPart', () => {
     });
 
     expect(screen.getByText('https://mui.com/x')).not.to.equal(null);
+  });
+
+  it('does not expose an unsafe URL as the link target', () => {
+    renderWithMessage({
+      id: 'm1',
+      role: 'assistant',
+      parts: [
+        {
+          type: 'source-url',
+          sourceId: 's1',
+          url: unsafeUrl,
+          title: 'MUI Docs',
+        },
+      ],
+    });
+
+    expect(screen.getByText('MUI Docs').closest('a')!.getAttribute('href')).to.equal(null);
   });
 });
 
@@ -331,6 +371,36 @@ describe('SourceDocumentPart', () => {
 });
 
 describe('defaultMessagePartRenderers', () => {
+  it('renderDefaultFilePart does not expose an unsafe URL as the link target', () => {
+    const part = {
+      type: 'file' as const,
+      mediaType: 'application/pdf',
+      url: unsafeUrl,
+      filename: 'doc.pdf',
+    };
+    const message: ChatMessage = { id: 'm1', role: 'assistant', parts: [part] };
+
+    render(<React.Fragment>{renderDefaultFilePart({ part, message, index: 0 })}</React.Fragment>);
+
+    expect(screen.getByText('doc.pdf').closest('a')!.getAttribute('href')).to.equal(null);
+  });
+
+  it('renderDefaultSourceUrlPart does not expose an unsafe URL as the link target', () => {
+    const part = {
+      type: 'source-url' as const,
+      sourceId: 's1',
+      url: unsafeUrl,
+      title: 'MUI Docs',
+    };
+    const message: ChatMessage = { id: 'm1', role: 'assistant', parts: [part] };
+
+    render(
+      <React.Fragment>{renderDefaultSourceUrlPart({ part, message, index: 0 })}</React.Fragment>,
+    );
+
+    expect(screen.getByText('MUI Docs').closest('a')!.getAttribute('href')).to.equal(null);
+  });
+
   it('getDefaultMessagePartRenderer returns correct renderer for text', () => {
     expect(getDefaultMessagePartRenderer({ type: 'text', text: 'hi' })).toBe(renderDefaultTextPart);
   });

--- a/packages/x-chat-headless/src/message/parts/SourceUrlPart.tsx
+++ b/packages/x-chat-headless/src/message/parts/SourceUrlPart.tsx
@@ -6,6 +6,7 @@ import type { ChatPartRenderer, ChatPartRendererProps } from '../../renderers/ch
 import type { ChatRole } from '../../types/chat-entities';
 import type { ChatSourceUrlMessagePart } from '../../types/chat-message-parts';
 import { useMessageContentTabIndex } from '../../message-list/internals/MessageRovingContext';
+import { safeUri } from './partUtils';
 
 export interface SourceUrlPartOwnerState {
   messageId: string;
@@ -104,7 +105,12 @@ export const SourceUrlPart = React.forwardRef(function SourceUrlPart(
       <Icon {...iconProps}>
         <ExternalLinkIcon />
       </Icon>
-      <LinkSlot href={part.url} rel="noreferrer noopener" target="_blank" {...linkProps}>
+      <LinkSlot
+        href={safeUri(part.url) || undefined}
+        rel="noreferrer noopener"
+        target="_blank"
+        {...linkProps}
+      >
         {part.title ?? part.url}
       </LinkSlot>
     </Root>

--- a/packages/x-chat-headless/src/message/parts/partUtils.test.ts
+++ b/packages/x-chat-headless/src/message/parts/partUtils.test.ts
@@ -4,6 +4,7 @@ import {
   formatStructuredValue,
   normalizeCodeContent,
   normalizeMarkdownForRender,
+  safeFileUri,
   safeUri,
   shouldCollapsePayload,
 } from './partUtils';
@@ -107,6 +108,22 @@ describe('safeUri', () => {
 
   it('blocks data: protocol', () => {
     expect(safeUri('data:text/html,<h1>Hi</h1>')).to.equal('');
+  });
+});
+
+describe('safeFileUri', () => {
+  it('allows same-origin blob URLs', () => {
+    const blobUrl = `blob:${window.location.origin}/attachment`;
+
+    expect(safeFileUri(blobUrl)).to.equal(blobUrl);
+  });
+
+  it('blocks cross-origin blob URLs', () => {
+    expect(safeFileUri('blob:https://example.invalid/attachment')).to.equal('');
+  });
+
+  it('blocks opaque-origin blob URLs', () => {
+    expect(safeFileUri('blob:null/attachment')).to.equal('');
   });
 });
 

--- a/packages/x-chat-headless/src/message/parts/partUtils.ts
+++ b/packages/x-chat-headless/src/message/parts/partUtils.ts
@@ -46,6 +46,31 @@ export function safeUri(uri: string | null | undefined): string {
   }
 }
 
+export function safeFileUri(uri: string | null | undefined): string {
+  const safe = safeUri(uri);
+
+  if (safe || uri == null || typeof window === 'undefined') {
+    return safe;
+  }
+
+  try {
+    const trimmed = uri.trim();
+    const parsed = new URL(trimmed);
+
+    if (
+      parsed.protocol.toLowerCase() === 'blob:' &&
+      parsed.origin !== 'null' &&
+      parsed.origin === window.location.origin
+    ) {
+      return trimmed;
+    }
+  } catch {
+    // Ignore malformed URLs.
+  }
+
+  return '';
+}
+
 export function normalizeMarkdownForRender(markdown: string): string {
   const fenceMatches = markdown.match(/```/g);
 

--- a/packages/x-chat/src/ChatMessageSources/ChatMessageSource.tsx
+++ b/packages/x-chat/src/ChatMessageSources/ChatMessageSource.tsx
@@ -5,6 +5,7 @@ import clsx from 'clsx';
 import useSlotProps from '@mui/utils/useSlotProps';
 import type { SlotComponentProps } from '@mui/utils/types';
 import { useMessageContentTabIndex } from '@mui/x-chat-headless';
+import { safeUri } from '@mui/x-chat-headless/internals';
 import { styled, createUseThemeProps } from '../internals/zero-styled';
 import {
   useChatMessageSourceUtilityClasses,
@@ -138,7 +139,7 @@ const ChatMessageSource = React.forwardRef(function ChatMessageSource(
     externalSlotProps: slotProps?.link,
     ownerState: {},
     additionalProps: {
-      href,
+      href: safeUri(href) || undefined,
       target: '_blank',
       rel: 'noreferrer noopener',
       className: classes.link,

--- a/packages/x-chat/src/ChatMessageSources/ChatMessageSources.test.tsx
+++ b/packages/x-chat/src/ChatMessageSources/ChatMessageSources.test.tsx
@@ -5,6 +5,8 @@ import { ChatMessageSources } from './ChatMessageSources';
 import { ChatMessageSource } from './ChatMessageSource';
 
 const { render } = createRenderer();
+// eslint-disable-next-line no-script-url
+const unsafeUrl = 'javascript:alert(document.domain)';
 
 describe('ChatMessageSources', () => {
   it('renders default "Sources" label', () => {
@@ -40,6 +42,12 @@ describe('ChatMessageSource', () => {
     const link = screen.getByRole('link');
     expect(link).not.toBe(null);
     expect(link.getAttribute('href')).toBe('https://example.com');
+  });
+
+  it('does not expose an unsafe URL as the link target', () => {
+    render(<ChatMessageSource href={unsafeUrl} title="Example" />);
+
+    expect(screen.getByText('Example').closest('a')!.getAttribute('href')).toBe(null);
   });
 
   it('renders title as link text', () => {


### PR DESCRIPTION
## Changelog

Use the existing URI normalization helper for file and source link targets.

These renderers previously passed link targets directly instead of using the helper already available in `x-chat-headless`. This keeps link handling consistent across the built-in component and fallback renderer paths, while preserving supported URLs as-is.

## Test plan

- `pnpm test:unit --project "x-chat-headless" --run`
- `pnpm test:browser --project "x-chat-headless" --run packages/x-chat-headless/src/message/parts/MessageParts.test.tsx`
- `pnpm --filter "@mui/x-chat-headless" run typescript`
- `pnpm eslint`

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
