### PR TITLE
[charts] Forward experimentalFeatures on RadarChart and Heatmap

### DIFF
--- a/packages/x-charts-pro/src/Heatmap/useHeatmapProps.ts
+++ b/packages/x-charts-pro/src/Heatmap/useHeatmapProps.ts
@@ -67,6 +67,7 @@ export function useHeatmapProps(props: UseHeatmapProps) {
     highlightedItem,
     onHighlightChange,
     disableKeyboardNavigation,
+    experimentalFeatures,
     borderRadius,
     hideLegend,
   } = props;
@@ -140,6 +141,7 @@ export function useHeatmapProps(props: UseHeatmapProps) {
       highlightedItem,
       onHighlightChange,
       disableKeyboardNavigation,
+      experimentalFeatures,
       onItemClick,
       plugins: HEATMAP_PLUGINS,
     };

--- a/packages/x-charts/src/RadarChart/experimentalFeatures.test.tsx
+++ b/packages/x-charts/src/RadarChart/experimentalFeatures.test.tsx
@@ -1,0 +1,20 @@
+import { createRenderer } from '@mui/internal-test-utils';
+import { RadarChart } from '@mui/x-charts/RadarChart';
+
+describe('<RadarChart /> - experimentalFeatures', () => {
+  const { render } = createRenderer();
+
+  it('should not forward experimentalFeatures to the DOM', async () => {
+    const { container } = render(
+      <RadarChart
+        height={100}
+        width={100}
+        series={[{ id: 'A', data: [1, 2, 3] }]}
+        radar={{ metrics: ['M1', 'M2', 'M3'] }}
+        experimentalFeatures={{}}
+      />,
+    );
+
+    expect(container.querySelector('[experimentalfeatures]')).to.equal(null);
+  });
+});

--- a/packages/x-charts/src/RadarChart/experimentalFeatures.test.tsx
+++ b/packages/x-charts/src/RadarChart/experimentalFeatures.test.tsx
@@ -5,16 +5,16 @@ describe('<RadarChart /> - experimentalFeatures', () => {
   const { render } = createRenderer();
 
   it('should not forward experimentalFeatures to the DOM', async () => {
-    const { container } = render(
-      <RadarChart
-        height={100}
-        width={100}
-        series={[{ id: 'A', data: [1, 2, 3] }]}
-        radar={{ metrics: ['M1', 'M2', 'M3'] }}
-        experimentalFeatures={{}}
-      />,
-    );
-
-    expect(container.querySelector('[experimentalfeatures]')).to.equal(null);
+    expect(() =>
+      render(
+        <RadarChart
+          height={100}
+          width={100}
+          series={[{ id: 'A', data: [1, 2, 3] }]}
+          radar={{ metrics: ['M1', 'M2', 'M3'] }}
+          experimentalFeatures={{}}
+        />,
+      ),
+    ).not.toWarnDev();
   });
 });

--- a/packages/x-charts/src/RadarChart/useRadarChartProps.ts
+++ b/packages/x-charts/src/RadarChart/useRadarChartProps.ts
@@ -44,6 +44,7 @@ export const useRadarChartProps = (props: RadarChartProps) => {
     onAreaClick,
     onMarkClick,
     disableKeyboardNavigation,
+    experimentalFeatures,
     className,
     ...other
   } = props;
@@ -62,6 +63,7 @@ export const useRadarChartProps = (props: RadarChartProps) => {
     skipAnimation,
     onAxisClick,
     disableKeyboardNavigation,
+    experimentalFeatures,
     plugins: RADAR_PLUGINS,
   };
 


### PR DESCRIPTION
## Summary

`RadarChart` and `Heatmap` never destructured `experimentalFeatures`, so it stayed in the rest props and was spread onto the chart surface. Two consequences:

- React logs `React does not recognize the `experimentalFeatures` prop on a DOM element` and the attribute lands in the DOM.
- The plugins never receive it, so any experimental feature is silently ignored on those two charts.

Both now destructure it and pass it to their data provider, like every other chart. Added a regression test asserting the attribute does not reach the DOM.

Found while working on #23208, split out because it stands on its own.
