### PR TITLE
[charts] Extract the axis click payload builders

### DIFF
--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/getAxisClickPayload.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/getAxisClickPayload.ts
@@ -1,0 +1,61 @@
+import type { AxisId, ChartsAxisData, ChartsAxisProps } from '../../../../models/axis';
+import type { SeriesId } from '../../../../models/seriesType/common';
+import type { ProcessedSeries } from '../../corePlugins/useChartSeries';
+import type { ChartSeriesType } from '../../../../models/seriesType/config';
+import type { ComputeResult } from './computeAxisValue';
+
+const AXIS_CLICK_SERIES_TYPES = new Set(['bar', 'rangeBar', 'line'] as const);
+type AxisClickSeriesType = typeof AXIS_CLICK_SERIES_TYPES extends Set<infer U> ? U : never;
+
+/**
+ * Builds the `onAxisClick` payload for a data index on a given axis.
+ * Returns `null` when the axis has no value at this index.
+ */
+export function getAxisClickPayload({
+  axisId,
+  dataIndex,
+  isXAxis,
+  axes,
+  processedSeries,
+}: {
+  axisId: AxisId;
+  dataIndex: number;
+  isXAxis: boolean;
+  axes: ComputeResult<ChartsAxisProps>['axis'];
+  processedSeries: ProcessedSeries<ChartSeriesType>;
+}): ChartsAxisData | null {
+  const axisValue = axes[axisId]?.data?.[dataIndex];
+
+  if (axisValue === undefined) {
+    return null;
+  }
+
+  const seriesValues: ChartsAxisData['seriesValues'] = {};
+
+  Object.keys(processedSeries)
+    .filter((seriesType): seriesType is AxisClickSeriesType =>
+      AXIS_CLICK_SERIES_TYPES.has(seriesType as AxisClickSeriesType),
+    )
+    .forEach((seriesType) => {
+      // @ts-ignore
+      const seriesTypeConfig = processedSeries[seriesType];
+
+      seriesTypeConfig?.seriesOrder.forEach((seriesId: SeriesId) => {
+        const seriesItem = seriesTypeConfig!.series[seriesId];
+
+        const providedXAxisId = seriesItem.xAxisId;
+        const providedYAxisId = seriesItem.yAxisId;
+
+        const axisKey = isXAxis ? providedXAxisId : providedYAxisId;
+        if (axisKey === undefined || axisKey === axisId) {
+          // @ts-ignore This is safe because users need to opt in to use range bar series.
+          // In that case, they should import the module augmentation from `x-charts-pro/moduleAugmentation/rangeBarOnClick`
+          // Which adds the proper type to the series data.
+          // TODO(v9): Remove this ts-ignore when we can make the breaking change to ChartsAxisData.
+          seriesValues[seriesId] = seriesItem.data[dataIndex];
+        }
+      });
+    });
+
+  return { dataIndex, axisValue, seriesValues };
+}

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/getAxisClickPayload.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/getAxisClickPayload.ts
@@ -51,7 +51,7 @@ export function getAxisClickPayload({
           // @ts-ignore This is safe because users need to opt in to use range bar series.
           // In that case, they should import the module augmentation from `x-charts-pro/moduleAugmentation/rangeBarOnClick`
           // Which adds the proper type to the series data.
-          // TODO(v9): Remove this ts-ignore when we can make the breaking change to ChartsAxisData.
+          // TODO(v10): Remove this ts-ignore when we can make the breaking change to ChartsAxisData.
           seriesValues[seriesId] = seriesItem.data[dataIndex];
         }
       });

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxis.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxis.ts
@@ -16,10 +16,7 @@ import { getChartPoint } from '../../../getChartPoint';
 import { selectorChartsInteractionIsInitialized } from '../useChartInteraction';
 import { selectorChartAxisInteraction } from './useChartCartesianInteraction.selectors';
 import { checkHasInteractionPlugin } from '../useChartInteraction/checkHasInteractionPlugin';
