### PR TITLE
[charts][accessibility] Focus point on click

### DIFF
--- a/packages/x-charts-premium/src/BarChartPremium/RangeBar/seriesConfig/getItemAtPosition.ts
+++ b/packages/x-charts-premium/src/BarChartPremium/RangeBar/seriesConfig/getItemAtPosition.ts
@@ -1,0 +1,61 @@
+import {
+  selectorAllSeriesOfType,
+  selectorChartXAxis,
+  selectorChartYAxis,
+} from '@mui/x-charts/internals';
+import type {
+  ChartState,
+  ProcessedSeries,
+  UseChartCartesianAxisSignature,
+} from '@mui/x-charts/internals';
+import type { FocusedItemIdentifier } from '@mui/x-charts/models';
+import { createGetRangeBarDimensions } from '../createGetRangeBarDimensions';
+
+export default function getItemAtPosition(
+  state: ChartState<[UseChartCartesianAxisSignature]>,
+  point: { x: number; y: number },
+): FocusedItemIdentifier<'rangeBar'> | undefined {
+  const { axis: xAxes, axisIds: xAxisIds } = selectorChartXAxis(state);
+  const { axis: yAxes, axisIds: yAxisIds } = selectorChartYAxis(state);
+  const seriesState = selectorAllSeriesOfType(state, 'rangeBar') as ProcessedSeries['rangeBar'];
+
+  if (!seriesState || seriesState.seriesOrder.length === 0) {
+    return undefined;
+  }
+
+  const defaultXAxisId = xAxisIds[0];
+  const defaultYAxisId = yAxisIds[0];
+
+  for (let seriesIndex = 0; seriesIndex < seriesState.seriesOrder.length; seriesIndex += 1) {
+    const seriesId = seriesState.seriesOrder[seriesIndex];
+    const series = seriesState.series[seriesId];
+
+    if (series.hidden) {
+      continue;
+    }
+
+    const getRangeBarDimensions = createGetRangeBarDimensions({
+      verticalLayout: series.layout === 'vertical',
+      xAxisConfig: xAxes[series.xAxisId ?? defaultXAxisId],
+      yAxisConfig: yAxes[series.yAxisId ?? defaultYAxisId],
+      series,
+      numberOfGroups: seriesState.seriesOrder.length,
+    });
+
+    for (let dataIndex = 0; dataIndex < series.data.length; dataIndex += 1) {
+      const dimensions = getRangeBarDimensions(dataIndex, seriesIndex);
+
+      if (
+        dimensions &&
+        point.x >= dimensions.x &&
+        point.x <= dimensions.x + dimensions.width &&
+        point.y >= dimensions.y &&
+        point.y <= dimensions.y + dimensions.height
+      ) {
+        return { type: 'rangeBar', seriesId, dataIndex };
+      }
+    }
+  }
+
+  return undefined;
+}

--- a/packages/x-charts-premium/src/BarChartPremium/RangeBar/seriesConfig/index.ts
+++ b/packages/x-charts-premium/src/BarChartPremium/RangeBar/seriesConfig/index.ts
@@ -17,6 +17,7 @@ import { selectorTooltipItemPosition } from './tooltipPosition';
 import { getSeriesWithDefaultValues } from './getSeriesWithDefaultValues';
 import descriptionGetter from './descriptionGetter';
 import { RangeBarPreviewPlot } from '../../../ChartsZoomSlider/internals/previews/RangeBarPreviewPlot';
+import getItemAtPosition from './getItemAtPosition';
 
 export const rangeBarSeriesConfig: ChartSeriesTypeConfig<'rangeBar'> = {
   seriesProcessor,
@@ -28,6 +29,7 @@ export const rangeBarSeriesConfig: ChartSeriesTypeConfig<'rangeBar'> = {
   xExtremumGetter: getExtremumX,
   yExtremumGetter: getExtremumY,
   getSeriesWithDefaultValues,
+  getItemAtPosition,
   keyboardFocusHandler,
   identifierSerializer: identifierSerializerSeriesIdDataIndex,
   identifierCleaner: identifierCleanerSeriesIdDataIndex,

--- a/packages/x-charts-premium/src/Map/MapShapePlot.tsx
+++ b/packages/x-charts-premium/src/Map/MapShapePlot.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { useZAxes } from '@mui/x-charts/hooks';
+import { useActivateChartItem } from '@mui/x-charts/internals';
 import type { MapShapeItemIdentifier } from '../models/seriesType/mapShape';
 import { useGeoData } from '../hooks/useGeoData';
 import { useGeoPath } from '../hooks/useGeoPath';
@@ -48,6 +49,7 @@ function MapShapePlot(props: MapShapePlotProps) {
   const series = useMapShapeSeries();
   const featureIndexesByName = useGeoFeatureIndexesByName();
   const { zAxis, zAxisIds } = useZAxes();
+  const activateItem = useActivateChartItem();
 
   if (!geoData || !path || series.length === 0) {
     return null;
@@ -97,11 +99,15 @@ function MapShapePlot(props: MapShapePlotProps) {
                         color={color}
                         stroke={stroke}
                         strokeWidth={strokeWidth}
-                        onClick={
-                          onItemClick &&
-                          ((event) =>
-                            onItemClick(event, { type: 'mapShape', seriesId: id, name: item.name }))
-                        }
+                        onClick={(event) => {
+                          const identifier: MapShapeItemIdentifier = {
+                            type: 'mapShape',
+                            seriesId: id,
+                            name: item.name,
+                          };
+                          activateItem(identifier);
+                          onItemClick?.(event, identifier);
+                        }}
                       />
                     );
                   })}

--- a/packages/x-charts-premium/src/Map/checkClickEvent.test.tsx
+++ b/packages/x-charts-premium/src/Map/checkClickEvent.test.tsx
@@ -103,4 +103,13 @@ describe('MapShapePlot - click event', () => {
       });
     });
   });
+
+  it('should focus a clicked shape for keyboard navigation without an onItemClick callback', async () => {
+    const { container, user } = render(renderMap({}));
+    const shape = container.querySelector<SVGPathElement>('path[data-name="B"]')!;
+
+    await user.click(shape);
+
+    expect(container.querySelector('g[aria-hidden="true"] path')).not.to.equal(null);
+  });
 });

--- a/packages/x-charts-premium/src/RadialBarChart/seriesConfig/getItemAtPosition.ts
+++ b/packages/x-charts-premium/src/RadialBarChart/seriesConfig/getItemAtPosition.ts
@@ -12,12 +12,12 @@ import type {
   ProcessedSeries,
   UseChartPolarAxisSignature,
 } from '@mui/x-charts/internals';
