### PR TITLE
[charts] Hide focus indicator when the chart loses focus

### DIFF
--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.test.tsx
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.test.tsx
@@ -60,6 +60,34 @@ describe('useChartKeyboardNavigation', () => {
     expect(container.querySelector(FOCUSED_BAR_SELECTOR)).to.equal(null);
   });
 
+  it.skipIf(isJSDOM)(
+    'should remove focus indicator when clicking a non-focusable element outside',
+    async () => {
+      const { container, user } = render(
+        <div>
+          <BarChart
+            height={100}
+            width={100}
+            skipAnimation
+            margin={0}
+            series={[{ id: 'A', data: [50, 100] }]}
+          />
+          <div id="test-outside" style={{ height: 50, width: 50 }} />
+        </div>,
+      );
+
+      await user.keyboard('{Tab}');
+      await user.keyboard('[ArrowRight]');
+
+      expect(container.querySelector(FOCUSED_BAR_SELECTOR)).not.to.equal(null);
+
+      // Clicking a non-focusable element gives a null `relatedTarget` on `focusout`.
+      await user.click(container.querySelector('#test-outside')!);
+
+      expect(container.querySelector(FOCUSED_BAR_SELECTOR)).to.equal(null);
+    },
+  );
+
   it.skipIf(isJSDOM)('should not focus a hidden series via keyboard navigation', async () => {
     const { container, user } = render(
       <BarChart

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.ts
@@ -23,18 +23,21 @@ export const useChartKeyboardNavigation: ChartPlugin<UseChartKeyboardNavigationS
     }
 
     function removeFocus(event: FocusEvent) {
-      const root = event.currentTarget as HTMLElement;
-      const next = event.relatedTarget as HTMLElement | null;
+      const root = event.currentTarget as HTMLElement | null;
+      const next = event.relatedTarget as Node | null;
 
       // Avoid removing focus if we know it is moving to another children in the chart.
       // This avoid extra computation ot remove/add focus at each keyboard pressed when navigating in the chart.
-      if (root && next instanceof Node && !root.contains(next)) {
-        if (store.state.keyboardNavigation.isFocused) {
-          store.set('keyboardNavigation', {
-            ...store.state.keyboardNavigation,
-            isFocused: false,
-          });
-        }
+      // A null relatedTarget means focus left to a non-focusable element (clicking outside), so focus is removed.
+      if (root && next !== null && root.contains(next)) {
+        return;
+      }
+
+      if (store.state.keyboardNavigation.isFocused) {
+        store.set('keyboardNavigation', {
+          ...store.state.keyboardNavigation,
+          isFocused: false,
+        });
       }
     }
 


### PR DESCRIPTION
## Problem

When navigating a chart with the keyboard, clicking outside the chart on a non-focusable element (empty page area, a plain `div`, ...) left the focus indicator visible.

`focusout` clears the keyboard focus state only when `relatedTarget` is a `Node`:

```ts
if (root && next instanceof Node && !root.contains(next)) { /* clear focus */ }
```

A click on a non-focusable element gives `relatedTarget === null`, so the condition was never met and `keyboardNavigation.isFocused` stayed `true`. The bug was invisible in the existing test because it clicks a `<button>`, which is focusable and therefore provides a `relatedTarget`.

## Fix

Invert the guard: bail out only when focus stays inside the chart. Every other case, including a `null` `relatedTarget`, clears the focus state.

## Tests

Added a browser test that clicks a non-focusable element outside the chart and asserts the focus indicator is gone. It fails on `master` and passes with the fix.