-import type { ChartsAxisData, SeriesId } from '../../../../models';
-
-const AXIS_CLICK_SERIES_TYPES = new Set(['bar', 'rangeBar', 'line'] as const);
-type AxisClickSeriesType = typeof AXIS_CLICK_SERIES_TYPES extends Set<infer U> ? U : never;
+import { getAxisClickPayload } from './getAxisClickPayload';
 
 export const useChartCartesianAxis: ChartPlugin<UseChartCartesianAxisSignature<any>> = ({
   params,
@@ -207,52 +204,30 @@ export const useChartCartesianAxis: ChartPlugin<UseChartCartesianAxisSignature<a
     }
 
     const axisClickHandler = instance.addInteractionListener('tap', (event) => {
-      let dataIndex: number | null = null;
-      let isXAxis: boolean = false;
-
       const svgPoint = getChartPoint(element, event.detail.srcEvent);
 
       const xIndex = getAxisIndex(xAxisWithScale[usedXAxis], svgPoint.x);
-      isXAxis = xIndex !== -1;
+      const isXAxis = xIndex !== -1;
 
-      dataIndex = isXAxis ? xIndex : getAxisIndex(yAxisWithScale[usedYAxis], svgPoint.y);
+      const dataIndex = isXAxis ? xIndex : getAxisIndex(yAxisWithScale[usedYAxis], svgPoint.y);
 
-      const USED_AXIS_ID = isXAxis ? xAxisIds[0] : yAxisIds[0];
-      if (dataIndex == null || dataIndex === -1) {
+      if (dataIndex === -1) {
         return;
       }
 
-      // The .data exist because otherwise the dataIndex would be null or -1.
-      const axisValue = (isXAxis ? xAxisWithScale : yAxisWithScale)[USED_AXIS_ID].data![dataIndex];
+      const payload = getAxisClickPayload({
+        axisId: isXAxis ? xAxisIds[0] : yAxisIds[0],
+        dataIndex,
+        isXAxis,
+        axes: isXAxis ? xAxisWithScale : yAxisWithScale,
+        processedSeries,
+      });
 
-      const seriesValues: ChartsAxisData['seriesValues'] = {};
+      if (payload === null) {
+        return;
+      }
 
-      Object.keys(processedSeries)
-        .filter((seriesType): seriesType is AxisClickSeriesType =>
-          AXIS_CLICK_SERIES_TYPES.has(seriesType as AxisClickSeriesType),
-        )
-        .forEach((seriesType) => {
-          // @ts-ignore
-          const seriesTypeConfig = processedSeries[seriesType];
-
-          seriesTypeConfig?.seriesOrder.forEach((seriesId: SeriesId) => {
-            const seriesItem = seriesTypeConfig!.series[seriesId];
-
-            const providedXAxisId = seriesItem.xAxisId;
-            const providedYAxisId = seriesItem.yAxisId;
-
-            const axisKey = isXAxis ? providedXAxisId : providedYAxisId;
-            if (axisKey === undefined || axisKey === USED_AXIS_ID) {
-              // @ts-ignore This is safe because users need to opt in to use range bar series.
-              // In that case, they should import the module augmentation from `x-charts-pro/moduleAugmentation/rangeBarOnClick`
-              // Which adds the proper type to the series data.
-              // TODO(v9): Remove this ts-ignore when we can make the breaking change to ChartsAxisData.
-              seriesValues[seriesId] = seriesItem.data[dataIndex];
-            }
-          });
-        });
-
-      onAxisClick(event.detail.srcEvent, { dataIndex, axisValue, seriesValues });
+      onAxisClick(event.detail.srcEvent, payload);
     });
 
     return () => {

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartPolarAxis/getPolarAxisClickPayload.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartPolarAxis/getPolarAxisClickPayload.ts
@@ -1,0 +1,45 @@
+import type { ChartsAxisData } from '../../../../models/axis';
+import type { ProcessedSeries } from '../../corePlugins/useChartSeries';
+import type { ChartSeriesType } from '../../../../models/seriesType/config';
+import { isPolarSeriesType } from '../../../isPolar';
+
+type PolarAxes = { axis: Record<string, { data?: readonly any[] }>; axisIds: string[] };
+
+/**
+ * Builds the `onAxisClick` payload for a data index on a polar axis.
+ * Returns `null` when the axis has no value at this index.
+ */
+export function getPolarAxisClickPayload({
+  dataIndex,
+  isRotationAxis,
+  rotationAxes,
+  radiusAxes,
+  processedSeries,
+}: {
+  dataIndex: number;
+  isRotationAxis: boolean;
+  rotationAxes: PolarAxes;
+  radiusAxes: PolarAxes;
+  processedSeries: ProcessedSeries<ChartSeriesType>;
+}): ChartsAxisData | null {
+  const axes = isRotationAxis ? rotationAxes : radiusAxes;
+  const axisValue = axes.axis[axes.axisIds[0]]?.data?.[dataIndex];
+
+  if (axisValue === undefined) {
+    return null;
+  }
+
+  const seriesValues: ChartsAxisData['seriesValues'] = {};
+
+  Object.keys(processedSeries)
+    .filter(isPolarSeriesType)
+    .forEach((seriesType) => {
+      processedSeries[seriesType]?.seriesOrder.forEach((seriesId) => {
+        const seriesItem = processedSeries[seriesType]!.series[seriesId];
+
+        seriesValues[seriesId] = seriesItem.data[dataIndex];
+      });
+    });
+
+  return { dataIndex, axisValue, seriesValues };
+}

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartPolarAxis/useChartPolarAxis.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartPolarAxis/useChartPolarAxis.ts
@@ -22,7 +22,7 @@ import {
 import { getRadiusAxisIndex, getRotationAxisIndex } from './getAxisIndex';
 import { selectorChartSeriesProcessed } from '../../corePlugins/useChartSeries';
 import { checkHasInteractionPlugin } from '../useChartInteraction/checkHasInteractionPlugin';
-import { isPolarSeriesType } from '../../../isPolar';
+import { getPolarAxisClickPayload } from './getPolarAxisClickPayload';
 
 export const useChartPolarAxis: ChartPlugin<UseChartPolarAxisSignature<any>> = ({
   params,
@@ -218,9 +218,6 @@ export const useChartPolarAxis: ChartPlugin<UseChartPolarAxisSignature<any>> = (
     }
 
     const axisClickHandler = instance.addInteractionListener('tap', (event) => {
-      let dataIndex: number | null = null;
-      let isRotationAxis: boolean = false;
-
       const svgPoint = getChartPoint(element, event.detail.srcEvent);
 
       const rotation = generateSvg2rotation(center)(svgPoint.x, svgPoint.y);
@@ -230,32 +227,27 @@ export const useChartPolarAxis: ChartPlugin<UseChartPolarAxisSignature<any>> = (
       );
       const radius = generateSvg2radius(center)(svgPoint.x, svgPoint.y);
       const radiusIndex = getRadiusAxisIndex(radiusAxisWithScale[usedRadiusAxisId], radius);
-      isRotationAxis = rotationIndex !== -1;
+      const isRotationAxis = rotationIndex !== -1;
 
-      dataIndex = isRotationAxis ? rotationIndex : radiusIndex;
+      const dataIndex = isRotationAxis ? rotationIndex : radiusIndex;
 
-      const USED_AXIS_ID = isRotationAxis ? usedRotationAxisId : usedRadiusAxisId;
-      if (dataIndex == null || dataIndex === -1) {
+      if (dataIndex === -1) {
         return;
       }
 
-      // The .data exist because otherwise the dataIndex would be null or -1.
-      const axisValue = (isRotationAxis ? rotationAxisWithScale : radiusAxisWithScale)[USED_AXIS_ID]
-        .data![dataIndex];
+      const payload = getPolarAxisClickPayload({
+        dataIndex,
+        isRotationAxis,
+        rotationAxes: { axis: rotationAxisWithScale, axisIds: [usedRotationAxisId] },
+        radiusAxes: { axis: radiusAxisWithScale, axisIds: [usedRadiusAxisId] },
+        processedSeries,
+      });
 
-      const seriesValues: Record<string, number | null | undefined> = {};
+      if (payload === null) {
+        return;
+      }
 
-      Object.keys(processedSeries)
-        .filter(isPolarSeriesType)
-        .forEach((seriesType) => {
-          processedSeries[seriesType]?.seriesOrder.forEach((seriesId) => {
-            const seriesItem = processedSeries[seriesType]!.series[seriesId];
-
-            seriesValues[seriesId] = seriesItem.data[dataIndex];
-          });
-        });
-
-      onAxisClick(event.detail.srcEvent, { dataIndex, axisValue, seriesValues });
+      onAxisClick(event.detail.srcEvent, payload);
     });
 
     return () => {


### PR DESCRIPTION
Split out of #23208 simplify it

## Summary

The cartesian and polar `tap` handlers built the `onAxisClick` payload inline: resolve the axis value, then walk the processed series to collect `seriesValues`. This moves that into `getAxisClickPayload` and `getPolarAxisClickPayload`, so the handlers keep only the hit-testing, and the payload can be built from something other than a pointer position.

Pure refactor — no behavior change. The handlers now bail on a `null` payload, which is the same condition the inline code expressed as "the axis has no value at this index".
