### PR TITLE
[docs] Fix clearing, layout shift, and prop leak in Pickers demos

### DIFF
--- a/docs/data/date-pickers/custom-field/behavior-button/MaterialDatePicker.js
+++ b/docs/data/date-pickers/custom-field/behavior-button/MaterialDatePicker.js
@@ -3,6 +3,7 @@ import Button from '@mui/material/Button';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+
 import { useValidation, validateDate } from '@mui/x-date-pickers/validation';
 import {
   useSplitFieldProps,

--- a/docs/data/date-pickers/custom-field/behavior-button/MaterialDatePicker.js
+++ b/docs/data/date-pickers/custom-field/behavior-button/MaterialDatePicker.js
@@ -3,7 +3,6 @@ import Button from '@mui/material/Button';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
-
 import { useValidation, validateDate } from '@mui/x-date-pickers/validation';
 import {
   useSplitFieldProps,

--- a/docs/data/date-pickers/custom-field/behavior-button/MaterialDatePicker.js
+++ b/docs/data/date-pickers/custom-field/behavior-button/MaterialDatePicker.js
@@ -12,6 +12,8 @@ import {
 
 function ButtonDateField(props) {
   const { internalProps, forwardedProps } = useSplitFieldProps(props, 'date');
+  // `slots`, `slotProps` and `inputRef` target the default text field, not a `<button>`.
+  const { slots, slotProps, inputRef, ...buttonProps } = forwardedProps;
 
   const pickerContext = usePickerContext();
   const handleRef = useForkRef(pickerContext.triggerRef, pickerContext.rootRef);
@@ -30,7 +32,7 @@ function ButtonDateField(props) {
 
   return (
     <Button
-      {...forwardedProps}
+      {...buttonProps}
       variant="outlined"
       color={hasValidationError ? 'error' : 'primary'}
       ref={handleRef}

--- a/docs/data/date-pickers/custom-field/behavior-button/MaterialDatePicker.tsx
+++ b/docs/data/date-pickers/custom-field/behavior-button/MaterialDatePicker.tsx
@@ -7,13 +7,13 @@ import {
   DatePickerProps,
   DatePickerFieldProps,
 } from '@mui/x-date-pickers/DatePicker';
-import { DateFieldProps } from '@mui/x-date-pickers/DateField';
 import { useValidation, validateDate } from '@mui/x-date-pickers/validation';
 import {
   useSplitFieldProps,
   useParsedFormat,
   usePickerContext,
 } from '@mui/x-date-pickers/hooks';
+import { DateFieldProps } from '@mui/x-date-pickers/DateField';
 
 function ButtonDateField(
   props: DatePickerFieldProps &

--- a/docs/data/date-pickers/custom-field/behavior-button/MaterialDatePicker.tsx
+++ b/docs/data/date-pickers/custom-field/behavior-button/MaterialDatePicker.tsx
@@ -16,6 +16,8 @@ import {
 
 function ButtonDateField(props: DatePickerFieldProps) {
   const { internalProps, forwardedProps } = useSplitFieldProps(props, 'date');
+  // `slots`, `slotProps` and `inputRef` target the default text field, not a `<button>`.
+  const { slots, slotProps, inputRef, ...buttonProps } = forwardedProps;
 
   const pickerContext = usePickerContext();
   const handleRef = useForkRef(pickerContext.triggerRef, pickerContext.rootRef);
@@ -34,7 +36,7 @@ function ButtonDateField(props: DatePickerFieldProps) {
 
   return (
     <Button
-      {...forwardedProps}
+      {...buttonProps}
       variant="outlined"
       color={hasValidationError ? 'error' : 'primary'}
       ref={handleRef}

--- a/docs/data/date-pickers/custom-field/behavior-button/MaterialDatePicker.tsx
+++ b/docs/data/date-pickers/custom-field/behavior-button/MaterialDatePicker.tsx
@@ -17,7 +17,12 @@ import {
 function ButtonDateField(props: DatePickerFieldProps) {
   const { internalProps, forwardedProps } = useSplitFieldProps(props, 'date');
   // `slots`, `slotProps` and `inputRef` target the default text field, not a `<button>`.
-  const { slots, slotProps, inputRef, ...buttonProps } = forwardedProps;
+  const { slots, slotProps, inputRef, ...buttonProps } =
+    forwardedProps as typeof forwardedProps & {
+      slots?: unknown;
+      slotProps?: unknown;
+      inputRef?: unknown;
+    };
 
   const pickerContext = usePickerContext();
   const handleRef = useForkRef(pickerContext.triggerRef, pickerContext.rootRef);

--- a/docs/data/date-pickers/custom-field/behavior-button/MaterialDatePicker.tsx
+++ b/docs/data/date-pickers/custom-field/behavior-button/MaterialDatePicker.tsx
@@ -7,6 +7,7 @@ import {
   DatePickerProps,
   DatePickerFieldProps,
 } from '@mui/x-date-pickers/DatePicker';
+import { DateFieldProps } from '@mui/x-date-pickers/DateField';
 import { useValidation, validateDate } from '@mui/x-date-pickers/validation';
 import {
   useSplitFieldProps,
@@ -14,15 +15,13 @@ import {
   usePickerContext,
 } from '@mui/x-date-pickers/hooks';
 
-function ButtonDateField(props: DatePickerFieldProps) {
+function ButtonDateField(
+  props: DatePickerFieldProps &
+    Pick<DateFieldProps, 'slots' | 'slotProps' | 'inputRef'>,
+) {
   const { internalProps, forwardedProps } = useSplitFieldProps(props, 'date');
   // `slots`, `slotProps` and `inputRef` target the default text field, not a `<button>`.
-  const { slots, slotProps, inputRef, ...buttonProps } =
-    forwardedProps as typeof forwardedProps & {
-      slots?: unknown;
-      slotProps?: unknown;
-      inputRef?: unknown;
-    };
+  const { slots, slotProps, inputRef, ...buttonProps } = forwardedProps;
 
   const pickerContext = usePickerContext();
   const handleRef = useForkRef(pickerContext.triggerRef, pickerContext.rootRef);

--- a/docs/data/date-pickers/custom-field/behavior-button/MaterialDateRangePicker.js
+++ b/docs/data/date-pickers/custom-field/behavior-button/MaterialDateRangePicker.js
@@ -13,6 +13,8 @@ import {
 
 function ButtonDateRangeField(props) {
   const { internalProps, forwardedProps } = useSplitFieldProps(props, 'date');
+  // `slots`, `slotProps` and `inputRef` target the default text field, not a `<button>`.
+  const { slots, slotProps, inputRef, ...buttonProps } = forwardedProps;
 
   const pickerContext = usePickerContext();
   const handleRef = useForkRef(pickerContext.triggerRef, pickerContext.rootRef);
@@ -32,7 +34,7 @@ function ButtonDateRangeField(props) {
 
   return (
     <Button
-      {...forwardedProps}
+      {...buttonProps}
       variant="outlined"
       color={hasValidationError ? 'error' : 'primary'}
       ref={handleRef}

--- a/docs/data/date-pickers/custom-field/behavior-button/MaterialDateRangePicker.js
+++ b/docs/data/date-pickers/custom-field/behavior-button/MaterialDateRangePicker.js
@@ -3,6 +3,7 @@ import Button from '@mui/material/Button';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker';
+
 import { useValidation } from '@mui/x-date-pickers/validation';
 import { validateDateRange } from '@mui/x-date-pickers-pro/validation';
 import {

--- a/docs/data/date-pickers/custom-field/behavior-button/MaterialDateRangePicker.js
+++ b/docs/data/date-pickers/custom-field/behavior-button/MaterialDateRangePicker.js
@@ -3,7 +3,6 @@ import Button from '@mui/material/Button';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker';
-
 import { useValidation } from '@mui/x-date-pickers/validation';
 import { validateDateRange } from '@mui/x-date-pickers-pro/validation';
 import {

--- a/docs/data/date-pickers/custom-field/behavior-button/MaterialDateRangePicker.tsx
+++ b/docs/data/date-pickers/custom-field/behavior-button/MaterialDateRangePicker.tsx
@@ -18,6 +18,8 @@ import {
 
 function ButtonDateRangeField(props: DateRangePickerFieldProps) {
   const { internalProps, forwardedProps } = useSplitFieldProps(props, 'date');
+  // `slots`, `slotProps` and `inputRef` target the default text field, not a `<button>`.
+  const { slots, slotProps, inputRef, ...buttonProps } = forwardedProps;
 
   const pickerContext = usePickerContext();
   const handleRef = useForkRef(pickerContext.triggerRef, pickerContext.rootRef);
@@ -37,7 +39,7 @@ function ButtonDateRangeField(props: DateRangePickerFieldProps) {
 
   return (
     <Button
-      {...forwardedProps}
+      {...buttonProps}
       variant="outlined"
       color={hasValidationError ? 'error' : 'primary'}
       ref={handleRef}

--- a/docs/data/date-pickers/custom-field/behavior-button/MaterialDateRangePicker.tsx
+++ b/docs/data/date-pickers/custom-field/behavior-button/MaterialDateRangePicker.tsx
@@ -19,7 +19,12 @@ import {
 function ButtonDateRangeField(props: DateRangePickerFieldProps) {
   const { internalProps, forwardedProps } = useSplitFieldProps(props, 'date');
   // `slots`, `slotProps` and `inputRef` target the default text field, not a `<button>`.
-  const { slots, slotProps, inputRef, ...buttonProps } = forwardedProps;
+  const { slots, slotProps, inputRef, ...buttonProps } =
+    forwardedProps as typeof forwardedProps & {
+      slots?: unknown;
+      slotProps?: unknown;
+      inputRef?: unknown;
+    };
 
   const pickerContext = usePickerContext();
   const handleRef = useForkRef(pickerContext.triggerRef, pickerContext.rootRef);

--- a/docs/data/date-pickers/custom-field/behavior-button/MaterialDateRangePicker.tsx
+++ b/docs/data/date-pickers/custom-field/behavior-button/MaterialDateRangePicker.tsx
@@ -8,6 +8,7 @@ import {
   DateRangePickerProps,
   DateRangePickerFieldProps,
 } from '@mui/x-date-pickers-pro/DateRangePicker';
+import { SingleInputDateRangeFieldProps } from '@mui/x-date-pickers-pro/SingleInputDateRangeField';
 import { useValidation } from '@mui/x-date-pickers/validation';
 import { validateDateRange } from '@mui/x-date-pickers-pro/validation';
 import {
@@ -16,15 +17,13 @@ import {
   usePickerContext,
 } from '@mui/x-date-pickers/hooks';
 
-function ButtonDateRangeField(props: DateRangePickerFieldProps) {
+function ButtonDateRangeField(
+  props: DateRangePickerFieldProps &
+    Pick<SingleInputDateRangeFieldProps, 'slots' | 'slotProps' | 'inputRef'>,
+) {
   const { internalProps, forwardedProps } = useSplitFieldProps(props, 'date');
   // `slots`, `slotProps` and `inputRef` target the default text field, not a `<button>`.
-  const { slots, slotProps, inputRef, ...buttonProps } =
-    forwardedProps as typeof forwardedProps & {
-      slots?: unknown;
-      slotProps?: unknown;
-      inputRef?: unknown;
-    };
+  const { slots, slotProps, inputRef, ...buttonProps } = forwardedProps;
 
   const pickerContext = usePickerContext();
   const handleRef = useForkRef(pickerContext.triggerRef, pickerContext.rootRef);

--- a/docs/data/date-pickers/custom-field/behavior-button/MaterialDateRangePicker.tsx
+++ b/docs/data/date-pickers/custom-field/behavior-button/MaterialDateRangePicker.tsx
@@ -8,7 +8,6 @@ import {
   DateRangePickerProps,
   DateRangePickerFieldProps,
 } from '@mui/x-date-pickers-pro/DateRangePicker';
-import { SingleInputDateRangeFieldProps } from '@mui/x-date-pickers-pro/SingleInputDateRangeField';
 import { useValidation } from '@mui/x-date-pickers/validation';
 import { validateDateRange } from '@mui/x-date-pickers-pro/validation';
 import {
@@ -16,6 +15,7 @@ import {
   useParsedFormat,
   usePickerContext,
 } from '@mui/x-date-pickers/hooks';
+import { SingleInputDateRangeFieldProps } from '@mui/x-date-pickers-pro/SingleInputDateRangeField';
 
 function ButtonDateRangeField(
   props: DateRangePickerFieldProps &

--- a/docs/src/modules/components/overview/pickers/mainDemo/Birthday.tsx
+++ b/docs/src/modules/components/overview/pickers/mainDemo/Birthday.tsx
@@ -7,8 +7,9 @@ import CakeIcon from '@mui/icons-material/Cake';
 import { DateField } from '@mui/x-date-pickers/DateField';
 
 export default function Birthday() {
+  // Fixed width (not `maxWidth`) so clearing the field doesn't resize the card and shift the layout.
   return (
-    <Card variant="outlined" sx={{ padding: 1, maxWidth: '265px' }}>
+    <Card variant="outlined" sx={{ padding: 1, width: '265px' }}>
       <Stack sx={{ height: 'fit-content', alignItems: 'center' }} spacing={1}>
         <DateField
           label="Enter your birthday"

--- a/docs/src/modules/components/overview/pickers/mainDemo/Birthday.tsx
+++ b/docs/src/modules/components/overview/pickers/mainDemo/Birthday.tsx
@@ -14,7 +14,7 @@ export default function Birthday() {
           label="Enter your birthday"
           clearable
           fullWidth
-          value={dayjs('2019-07-11T15:30')}
+          defaultValue={dayjs('2019-07-11T15:30')}
           variant="filled"
           slotProps={{
             textField: {

--- a/docs/src/modules/components/overview/pickers/mainDemo/PickerButton.tsx
+++ b/docs/src/modules/components/overview/pickers/mainDemo/PickerButton.tsx
@@ -9,6 +9,8 @@ import { useValidation, validateDate } from '@mui/x-date-pickers/validation';
 
 function ButtonDateField(props: DatePickerFieldProps) {
   const { internalProps, forwardedProps } = useSplitFieldProps(props, 'date');
+  // `slots`, `slotProps` and `inputRef` target the default text field, not a `<button>`.
+  const { slots, slotProps, inputRef, ...buttonProps } = forwardedProps;
 
   const pickerContext = usePickerContext();
 
@@ -27,7 +29,7 @@ function ButtonDateField(props: DatePickerFieldProps) {
 
   return (
     <Button
-      {...forwardedProps}
+      {...buttonProps}
       variant="outlined"
       size="small"
       startIcon={<CalendarTodayRoundedIcon fontSize="small" />}

--- a/docs/src/modules/components/overview/pickers/mainDemo/PickerButton.tsx
+++ b/docs/src/modules/components/overview/pickers/mainDemo/PickerButton.tsx
@@ -4,17 +4,16 @@ import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
 import CalendarTodayRoundedIcon from '@mui/icons-material/CalendarTodayRounded';
 import { DatePicker, DatePickerFieldProps } from '@mui/x-date-pickers/DatePicker';
+import { DateFieldProps } from '@mui/x-date-pickers/DateField';
 import { useParsedFormat, usePickerContext, useSplitFieldProps } from '@mui/x-date-pickers/hooks';
 import { useValidation, validateDate } from '@mui/x-date-pickers/validation';
 
-function ButtonDateField(props: DatePickerFieldProps) {
+function ButtonDateField(
+  props: DatePickerFieldProps & Pick<DateFieldProps, 'slots' | 'slotProps' | 'inputRef'>,
+) {
   const { internalProps, forwardedProps } = useSplitFieldProps(props, 'date');
   // `slots`, `slotProps` and `inputRef` target the default text field, not a `<button>`.
-  const { slots, slotProps, inputRef, ...buttonProps } = forwardedProps as typeof forwardedProps & {
-    slots?: unknown;
-    slotProps?: unknown;
-    inputRef?: unknown;
-  };
+  const { slots, slotProps, inputRef, ...buttonProps } = forwardedProps;
 
   const pickerContext = usePickerContext();
 

--- a/docs/src/modules/components/overview/pickers/mainDemo/PickerButton.tsx
+++ b/docs/src/modules/components/overview/pickers/mainDemo/PickerButton.tsx
@@ -10,7 +10,11 @@ import { useValidation, validateDate } from '@mui/x-date-pickers/validation';
 function ButtonDateField(props: DatePickerFieldProps) {
   const { internalProps, forwardedProps } = useSplitFieldProps(props, 'date');
   // `slots`, `slotProps` and `inputRef` target the default text field, not a `<button>`.
-  const { slots, slotProps, inputRef, ...buttonProps } = forwardedProps;
+  const { slots, slotProps, inputRef, ...buttonProps } = forwardedProps as typeof forwardedProps & {
+    slots?: unknown;
+    slotProps?: unknown;
+    inputRef?: unknown;
+  };
 
   const pickerContext = usePickerContext();
 

--- a/docs/src/modules/components/overview/pickers/mainDemo/PickerButton.tsx
+++ b/docs/src/modules/components/overview/pickers/mainDemo/PickerButton.tsx
@@ -4,9 +4,9 @@ import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
 import CalendarTodayRoundedIcon from '@mui/icons-material/CalendarTodayRounded';
 import { DatePicker, DatePickerFieldProps } from '@mui/x-date-pickers/DatePicker';
-import { DateFieldProps } from '@mui/x-date-pickers/DateField';
 import { useParsedFormat, usePickerContext, useSplitFieldProps } from '@mui/x-date-pickers/hooks';
 import { useValidation, validateDate } from '@mui/x-date-pickers/validation';
+import { DateFieldProps } from '@mui/x-date-pickers/DateField';
 
 function ButtonDateField(
   props: DatePickerFieldProps & Pick<DateFieldProps, 'slots' | 'slotProps' | 'inputRef'>,


### PR DESCRIPTION
Three fixes to Pickers documentation demos, all surfaced on the Pickers overview page.

## Clear button no-op in the birthday demo

The "Enter your birthday" `DateField` in the Pickers overview main demo was controlled (`value={dayjs(...)}`) with no `onChange` and no `defaultValue`. Because a controlled input's value is locked to the prop, the `clearable` clear button (and manual typing) could never change it, so clicking clear was a no-op. Switched to `defaultValue` so the field is uncontrolled and clearing works, consistent with the sibling demos (`Clock`, `CustomLayoutRangePicker`). The field has been controlled-without-`onChange` since it was first written, so this is a long-standing demo bug rather than a recent regression.

## Layout shift when clearing the birthday field

The birthday `Card` used `maxWidth` with no fixed `width`, so it shrank to fit its content. The field's intrinsic width (which includes the `clearable` clear button) drove the width of the whole right column, so clearing the field - which unmounts the clear button - narrowed the card and shifted the entire column, including the clock card above it. Pinned the card to a fixed `width` so it stays a constant size.

## `slotProps` / `inputRef` prop leak in the custom Button field demos

The custom Button field spread `forwardedProps` from `useSplitFieldProps` directly onto a Material `<Button>`. `useSplitFieldProps` only extracts the value/format/validation props into `internalProps`; the rest (`id`, `slots`, `slotProps`, `inputRef`, ...) stays in `forwardedProps` for the default text field. Spreading those onto a `<Button>` forwarded `slotProps` and `inputRef` down to the DOM `<button>`, producing `React does not recognize the ... prop on a DOM element` console errors. Typed the forwarded field-only props on the field component (via `Pick<DateFieldProps, ...>`, and `SingleInputDateRangeFieldProps` for the range demo) and destructured them out before spreading. This affected the overview `PickerButton` demo and the canonical `behavior-button` custom-field examples that users copy from.

## Verification

- Reproduced both field bugs in jsdom: the buggy Button pattern emits 2 warnings (`slotProps`, `inputRef`), the fixed pattern emits 0; clearing is a no-op with `value` and empties the field with `defaultValue`.
- Confirmed live on the running overview page: the clear button now empties the birthday field, the `does not recognize` console errors are gone, and clearing no longer shifts the layout - the birthday card, the clock card, and the Submit button all keep their exact position (measured zero delta before/after clear; without the fix they moved 11px).
- `.js` demo files regenerated via `pnpm docs:typescript:formatted`; docs TypeScript, ESLint (no cache) and Prettier all clean.

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
