### PR TITLE
[charts-pro] Fix highlight shifting on sampled bar charts

### DIFF
--- a/packages/x-charts-pro/src/BarChartPro/BarChartPro.sampling.test.tsx
+++ b/packages/x-charts-pro/src/BarChartPro/BarChartPro.sampling.test.tsx
@@ -73,26 +73,31 @@ describe('<BarChartPro /> - Sampling', () => {
   it('mirrors sampled bucket geometry on a reversed band axis', () => {
     const width = 200;
 
-    const geometry = (reverse: boolean) => {
-      const { container } = render(
-        <BarChartPro
-          series={[{ data: range(256) }]}
-          xAxis={[{ data: range(256).map(String), zoom: true, reverse }]}
-          yAxis={[{ position: 'none' }]}
-          width={width}
-          height={200}
-          margin={0}
-          sampling="minmax"
-          skipAnimation
-        />,
-      );
-      return Array.from(container.querySelectorAll(`.${barClasses.element}`))
-        .map((bar) => ({ x: Number(bar.getAttribute('x')), width: Number(bar.getAttribute('width')) }))
+    const geometryOf = (container: HTMLElement) =>
+      Array.from(container.querySelectorAll(`.${barClasses.element}`))
+        .map((bar) => ({
+          x: Number(bar.getAttribute('x')),
+          width: Number(bar.getAttribute('width')),
+        }))
         .sort((a, b) => a.x - b.x);
-    };
 
-    const normal = geometry(false);
-    const reversed = geometry(true);
+    const props = (reverse: boolean) =>
+      ({
+        series: [{ data: range(256) }],
+        xAxis: [{ data: range(256).map(String), zoom: true, reverse }],
+        yAxis: [{ position: 'none' }],
+        width,
+        height: 200,
+        margin: 0,
+        sampling: 'minmax',
+        skipAnimation: true,
+      }) as const;
+
+    const { container, setProps } = render(<BarChartPro {...props(false)} />);
+    const normal = geometryOf(container);
+
+    setProps(props(true));
+    const reversed = geometryOf(container);
 
     expect(normal.length).to.be.greaterThan(0); // sampling is active
     expect(reversed.length).to.equal(normal.length);

--- a/packages/x-charts-pro/src/BarChartPro/BarChartPro.sampling.test.tsx
+++ b/packages/x-charts-pro/src/BarChartPro/BarChartPro.sampling.test.tsx
@@ -69,6 +69,44 @@ describe('<BarChartPro /> - Sampling', () => {
     expect(rendered).to.be.lessThan(dataLength / 2);
   });
 
+  // Regression #22997: reversing a sampled axis should mirror the bars, not shift them off-screen.
+  it('mirrors sampled bucket geometry on a reversed band axis', () => {
+    const width = 200;
+
+    const geometry = (reverse: boolean) => {
+      const { container } = render(
+        <BarChartPro
+          series={[{ data: range(256) }]}
+          xAxis={[{ data: range(256).map(String), zoom: true, reverse }]}
+          yAxis={[{ position: 'none' }]}
+          width={width}
+          height={200}
+          margin={0}
+          sampling="minmax"
+          skipAnimation
+        />,
+      );
+      return Array.from(container.querySelectorAll(`.${barClasses.element}`))
+        .map((bar) => ({ x: Number(bar.getAttribute('x')), width: Number(bar.getAttribute('width')) }))
+        .sort((a, b) => a.x - b.x);
+    };
+
+    const normal = geometry(false);
+    const reversed = geometry(true);
+
+    expect(normal.length).to.be.greaterThan(0); // sampling is active
+    expect(reversed.length).to.equal(normal.length);
+
+    reversed.forEach(({ x, width: w }, i) => {
+      // Stays on-screen (the bug pushed buckets off the right edge).
+      expect(x).to.be.greaterThanOrEqual(0);
+      expect(x + w).to.be.lessThanOrEqual(width + 0.5);
+      // Mirrors the non-reversed bar: [x, x+w] maps to [width - (x+w), width - x].
+      const mirror = normal[normal.length - 1 - i];
+      expect(width - (x + w)).to.be.closeTo(mirror.x, 1);
+    });
+  });
+
   it('renders every bar when sampling is disabled (default)', () => {
     const dataLength = 256;
     const { container } = render(

--- a/packages/x-charts/src/ChartsAxisHighlight/getSampledBandHighlight.test.ts
+++ b/packages/x-charts/src/ChartsAxisHighlight/getSampledBandHighlight.test.ts
@@ -1,0 +1,78 @@
+import { scaleBand, scaleLinear } from '@mui/x-charts-vendor/d3-scale';
+import { getSampledBandHighlight } from './getSampledBandHighlight';
+import { createGetBucketBarDimensions } from '../internals/createGetBarDimensions';
+import type { D3OrdinalScale } from '../models/axis';
+
+const data = [0, 1, 2, 3, 4, 5, 6, 7];
+const halfPaddingOf = (scale: D3OrdinalScale) => (scale.step() - scale.bandwidth()) / 2;
+
+describe('getSampledBandHighlight', () => {
+  it('covers a single band when the series is not sampled', () => {
+    const scale = scaleBand(data, [0, 800]) as unknown as D3OrdinalScale;
+    const { bandStart, bandSize } = getSampledBandHighlight({
+      scale,
+      value: 3,
+      dataIndex: 3,
+      data,
+      bucketSize: 1,
+    });
+
+    expect(bandSize).to.equal(scale.step());
+    expect(bandStart).to.equal(scale(3)! - halfPaddingOf(scale));
+  });
+
+  // Reversed axis: data[0] is on the right, so the bucket's left edge is data[3] (#22997).
+  [
+    { reverse: false, leftIndex: 0 },
+    { reverse: true, leftIndex: 3 },
+  ].forEach(({ reverse, leftIndex }) => {
+    it(`anchors a bucket at its left-most slot (reverse: ${reverse})`, () => {
+      const scale = scaleBand(data, reverse ? [800, 0] : [0, 800]) as unknown as D3OrdinalScale;
+      const { bandStart, bandSize } = getSampledBandHighlight({
+        scale,
+        value: 1,
+        dataIndex: 1,
+        data,
+        bucketSize: 4,
+      });
+
+      expect(bandStart).to.equal(scale(leftIndex)! - halfPaddingOf(scale));
+      expect(bandSize).to.equal(4 * scale.step());
+    });
+  });
+});
+
+// The bar and its highlight come from two functions; they must stay centered on each other (#22997).
+describe('sampled bucket bar / highlight alignment', () => {
+  const bars = Array.from({ length: 64 }, (_, i) => i);
+
+  [false, true].forEach((reverse) => {
+    it(`centers the bar under the highlight (reverse: ${reverse})`, () => {
+      const bucketSize = 8;
+      const scale = scaleBand(bars, reverse ? [600, 0] : [0, 600])
+        .paddingInner(0.3)
+        .paddingOuter(0.15) as unknown as D3OrdinalScale;
+      const getBar = createGetBucketBarDimensions({
+        verticalLayout: true,
+        xAxisConfig: { scale, data: bars, barGapRatio: 0.1, reverse } as any,
+        yAxisConfig: { scale: scaleLinear([0, 100], [200, 0]) } as any,
+        series: { hidden: false, minBarSize: 0 } as any,
+        numberOfGroups: 1,
+      });
+
+      // Bucket covering indices [16..23], highlight hovering index 20.
+      const bar = getBar(16, 23, 10, 40, 0);
+      const { bandStart, bandSize } = getSampledBandHighlight({
+        scale,
+        value: 20,
+        dataIndex: 20,
+        data: bars,
+        bucketSize,
+      });
+
+      expect(bar.x + bar.width / 2).to.be.closeTo(bandStart + bandSize / 2, 0.5);
+      expect(bar.x).to.be.greaterThanOrEqual(bandStart - 0.5);
+      expect(bar.x + bar.width).to.be.lessThanOrEqual(bandStart + bandSize + 0.5);
+    });
+  });
+});

--- a/packages/x-charts/src/ChartsAxisHighlight/getSampledBandHighlight.ts
+++ b/packages/x-charts/src/ChartsAxisHighlight/getSampledBandHighlight.ts
@@ -1,4 +1,5 @@
 import type { D3OrdinalScale } from '../models/axis';
+import { getSampledBucketRegion } from '../internals/getSampledBucketRegion';
 
 interface SampledBandHighlightParams {
   scale: D3OrdinalScale;
@@ -34,9 +35,14 @@ export function getSampledBandHighlight({
     if (index >= 0) {
       const bucketStart = Math.floor(index / bucketSize) * bucketSize;
       const bucketEnd = Math.min(bucketStart + bucketSize - 1, data.length - 1);
-      // Anchor at the left edge: on a reversed axis `data[bucketStart]` is the right-most slot.
-      bandStart = Math.min(scale(data[bucketStart])!, scale(data[bucketEnd])!) - halfPadding;
-      bandSize = (bucketEnd - bucketStart + 1) * step;
+      const { regionStart, regionSize } = getSampledBucketRegion(
+        scale,
+        data,
+        bucketStart,
+        bucketEnd,
+      );
+      bandStart = regionStart;
+      bandSize = regionSize;
     }
   }
 

--- a/packages/x-charts/src/ChartsAxisHighlight/getSampledBandHighlight.ts
+++ b/packages/x-charts/src/ChartsAxisHighlight/getSampledBandHighlight.ts
@@ -34,7 +34,8 @@ export function getSampledBandHighlight({
     if (index >= 0) {
       const bucketStart = Math.floor(index / bucketSize) * bucketSize;
       const bucketEnd = Math.min(bucketStart + bucketSize - 1, data.length - 1);
-      bandStart = scale(data[bucketStart])! - halfPadding;
+      // Anchor at the left edge: on a reversed axis `data[bucketStart]` is the right-most slot.
+      bandStart = Math.min(scale(data[bucketStart])!, scale(data[bucketEnd])!) - halfPadding;
       bandSize = (bucketEnd - bucketStart + 1) * step;
     }
   }

--- a/packages/x-charts/src/internals/createGetBarDimensions.ts
+++ b/packages/x-charts/src/internals/createGetBarDimensions.ts
@@ -98,9 +98,16 @@ export function createGetBucketBarDimensions(params: {
     max: number,
     groupIndex: number,
   ) {
-    const spanStart = baseScale(baseScaleConfig.data![startIndex])!;
+    // Reversed axes flip index→position, so the left edge is the smaller of the two endpoints.
+    const startPos = baseScale(baseScaleConfig.data![startIndex])!;
+    const endPos = baseScale(baseScaleConfig.data![endIndex])!;
+    const spanStart = Math.min(startPos, endPos);
     const bucketCount = endIndex - startIndex + 1;
     const bucketStride = bucketCount * step;
+
+    // Bucket band region left edge, matching the axis highlight (see `getSampledBandHighlight`).
+    const halfPadding = (step - bandwidth) / 2;
+    const regionStart = spanStart - halfPadding;
 
     // Keep the gap between buckets proportional to the bucket (same ratio as an unsampled chart),
     // but never thinner than MIN_SAMPLED_BAR_GAP_PX so it stays visible at every level and zoom.
@@ -113,7 +120,8 @@ export function createGetBucketBarDimensions(params: {
       numberOfGroups,
       baseScaleConfig.barGapRatio,
     );
-    const barOffset = groupIndex * (barWidth + offset);
+    // Center the bars in the region (split the gap to both sides) so they sit under the highlight.
+    const barOffset = gap / 2 + groupIndex * (barWidth + offset);
 
     const valueCoordinates = [valueScale(min)!, valueScale(max)!];
     const [minValueCoord, maxValueCoord] = findMinMax(valueCoordinates).map((v) => Math.round(v));
@@ -124,8 +132,8 @@ export function createGetBucketBarDimensions(params: {
     }
 
     return {
-      x: verticalLayout ? spanStart + barOffset : minValueCoord,
-      y: verticalLayout ? minValueCoord : spanStart + barOffset,
+      x: verticalLayout ? regionStart + barOffset : minValueCoord,
+      y: verticalLayout ? minValueCoord : regionStart + barOffset,
       height: verticalLayout ? barSize : barWidth,
       width: verticalLayout ? barWidth : barSize,
     };

--- a/packages/x-charts/src/internals/createGetBarDimensions.ts
+++ b/packages/x-charts/src/internals/createGetBarDimensions.ts
@@ -2,6 +2,7 @@ import type { ChartsXAxisProps, ChartsYAxisProps, ComputedAxis, ScaleName } from
 import type { ChartSeriesDefaultized } from '../models/seriesType/config';
 import { findMinMax } from './findMinMax';
 import { getBandSize } from './getBandSize';
+import { getSampledBucketRegion } from './getSampledBucketRegion';
 
 /** Minimum on-screen gap (px) kept between merged (sampled) bars so they stay distinguishable. */
 const MIN_SAMPLED_BAR_GAP_PX = 2;
@@ -98,16 +99,14 @@ export function createGetBucketBarDimensions(params: {
     max: number,
     groupIndex: number,
   ) {
-    // Reversed axes flip index→position, so the left edge is the smaller of the two endpoints.
-    const startPos = baseScale(baseScaleConfig.data![startIndex])!;
-    const endPos = baseScale(baseScaleConfig.data![endIndex])!;
-    const spanStart = Math.min(startPos, endPos);
+    // Region matches the axis highlight (see `getSampledBandHighlight`) so bar and highlight stay in sync.
+    const { regionStart, regionSize: bucketStride } = getSampledBucketRegion(
+      baseScale,
+      baseScaleConfig.data!,
+      startIndex,
+      endIndex,
+    );
     const bucketCount = endIndex - startIndex + 1;
-    const bucketStride = bucketCount * step;
-
-    // Bucket band region left edge, matching the axis highlight (see `getSampledBandHighlight`).
-    const halfPadding = (step - bandwidth) / 2;
-    const regionStart = spanStart - halfPadding;
 
     // Keep the gap between buckets proportional to the bucket (same ratio as an unsampled chart),
     // but never thinner than MIN_SAMPLED_BAR_GAP_PX so it stays visible at every level and zoom.

--- a/packages/x-charts/src/internals/getSampledBucketRegion.ts
+++ b/packages/x-charts/src/internals/getSampledBucketRegion.ts
@@ -1,0 +1,26 @@
+import type { D3OrdinalScale } from '../models/axis';
+
+/**
+ * Computes the band region covered by a sampled bucket spanning `data[startIndex..endIndex]`.
+ *
+ * The region is anchored at its left-most slot and spans whole steps, so both the rendered bar
+ * (see `createGetBucketBarDimensions`) and the axis highlight (see `getSampledBandHighlight`)
+ * stay in sync — on a reversed axis `startIndex` maps to the right, hence the `Math.min`.
+ */
+export function getSampledBucketRegion(
+  scale: D3OrdinalScale,
+  data: readonly any[],
+  startIndex: number,
+  endIndex: number,
+): { regionStart: number; regionSize: number } {
+  const step = scale.step();
+  const halfPadding = (step - scale.bandwidth()) / 2;
+
+  const startPos = scale(data[startIndex])!;
+  const endPos = scale(data[endIndex])!;
+
+  return {
+    regionStart: Math.min(startPos, endPos) - halfPadding,
+    regionSize: (endIndex - startIndex + 1) * step,
+  };
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fix sampled bars and axis highlight misaligning on band axes (#22997):

- Anchor sampled buckets at their left-most slot so reversed axes mirror instead of shifting off-screen.
- Center the merged bar within its bucket region so the axis highlight sits on the bar instead of drifting into the inter-bucket gap

Before:
<img width="283" height="457" alt="image" src="https://github.com/user-attachments/assets/8ba58524-f1c1-43eb-956d-1ee483fbeee0" />
After:
<img width="1247" height="717" alt="image" src="https://github.com/user-attachments/assets/b18ecee8-9d89-46da-8f97-bd47691ffc49" />

closes https://github.com/mui/mui-x/issues/22997
