### PR TITLE
[DateRangePicker] Fix broken active range position underline in single input range fields

### DIFF
--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.test.tsx
@@ -1,13 +1,17 @@
 import { DateRangePicker, DateRangePickerProps } from '@mui/x-date-pickers-pro/DateRangePicker';
-import { screen } from '@mui/internal-test-utils/createRenderer';
+import { screen, waitFor, within } from '@mui/internal-test-utils';
 import { spy } from 'sinon';
 import {
+  adapterToUse,
   buildFieldInteractions,
   createPickerRenderer,
   openPicker,
+  openPickerAsync,
   stubMatchMedia,
 } from 'test/utils/pickers';
 import { pickerPopperClasses } from '@mui/x-date-pickers/internals';
+import { pickersInputBaseClasses } from '@mui/x-date-pickers/PickersTextField';
+import { isJSDOM } from 'test/utils/skipIf';
 import { MultiInputDateRangeField } from '../MultiInputDateRangeField';
 
 describe('<DateRangePicker />', () => {
@@ -125,5 +129,77 @@ describe('<DateRangePicker />', () => {
 
       expect(handleSubmit.callCount).to.equal(0);
     });
+  });
+
+  // The active range position underline (`activeBar`) is measured from the rendered
+  // section widths (`offsetWidth`), which is always `0` in jsdom, so these run in the browser.
+  describe('active range position underline (single input)', () => {
+    const getPickerDay = (name: string, picker = 'January 2018') =>
+      within(screen.getByRole('grid', { name: picker })).getByRole('gridcell', { name });
+
+    it.skipIf(isJSDOM)(
+      'should render the active bar with a non-zero width for the focused range position',
+      async () => {
+        stubMatchMedia(true);
+        const { user } = renderWithProps({
+          enableAccessibleFieldDOMStructure: true,
+          defaultValue: [adapterToUse.date('2022-04-17'), adapterToUse.date('2022-04-21')],
+        });
+        await openPickerAsync(user, {
+          type: 'date-range',
+          initialFocus: 'start',
+          fieldType: 'single-input',
+        });
+
+        const fieldRoot = document.querySelector<HTMLElement>('[data-active-range-position]');
+        expect(fieldRoot).to.have.attribute('data-active-range-position', 'start');
+
+        const activeBar = document.querySelector<HTMLElement>(
+          `.${pickersInputBaseClasses.activeBar}`,
+        );
+        expect(activeBar).not.to.equal(null);
+        await waitFor(() => {
+          expect(activeBar!.offsetWidth).to.be.greaterThan(0);
+        });
+      },
+    );
+
+    it.skipIf(isJSDOM)(
+      'should move the active bar to the end range position after selecting the start date',
+      async () => {
+        stubMatchMedia(true);
+        const { user } = renderWithProps({
+          enableAccessibleFieldDOMStructure: true,
+          defaultValue: [adapterToUse.date('2018-01-01'), adapterToUse.date('2018-01-06')],
+        });
+        await openPickerAsync(user, {
+          type: 'date-range',
+          initialFocus: 'start',
+          fieldType: 'single-input',
+        });
+
+        const activeBarSelector = `.${pickersInputBaseClasses.activeBar}`;
+        let startLeft = 0;
+        await waitFor(() => {
+          const activeBar = document.querySelector<HTMLElement>(activeBarSelector)!;
+          expect(activeBar.offsetWidth).to.be.greaterThan(0);
+          startLeft = activeBar.offsetLeft;
+        });
+
+        // Selecting the start date advances the picker to the end range position.
+        await user.click(getPickerDay('3'));
+
+        await waitFor(() => {
+          expect(document.querySelector('[data-active-range-position]')).to.have.attribute(
+            'data-active-range-position',
+            'end',
+          );
+          // The bar now sits under the end date sections, well to the right of the start
+          // sections (observed gap is ~100px; 40px keeps the assertion comfortably robust).
+          const activeBar = document.querySelector<HTMLElement>(activeBarSelector)!;
+          expect(activeBar.offsetLeft).to.be.greaterThan(startLeft + 40);
+        });
+      },
+    );
   });
 });

--- a/packages/x-date-pickers/src/PickersTextField/PickersInputBase/PickersInputBase.tsx
+++ b/packages/x-date-pickers/src/PickersTextField/PickersInputBase/PickersInputBase.tsx
@@ -237,7 +237,8 @@ function resolveSectionElementWidth(
   index: number,
   dateRangePosition: 'start' | 'end',
 ) {
-  if (sectionElement.content.id) {
+  // Only measure sections that belong to a range date.
+  if (sectionElement.content['data-range-position'] !== undefined) {
     const activeSectionElements = rootRef.current?.querySelectorAll<HTMLSpanElement>(
       `[data-sectionindex="${index}"] [data-range-position="${dateRangePosition}"]`,
     );


### PR DESCRIPTION
Cherry-pick of https://github.com/mui/mui-x/pull/23166

Done manually: the automated cherry-pick could not run for that PR. The `pull_request_target` run failed on the new `actions/checkout` v7 fork guard (since fixed in https://github.com/mui/mui-public/pull/1694), and that event cannot be replayed, so the workflow could not produce this PR.

## Adaptations for v8.x

The source fix applied cleanly. The test file needed two adjustments, since v8.x predates some master-only changes:

- `openPicker(user, params)` on master is `openPickerAsync(user, params)` on v8.x (v8.x's `openPicker` is synchronous and takes no `user`).
- `enableAccessibleFieldDOMStructure: true` is passed explicitly, since v8.x still supports the non-accessible DOM structure, in which the active bar does not render.

Verified on this branch: TypeScript, ESLint and Prettier all pass.