-import type { SeriesItemIdentifierWithType } from '@mui/x-charts/models';
+import type { FocusedItemIdentifier } from '@mui/x-charts/models';
 
 export default function getItemAtPosition(
   state: ChartState<[UseChartPolarAxisSignature]>,
   point: { x: number; y: number },
-): SeriesItemIdentifierWithType<'radialBar'> | undefined {
+): FocusedItemIdentifier<'radialBar'> | undefined {
   const { axis: rotationAxes, axisIds: rotationAxisIds } = selectorChartRotationAxis(state);
   const { axis: radiusAxes, axisIds: radiusAxisIds } = selectorChartRadiusAxis(state);
   const center = selectorChartPolarCenter(state);

--- a/packages/x-charts-premium/src/RadialLineChart/seriesConfig/getItemAtPosition.ts
+++ b/packages/x-charts-premium/src/RadialLineChart/seriesConfig/getItemAtPosition.ts
@@ -18,7 +18,7 @@ import type {
   ChartsRadiusAxisProps,
   ChartsRotationAxisProps,
 } from '@mui/x-charts/internals';
-import type { ScaleName, SeriesItemIdentifierWithType } from '@mui/x-charts/models';
+import type { FocusedItemIdentifier, ScaleName } from '@mui/x-charts/models';
 
 /**
  * For a continuous rotation axis, find the two data indices that bracket the pointer's angle position.
@@ -176,7 +176,7 @@ const LINE_PROXIMITY_THRESHOLD = 15;
 export default function getItemAtPosition(
   state: ChartState<[UseChartPolarAxisSignature]>,
   point: { x: number; y: number },
-): SeriesItemIdentifierWithType<'radialLine'> | undefined {
+): FocusedItemIdentifier<'radialLine'> | undefined {
   const { axis: rotationAxes, axisIds: rotationAxisIds } = selectorChartRotationAxis(state);
   const { axis: radiusAxes, axisIds: radiusAxisIds } = selectorChartRadiusAxis(state);
   const center = selectorChartPolarCenter(state);
@@ -197,7 +197,7 @@ export default function getItemAtPosition(
 
   // Step 1: Find the closest line across all series (measured as radial distance).
   let closestDistance = Infinity;
-  let closestItem: SeriesItemIdentifierWithType<'radialLine'> | undefined;
+  let closestItem: FocusedItemIdentifier<'radialLine'> | undefined;
 
   for (const seriesId of series.seriesOrder) {
     const seriesItem = series.series[seriesId];

--- a/packages/x-charts-pro/src/FunnelChart/FunnelChart.test.tsx
+++ b/packages/x-charts-pro/src/FunnelChart/FunnelChart.test.tsx
@@ -183,6 +183,25 @@ describe('FunnelChart', () => {
     });
   });
 
+  it('should continue keyboard navigation from a clicked section', async () => {
+    const { container, user } = render(
+      <FunnelChart {...config} series={[{ id: 'A', data: [{ value: 200 }, { value: 100 }] }]} />,
+    );
+
+    const sections = container.querySelectorAll<SVGPathElement>(`.${funnelClasses.section}`);
+    await user.click(sections[0]);
+
+    expect(container.querySelector('path[fill="none"]')?.getAttribute('d')).to.equal(
+      sections[0].getAttribute('d'),
+    );
+
+    await user.keyboard('[ArrowRight]');
+
+    expect(container.querySelector('path[fill="none"]')?.getAttribute('d')).to.equal(
+      sections[1].getAttribute('d'),
+    );
+  });
+
   describe.skipIf(isJSDOM)('gap', () => {
     it('should properly distance sections based on gap', async () => {
       render(<FunnelChart {...config} gap={13} />);

--- a/packages/x-charts-pro/src/FunnelChart/FunnelPlot.tsx
+++ b/packages/x-charts-pro/src/FunnelChart/FunnelPlot.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 
 import { line as d3Line } from '@mui/x-charts-vendor/d3-shape';
-import { cartesianSeriesTypes, useStore } from '@mui/x-charts/internals';
+import { cartesianSeriesTypes, useActivateChartItem, useStore } from '@mui/x-charts/internals';
 import type { FunnelItemIdentifier } from './funnel.types';
 import { FunnelSection } from './FunnelSection';
 import { alignLabel, positionLabel } from './labelUtils';
@@ -143,6 +143,7 @@ function FunnelPlot(props: FunnelPlotProps) {
 
   const data = useAggregatedData();
   const classes = useUtilityClasses();
+  const activateItem = useActivateChartItem();
 
   return (
     <g className={clsx(classes.root, className)}>
@@ -162,12 +163,11 @@ function FunnelPlot(props: FunnelPlotProps) {
                 dataIndex={dataIndex}
                 seriesId={seriesId}
                 variant={variant}
-                onClick={
-                  onItemClick &&
-                  ((event) => {
-                    onItemClick(event, { type: 'funnel', seriesId, dataIndex });
-                  })
-                }
+                onClick={(event) => {
+                  const item: FunnelItemIdentifier = { type: 'funnel', seriesId, dataIndex };
+                  activateItem(item);
+                  onItemClick?.(event, item);
+                }}
               />
             ))}
           </g>

--- a/packages/x-charts-pro/src/FunnelChart/FunnelSection.tsx
+++ b/packages/x-charts-pro/src/FunnelChart/FunnelSection.tsx
@@ -7,6 +7,7 @@ import { useItemHighlightState } from '@mui/x-charts/hooks';
 import clsx from 'clsx';
 import { useUtilityClasses } from './funnelClasses';
 import type { FunnelClasses } from './funnelClasses';
+import type { FunnelItemIdentifier } from './funnel.types';
 
 export interface FunnelSectionProps extends Omit<React.SVGProps<SVGPathElement>, 'ref'> {
   seriesId: SeriesId;
@@ -48,8 +49,8 @@ const FunnelSection = consumeSlots<FunnelSectionProps, SVGPathElement>(
       ...other
     } = props;
 
-    const identifier = React.useMemo(
-      () => ({ type: 'funnel' as const, seriesId, dataIndex }),
+    const identifier = React.useMemo<FunnelItemIdentifier>(
+      () => ({ type: 'funnel', seriesId, dataIndex }),
       [seriesId, dataIndex],
     );
 

--- a/packages/x-charts-pro/src/FunnelChart/useFunnelChartProps.ts
+++ b/packages/x-charts-pro/src/FunnelChart/useFunnelChartProps.ts
@@ -13,6 +13,7 @@ import { FUNNEL_CHART_PLUGINS } from './FunnelChart.plugins';
 import type { FunnelChartPluginSignatures } from './FunnelChart.plugins';
 import type { FunnelPlotProps } from './FunnelPlot';
 import type { FunnelChartProps } from './FunnelChart';
+import type { FunnelSeriesType } from './funnel.types';
 import type { ChartsContainerProProps } from '../ChartsContainerPro';
 
 function getCategoryAxisConfig(
@@ -151,8 +152,8 @@ export const useFunnelChartProps = (props: FunnelChartProps) => {
 
   const chartsContainerProps: ChartsContainerProProps<'funnel', FunnelChartPluginSignatures> = {
     ...other,
-    series: series.map((s) => ({
-      type: 'funnel' as const,
+    series: series.map((s): FunnelSeriesType => ({
+      type: 'funnel',
       layout: isHorizontal ? 'horizontal' : 'vertical',
       ...s,
     })),

--- a/packages/x-charts-pro/src/SankeyChart/SankeyLinkElement.tsx
+++ b/packages/x-charts-pro/src/SankeyChart/SankeyLinkElement.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import useEventCallback from '@mui/utils/useEventCallback';
 import type { SeriesId } from '@mui/x-charts/internals';
-import { useInteractionItemProps } from '@mui/x-charts/internals';
+import { useActivateChartItem, useInteractionItemProps } from '@mui/x-charts/internals';
 import type { SankeyLayoutLink, SankeyLinkIdentifierWithData } from './sankey.types';
 import { useSankeyLinkHighlightState } from './sankeyHighlightHooks';
 import { useUtilityClasses } from './sankeyClasses';
@@ -55,8 +55,10 @@ export const SankeyLinkElement = React.forwardRef<SVGPathElement, SankeyLinkElem
     const interactionProps = useInteractionItemProps(identifier);
 
     const classes = useUtilityClasses();
+    const activateItem = useActivateChartItem();
 
     const handleClick = useEventCallback((event: React.MouseEvent<SVGPathElement>) => {
+      activateItem(identifier);
       onClick?.(event, identifier);
     });
 
@@ -82,7 +84,7 @@ export const SankeyLinkElement = React.forwardRef<SVGPathElement, SankeyLinkElem
         data-link-target={link.target.id}
         data-highlighted={isHighlighted || undefined}
         data-faded={isFaded || undefined}
-        onClick={onClick ? handleClick : undefined}
+        onClick={handleClick}
         cursor={onClick ? 'pointer' : 'default'}
         {...interactionProps}
       />

--- a/packages/x-charts-pro/src/SankeyChart/SankeyNodeElement.tsx
+++ b/packages/x-charts-pro/src/SankeyChart/SankeyNodeElement.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import useEventCallback from '@mui/utils/useEventCallback';
 import type { SeriesId } from '@mui/x-charts/internals';
-import { useInteractionItemProps } from '@mui/x-charts/internals';
+import { useActivateChartItem, useInteractionItemProps } from '@mui/x-charts/internals';
 import type { SankeyLayoutNode, SankeyNodeIdentifierWithData } from './sankey.types';
 import { useSankeyNodeHighlightState } from './sankeyHighlightHooks';
 import { useUtilityClasses } from './sankeyClasses';
@@ -58,8 +58,10 @@ export const SankeyNodeElement = React.forwardRef<SVGRectElement, SankeyNodeElem
     const interactionProps = useInteractionItemProps(identifier);
 
     const classes = useUtilityClasses();
+    const activateItem = useActivateChartItem();
 
     const handleClick = useEventCallback((event: React.MouseEvent<SVGRectElement>) => {
+      activateItem(identifier);
       onClick?.(event, identifier);
     });
 
@@ -78,7 +80,7 @@ export const SankeyNodeElement = React.forwardRef<SVGRectElement, SankeyNodeElem
         height={nodeHeight}
         fill={node.color}
         opacity={opacity}
-        onClick={onClick ? handleClick : undefined}
+        onClick={handleClick}
         cursor={onClick ? 'pointer' : 'default'}
         stroke="none"
         data-highlighted={isHighlighted || undefined}

--- a/packages/x-charts-pro/src/SankeyChart/SankeyPlot.test.tsx
+++ b/packages/x-charts-pro/src/SankeyChart/SankeyPlot.test.tsx
@@ -73,4 +73,27 @@ describe('<SankeyPlot />', () => {
       expect(wasNotifiedAboutControlledNode).to.equal(false);
     },
   );
+
+  it('should focus a clicked node for keyboard navigation', async () => {
+    const { container, user } = render(
+      <SankeyChart
+        series={{
+          type: 'sankey',
+          data: {
+            nodes: [
+              { id: 'A', label: 'A' },
+              { id: 'B', label: 'B' },
+            ],
+            links: [{ source: 'A', target: 'B', value: 5 }],
+          },
+        }}
+        width={200}
+        height={200}
+      />,
+    );
+
+    await user.click(container.querySelector<SVGRectElement>('[data-node="A"]')!);
+
+    expect(container.querySelector('rect[fill="none"]')).not.to.equal(null);
+  });
 });

--- a/packages/x-charts/src/ChartsLayerContainer/ChartsLayerContainer.tsx
+++ b/packages/x-charts/src/ChartsLayerContainer/ChartsLayerContainer.tsx
@@ -13,6 +13,7 @@ import {
   selectorChartPropsWidth,
 } from '../internals/plugins/corePlugins/useChartDimensions';
 import { selectorChartsIsKeyboardNavigationEnabled } from '../internals/plugins/featurePlugins/useChartKeyboardNavigation';
+import type { UseChartKeyboardNavigationSignature } from '../internals/plugins/featurePlugins/useChartKeyboardNavigation';
 import type { UseChartItemClickSignature } from '../internals/plugins/featurePlugins/useChartItemClick';
 import type { UseChartInteractionSignature } from '../internals/plugins/featurePlugins/useChartInteraction';
 import { useChartsContext } from '../context/ChartsProvider';
@@ -63,7 +64,11 @@ const ChartsLayerContainer = React.forwardRef<HTMLDivElement, ChartsLayerContain
   function ChartsLayerContainer(inProps, ref) {
     const { store, instance } = useChartsContext<
       [],
-      [UseChartInteractionSignature, UseChartItemClickSignature]
+      [
+        UseChartInteractionSignature,
+        UseChartItemClickSignature,
+        UseChartKeyboardNavigationSignature,
+      ]
     >();
     const propsWidth = store.use(selectorChartPropsWidth);
     const propsHeight = store.use(selectorChartPropsHeight);
@@ -118,6 +123,7 @@ const ChartsLayerContainer = React.forwardRef<HTMLDivElement, ChartsLayerContain
         }}
         onClick={(event) => {
           other.onClick?.(event);
+          instance.handleKeyboardNavigationClick?.(event);
           instance.handleClick?.(event);
         }}
       >

--- a/packages/x-charts/src/LineChart/MarkPlot.tsx
+++ b/packages/x-charts/src/LineChart/MarkPlot.tsx
@@ -19,6 +19,7 @@ import { useChartsContext } from '../context/ChartsProvider';
 import { useMarkPlotData } from './useMarkPlotData';
 import { useUtilityClasses } from './lineClasses';
 import type { MarkPropsOverrides } from '../models/chartsSlotsComponentsProps';
+import { useActivateChartItem } from '../hooks/useActivateChartItem';
 
 export interface MarkPlotSlots {
   mark?: React.JSXElementConstructor<MarkElementProps & MarkPropsOverrides>;
@@ -100,6 +101,7 @@ function MarkPlot(props: MarkPlotProps) {
 
   const completedData = useMarkPlotData(xAxis, yAxis);
   const classes = useUtilityClasses();
+  const activateItem = useActivateChartItem();
 
   return (
     <MarkPlotRoot className={clsx(classes.markPlot, className)} {...other}>
@@ -125,10 +127,15 @@ function MarkPlot(props: MarkPlotProps) {
                   x={x}
                   y={y}
                   skipAnimation={skipAnimation}
-                  onClick={
-                    onItemClick &&
-                    ((event) => onItemClick(event, { type: 'line', seriesId, dataIndex: index }))
-                  }
+                  onClick={(event) => {
+                    const item: LineItemClickIdentifier = {
+                      type: 'line',
+                      seriesId,
+                      dataIndex: index,
+                    };
+                    activateItem(item);
+                    onItemClick?.(event, item);
+                  }}
                   isHighlighted={highlightedItems[xAxisId]?.has(index) || isSeriesHighlighted}
                   isFaded={isSeriesFaded}
                   hidden={hidden}

--- a/packages/x-charts/src/LineChart/seriesConfig/getItemAtPosition.ts
+++ b/packages/x-charts/src/LineChart/seriesConfig/getItemAtPosition.ts
@@ -7,7 +7,7 @@ import {
 import { selectorAllSeriesOfType } from '../../internals/seriesSelectorOfType';
 import type { ProcessedSeries } from '../../internals/plugins/corePlugins/useChartSeries';
 import { getAxisIndex } from '../../internals/plugins/featurePlugins/useChartCartesianAxis/getAxisValue';
-import type { SeriesItemIdentifierWithType } from '../../models/seriesType';
+import type { FocusedItemIdentifier } from '../../models/seriesType';
 import { isOrdinalScale } from '../../internals/scaleGuards';
 import { getAsNumber } from '../../internals/getAsNumber';
 import { getValueToPositionMapper } from '../../hooks/getValueToPositionMapper';
@@ -157,7 +157,7 @@ const LINE_PROXIMITY_THRESHOLD = 15;
 export default function getItemAtPosition(
   state: ChartState<[UseChartCartesianAxisSignature]>,
   point: { x: number; y: number },
-): SeriesItemIdentifierWithType<'line'> | undefined {
+): FocusedItemIdentifier<'line'> | undefined {
   if (!state.experimentalFeatures?.enablePositionBasedPointerInteraction) {
     return undefined;
   }
@@ -175,7 +175,7 @@ export default function getItemAtPosition(
 
   // Step 1: Find the closest line (curve) across all series.
   let closestDistance = Infinity;
-  let closestItem: SeriesItemIdentifierWithType<'line'> | undefined;
+  let closestItem: FocusedItemIdentifier<'line'> | undefined;
 
   for (const seriesId of series.seriesOrder) {
     const seriesItem = series.series[seriesId];

--- a/packages/x-charts/src/LineChart/useLineItemClickHandler.ts
+++ b/packages/x-charts/src/LineChart/useLineItemClickHandler.ts
@@ -7,6 +7,7 @@ import { getChartPoint } from '../internals/getChartPoint';
 import { getAxisIndex } from '../internals/plugins/featurePlugins/useChartCartesianAxis/getAxisValue';
 import type { LineItemClickIdentifier } from '../models/seriesType/line';
 import type { SeriesId } from '../models/seriesType/common';
+import { useActivateChartItem } from '../hooks/useActivateChartItem';
 
 /**
  * Creates a click handler for line and area paths that enriches the item
@@ -23,15 +24,12 @@ export function useLineItemClickHandler(
   ) => void,
 ): ((event: React.MouseEvent<SVGElement, MouseEvent>, seriesId: SeriesId) => void) | undefined {
   const chartsLayerContainerRef = useChartsLayerContainerRef();
+  const activateItem = useActivateChartItem();
   const { xAxis: xAxes, xAxisIds } = useXAxes();
   const seriesData = useLineSeriesContext();
   const defaultXAxisId = xAxisIds[0];
 
   return React.useMemo(() => {
-    if (!onItemClick) {
-      return undefined;
-    }
-
     return (event: React.MouseEvent<SVGElement, MouseEvent>, seriesId: SeriesId) => {
       const element = chartsLayerContainerRef.current;
       const xAxisId = seriesData?.series[seriesId]?.xAxisId ?? defaultXAxisId;
@@ -47,7 +45,9 @@ export function useLineItemClickHandler(
         return;
       }
 
-      onItemClick(event, { type: 'line', seriesId, dataIndex });
+      const identifier: LineItemClickIdentifier = { type: 'line', seriesId, dataIndex };
+      activateItem(identifier);
+      onItemClick?.(event, identifier);
     };
-  }, [onItemClick, chartsLayerContainerRef, seriesData, defaultXAxisId, xAxes]);
+  }, [activateItem, onItemClick, chartsLayerContainerRef, seriesData, defaultXAxisId, xAxes]);
 }

--- a/packages/x-charts/src/PieChart/PieArcPlot.tsx
+++ b/packages/x-charts/src/PieChart/PieArcPlot.tsx
@@ -13,6 +13,7 @@ import type {
 } from '../models/seriesType/pie';
 import { useTransformData } from './dataTransform/useTransformData';
 import type { PieArcPropsOverrides } from '../models/chartsSlotsComponentsProps';
+import { useActivateChartItem } from '../hooks/useActivateChartItem';
 
 export interface PieArcPlotSlots {
   pieArc?: React.JSXElementConstructor<PieArcProps & PieArcPropsOverrides>;
@@ -98,6 +99,7 @@ function PieArcPlot(props: PieArcPlotProps) {
     faded,
     data,
   });
+  const activateItem = useActivateChartItem();
 
   if (data.length === 0) {
     return null;
@@ -123,12 +125,11 @@ function PieArcPlot(props: PieArcPlotProps) {
           isFaded={item.isFaded}
           isHighlighted={item.isHighlighted}
           isFocused={item.isFocused}
-          onClick={
-            onItemClick &&
-            ((event) => {
-              onItemClick(event, { type: 'pie', seriesId, dataIndex: index }, item);
-            })
-          }
+          onClick={(event) => {
+            const identifier: PieItemIdentifier = { type: 'pie', seriesId, dataIndex: index };
+            activateItem(identifier);
+            onItemClick?.(event, identifier, item);
+          }}
           {...slotProps?.pieArc}
         />
       ))}

--- a/packages/x-charts/src/RadarChart/RadarSeriesPlot/RadarSeriesArea.tsx
+++ b/packages/x-charts/src/RadarChart/RadarSeriesPlot/RadarSeriesArea.tsx
@@ -8,8 +8,10 @@ import type { RadarClasses } from '../radarClasses';
 import { useItemHighlightStateGetter } from '../../hooks/useItemHighlightStateGetter';
 import { useInteractionAllItemProps } from './useInteractionAllItemProps';
 import type { SeriesId, HighlightItemIdentifierWithType } from '../../models/seriesType';
+import type { RadarItemIdentifier } from '../../models/seriesType/radar';
 import type { HighlightState } from '../../hooks/useItemHighlightState';
 import { useRadarRotationIndex } from './useRadarRotationIndex';
+import { useActivateChartItem } from '../../hooks/useActivateChartItem';
 
 interface GetPathPropsParams {
   seriesId: SeriesId;
@@ -43,6 +45,7 @@ function RadarSeriesArea(props: RadarSeriesAreaProps) {
   const { seriesId, onItemClick, classes: inClasses, ...other } = props;
   const seriesCoordinates = useRadarSeriesData(seriesId);
   const getRotationIndex = useRadarRotationIndex();
+  const activateItem = useActivateChartItem();
 
   const interactionProps = useInteractionAllItemProps(seriesCoordinates);
   const getHighlightState = useItemHighlightStateGetter<'radar'>();
@@ -67,13 +70,15 @@ function RadarSeriesArea(props: RadarSeriesAreaProps) {
               getHighlightState,
               classes,
             })}
-            onClick={(event) =>
-              onItemClick?.(event, {
+            onClick={(event) => {
+              const item: Required<RadarItemIdentifier> = {
                 type: 'radar',
                 seriesId: id,
                 dataIndex: getRotationIndex(event),
-              })
-            }
+              };
+              activateItem(item);
+              onItemClick?.(event, item);
+            }}
             cursor={onItemClick ? 'pointer' : 'unset'}
             {...interactionProps[seriesIndex]}
             {...other}

--- a/packages/x-charts/src/RadarChart/RadarSeriesPlot/RadarSeriesMarks.tsx
+++ b/packages/x-charts/src/RadarChart/RadarSeriesPlot/RadarSeriesMarks.tsx
@@ -7,7 +7,9 @@ import type { RadarClasses } from '../radarClasses';
 import { useItemHighlightStateGetter } from '../../hooks/useItemHighlightStateGetter';
 import type { SeriesId } from '../../models/seriesType/common';
 import type { HighlightItemIdentifierWithType } from '../../models';
+import type { RadarItemIdentifier } from '../../models/seriesType/radar';
 import type { HighlightState } from '../../hooks/useItemHighlightState';
+import { useActivateChartItem } from '../../hooks/useActivateChartItem';
 
 interface GetCirclePropsParams {
   seriesId: SeriesId;
@@ -43,6 +45,7 @@ function RadarSeriesMarks(props: RadarSeriesMarksProps) {
 
   const classes = useUtilityClasses(inClasses);
   const getHighlightState = useItemHighlightStateGetter();
+  const activateItem = useActivateChartItem();
 
   return (
     <React.Fragment>
@@ -65,9 +68,15 @@ function RadarSeriesMarks(props: RadarSeriesMarksProps) {
                   classes,
                 })}
                 pointerEvents={onItemClick ? undefined : 'none'}
-                onClick={(event) =>
-                  onItemClick?.(event, { type: 'radar', seriesId: id, dataIndex: index })
-                }
+                onClick={(event) => {
+                  const item: Required<RadarItemIdentifier> = {
+                    type: 'radar',
+                    seriesId: id,
+                    dataIndex: index,
+                  };
+                  activateItem(item);
+                  onItemClick?.(event, item);
+                }}
                 cursor={onItemClick ? 'pointer' : 'unset'}
                 {...other}
               />

--- a/packages/x-charts/src/RadarChart/RadarSeriesPlot/RadarSeriesMarks.tsx
+++ b/packages/x-charts/src/RadarChart/RadarSeriesPlot/RadarSeriesMarks.tsx
@@ -67,7 +67,6 @@ function RadarSeriesMarks(props: RadarSeriesMarksProps) {
                   getHighlightState,
                   classes,
                 })}
-                pointerEvents={onItemClick ? undefined : 'none'}
                 onClick={(event) => {
                   const item: Required<RadarItemIdentifier> = {
                     type: 'radar',

--- a/packages/x-charts/src/RadarChart/RadarSeriesPlot/RadarSeriesPlot.tsx
+++ b/packages/x-charts/src/RadarChart/RadarSeriesPlot/RadarSeriesPlot.tsx
@@ -8,11 +8,14 @@ import { useItemHighlightStateGetter } from '../../hooks/useItemHighlightStateGe
 import { getPathProps } from './RadarSeriesArea';
 import { getCircleProps } from './RadarSeriesMarks';
 import { useRadarRotationIndex } from './useRadarRotationIndex';
+import { useActivateChartItem } from '../../hooks/useActivateChartItem';
+import type { RadarItemIdentifier } from '../../models/seriesType/radar';
 
 function RadarSeriesPlot(props: RadarSeriesPlotProps) {
   const { seriesId: inSeriesId, className, classes: inClasses, onAreaClick, onMarkClick } = props;
   const seriesCoordinates = useRadarSeriesData(inSeriesId);
   const getRotationIndex = useRadarRotationIndex();
+  const activateItem = useActivateChartItem();
 
   const interactionProps = useInteractionAllItemProps(seriesCoordinates);
   const getHighlightState = useItemHighlightStateGetter();
@@ -40,13 +43,15 @@ function RadarSeriesPlot(props: RadarSeriesPlotProps) {
                     getHighlightState,
                     classes,
                   })}
-                  onClick={(event) =>
-                    onAreaClick?.(event, {
+                  onClick={(event) => {
+                    const item: Required<RadarItemIdentifier> = {
                       type: 'radar',
                       seriesId,
                       dataIndex: getRotationIndex(event),
-                    })
-                  }
+                    };
+                    activateItem(item);
+                    onAreaClick?.(event, item);
+                  }}
                   cursor={onAreaClick ? 'pointer' : 'unset'}
                   {...interactionProps[seriesIndex]}
                 />
@@ -63,9 +68,15 @@ function RadarSeriesPlot(props: RadarSeriesPlotProps) {
                       getHighlightState,
                       classes,
                     })}
-                    onClick={(event) =>
-                      onMarkClick?.(event, { type: 'radar', seriesId, dataIndex: index })
-                    }
+                    onClick={(event) => {
+                      const item: Required<RadarItemIdentifier> = {
+                        type: 'radar',
+                        seriesId,
+                        dataIndex: index,
+                      };
+                      activateItem(item);
+                      onMarkClick?.(event, item);
+                    }}
                     cursor={onMarkClick ? 'pointer' : 'unset'}
                   />
                 ))}

--- a/packages/x-charts/src/ScatterChart/Scatter.tsx
+++ b/packages/x-charts/src/ScatterChart/Scatter.tsx
@@ -24,6 +24,7 @@ import { useChartsContext } from '../context/ChartsProvider';
 import type { UseChartTooltipSignature } from '../internals/plugins/featurePlugins/useChartTooltip';
 import type { UseChartInteractionSignature } from '../internals/plugins/featurePlugins/useChartInteraction';
 import type { UseChartHighlightSignature } from '../internals/plugins/featurePlugins/useChartHighlight';
+import { useActivateChartItem } from '../hooks/useActivateChartItem';
 
 /**
  * @deprecated The `Scatter` component is an internal implementation detail of `ScatterPlot` and will be removed from the public API in v10. Use `ScatterPlot` instead.
@@ -107,6 +108,25 @@ function Scatter(props: ScatterProps) {
   const getHighlightState = useItemHighlightStateGetter();
 
   const scatterPlotData = useScatterPlotData(series, xScale, yScale, instance.isPointInside);
+  const activateItem = useActivateChartItem();
+  const shouldAttachMarkerClick = !isVoronoiEnabled || onItemClick !== undefined;
+
+  const handleMarkerClick = (
+    event: React.MouseEvent<SVGElement, MouseEvent>,
+    dataIndex: number,
+  ) => {
+    const item: ScatterItemIdentifier = {
+      type: 'scatter',
+      seriesId: series.id,
+      dataIndex,
+    };
+
+    if (!isVoronoiEnabled) {
+      activateItem(item);
+    }
+
+    onItemClick?.(event, item);
+  };
 
   const Marker = slots?.marker ?? ScatterMarker;
   const { ownerState, ...markerProps } = useSlotProps({
@@ -139,13 +159,9 @@ function Scatter(props: ScatterProps) {
             x={dataPoint.x}
             y={dataPoint.y}
             onClick={
-              onItemClick &&
-              ((event) =>
-                onItemClick(event, {
-                  type: 'scatter',
-                  seriesId: series.id,
-                  dataIndex: dataPoint.dataIndex,
-                }))
+              shouldAttachMarkerClick
+                ? (event) => handleMarkerClick(event, dataPoint.dataIndex)
+                : undefined
             }
             data-highlighted={isItemHighlighted || undefined}
             data-faded={isItemFaded || undefined}

--- a/packages/x-charts/src/ScatterChart/Scatter.tsx
+++ b/packages/x-charts/src/ScatterChart/Scatter.tsx
@@ -123,9 +123,8 @@ function Scatter(props: ScatterProps) {
 
     if (!isVoronoiEnabled) {
       activateItem(item);
+      onItemClick?.(event, item);
     }
-
-    onItemClick?.(event, item);
   };
 
   const Marker = slots?.marker ?? ScatterMarker;

--- a/packages/x-charts/src/ScatterChart/async/ScatterAsyncBatch.tsx
+++ b/packages/x-charts/src/ScatterChart/async/ScatterAsyncBatch.tsx
@@ -2,7 +2,10 @@
 import * as React from 'react';
 import clsx from 'clsx';
 import useSlotProps from '@mui/utils/useSlotProps';
-import type { DefaultizedScatterSeriesType } from '../../models/seriesType/scatter';
+import type {
+  DefaultizedScatterSeriesType,
+  ScatterItemIdentifier,
+} from '../../models/seriesType/scatter';
 import { getInteractionItemProps } from '../../hooks/useInteractionItemProps';
 import { useStore } from '../../internals/store/useStore';
 import { useItemHighlightStateGetter } from '../../hooks/useItemHighlightStateGetter';
@@ -17,6 +20,7 @@ import type { UseChartInteractionSignature } from '../../internals/plugins/featu
 import type { UseChartHighlightSignature } from '../../internals/plugins/featurePlugins/useChartHighlight';
 import type { ScatterProps } from '../Scatter';
 import { selectorScatterSeriesRenderData } from './scatterRenderData.selectors';
+import { useActivateChartItem } from '../../hooks/useActivateChartItem';
 
 export interface ScatterAsyncBatchProps extends Pick<
   ScatterProps,
@@ -74,6 +78,25 @@ function ScatterAsyncBatchComponent(props: ScatterAsyncBatchProps) {
   const getHighlightState = useItemHighlightStateGetter();
 
   const renderData = store.use(selectorScatterSeriesRenderData, series.id);
+  const activateItem = useActivateChartItem();
+  const shouldAttachMarkerClick = !isVoronoiEnabled || onItemClick !== undefined;
+
+  const handleMarkerClick = (
+    event: React.MouseEvent<SVGElement, MouseEvent>,
+    dataIndex: number,
+  ) => {
+    const item: ScatterItemIdentifier = {
+      type: 'scatter',
+      seriesId: series.id,
+      dataIndex,
+    };
+
+    if (!isVoronoiEnabled) {
+      activateItem(item);
+    }
+
+    onItemClick?.(event, item);
+  };
 
   const Marker = slots?.marker ?? ScatterMarker;
   const { ownerState, ...markerProps } = useSlotProps({
@@ -118,13 +141,9 @@ function ScatterAsyncBatchComponent(props: ScatterAsyncBatchProps) {
         x={x}
         y={y}
         onClick={
-          onItemClick &&
-          ((event: React.MouseEvent<SVGElement, MouseEvent>) =>
-            onItemClick(event, {
-              type: 'scatter',
-              seriesId: series.id,
-              dataIndex,
-            }))
+          shouldAttachMarkerClick
+            ? (event) => handleMarkerClick(event, dataIndex)
+            : undefined
         }
         data-highlighted={isItemHighlighted || undefined}
         data-faded={isItemFaded || undefined}

--- a/packages/x-charts/src/ScatterChart/async/ScatterAsyncBatch.tsx
+++ b/packages/x-charts/src/ScatterChart/async/ScatterAsyncBatch.tsx
@@ -141,9 +141,7 @@ function ScatterAsyncBatchComponent(props: ScatterAsyncBatchProps) {
         x={x}
         y={y}
         onClick={
-          shouldAttachMarkerClick
-            ? (event) => handleMarkerClick(event, dataIndex)
-            : undefined
+          shouldAttachMarkerClick ? (event) => handleMarkerClick(event, dataIndex) : undefined
         }
         data-highlighted={isItemHighlighted || undefined}
         data-faded={isItemFaded || undefined}

--- a/packages/x-charts/src/ScatterChart/async/ScatterAsyncBatch.tsx
+++ b/packages/x-charts/src/ScatterChart/async/ScatterAsyncBatch.tsx
@@ -93,9 +93,8 @@ function ScatterAsyncBatchComponent(props: ScatterAsyncBatchProps) {
 
     if (!isVoronoiEnabled) {
       activateItem(item);
+      onItemClick?.(event, item);
     }
-
-    onItemClick?.(event, item);
   };
 
   const Marker = slots?.marker ?? ScatterMarker;

--- a/packages/x-charts/src/hooks/useActivateChartItem.ts
+++ b/packages/x-charts/src/hooks/useActivateChartItem.ts
@@ -1,0 +1,17 @@
+'use client';
+import useEventCallback from '@mui/utils/useEventCallback';
+import { useChartsContext } from '../context/ChartsProvider';
+import type { FocusedItemIdentifier } from '../models/seriesType';
+import type { ChartSeriesType } from '../models/seriesType/config';
+import type { UseChartKeyboardNavigationSignature } from '../internals/plugins/featurePlugins/useChartKeyboardNavigation';
+
+/**
+ * Returns a callback that makes a chart item the starting point for keyboard navigation.
+ */
+export function useActivateChartItem() {
+  const { instance } = useChartsContext<[], [UseChartKeyboardNavigationSignature]>();
+
+  return useEventCallback((item: FocusedItemIdentifier<ChartSeriesType>) => {
+    instance.setKeyboardNavigationItem?.(item);
+  });
+}

--- a/packages/x-charts/src/internals/components/ChartsAccessibilityProxy/ChartsAccessibilityProxy.tsx
+++ b/packages/x-charts/src/internals/components/ChartsAccessibilityProxy/ChartsAccessibilityProxy.tsx
@@ -2,6 +2,8 @@
 import * as React from 'react';
 import { useChartId } from '../../../hooks/useChartId';
 import { useDescription } from './useDescription';
+import { useStore } from '../../store/useStore';
+import { selectorChartsFocusRequestId } from '../../plugins/featurePlugins/useChartKeyboardNavigation';
 
 /**
  * Make the proxy looks like a layer.
@@ -29,8 +31,9 @@ const fullSizeLayerStyle: React.CSSProperties = {
 export function ChartsAccessibilityProxy() {
   const message = useDescription();
   const chartId = useChartId();
+  const store = useStore();
+  const focusRequestId = store.use(selectorChartsFocusRequestId);
 
-  const currentFormatRef = React.useRef<string | null>(null);
   const currentIndexRef = React.useRef<number>(0);
   const containerRef = React.useRef(null);
 
@@ -68,9 +71,7 @@ export function ChartsAccessibilityProxy() {
       }
     }
 
-    if (message && message !== currentFormatRef.current) {
-      currentFormatRef.current = message;
-
+    if (message) {
       const inactiveIndex = currentIndexRef.current;
 
       currentIndexRef.current = (currentIndexRef.current + 1) % 2;
@@ -105,7 +106,7 @@ export function ChartsAccessibilityProxy() {
 
       activeDiv.focus();
     }
-  }, [message, chartId]);
+  }, [message, chartId, focusRequestId]);
 
   return (
     <div

--- a/packages/x-charts/src/internals/index.ts
+++ b/packages/x-charts/src/internals/index.ts
@@ -8,6 +8,7 @@ export * from '../BarChart/BarClipPath';
 // hooks
 export { useSeries } from '../hooks/useSeries';
 export { useInteractionItemProps } from '../hooks/useInteractionItemProps';
+export { useActivateChartItem } from '../hooks/useActivateChartItem';
 export { useDrawingArea } from '../hooks/useDrawingArea';
 export { useScatterChartProps } from '../ScatterChart/useScatterChartProps';
 export { useScatterPlotData } from '../ScatterChart/useScatterPlotData';

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/getItemAtPosition.types.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/getItemAtPosition.types.ts
@@ -1,4 +1,4 @@
-import type { SeriesItemIdentifierWithType } from '../../../../../models/seriesType';
+import type { FocusedItemIdentifier } from '../../../../../models/seriesType';
 import type { ChartState } from '../../../models/chart';
 import type { ChartSeriesType } from '../../../../../models/seriesType/config';
 import type { ChartSeriesTypeRequiredPlugins } from './seriesConfig.types';
@@ -6,4 +6,4 @@ import type { ChartSeriesTypeRequiredPlugins } from './seriesConfig.types';
 export type GetItemAtPosition<SeriesType extends ChartSeriesType> = (
   state: ChartState<ChartSeriesTypeRequiredPlugins<SeriesType>>,
   point: { x: number; y: number },
-) => SeriesItemIdentifierWithType<SeriesType> | undefined;
+) => FocusedItemIdentifier<SeriesType> | undefined;

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartClosestPoint/useChartClosestPoint.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartClosestPoint/useChartClosestPoint.ts
@@ -5,6 +5,7 @@ import useEventCallback from '@mui/utils/useEventCallback';
 import type { PointerGestureEventData } from '@mui/x-internal-gestures/core';
 import type { ChartPlugin } from '../../models';
 import type { SeriesId } from '../../../../models/seriesType/common';
+import type { ScatterItemIdentifier } from '../../../../models/seriesType/scatter';
 import type { UseChartClosestPointSignature } from './useChartClosestPoint.types';
 import { getChartPoint } from '../../../getChartPoint';
 import {
@@ -224,9 +225,11 @@ export const useChartClosestPoint: ChartPlugin<UseChartClosestPointSignature> = 
     const tapHandler = instance.addInteractionListener('tap', (event) => {
       const closestPoint = getClosestPoint(event.detail.srcEvent);
 
-      if (typeof closestPoint !== 'string' && onItemClick) {
+      if (typeof closestPoint !== 'string') {
         const { seriesId, dataIndex } = closestPoint;
-        onItemClick(event.detail.srcEvent, { type: 'scatter', seriesId, dataIndex });
+        const item: ScatterItemIdentifier = { type: 'scatter', seriesId, dataIndex };
+        instance.setKeyboardNavigationItem?.(item);
+        onItemClick?.(event.detail.srcEvent, item);
       }
     });
 

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartClosestPoint/useChartClosestPoint.types.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartClosestPoint/useChartClosestPoint.types.ts
@@ -7,6 +7,7 @@ import type { UseChartHighlightSignature } from '../useChartHighlight';
 import type { UseChartInteractionSignature } from '../useChartInteraction';
 import type { UseChartTooltipSignature } from '../useChartTooltip';
 import type { UseChartZAxisSignature } from '../useChartZAxis';
+import type { UseChartKeyboardNavigationSignature } from '../useChartKeyboardNavigation';
 
 export interface UseChartVoronoiInstance {
   /**
@@ -66,5 +67,6 @@ export type UseChartClosestPointSignature<SeriesType extends ChartSeriesType = C
       UseChartHighlightSignature<SeriesType>,
       UseChartTooltipSignature,
       UseChartZAxisSignature,
+      UseChartKeyboardNavigationSignature,
     ];
   }>;

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartItemClick/useChartItemClick.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartItemClick/useChartItemClick.ts
@@ -2,7 +2,7 @@
 import type { ChartPlugin } from '../../models';
 import type { ChartSeriesType } from '../../../../models/seriesType/config';
 import type { UseChartItemClickSignature } from './useChartItemClick.types';
-import type { SeriesItemIdentifierWithType } from '../../../../models/seriesType';
+import type { FocusedItemIdentifier } from '../../../../models/seriesType';
 import { getChartPoint } from '../../../getChartPoint';
 
 export const useChartItemClick: ChartPlugin<UseChartItemClickSignature<any>> = ({
@@ -23,7 +23,7 @@ export const useChartItemClick: ChartPlugin<UseChartItemClickSignature<any>> = (
       return undefined;
     }
 
-    let item: SeriesItemIdentifierWithType<ChartSeriesType> | undefined = undefined;
+    let item: FocusedItemIdentifier<ChartSeriesType> | undefined = undefined;
 
     for (const seriesType of Object.keys(store.state.seriesConfig.config)) {
       // @ts-ignore The type inference for store.state does not support generic yet

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.selectors.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.selectors.ts
@@ -52,6 +52,11 @@ export const selectorChartsIsKeyboardNavigationEnabled = createSelector(
   (keyboardNavigationState) => !!keyboardNavigationState?.enabled,
 );
 
+export const selectorChartsFocusRequestId = createSelector(
+  selectKeyboardNavigation,
+  (keyboardNavigationState) => keyboardNavigationState?.focusRequestId ?? 0,
+);
+
 /**
  * Selectors to override highlight behavior.
  */

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.test.tsx
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.test.tsx
@@ -4,6 +4,7 @@ import { BarChart, barClasses } from '@mui/x-charts/BarChart';
 import { PieChart, pieClasses } from '@mui/x-charts/PieChart';
 import { ScatterChart } from '@mui/x-charts/ScatterChart';
 import { LineChart } from '@mui/x-charts/LineChart';
+import { getCenter } from 'test/utils/charts/getCenter';
 
 describe('useChartKeyboardNavigation', () => {
   const { render } = createRenderer();
@@ -414,4 +415,100 @@ describe('useChartKeyboardNavigation', () => {
       expect(firstBar!.getAttribute('data-highlighted')).to.equal(null);
     },
   );
+
+  it('should use a clicked item as the starting point for keyboard navigation', async () => {
+    const { container, user } = render(
+      <PieChart
+        height={200}
+        width={200}
+        hideLegend
+        series={[
+          {
+            id: 'pie',
+            data: [
+              { id: 0, value: 10 },
+              { id: 1, value: 20 },
+              { id: 2, value: 30 },
+            ],
+          },
+        ]}
+      />,
+    );
+
+    const arcs = container.querySelectorAll<SVGPathElement>(`.${pieClasses.arc}`);
+    await user.click(arcs[1]);
+
+    expect(container.querySelector(`.${pieClasses.focusIndicator}[data-index="1"]`)).not.to.equal(
+      null,
+    );
+
+    await user.keyboard('[ArrowRight]');
+
+    expect(container.querySelector(`.${pieClasses.focusIndicator}[data-index="2"]`)).not.to.equal(
+      null,
+    );
+  });
+
+  it.skipIf(isJSDOM)(
+    'should activate an item through position-based click hit-testing without an onItemClick callback',
+    async () => {
+      const { container, user } = render(
+        <BarChart
+          height={200}
+          width={200}
+          skipAnimation
+          margin={0}
+          series={[{ id: 'A', data: [50, 100], highlightScope: { highlight: 'item' } }]}
+        />,
+      );
+
+      const bars = container.querySelectorAll<SVGRectElement>(`.${barClasses.element}`);
+      await user.pointer({ keys: '[MouseLeft]', target: bars[0], coords: getCenter(bars[0]) });
+
+      expect(bars[0].getAttribute('data-highlighted')).to.equal('true');
+
+      await user.keyboard('[ArrowRight]');
+
+      expect(bars[1].getAttribute('data-highlighted')).to.equal('true');
+    },
+  );
+
+  it('should refocus the accessibility proxy when clicking the same item again', async () => {
+    const { container, user } = render(
+      <PieChart
+        height={200}
+        width={200}
+        hideLegend
+        series={[{ id: 'pie', data: [{ id: 0, value: 10 }] }]}
+      />,
+    );
+
+    const arc = container.querySelector<SVGPathElement>(`.${pieClasses.arc}`)!;
+    await user.click(arc);
+    const firstProxy = document.activeElement;
+
+    expect(firstProxy?.getAttribute('role')).to.equal('img');
+
+    await user.click(arc);
+
+    expect(document.activeElement?.getAttribute('role')).to.equal('img');
+    expect(document.activeElement).not.to.equal(firstProxy);
+  });
+
+  it('should not activate a clicked item when keyboard navigation is disabled', async () => {
+    const { container, user } = render(
+      <PieChart
+        height={200}
+        width={200}
+        hideLegend
+        disableKeyboardNavigation
+        series={[{ id: 'pie', data: [{ id: 0, value: 10 }] }]}
+      />,
+    );
+
+    await user.click(container.querySelector<SVGPathElement>(`.${pieClasses.arc}`)!);
+
+    expect(container.querySelector(`.${pieClasses.focusIndicator}`)).to.equal(null);
+    expect(container.querySelector('[role="img"]')).to.equal(null);
+  });
 });

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.ts
@@ -1,6 +1,9 @@
 'use client';
 import * as React from 'react';
 import useEnhancedEffect from '@mui/utils/useEnhancedEffect';
+import useEventCallback from '@mui/utils/useEventCallback';
+import type { FocusedItemIdentifier } from '../../../../models/seriesType';
+import { getChartPoint } from '../../../getChartPoint';
 import { selectorChartDefaultizedSeries } from '../../corePlugins/useChartSeries/useChartSeries.selectors';
 import { selectorChartSeriesConfig } from '../../corePlugins/useChartSeriesConfig';
 import type { ChartPlugin } from '../../models';
@@ -14,6 +17,69 @@ export const useChartKeyboardNavigation: ChartPlugin<UseChartKeyboardNavigationS
   instance,
 }) => {
   const { chartsLayerContainerRef } = instance;
+
+  const setKeyboardNavigationItem = useEventCallback(
+    (item: FocusedItemIdentifier<ChartSeriesType> | null) => {
+      if (params.disableKeyboardNavigation) {
+        return;
+      }
+
+      const cleanedItem =
+        item === null
+          ? null
+          : (instance.cleanIdentifier(
+              item,
+              'seriesItem',
+            ) as FocusedItemIdentifier<ChartSeriesType>);
+
+      store.update({
+        ...(store.state.highlight && {
+          highlight: {
+            ...store.state.highlight,
+            lastUpdate: 'keyboard',
+          },
+        }),
+        ...(store.state.interaction && {
+          interaction: {
+            ...store.state.interaction,
+            lastUpdate: 'keyboard',
+          },
+        }),
+        keyboardNavigation: {
+          ...store.state.keyboardNavigation,
+          item: cleanedItem,
+          focusRequestId: store.state.keyboardNavigation.focusRequestId + 1,
+        },
+      });
+    },
+  );
+
+  const handleKeyboardNavigationClick = useEventCallback(
+    (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+      if (params.disableKeyboardNavigation) {
+        return;
+      }
+
+      const point = getChartPoint(event.currentTarget, event);
+
+      if (!instance.isPointInside(point.x, point.y)) {
+        return;
+      }
+
+      for (const seriesType of Object.keys(store.state.seriesConfig.config)) {
+        // @ts-ignore The type inference for store.state does not support generic series configs yet.
+        const item = store.state.seriesConfig.config[seriesType].getItemAtPosition?.(store.state, {
+          x: point.x,
+          y: point.y,
+        });
+
+        if (item) {
+          setKeyboardNavigationItem(item);
+          return;
+        }
+      }
+    },
+  );
 
   React.useEffect(() => {
     const element = chartsLayerContainerRef.current;
@@ -85,19 +151,7 @@ export const useChartKeyboardNavigation: ChartPlugin<UseChartKeyboardNavigationS
 
       if (newFocusedItem !== store.state.keyboardNavigation.item) {
         event.preventDefault();
-
-        store.update({
-          ...(store.state.highlight && {
-            highlight: { ...store.state.highlight, lastUpdate: 'keyboard' },
-          }),
-          ...(store.state.interaction && {
-            interaction: { ...store.state.interaction, lastUpdate: 'keyboard' },
-          }),
-          keyboardNavigation: {
-            ...store.state.keyboardNavigation,
-            item: newFocusedItem,
-          },
-        });
+        setKeyboardNavigationItem(newFocusedItem);
       }
     }
 
@@ -109,7 +163,7 @@ export const useChartKeyboardNavigation: ChartPlugin<UseChartKeyboardNavigationS
       element.removeEventListener('focusout', removeFocus);
       element.removeEventListener('focusin', restoreFocus);
     };
-  }, [chartsLayerContainerRef, params.disableKeyboardNavigation, store]);
+  }, [chartsLayerContainerRef, params.disableKeyboardNavigation, setKeyboardNavigationItem, store]);
 
   useEnhancedEffect(() => {
     store.set('keyboardNavigation', {
@@ -118,7 +172,12 @@ export const useChartKeyboardNavigation: ChartPlugin<UseChartKeyboardNavigationS
     });
   }, [store, params.disableKeyboardNavigation]);
 
