### PR TITLE
[charts-premium] Fix `RangeBar` type override

### DIFF
--- a/packages/x-charts/src/models/axis.ts
+++ b/packages/x-charts/src/models/axis.ts
@@ -788,7 +788,7 @@ export interface ChartsAxisData {
    */
   seriesValues: Record<
     string,
-    HasProperty<ChartsTypeFeatureFlags, 'seriesValueOverride'> extends true
+    HasProperty<ChartsTypeFeatureFlags, 'seriesValuesOverride'> extends true
       ? // @ts-ignore this property is added through module augmentation
         ChartsTypeFeatureFlags['seriesValuesOverride']
       : number | null | undefined


### PR DESCRIPTION
## Summary

`ChartsAxisData['seriesValues']` gates the override on `HasProperty<ChartsTypeFeatureFlags, 'seriesValueOverride'>` (singular) but reads `ChartsTypeFeatureFlags['seriesValuesOverride']` (plural). Only the plural key is declared, by `moduleAugmentation/rangeBarOnClick`, so the condition is always `false` and the augmentation never had any effect.

One-character class of bug, but it means range-bar users importing that augmentation still get `number | null | undefined` in `onAxisClick`'s `seriesValues` instead of including `RangeBarValueType`.

Verified with a type-equality assertion against the augmented type: it fails on `master` and passes with this fix. (The assertion was only a scratch check and is not part of the diff, since the repo has no type-test setup for this.)

### Note for review

For anyone who already imports the range-bar augmentation, `seriesValues` becomes the wider union it was always meant to be, so handlers that assume `number | null | undefined` may now need a narrowing. That is the intended behavior of the augmentation.

Found while working on #23208.
