### PR TITLE
[core] Remove unused `@types/react-router` and `react-router` deps

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -78,7 +78,6 @@
     "react": "catalog:",
     "react-dom": "catalog:",
     "react-hook-form": "^7.81.0",
-    "react-router": "catalog:",
     "react-runner": "^1.0.5",
     "react-simple-code-editor": "^0.14.1",
     "rifm": "0.12.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,9 +102,6 @@ catalogs:
     '@types/react-dom':
       specifier: 19.2.3
       version: 19.2.3
-    '@types/react-router':
-      specifier: ^5.1.20
-      version: 5.1.20
     '@types/react-transition-group':
       specifier: ^4.4.12
       version: 4.4.12
@@ -660,9 +657,6 @@ importers:
       react-hook-form:
         specifier: ^7.81.0
         version: 7.81.0(react@19.2.7)
-      react-router:
-        specifier: 'catalog:'
-        version: 8.2.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react-runner:
         specifier: ^1.0.5
         version: 1.0.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -2233,9 +2227,6 @@ importers:
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.17
-      '@types/react-router':
-        specifier: 'catalog:'
-        version: 5.1.20
       '@types/react-transition-group':
         specifier: 'catalog:'
         version: 4.4.12(@types/react@19.2.17)
@@ -2371,9 +2362,6 @@ importers:
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.17
-      '@types/react-router':
-        specifier: 'catalog:'
-        version: 5.1.20
       '@types/semver':
         specifier: 'catalog:'
         version: 7.7.1
@@ -2500,9 +2488,6 @@ importers:
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.17
-      '@types/react-router':
-        specifier: 'catalog:'
-        version: 5.1.20
       '@types/semver':
         specifier: 'catalog:'
         version: 7.7.1
@@ -5703,9 +5688,6 @@ packages:
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
-  '@types/history@4.7.11':
-    resolution: {integrity: sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==}
-
   '@types/is-empty@1.2.3':
     resolution: {integrity: sha512-4J1l5d79hoIvsrKh5VUKVRA1aIdsOb10Hu5j3J2VfP/msDnfTdGPmNp2E1Wg+vs97Bktzo+MZePFFXSGoykYJw==}
 
@@ -5762,9 +5744,6 @@ packages:
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
       '@types/react': ^19.2.0
-
-  '@types/react-router@5.1.20':
-    resolution: {integrity: sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==}
 
   '@types/react-transition-group@4.4.12':
     resolution: {integrity: sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==}
@@ -6877,7 +6856,6 @@ packages:
   conventional-changelog-core@5.0.1:
     resolution: {integrity: sha512-Rvi5pH+LvgsqGwZPZ3Cq/tz4ty7mjijhr3qR4m9IBXNbxGGYgTVVO+duXzz9aArmHxFtwZ+LRkrNIMDQzgoY4A==}
     engines: {node: '>=14'}
-    deprecated: Deprecated and no longer maintained. Please use conventional-changelog instead.
 
   conventional-changelog-preset-loader@3.0.0:
     resolution: {integrity: sha512-qy9XbdSLmVnwnvzEisjxdDiLA4OmV3o8db+Zdg4WiFw14fP3B6XNz98X0swPPpkTd/pc1K7+adKgEDM1JCUMiA==}
@@ -15204,8 +15182,6 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
-  '@types/history@4.7.11': {}
-
   '@types/is-empty@1.2.3': {}
 
   '@types/jscodeshift@17.3.0':
@@ -15255,11 +15231,6 @@ snapshots:
 
   '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:
-      '@types/react': 19.2.17
-
-  '@types/react-router@5.1.20':
-    dependencies:
-      '@types/history': 4.7.11
       '@types/react': 19.2.17
 
   '@types/react-transition-group@4.4.12(@types/react@19.2.17)':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,7 +38,6 @@ catalog:
   '@types/prop-types': ^15.7.15
   '@types/react': 19.2.17
   '@types/react-dom': 19.2.3
-  '@types/react-router': ^5.1.20
   '@types/react-transition-group': ^4.4.12
   '@types/semver': ^7.7.1
   '@types/use-sync-external-store': ^1.5.0

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -25,7 +25,6 @@
     "@mui/x-license": "workspace:^",
     "@types/moment-jalaali": "catalog:",
     "@types/react": "catalog:",
-    "@types/react-router": "catalog:",
     "@types/semver": "catalog:",
     "@vitejs/plugin-react": "catalog:",
     "react": "catalog:",

--- a/test/package.json
+++ b/test/package.json
@@ -28,7 +28,6 @@
     "@types/moment-jalaali": "catalog:",
     "@types/prop-types": "catalog:",
     "@types/react": "catalog:",
-    "@types/react-router": "catalog:",
     "@types/react-transition-group": "catalog:",
     "@types/semver": "catalog:",
     "date-fns": "catalog:",

--- a/test/regressions/package.json
+++ b/test/regressions/package.json
@@ -32,7 +32,6 @@
     "@mui/x-tree-view-pro": "workspace:^",
     "@types/moment-jalaali": "catalog:",
     "@types/react": "catalog:",
-    "@types/react-router": "catalog:",
     "@types/semver": "catalog:",
     "@vitejs/plugin-react": "catalog:",
     "minimatch": "10.2.5",


### PR DESCRIPTION
- `@types/react-router` is no longer needed since `react-router` ships with types
- `react-router` is not used in `/docs`