-  return {};
+  return {
+    instance: {
+      handleKeyboardNavigationClick,
+      setKeyboardNavigationItem,
+    },
+  };
 };
 
 useChartKeyboardNavigation.getInitialState = (params) => ({
@@ -126,6 +185,7 @@ useChartKeyboardNavigation.getInitialState = (params) => ({
     item: null,
     isFocused: false,
     enabled: !params.disableKeyboardNavigation,
+    focusRequestId: 0,
   },
 });
 

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.types.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.types.ts
@@ -5,7 +5,10 @@ import type { UseChartHighlightSignature } from '../useChartHighlight';
 import type { FocusedItemIdentifier } from '../../../../models/seriesType';
 import type { ChartSeriesType } from '../../../../models/seriesType/config';
 
-export interface UseChartKeyboardNavigationInstance {}
+export interface UseChartKeyboardNavigationInstance {
+  handleKeyboardNavigationClick: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
+  setKeyboardNavigationItem: (item: FocusedItemIdentifier<ChartSeriesType> | null) => void;
+}
 
 export interface UseChartKeyboardNavigationState {
   keyboardNavigation: {
@@ -21,6 +24,11 @@ export interface UseChartKeyboardNavigationState {
      * Indicates whether keyboard navigation is enabled or not.
      */
     enabled: boolean;
+    /**
+     * Incremented whenever an item should receive focus in the accessibility proxy.
+     * This lets the proxy react when two items have the same description or the same item is clicked again.
+     */
+    focusRequestId: number;
   };
 }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

## Summary

Make a clicked chart item the active item for keyboard navigation and screen-reader narration across all keyboard-navigable series. The keyboard navigation for charts is a great feature, and I believe adding the click support just makes it easier to start the navigation (rather than hitting Tab and hoping that you ended up on the proper proxy div) and also to jump to a point faster.

## Implementation notes

### Shared activation state

Keyboard and click navigation now use the same `setKeyboardNavigationItem` path. It:

- ignores activation when keyboard navigation is disabled;
- removes extra click payload fields before storing the identifier;
- marks highlight/interaction state as keyboard-driven;
- requests the accessibility proxy to focus and announce the item.

Activation is separate from `onItemClick`, so it works without a public callback and existing callbacks are not invoked twice.

### Resolving the clicked item

Two strategies are needed because not every renderer has one DOM element per item:

- Renderers with `getItemAtPosition` resolve the item from click coordinates. This covers batched/WebGL bars, heatmaps, radial charts, and the new range-bar hit-testing.
- Other charts activate the identifier already known by the clicked element. This covers pie, line, radar, funnel, Sankey, and map items.

Line and area clicks still calculate the nearest `dataIndex` from the x-axis, but now do so even when no public click callback is provided.

### Scatter and Voronoi handling

Scatter clicks can be handled either by an individual marker or by the Voronoi closest-point plugin:

- When Voronoi is enabled, the tap handler activates the closest item. This also supports clicks around markers and renderers without individual marker elements.
- When Voronoi is disabled, the marker click handler performs the activation.

The `isVoronoiEnabled` check prevents the same marker click from being activated by both paths.

### Accessibility proxy

The proxy previously moved focus only when the narration text changed. This missed repeated clicks on the same item and different items with identical descriptions.

Each activation now increments a `focusRequestId`. The proxy observes this value and alternates its focus target even when the narration string is unchanged, forcing a new screen-reader announcement.

## Coverage

Bar, line, pie, scatter, radar, funnel, heatmap, Sankey, range bar, map shape, radial bar, and radial line. Sparklines inherit bar and line support.

## Testing

Added coverage for continuing keyboard navigation from a clicked item, repeated activation, disabled keyboard navigation, and representative Community, Pro, and Premium charts.
