### PR TITLE
[charts] Activate the focused item with Enter/Space

### DIFF
--- a/docs/data/charts/accessibility/KeyboardActivation.js
+++ b/docs/data/charts/accessibility/KeyboardActivation.js
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import Stack from '@mui/material/Stack';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import IconButton from '@mui/material/IconButton';
+import UndoOutlinedIcon from '@mui/icons-material/UndoOutlined';
+
+import { LineChart } from '@mui/x-charts/LineChart';
+
+import { HighlightedCode } from '@mui/internal-core-docs/HighlightedCode';
+
+const lineChartsParams = {
+  series: [
+    { id: 'series-1', data: [3, 4, 1, 6, 5], label: 'A' },
+    { id: 'series-2', data: [4, 3, 1, 5, 8], label: 'B' },
+  ],
+  xAxis: [{ data: [0, 3, 6, 9, 12], scaleType: 'linear' }],
+  height: 400,
+};
+
+export default function KeyboardActivation() {
+  const [itemData, setItemData] = React.useState();
+
+  return (
+    <Stack
+      direction={{ xs: 'column', md: 'row' }}
+      spacing={{ xs: 0, md: 4 }}
+      sx={{ width: '100%' }}
+    >
+      <Box sx={{ flexGrow: 1 }}>
+        <LineChart
+          {...lineChartsParams}
+          experimentalFeatures={{ keyboardActivation: true }}
+          onMarkClick={(event, d) => setItemData(d)}
+        />
+      </Box>
+
+      <Stack direction="column" sx={{ width: { xs: '100%', md: '40%' } }}>
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+          }}
+        >
+          <Typography>
+            Focus the chart, then press <kbd className="key">Enter</kbd>
+          </Typography>
+          <IconButton
+            aria-label="reset"
+            size="small"
+            onClick={() => {
+              setItemData(undefined);
+            }}
+          >
+            <UndoOutlinedIcon fontSize="small" />
+          </IconButton>
+        </Box>
+        <HighlightedCode
+          code={`// Data from item click
+${itemData ? JSON.stringify(itemData, null, 2) : '// The data will appear here'}
+
+`}
+          language="json"
+          copyButtonHidden
+        />
+      </Stack>
+    </Stack>
+  );
+}

--- a/docs/data/charts/accessibility/KeyboardActivation.js
+++ b/docs/data/charts/accessibility/KeyboardActivation.js
@@ -11,8 +11,8 @@ import { HighlightedCode } from '@mui/internal-core-docs/HighlightedCode';
 
 const lineChartsParams = {
   series: [
-    { id: 'series-1', data: [3, 4, 1, 6, 5], label: 'A' },
-    { id: 'series-2', data: [4, 3, 1, 5, 8], label: 'B' },
+    { id: 'series-1', data: [3, 4, 1, 6, 5], label: 'A', showMark: true },
+    { id: 'series-2', data: [4, 3, 1, 5, 8], label: 'B', showMark: true },
   ],
   xAxis: [{ data: [0, 3, 6, 9, 12], scaleType: 'linear' }],
   height: 400,

--- a/docs/data/charts/accessibility/KeyboardActivation.js
+++ b/docs/data/charts/accessibility/KeyboardActivation.js
@@ -31,6 +31,8 @@ export default function KeyboardActivation() {
         <LineChart
           {...lineChartsParams}
           experimentalFeatures={{ keyboardActivation: true }}
+          onAreaClick={(event, d) => setItemData(d)}
+          onLineClick={(event, d) => setItemData(d)}
           onMarkClick={(event, d) => setItemData(d)}
         />
       </Box>

--- a/docs/data/charts/accessibility/KeyboardActivation.tsx
+++ b/docs/data/charts/accessibility/KeyboardActivation.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react';
+import Stack from '@mui/material/Stack';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import IconButton from '@mui/material/IconButton';
+import UndoOutlinedIcon from '@mui/icons-material/UndoOutlined';
+
+import { LineChart } from '@mui/x-charts/LineChart';
+
+import { HighlightedCode } from '@mui/internal-core-docs/HighlightedCode';
+import { LineItemIdentifier } from '@mui/x-charts/models';
+
+const lineChartsParams = {
+  series: [
+    { id: 'series-1', data: [3, 4, 1, 6, 5], label: 'A' },
+    { id: 'series-2', data: [4, 3, 1, 5, 8], label: 'B' },
+  ],
+  xAxis: [{ data: [0, 3, 6, 9, 12], scaleType: 'linear' }],
+  height: 400,
+} as const;
+
+export default function KeyboardActivation() {
+  const [itemData, setItemData] = React.useState<LineItemIdentifier>();
+
+  return (
+    <Stack
+      direction={{ xs: 'column', md: 'row' }}
+      spacing={{ xs: 0, md: 4 }}
+      sx={{ width: '100%' }}
+    >
+      <Box sx={{ flexGrow: 1 }}>
+        <LineChart
+          {...lineChartsParams}
+          experimentalFeatures={{ keyboardActivation: true }}
+          onMarkClick={(event, d) => setItemData(d)}
+        />
+      </Box>
+
+      <Stack direction="column" sx={{ width: { xs: '100%', md: '40%' } }}>
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+          }}
+        >
+          <Typography>
+            Focus the chart, then press <kbd className="key">Enter</kbd>
+          </Typography>
+          <IconButton
+            aria-label="reset"
+            size="small"
+            onClick={() => {
+              setItemData(undefined);
+            }}
+          >
+            <UndoOutlinedIcon fontSize="small" />
+          </IconButton>
+        </Box>
+        <HighlightedCode
+          code={`// Data from item click
+${itemData ? JSON.stringify(itemData, null, 2) : '// The data will appear here'}
+
+`}
+          language="json"
+          copyButtonHidden
+        />
+      </Stack>
+    </Stack>
+  );
+}

--- a/docs/data/charts/accessibility/KeyboardActivation.tsx
+++ b/docs/data/charts/accessibility/KeyboardActivation.tsx
@@ -32,6 +32,8 @@ export default function KeyboardActivation() {
         <LineChart
           {...lineChartsParams}
           experimentalFeatures={{ keyboardActivation: true }}
+          onAreaClick={(event, d) => setItemData(d)}
+          onLineClick={(event, d) => setItemData(d)}
           onMarkClick={(event, d) => setItemData(d)}
         />
       </Box>

--- a/docs/data/charts/accessibility/KeyboardActivation.tsx
+++ b/docs/data/charts/accessibility/KeyboardActivation.tsx
@@ -12,8 +12,8 @@ import { LineItemIdentifier } from '@mui/x-charts/models';
 
 const lineChartsParams = {
   series: [
-    { id: 'series-1', data: [3, 4, 1, 6, 5], label: 'A' },
-    { id: 'series-2', data: [4, 3, 1, 5, 8], label: 'B' },
+    { id: 'series-1', data: [3, 4, 1, 6, 5], label: 'A', showMark: true },
+    { id: 'series-2', data: [4, 3, 1, 5, 8], label: 'B', showMark: true },
   ],
   xAxis: [{ data: [0, 3, 6, 9, 12], scaleType: 'linear' }],
   height: 400,

--- a/docs/data/charts/accessibility/accessibility.md
+++ b/docs/data/charts/accessibility/accessibility.md
@@ -76,6 +76,36 @@ When focused, the chart highlights a value item that can be modified with arrow 
 | <kbd class="key">Arrow Left</kbd>, <kbd class="key">Arrow Right</kbd> | Moves focus inside the series |
 |    <kbd class="key">Arrow Up</kbd>, <kbd class="key">Arrow Down</kbd> | Move focus between series     |
 
+### Activating the focused item
+
+Charts can trigger their click callbacks from the keyboard, so mouse-only interactions such as drill-down or filtering stay available to keyboard users ([WCAG 2.1 SC 2.1.1](https://www.w3.org/WAI/WCAG21/Understanding/keyboard.html)).
+
+It is opt-in on every chart, so existing callbacks keep receiving pointer events only:
+
+```jsx
+<BarChart
+  experimentalFeatures={{ keyboardActivation: true }}
+  onItemClick={(event, item) => {}}
+  {...otherProps}
+/>
+```
+
+Pressing <kbd class="key">Enter</kbd> or <kbd class="key">Space</kbd> on the focused item then calls `onItemClick` with the same payload a click provides.
+
+The `event` argument is the `KeyboardEvent` that triggered the activation.
+The callback types keep describing the pointer event to avoid a breaking change, so opt into the wider type with a module augmentation:
+
+```ts
+import type {} from '@mui/x-charts/moduleAugmentation/keyboardActivation';
+```
+
+The click callbacks then receive `MouseEvent | KeyboardEvent`, and you can narrow with `event instanceof KeyboardEvent` before reading pointer-only properties such as `clientX`.
+Both become the default in v10.
+
+{{"demo": "KeyboardActivation.js"}}
+
+When a chart exposes several item callbacks, activation fires the one a pointer would reach first on the focused data point: line charts try `onMarkClick`, then `onLineClick`, then `onAreaClick`; radar charts try `onMarkClick`, then `onAreaClick`; and Sankey charts call `onNodeClick` or `onLinkClick` depending on the focused element. Only one of them fires.
+
 ## Screen reader compatibility
 
 Charts use a proxy strategy to support screen reader when user navigate with keyboard navigation.

--- a/docs/pages/x/api/charts/area-plot.json
+++ b/docs/pages/x/api/charts/area-plot.json
@@ -3,7 +3,7 @@
     "onItemClick": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: React.MouseEvent<SVGPathElement, MouseEvent>, lineItemIdentifier: LineItemClickIdentifier) => void",
+        "type": "function(event: ChartsActivationEvent<SVGElement>, lineItemIdentifier: LineItemClickIdentifier) => void",
         "describedArgs": ["event", "lineItemIdentifier"]
       }
     },

--- a/docs/pages/x/api/charts/bar-chart-premium.json
+++ b/docs/pages/x/api/charts/bar-chart-premium.json
@@ -30,7 +30,9 @@
     "desc": { "type": { "name": "string" } },
     "disableAxisListener": { "type": { "name": "bool" }, "default": "false" },
     "disableKeyboardNavigation": { "type": { "name": "bool" } },
-    "experimentalFeatures": { "type": { "name": "object" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ keyboardActivation?: bool }" }
+    },
     "grid": {
       "type": { "name": "shape", "description": "{ horizontal?: bool, vertical?: bool }" }
     },

--- a/docs/pages/x/api/charts/bar-chart-pro.json
+++ b/docs/pages/x/api/charts/bar-chart-pro.json
@@ -30,7 +30,9 @@
     "desc": { "type": { "name": "string" } },
     "disableAxisListener": { "type": { "name": "bool" }, "default": "false" },
     "disableKeyboardNavigation": { "type": { "name": "bool" } },
-    "experimentalFeatures": { "type": { "name": "object" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ keyboardActivation?: bool }" }
+    },
     "grid": {
       "type": { "name": "shape", "description": "{ horizontal?: bool, vertical?: bool }" }
     },
@@ -110,7 +112,7 @@
     "onItemClick": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: MouseEvent, barItemIdentifier: BarItemIdentifier) => void",
+        "type": "function(event: ChartsActivationEvent, barItemIdentifier: BarItemIdentifier) => void",
         "describedArgs": ["event", "barItemIdentifier"]
       }
     },

--- a/docs/pages/x/api/charts/bar-chart.json
+++ b/docs/pages/x/api/charts/bar-chart.json
@@ -30,7 +30,9 @@
     "desc": { "type": { "name": "string" } },
     "disableAxisListener": { "type": { "name": "bool" }, "default": "false" },
     "disableKeyboardNavigation": { "type": { "name": "bool" } },
-    "experimentalFeatures": { "type": { "name": "object" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ keyboardActivation?: bool }" }
+    },
     "grid": {
       "type": { "name": "shape", "description": "{ horizontal?: bool, vertical?: bool }" }
     },
@@ -104,7 +106,7 @@
     "onItemClick": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: MouseEvent | React.MouseEvent<SVGElement, MouseEvent>, barItemIdentifier: BarItemIdentifier) => void",
+        "type": "function(event: ChartsActivationEvent | ChartsActivationEvent<SVGElement>, barItemIdentifier: BarItemIdentifier) => void",
         "describedArgs": ["event", "barItemIdentifier"]
       }
     },

--- a/docs/pages/x/api/charts/bar-plot-premium.json
+++ b/docs/pages/x/api/charts/bar-plot-premium.json
@@ -5,7 +5,7 @@
     "onItemClick": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: MouseEvent, barItemIdentifier: BarItemIdentifier) => void",
+        "type": "function(event: ChartsActivationEvent, barItemIdentifier: BarItemIdentifier) => void",
         "describedArgs": ["event", "barItemIdentifier"]
       }
     },

--- a/docs/pages/x/api/charts/bar-plot.json
+++ b/docs/pages/x/api/charts/bar-plot.json
@@ -5,7 +5,7 @@
     "onItemClick": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: MouseEvent | React.MouseEvent<SVGElement, MouseEvent>, barItemIdentifier: BarItemIdentifier) => void",
+        "type": "function(event: ChartsActivationEvent | ChartsActivationEvent<SVGElement>, barItemIdentifier: BarItemIdentifier) => void",
         "describedArgs": ["event", "barItemIdentifier"]
       }
     },

--- a/docs/pages/x/api/charts/charts-container.json
+++ b/docs/pages/x/api/charts/charts-container.json
@@ -16,7 +16,9 @@
     "disableAxisListener": { "type": { "name": "bool" }, "default": "false" },
     "disableHitArea": { "type": { "name": "bool" } },
     "disableKeyboardNavigation": { "type": { "name": "bool" } },
-    "experimentalFeatures": { "type": { "name": "any" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ keyboardActivation?: bool }" }
+    },
     "height": { "type": { "name": "number" } },
     "hiddenItems": {
       "type": {
@@ -82,7 +84,7 @@
     "onItemClick": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: MouseEvent, scatterItemIdentifier: ScatterItemIdentifier) => void",
+        "type": "function(event: ChartsActivationEvent, scatterItemIdentifier: ScatterItemIdentifier) => void",
         "describedArgs": ["event", "scatterItemIdentifier"]
       }
     },

--- a/docs/pages/x/api/charts/charts-data-provider-premium.json
+++ b/docs/pages/x/api/charts/charts-data-provider-premium.json
@@ -5,7 +5,9 @@
       "default": "rainbowSurgePalette"
     },
     "dataset": { "type": { "name": "arrayOf", "description": "Array&lt;object&gt;" } },
-    "experimentalFeatures": { "type": { "name": "any" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ keyboardActivation?: bool }" }
+    },
     "height": { "type": { "name": "number" } },
     "id": { "type": { "name": "string" } },
     "localeText": { "type": { "name": "object" } },

--- a/docs/pages/x/api/charts/charts-data-provider-pro.json
+++ b/docs/pages/x/api/charts/charts-data-provider-pro.json
@@ -5,7 +5,9 @@
       "default": "rainbowSurgePalette"
     },
     "dataset": { "type": { "name": "arrayOf", "description": "Array&lt;object&gt;" } },
-    "experimentalFeatures": { "type": { "name": "any" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ keyboardActivation?: bool }" }
+    },
     "height": { "type": { "name": "number" } },
     "id": { "type": { "name": "string" } },
     "localeText": { "type": { "name": "object" } },

--- a/docs/pages/x/api/charts/charts-data-provider.json
+++ b/docs/pages/x/api/charts/charts-data-provider.json
@@ -5,7 +5,9 @@
       "default": "rainbowSurgePalette"
     },
     "dataset": { "type": { "name": "arrayOf", "description": "Array&lt;object&gt;" } },
-    "experimentalFeatures": { "type": { "name": "any" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ keyboardActivation?: bool }" }
+    },
     "height": { "type": { "name": "number" } },
     "id": { "type": { "name": "string" } },
     "localeText": { "type": { "name": "object" } },

--- a/docs/pages/x/api/charts/charts-geo-data-provider-premium.json
+++ b/docs/pages/x/api/charts/charts-geo-data-provider-premium.json
@@ -5,7 +5,9 @@
       "default": "rainbowSurgePalette"
     },
     "dataset": { "type": { "name": "arrayOf", "description": "Array&lt;object&gt;" } },
-    "experimentalFeatures": { "type": { "name": "any" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ keyboardActivation?: bool }" }
+    },
     "height": { "type": { "name": "number" } },
     "id": { "type": { "name": "string" } },
     "localeText": { "type": { "name": "object" } },

--- a/docs/pages/x/api/charts/charts-radial-data-provider-premium.json
+++ b/docs/pages/x/api/charts/charts-radial-data-provider-premium.json
@@ -5,7 +5,9 @@
       "default": "rainbowSurgePalette"
     },
     "dataset": { "type": { "name": "arrayOf", "description": "Array&lt;object&gt;" } },
-    "experimentalFeatures": { "type": { "name": "any" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ keyboardActivation?: bool }" }
+    },
     "height": { "type": { "name": "number" } },
     "id": { "type": { "name": "string" } },
     "localeText": { "type": { "name": "object" } },

--- a/docs/pages/x/api/charts/charts-radial-data-provider.json
+++ b/docs/pages/x/api/charts/charts-radial-data-provider.json
@@ -5,7 +5,9 @@
       "default": "rainbowSurgePalette"
     },
     "dataset": { "type": { "name": "arrayOf", "description": "Array&lt;object&gt;" } },
-    "experimentalFeatures": { "type": { "name": "any" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ keyboardActivation?: bool }" }
+    },
     "height": { "type": { "name": "number" } },
     "id": { "type": { "name": "string" } },
     "localeText": { "type": { "name": "object" } },

--- a/docs/pages/x/api/charts/funnel-chart.json
+++ b/docs/pages/x/api/charts/funnel-chart.json
@@ -28,7 +28,9 @@
     "desc": { "type": { "name": "string" } },
     "disableAxisListener": { "type": { "name": "bool" }, "default": "false" },
     "disableKeyboardNavigation": { "type": { "name": "bool" } },
-    "experimentalFeatures": { "type": { "name": "object" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ keyboardActivation?: bool }" }
+    },
     "gap": { "type": { "name": "number" }, "default": "0" },
     "height": { "type": { "name": "number" } },
     "hiddenItems": {
@@ -83,7 +85,7 @@
     "onItemClick": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: React.MouseEvent<SVGElement, MouseEvent>, funnelItemIdentifier: FunnelItemIdentifier) => void",
+        "type": "function(event: ChartsActivationEvent<SVGElement>, funnelItemIdentifier: FunnelItemIdentifier) => void",
         "describedArgs": ["event", "funnelItemIdentifier"]
       }
     },

--- a/docs/pages/x/api/charts/funnel-plot.json
+++ b/docs/pages/x/api/charts/funnel-plot.json
@@ -4,7 +4,7 @@
     "onItemClick": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: React.MouseEvent<SVGElement, MouseEvent>, funnelItemIdentifier: FunnelItemIdentifier) => void",
+        "type": "function(event: ChartsActivationEvent<SVGElement>, funnelItemIdentifier: FunnelItemIdentifier) => void",
         "describedArgs": ["event", "funnelItemIdentifier"]
       }
     },

--- a/docs/pages/x/api/charts/heatmap-premium.json
+++ b/docs/pages/x/api/charts/heatmap-premium.json
@@ -27,7 +27,9 @@
     "desc": { "type": { "name": "string" } },
     "disableAxisListener": { "type": { "name": "bool" }, "default": "false" },
     "disableKeyboardNavigation": { "type": { "name": "bool" } },
-    "experimentalFeatures": { "type": { "name": "object" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ keyboardActivation?: bool }" }
+    },
     "height": { "type": { "name": "number" } },
     "hideLegend": { "type": { "name": "bool" } },
     "highlightedItem": {
@@ -61,7 +63,7 @@
     "onItemClick": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: React.MouseEvent<HTMLDivElement, MouseEvent>, item: SeriesItemIdentifierWithType<SeriesType>) => void",
+        "type": "function(event: ChartsActivationEvent<HTMLDivElement>, item: SeriesItemIdentifierWithType<SeriesType>) => void",
         "describedArgs": ["event", "item"]
       }
     },

--- a/docs/pages/x/api/charts/heatmap.json
+++ b/docs/pages/x/api/charts/heatmap.json
@@ -27,7 +27,9 @@
     "desc": { "type": { "name": "string" } },
     "disableAxisListener": { "type": { "name": "bool" }, "default": "false" },
     "disableKeyboardNavigation": { "type": { "name": "bool" } },
-    "experimentalFeatures": { "type": { "name": "object" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ keyboardActivation?: bool }" }
+    },
     "height": { "type": { "name": "number" } },
     "hideLegend": { "type": { "name": "bool" } },
     "highlightedItem": {
@@ -61,7 +63,7 @@
     "onItemClick": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: React.MouseEvent<HTMLDivElement, MouseEvent>, item: SeriesItemIdentifierWithType<SeriesType>) => void",
+        "type": "function(event: ChartsActivationEvent<HTMLDivElement>, item: SeriesItemIdentifierWithType<SeriesType>) => void",
         "describedArgs": ["event", "item"]
       }
     },

--- a/docs/pages/x/api/charts/line-chart-pro.json
+++ b/docs/pages/x/api/charts/line-chart-pro.json
@@ -32,7 +32,10 @@
     "disableKeyboardNavigation": { "type": { "name": "bool" } },
     "disableLineItemHighlight": { "type": { "name": "bool" } },
     "experimentalFeatures": {
-      "type": { "name": "shape", "description": "{ enablePositionBasedPointerInteraction?: bool }" }
+      "type": {
+        "name": "shape",
+        "description": "{ enablePositionBasedPointerInteraction?: bool, keyboardActivation?: bool }"
+      }
     },
     "grid": {
       "type": { "name": "shape", "description": "{ horizontal?: bool, vertical?: bool }" }

--- a/docs/pages/x/api/charts/line-chart.json
+++ b/docs/pages/x/api/charts/line-chart.json
@@ -32,7 +32,10 @@
     "disableKeyboardNavigation": { "type": { "name": "bool" } },
     "disableLineItemHighlight": { "type": { "name": "bool" } },
     "experimentalFeatures": {
-      "type": { "name": "shape", "description": "{ enablePositionBasedPointerInteraction?: bool }" }
+      "type": {
+        "name": "shape",
+        "description": "{ enablePositionBasedPointerInteraction?: bool, keyboardActivation?: bool }"
+      }
     },
     "grid": {
       "type": { "name": "shape", "description": "{ horizontal?: bool, vertical?: bool }" }

--- a/docs/pages/x/api/charts/line-plot.json
+++ b/docs/pages/x/api/charts/line-plot.json
@@ -3,7 +3,7 @@
     "onItemClick": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: React.MouseEvent<SVGPathElement, MouseEvent>, lineItemIdentifier: LineItemClickIdentifier) => void",
+        "type": "function(event: ChartsActivationEvent<SVGElement>, lineItemIdentifier: LineItemClickIdentifier) => void",
         "describedArgs": ["event", "lineItemIdentifier"]
       }
     },

--- a/docs/pages/x/api/charts/map-shape-plot.json
+++ b/docs/pages/x/api/charts/map-shape-plot.json
@@ -4,7 +4,7 @@
     "onItemClick": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: React.MouseEvent<SVGPathElement, MouseEvent>, mapShapeItemIdentifier: MapShapeItemIdentifier) => void",
+        "type": "function(event: ChartsActivationEvent<SVGPathElement>, mapShapeItemIdentifier: MapShapeItemIdentifier) => void",
         "describedArgs": ["event", "mapShapeItemIdentifier"]
       }
     },

--- a/docs/pages/x/api/charts/mark-plot.json
+++ b/docs/pages/x/api/charts/mark-plot.json
@@ -3,7 +3,7 @@
     "onItemClick": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: React.MouseEvent<SVGPathElement, MouseEvent>, lineItemIdentifier: LineItemClickIdentifier) => void",
+        "type": "function(event: ChartsActivationEvent<SVGElement>, lineItemIdentifier: LineItemClickIdentifier) => void",
         "describedArgs": ["event", "lineItemIdentifier"]
       }
     },

--- a/docs/pages/x/api/charts/pie-arc-plot.json
+++ b/docs/pages/x/api/charts/pie-arc-plot.json
@@ -24,7 +24,7 @@
     "onItemClick": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: React.MouseEvent<SVGPathElement, MouseEvent>, pieItemIdentifier: PieItemIdentifier, item: DefaultizedPieValueType) => void",
+        "type": "function(event: ChartsActivationEvent<SVGPathElement>, pieItemIdentifier: PieItemIdentifier, item: DefaultizedPieValueType) => void",
         "describedArgs": ["event", "pieItemIdentifier", "item"]
       }
     },

--- a/docs/pages/x/api/charts/pie-chart-pro.json
+++ b/docs/pages/x/api/charts/pie-chart-pro.json
@@ -11,7 +11,9 @@
     "dataset": { "type": { "name": "arrayOf", "description": "Array&lt;object&gt;" } },
     "desc": { "type": { "name": "string" } },
     "disableKeyboardNavigation": { "type": { "name": "bool" } },
-    "experimentalFeatures": { "type": { "name": "object" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ keyboardActivation?: bool }" }
+    },
     "height": { "type": { "name": "number" } },
     "hiddenItems": {
       "type": {

--- a/docs/pages/x/api/charts/pie-chart.json
+++ b/docs/pages/x/api/charts/pie-chart.json
@@ -11,7 +11,9 @@
     "dataset": { "type": { "name": "arrayOf", "description": "Array&lt;object&gt;" } },
     "desc": { "type": { "name": "string" } },
     "disableKeyboardNavigation": { "type": { "name": "bool" } },
-    "experimentalFeatures": { "type": { "name": "object" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ keyboardActivation?: bool }" }
+    },
     "height": { "type": { "name": "number" } },
     "hiddenItems": {
       "type": {

--- a/docs/pages/x/api/charts/pie-plot.json
+++ b/docs/pages/x/api/charts/pie-plot.json
@@ -3,7 +3,7 @@
     "onItemClick": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: React.MouseEvent<SVGPathElement, MouseEvent>, pieItemIdentifier: PieItemIdentifier, item: DefaultizedPieValueType) => void",
+        "type": "function(event: ChartsActivationEvent<SVGPathElement>, pieItemIdentifier: PieItemIdentifier, item: DefaultizedPieValueType) => void",
         "describedArgs": ["event", "pieItemIdentifier", "item"]
       }
     },

--- a/docs/pages/x/api/charts/radar-chart-pro.json
+++ b/docs/pages/x/api/charts/radar-chart-pro.json
@@ -20,7 +20,9 @@
     "disableAxisListener": { "type": { "name": "bool" }, "default": "false" },
     "disableKeyboardNavigation": { "type": { "name": "bool" } },
     "divisions": { "type": { "name": "number" }, "default": "5" },
-    "experimentalFeatures": { "type": { "name": "object" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ keyboardActivation?: bool }" }
+    },
     "height": { "type": { "name": "number" } },
     "hiddenItems": {
       "type": {

--- a/docs/pages/x/api/charts/radar-chart.json
+++ b/docs/pages/x/api/charts/radar-chart.json
@@ -20,7 +20,9 @@
     "disableAxisListener": { "type": { "name": "bool" }, "default": "false" },
     "disableKeyboardNavigation": { "type": { "name": "bool" } },
     "divisions": { "type": { "name": "number" }, "default": "5" },
-    "experimentalFeatures": { "type": { "name": "object" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ keyboardActivation?: bool }" }
+    },
     "height": { "type": { "name": "number" } },
     "hiddenItems": {
       "type": {

--- a/docs/pages/x/api/charts/radar-series-area.json
+++ b/docs/pages/x/api/charts/radar-series-area.json
@@ -5,7 +5,7 @@
     "onItemClick": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: React.MouseEvent<SVGPathElement, MouseEvent>, radarItemIdentifier: RadarItemIdentifier) => void",
+        "type": "function(event: ChartsActivationEvent<SVGElement>, radarItemIdentifier: RadarItemIdentifier) => void",
         "describedArgs": ["event", "radarItemIdentifier"]
       }
     },

--- a/docs/pages/x/api/charts/radar-series-marks.json
+++ b/docs/pages/x/api/charts/radar-series-marks.json
@@ -5,7 +5,7 @@
     "onItemClick": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: React.MouseEvent<SVGPathElement, MouseEvent>, radarItemIdentifier: RadarItemIdentifier) => void",
+        "type": "function(event: ChartsActivationEvent<SVGElement>, radarItemIdentifier: RadarItemIdentifier) => void",
         "describedArgs": ["event", "radarItemIdentifier"]
       }
     },

--- a/docs/pages/x/api/charts/radial-bar-chart.json
+++ b/docs/pages/x/api/charts/radial-bar-chart.json
@@ -22,7 +22,9 @@
     "dataset": { "type": { "name": "arrayOf", "description": "Array&lt;object&gt;" } },
     "disableAxisListener": { "type": { "name": "bool" }, "default": "false" },
     "disableKeyboardNavigation": { "type": { "name": "bool" } },
-    "experimentalFeatures": { "type": { "name": "object" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ keyboardActivation?: bool }" }
+    },
     "grid": { "type": { "name": "shape", "description": "{ radius?: bool, rotation?: bool }" } },
     "height": { "type": { "name": "number" } },
     "hiddenItems": {

--- a/docs/pages/x/api/charts/radial-line-chart.json
+++ b/docs/pages/x/api/charts/radial-line-chart.json
@@ -23,7 +23,9 @@
     "disableAxisListener": { "type": { "name": "bool" }, "default": "false" },
     "disableKeyboardNavigation": { "type": { "name": "bool" } },
     "disableLineItemHighlight": { "type": { "name": "bool" } },
-    "experimentalFeatures": { "type": { "name": "object" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ keyboardActivation?: bool }" }
+    },
     "grid": { "type": { "name": "shape", "description": "{ radius?: bool, rotation?: bool }" } },
     "height": { "type": { "name": "number" } },
     "hiddenItems": {

--- a/docs/pages/x/api/charts/range-bar-plot.json
+++ b/docs/pages/x/api/charts/range-bar-plot.json
@@ -4,7 +4,7 @@
     "onItemClick": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: React.MouseEvent<SVGElement, MouseEvent>, barItemIdentifier: RangeBarItemIdentifier) => void",
+        "type": "function(event: ChartsActivationEvent<SVGElement>, barItemIdentifier: RangeBarItemIdentifier) => void",
         "describedArgs": ["event", "barItemIdentifier"]
       }
     },

--- a/docs/pages/x/api/charts/sankey-chart.json
+++ b/docs/pages/x/api/charts/sankey-chart.json
@@ -8,7 +8,9 @@
     },
     "desc": { "type": { "name": "string" } },
     "disableKeyboardNavigation": { "type": { "name": "bool" } },
-    "experimentalFeatures": { "type": { "name": "object" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ keyboardActivation?: bool }" }
+    },
     "height": { "type": { "name": "number" } },
     "highlightedItem": {
       "type": {

--- a/docs/pages/x/api/charts/sankey-data-provider.json
+++ b/docs/pages/x/api/charts/sankey-data-provider.json
@@ -6,7 +6,9 @@
     },
     "desc": { "type": { "name": "string" } },
     "disableKeyboardNavigation": { "type": { "name": "bool" } },
-    "experimentalFeatures": { "type": { "name": "object" } },
+    "experimentalFeatures": {
+      "type": { "name": "shape", "description": "{ keyboardActivation?: bool }" }
+    },
     "height": { "type": { "name": "number" } },
     "highlightedItem": {
       "type": {

--- a/docs/pages/x/api/charts/scatter-chart-premium.json
+++ b/docs/pages/x/api/charts/scatter-chart-premium.json
@@ -44,7 +44,10 @@
       "deprecationInfo": "Use <code>disableHitArea</code> instead."
     },
     "experimentalFeatures": {
-      "type": { "name": "shape", "description": "{ progressiveRendering?: bool }" }
+      "type": {
+        "name": "shape",
+        "description": "{ keyboardActivation?: bool, progressiveRendering?: bool }"
+      }
     },
     "grid": {
       "type": { "name": "shape", "description": "{ horizontal?: bool, vertical?: bool }" }

--- a/docs/pages/x/api/charts/scatter-chart-pro.json
+++ b/docs/pages/x/api/charts/scatter-chart-pro.json
@@ -44,7 +44,10 @@
       "deprecationInfo": "Use <code>disableHitArea</code> instead."
     },
     "experimentalFeatures": {
-      "type": { "name": "shape", "description": "{ progressiveRendering?: bool }" }
+      "type": {
+        "name": "shape",
+        "description": "{ keyboardActivation?: bool, progressiveRendering?: bool }"
+      }
     },
     "grid": {
       "type": { "name": "shape", "description": "{ horizontal?: bool, vertical?: bool }" }

--- a/docs/pages/x/api/charts/scatter-chart.json
+++ b/docs/pages/x/api/charts/scatter-chart.json
@@ -44,7 +44,10 @@
       "deprecationInfo": "Use <code>disableHitArea</code> instead."
     },
     "experimentalFeatures": {
-      "type": { "name": "shape", "description": "{ progressiveRendering?: bool }" }
+      "type": {
+        "name": "shape",
+        "description": "{ keyboardActivation?: bool, progressiveRendering?: bool }"
+      }
     },
     "grid": {
       "type": { "name": "shape", "description": "{ horizontal?: bool, vertical?: bool }" }

--- a/docs/pages/x/api/charts/scatter.json
+++ b/docs/pages/x/api/charts/scatter.json
@@ -5,7 +5,7 @@
     "onItemClick": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: MouseEvent, scatterItemIdentifier: ScatterItemIdentifier) => void",
+        "type": "function(event: ChartsActivationEvent<SVGElement>, scatterItemIdentifier: ScatterItemIdentifier) => void",
         "describedArgs": ["event", "scatterItemIdentifier"]
       }
     }

--- a/docs/pages/x/api/charts/spark-line-chart.json
+++ b/docs/pages/x/api/charts/spark-line-chart.json
@@ -38,7 +38,7 @@
     "experimentalFeatures": {
       "type": {
         "name": "shape",
-        "description": "{ enablePositionBasedPointerInteraction?: bool, progressiveRendering?: bool }"
+        "description": "{ enablePositionBasedPointerInteraction?: bool, keyboardActivation?: bool, progressiveRendering?: bool }"
       }
     },
     "height": { "type": { "name": "number" } },
@@ -107,7 +107,7 @@
     "onItemClick": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: MouseEvent, scatterItemIdentifier: ScatterItemIdentifier) => void",
+        "type": "function(event: ChartsActivationEvent, scatterItemIdentifier: ScatterItemIdentifier) => void",
         "describedArgs": ["event", "scatterItemIdentifier"]
       }
     },

--- a/docs/translations/api-docs/charts/charts-container/charts-container.json
+++ b/docs/translations/api-docs/charts/charts-container/charts-container.json
@@ -89,7 +89,7 @@
     "onItemClick": {
       "description": "Callback fired when clicking close to an item. This is only available for scatter plot for now.",
       "typeDescriptions": {
-        "event": { "name": "event", "description": "Mouse event caught at the svg level" },
+        "event": { "name": "event", "description": "Event caught at the svg level" },
         "scatterItemIdentifier": {
           "name": "scatterItemIdentifier",
           "description": "Identify which item got clicked"

--- a/docs/translations/api-docs/charts/scatter/scatter.json
+++ b/docs/translations/api-docs/charts/scatter/scatter.json
@@ -10,7 +10,7 @@
       "typeDescriptions": {
         "event": {
           "name": "event",
-          "description": "Mouse event recorded on the <code>&lt;svg/&gt;</code> element."
+          "description": "Event recorded on the <code>&lt;svg/&gt;</code> element."
         },
         "scatterItemIdentifier": {
           "name": "scatterItemIdentifier",

--- a/docs/translations/api-docs/charts/spark-line-chart/spark-line-chart.json
+++ b/docs/translations/api-docs/charts/spark-line-chart/spark-line-chart.json
@@ -99,7 +99,7 @@
     "onItemClick": {
       "description": "Callback fired when clicking close to an item. This is only available for scatter plot for now.",
       "typeDescriptions": {
-        "event": { "name": "event", "description": "Mouse event caught at the svg level" },
+        "event": { "name": "event", "description": "Event caught at the svg level" },
         "scatterItemIdentifier": {
           "name": "scatterItemIdentifier",
           "description": "Identify which item got clicked"

--- a/packages/x-charts-premium/src/BarChartPremium/BarChartPremium.tsx
+++ b/packages/x-charts-premium/src/BarChartPremium/BarChartPremium.tsx
@@ -23,6 +23,7 @@ import { ChartsZoomSlider } from '@mui/x-charts-pro/ChartsZoomSlider';
 import { ChartsBrushOverlay } from '@mui/x-charts/ChartsBrushOverlay';
 import { ChartsClipPath } from '@mui/x-charts/ChartsClipPath';
 import { useChartsContainerProProps } from '@mui/x-charts-pro/internals';
+import type { ChartsActivationEvent } from '@mui/x-charts/models';
 import type { BarChartPremiumPluginSignatures } from './BarChartPremium.plugins';
 import { useBarChartPremiumProps } from './useBarChartPremiumProps';
 import { BAR_CHART_PREMIUM_PLUGINS } from './BarChartPremium.plugins';
@@ -69,7 +70,10 @@ export interface BarChartPremiumProps
    * @param {MouseEvent} event The event source of the callback.
    * @param {BarItemIdentifier | RangeBarItemIdentifier} itemIdentifier The item identifier.
    */
-  onItemClick?(event: MouseEvent, itemIdentifier: BarItemIdentifier | RangeBarItemIdentifier): void;
+  onItemClick?(
+    event: ChartsActivationEvent,
+    itemIdentifier: BarItemIdentifier | RangeBarItemIdentifier,
+  ): void;
 
   /**
    * The series to display in the bar chart.
@@ -241,7 +245,9 @@ BarChartPremium.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.object,
+  experimentalFeatures: PropTypes.shape({
+    keyboardActivation: PropTypes.bool,
+  }),
   /**
    * Option to display a cartesian grid in the background.
    */

--- a/packages/x-charts-premium/src/BarChartPremium/BarPlotPremium.tsx
+++ b/packages/x-charts-premium/src/BarChartPremium/BarPlotPremium.tsx
@@ -65,7 +65,7 @@ BarPlotPremium.propTypes /* remove-proptypes */ = {
   className: PropTypes.string,
   /**
    * Callback fired when a bar item is clicked.
-   * @param {MouseEvent} event The event source of the callback.
+   * @param {ChartsActivationEvent} event The event source of the callback.
    * @param {BarItemIdentifier} barItemIdentifier The bar item identifier.
    */
   onItemClick: PropTypes.func,

--- a/packages/x-charts-premium/src/BarChartPremium/RangeBar/RangeBarPlot.tsx
+++ b/packages/x-charts-premium/src/BarChartPremium/RangeBar/RangeBarPlot.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
-import { useSkipAnimation } from '@mui/x-charts/internals';
+import { useSkipAnimation, useRegisterItemActivation } from '@mui/x-charts/internals';
 import { BarElement, barClasses } from '@mui/x-charts/BarChart';
 import type {
   BarElementSlotProps,
@@ -12,6 +12,7 @@ import type {
 } from '@mui/x-charts/BarChart';
 import { useDrawingArea, useXAxes, useYAxes } from '@mui/x-charts/hooks';
 import { useIsZoomInteracting } from '@mui/x-charts-pro/hooks';
+import type { ChartsActivationEvent } from '@mui/x-charts/models';
 import { useUtilityClasses } from './useUtilityClasses';
 import { useRangeBarPlotData } from './useRangeBarPlotData';
 import { AnimatedRangeBarElement } from './AnimatedRangeBarElement';
@@ -32,11 +33,11 @@ export interface RangeBarPlotProps {
   skipAnimation?: boolean;
   /**
    * Callback fired when a bar item is clicked.
-   * @param {React.MouseEvent<SVGElement, MouseEvent>} event The event source of the callback.
+   * @param {ChartsActivationEvent<SVGElement>} event The event source of the callback.
    * @param {RangeBarItemIdentifier} barItemIdentifier The range bar item identifier.
    */
   onItemClick?: (
-    event: React.MouseEvent<SVGElement, MouseEvent>,
+    event: ChartsActivationEvent<SVGElement>,
     barItemIdentifier: RangeBarItemIdentifier,
   ) => void;
   /**
@@ -99,6 +100,18 @@ function RangeBarSvgPlot(props: Omit<RangeBarPlotProps, 'renderer'>): React.JSX.
   const completedData = useRangeBarPlotData(useDrawingArea(), xAxes, yAxes);
 
   const classes = useUtilityClasses();
+
+  useRegisterItemActivation(
+    { type: 'rangeBar' },
+    onItemClick &&
+      ((event, item) =>
+        onItemClick(event, {
+          type: 'rangeBar',
+          seriesId: item.seriesId,
+          dataIndex: item.dataIndex,
+        })),
+  );
+
   const slots: BarElementSlots = {
     ...props.slots,
     bar: props.slots?.bar ?? AnimatedRangeBarElement,
@@ -156,7 +169,7 @@ RangeBarSvgPlot.propTypes /* remove-proptypes */ = {
   borderRadius: PropTypes.number,
   /**
    * Callback fired when a bar item is clicked.
-   * @param {React.MouseEvent<SVGElement, MouseEvent>} event The event source of the callback.
+   * @param {ChartsActivationEvent<SVGElement>} event The event source of the callback.
    * @param {RangeBarItemIdentifier} barItemIdentifier The range bar item identifier.
    */
   onItemClick: PropTypes.func,
@@ -188,7 +201,7 @@ RangeBarPlot.propTypes /* remove-proptypes */ = {
   borderRadius: PropTypes.number,
   /**
    * Callback fired when a bar item is clicked.
-   * @param {React.MouseEvent<SVGElement, MouseEvent>} event The event source of the callback.
+   * @param {ChartsActivationEvent<SVGElement>} event The event source of the callback.
    * @param {RangeBarItemIdentifier} barItemIdentifier The range bar item identifier.
    */
   onItemClick: PropTypes.func,

--- a/packages/x-charts-premium/src/ChartsDataProviderPremium/ChartsDataProviderPremium.tsx
+++ b/packages/x-charts-premium/src/ChartsDataProviderPremium/ChartsDataProviderPremium.tsx
@@ -131,7 +131,9 @@ ChartsDataProviderPremium.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.any,
+  experimentalFeatures: PropTypes.shape({
+    keyboardActivation: PropTypes.bool,
+  }),
   /**
    * The height of the chart in px. If not defined, it takes the height of the parent element.
    */

--- a/packages/x-charts-premium/src/ChartsGeoDataProviderPremium/ChartsGeoDataProviderPremium.tsx
+++ b/packages/x-charts-premium/src/ChartsGeoDataProviderPremium/ChartsGeoDataProviderPremium.tsx
@@ -105,7 +105,9 @@ ChartsGeoDataProviderPremium.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.any,
+  experimentalFeatures: PropTypes.shape({
+    keyboardActivation: PropTypes.bool,
+  }),
   /**
    * The height of the chart in px. If not defined, it takes the height of the parent element.
    */

--- a/packages/x-charts-premium/src/ChartsRadialDataProviderPremium/ChartsRadialDataProviderPremium.tsx
+++ b/packages/x-charts-premium/src/ChartsRadialDataProviderPremium/ChartsRadialDataProviderPremium.tsx
@@ -112,7 +112,9 @@ ChartsRadialDataProviderPremium.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.any,
+  experimentalFeatures: PropTypes.shape({
+    keyboardActivation: PropTypes.bool,
+  }),
   /**
    * The height of the chart in px. If not defined, it takes the height of the parent element.
    */

--- a/packages/x-charts-premium/src/HeatmapPremium/HeatmapPremium.tsx
+++ b/packages/x-charts-premium/src/HeatmapPremium/HeatmapPremium.tsx
@@ -139,7 +139,9 @@ HeatmapPremium.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.object,
+  experimentalFeatures: PropTypes.shape({
+    keyboardActivation: PropTypes.bool,
+  }),
   /**
    * The height of the chart in px. If not defined, it takes the height of the parent element.
    */
@@ -241,7 +243,7 @@ HeatmapPremium.propTypes /* remove-proptypes */ = {
   /**
    * The callback fired when an item is clicked.
    *
-   * @param {React.MouseEvent<HTMLDivElement, MouseEvent>} event The click event.
+   * @param {ChartsActivationEvent<HTMLDivElement>} event The click event.
    * @param {SeriesItemIdentifierWithType<SeriesType>} item The clicked item.
    */
   onItemClick: PropTypes.func,

--- a/packages/x-charts-premium/src/Map/MapShapePlot.tsx
+++ b/packages/x-charts-premium/src/Map/MapShapePlot.tsx
@@ -2,6 +2,8 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { useZAxes } from '@mui/x-charts/hooks';
+import { useRegisterItemActivation } from '@mui/x-charts/internals';
+import type { ChartsActivationEvent } from '@mui/x-charts/models';
 import type { MapShapeItemIdentifier } from '../models/seriesType/mapShape';
 import { useGeoData } from '../hooks/useGeoData';
 import { useGeoPath } from '../hooks/useGeoPath';
@@ -14,11 +16,11 @@ import { mapShapeSeriesConfig } from './seriesConfig';
 export interface MapShapePlotProps {
   /**
    * Callback fired when clicking on a map shape.
-   * @param {React.MouseEvent<SVGPathElement, MouseEvent>} event The event source of the callback.
+   * @param {ChartsActivationEvent<SVGPathElement>} event The event source of the callback.
    * @param {MapShapeItemIdentifier} mapShapeItemIdentifier The identifier of the clicked map shape.
    */
   onItemClick?: (
-    event: React.MouseEvent<SVGPathElement, MouseEvent>,
+    event: ChartsActivationEvent<SVGPathElement>,
     mapShapeItemIdentifier: MapShapeItemIdentifier,
   ) => void;
   className?: string;
@@ -48,6 +50,13 @@ function MapShapePlot(props: MapShapePlotProps) {
   const series = useMapShapeSeries();
   const featureIndexesByName = useGeoFeatureIndexesByName();
   const { zAxis, zAxisIds } = useZAxes();
+
+  useRegisterItemActivation(
+    { type: 'mapShape' },
+    onItemClick &&
+      ((event, item) =>
+        onItemClick(event, { type: 'mapShape', seriesId: item.seriesId, name: item.name })),
+  );
 
   if (!geoData || !path || series.length === 0) {
     return null;
@@ -128,7 +137,7 @@ MapShapePlot.propTypes /* remove-proptypes */ = {
   fill: PropTypes.string,
   /**
    * Callback fired when clicking on a map shape.
-   * @param {React.MouseEvent<SVGPathElement, MouseEvent>} event The event source of the callback.
+   * @param {ChartsActivationEvent<SVGPathElement>} event The event source of the callback.
    * @param {MapShapeItemIdentifier} mapShapeItemIdentifier The identifier of the clicked map shape.
    */
   onItemClick: PropTypes.func,

--- a/packages/x-charts-premium/src/RadialBarChart/RadialBarChart.tsx
+++ b/packages/x-charts-premium/src/RadialBarChart/RadialBarChart.tsx
@@ -203,7 +203,9 @@ RadialBarChart.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.object,
+  experimentalFeatures: PropTypes.shape({
+    keyboardActivation: PropTypes.bool,
+  }),
   /**
    * Option to display a radial grid in the background.
    */

--- a/packages/x-charts-premium/src/RadialLineChart/RadialLineChart.tsx
+++ b/packages/x-charts-premium/src/RadialLineChart/RadialLineChart.tsx
@@ -220,7 +220,9 @@ RadialLineChart.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.object,
+  experimentalFeatures: PropTypes.shape({
+    keyboardActivation: PropTypes.bool,
+  }),
   /**
    * Option to display a radial grid in the background.
    */

--- a/packages/x-charts-premium/src/ScatterChartPremium/ScatterChartPremium.tsx
+++ b/packages/x-charts-premium/src/ScatterChartPremium/ScatterChartPremium.tsx
@@ -250,6 +250,7 @@ ScatterChartPremium.propTypes /* remove-proptypes */ = {
    * Options to enable features planned for the next major.
    */
   experimentalFeatures: PropTypes.shape({
+    keyboardActivation: PropTypes.bool,
     progressiveRendering: PropTypes.bool,
   }),
   /**

--- a/packages/x-charts-premium/src/tests/keyboardActivation.test.tsx
+++ b/packages/x-charts-premium/src/tests/keyboardActivation.test.tsx
@@ -1,0 +1,101 @@
+import { createRenderer } from '@mui/internal-test-utils';
+import { vi } from 'vitest';
+import { ChartsLayerContainer } from '@mui/x-charts/ChartsLayerContainer';
+import { ChartsSvgLayer } from '@mui/x-charts/ChartsSvgLayer';
+import type { ExtendedFeatureCollection } from '@mui/x-charts-vendor/d3-geo';
+import { BarChartPremium } from '@mui/x-charts-premium/BarChartPremium';
+import { Unstable_ChartsGeoDataProviderPremium as ChartsGeoDataProviderPremium } from '../ChartsGeoDataProviderPremium';
+import { MapShapePlot } from '../Map/MapShapePlot';
+
+const geoData = {
+  type: 'FeatureCollection',
+  features: [
+    {
+      type: 'Feature',
+      properties: { name: 'A' },
+      geometry: {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [0, 0],
+            [10, 0],
+            [10, 10],
+            [0, 10],
+            [0, 0],
+          ],
+        ],
+      },
+    },
+  ],
+} as unknown as ExtendedFeatureCollection;
+
+describe('keyboard item activation - premium charts', () => {
+  const { render } = createRenderer();
+
+  it('should fire onItemClick with the focused range bar item', async () => {
+    const onItemClick = vi.fn();
+    const { user } = render(
+      <BarChartPremium
+        height={100}
+        width={100}
+        margin={0}
+        skipAnimation
+        series={[
+          {
+            type: 'rangeBar',
+            id: 'A',
+            data: [
+              [1, 4],
+              [2, 5],
+            ],
+          },
+        ]}
+        xAxis={[{ scaleType: 'band', data: ['a', 'b'] }]}
+        onItemClick={onItemClick}
+        experimentalFeatures={{ keyboardActivation: true }}
+      />,
+    );
+
+    await user.keyboard('{Tab}');
+    await user.keyboard('[ArrowRight]');
+    await user.keyboard('[Enter]');
+
+    expect(onItemClick.mock.calls.length).to.equal(1);
+    expect(onItemClick.mock.lastCall?.[1]).to.deep.equal({
+      type: 'rangeBar',
+      seriesId: 'A',
+      dataIndex: 0,
+    });
+  });
+
+  it('should fire onItemClick with the focused map shape', async () => {
+    const onItemClick = vi.fn();
+    const { user } = render(
+      <ChartsGeoDataProviderPremium
+        geoData={geoData}
+        projection="naturalEarth1"
+        width={400}
+        height={400}
+        series={[{ type: 'mapShape', id: 's1', data: [{ name: 'A' }] }]}
+        experimentalFeatures={{ keyboardActivation: true }}
+      >
+        <ChartsLayerContainer>
+          <ChartsSvgLayer>
+            <MapShapePlot onItemClick={onItemClick} />
+          </ChartsSvgLayer>
+        </ChartsLayerContainer>
+      </ChartsGeoDataProviderPremium>,
+    );
+
+    await user.keyboard('{Tab}');
+    await user.keyboard('[ArrowRight]');
+    await user.keyboard('[Enter]');
+
+    expect(onItemClick.mock.calls.length).to.equal(1);
+    expect(onItemClick.mock.lastCall?.[1]).to.deep.equal({
+      type: 'mapShape',
+      seriesId: 's1',
+      name: 'A',
+    });
+  });
+});

--- a/packages/x-charts-pro/src/BarChartPro/BarChartPro.tsx
+++ b/packages/x-charts-pro/src/BarChartPro/BarChartPro.tsx
@@ -206,7 +206,9 @@ BarChartPro.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.object,
+  experimentalFeatures: PropTypes.shape({
+    keyboardActivation: PropTypes.bool,
+  }),
   /**
    * Option to display a cartesian grid in the background.
    */
@@ -416,7 +418,7 @@ BarChartPro.propTypes /* remove-proptypes */ = {
   onHighlightedAxisChange: PropTypes.func,
   /**
    * Callback fired when a bar item is clicked.
-   * @param {MouseEvent} event The event source of the callback.
+   * @param {ChartsActivationEvent} event The event source of the callback.
    * @param {BarItemIdentifier} barItemIdentifier The bar item identifier.
    */
   onItemClick: PropTypes.func,

--- a/packages/x-charts-pro/src/ChartsDataProviderPro/ChartsDataProviderPro.tsx
+++ b/packages/x-charts-pro/src/ChartsDataProviderPro/ChartsDataProviderPro.tsx
@@ -128,7 +128,9 @@ ChartsDataProviderPro.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.any,
+  experimentalFeatures: PropTypes.shape({
+    keyboardActivation: PropTypes.bool,
+  }),
   /**
    * The height of the chart in px. If not defined, it takes the height of the parent element.
    */

--- a/packages/x-charts-pro/src/FunnelChart/FunnelChart.tsx
+++ b/packages/x-charts-pro/src/FunnelChart/FunnelChart.tsx
@@ -259,7 +259,9 @@ FunnelChart.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.object,
+  experimentalFeatures: PropTypes.shape({
+    keyboardActivation: PropTypes.bool,
+  }),
   /**
    * The gap, in pixels, between funnel sections.
    * @default 0
@@ -407,7 +409,7 @@ FunnelChart.propTypes /* remove-proptypes */ = {
   onHighlightChange: PropTypes.func,
   /**
    * Callback fired when a funnel item is clicked.
-   * @param {React.MouseEvent<SVGElement, MouseEvent>} event The event source of the callback.
+   * @param {ChartsActivationEvent<SVGElement>} event The event source of the callback.
    * @param {FunnelItemIdentifier} funnelItemIdentifier The funnel item identifier.
    */
   onItemClick: PropTypes.func,

--- a/packages/x-charts-pro/src/FunnelChart/FunnelPlot.tsx
+++ b/packages/x-charts-pro/src/FunnelChart/FunnelPlot.tsx
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 
 import { line as d3Line } from '@mui/x-charts-vendor/d3-shape';
-import { cartesianSeriesTypes, useStore } from '@mui/x-charts/internals';
+import { cartesianSeriesTypes, useRegisterItemActivation, useStore } from '@mui/x-charts/internals';
+import type { ChartsActivationEvent } from '@mui/x-charts/models';
 import type { FunnelItemIdentifier } from './funnel.types';
 import { FunnelSection } from './FunnelSection';
 import { alignLabel, positionLabel } from './labelUtils';
@@ -30,11 +31,11 @@ export interface FunnelPlotProps extends FunnelPlotSlotExtension {
   className?: string;
   /**
    * Callback fired when a funnel item is clicked.
-   * @param {React.MouseEvent<SVGElement, MouseEvent>} event The event source of the callback.
+   * @param {ChartsActivationEvent<SVGElement>} event The event source of the callback.
    * @param {FunnelItemIdentifier} funnelItemIdentifier The funnel item identifier.
    */
   onItemClick?: (
-    event: React.MouseEvent<SVGElement, MouseEvent>,
+    event: ChartsActivationEvent<SVGElement>,
     funnelItemIdentifier: FunnelItemIdentifier,
   ) => void;
 }
@@ -144,6 +145,17 @@ function FunnelPlot(props: FunnelPlotProps) {
   const data = useAggregatedData();
   const classes = useUtilityClasses();
 
+  useRegisterItemActivation(
+    { type: 'funnel' },
+    onItemClick &&
+      ((event, item) =>
+        onItemClick(event, {
+          type: 'funnel',
+          seriesId: item.seriesId,
+          dataIndex: item.dataIndex,
+        })),
+  );
+
   return (
     <g className={clsx(classes.root, className)}>
       {data.map((series) => {
@@ -214,7 +226,7 @@ FunnelPlot.propTypes /* remove-proptypes */ = {
   className: PropTypes.string,
   /**
    * Callback fired when a funnel item is clicked.
-   * @param {React.MouseEvent<SVGElement, MouseEvent>} event The event source of the callback.
+   * @param {ChartsActivationEvent<SVGElement>} event The event source of the callback.
    * @param {FunnelItemIdentifier} funnelItemIdentifier The funnel item identifier.
    */
   onItemClick: PropTypes.func,

--- a/packages/x-charts-pro/src/Heatmap/Heatmap.tsx
+++ b/packages/x-charts-pro/src/Heatmap/Heatmap.tsx
@@ -233,7 +233,9 @@ Heatmap.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.object,
+  experimentalFeatures: PropTypes.shape({
+    keyboardActivation: PropTypes.bool,
+  }),
   /**
    * The height of the chart in px. If not defined, it takes the height of the parent element.
    */
@@ -335,7 +337,7 @@ Heatmap.propTypes /* remove-proptypes */ = {
   /**
    * The callback fired when an item is clicked.
    *
-   * @param {React.MouseEvent<HTMLDivElement, MouseEvent>} event The click event.
+   * @param {ChartsActivationEvent<HTMLDivElement>} event The click event.
    * @param {SeriesItemIdentifierWithType<SeriesType>} item The clicked item.
    */
   onItemClick: PropTypes.func,

--- a/packages/x-charts-pro/src/Heatmap/seriesConfig/getItemWithData.ts
+++ b/packages/x-charts-pro/src/Heatmap/seriesConfig/getItemWithData.ts
@@ -1,0 +1,21 @@
+import type {
+  ChartState,
+  UseChartCartesianAxisSignature,
+  ProcessedSeries,
+} from '@mui/x-charts/internals';
+import { selectorAllSeriesOfType } from '@mui/x-charts/internals';
+import type { SeriesItemIdentifierWithData } from '@mui/x-charts/models';
+import type { HeatmapItemIdentifier } from '../../models/seriesType/heatmap';
+
+export default function getItemWithData(
+  state: ChartState<[UseChartCartesianAxisSignature]>,
+  identifier: HeatmapItemIdentifier,
+): SeriesItemIdentifierWithData<'heatmap'> {
+  const series = selectorAllSeriesOfType(state, 'heatmap') as ProcessedSeries['heatmap'];
+  const { xIndex, yIndex } = identifier;
+
+  return {
+    ...identifier,
+    value: series?.series[identifier.seriesId]?.heatmapData.getValue(xIndex, yIndex) ?? null,
+  };
+}

--- a/packages/x-charts-pro/src/Heatmap/seriesConfig/index.ts
+++ b/packages/x-charts-pro/src/Heatmap/seriesConfig/index.ts
@@ -7,6 +7,7 @@ import tooltipGetter from './tooltip';
 import getSeriesWithDefaultValues from './getSeriesWithDefaultValues';
 import { selectorTooltipItemPosition } from './tooltipPosition';
 import getItemAtPosition from './getItemAtPosition';
+import getItemWithData from './getItemWithData';
 import keyboardFocusHandler from './keyboardFocusHandler';
 import { createIsFaded, createIsHighlighted } from './highlight';
 import identifierSerializer from './identifierSerializer';
@@ -27,6 +28,7 @@ export const heatmapSeriesConfig: ChartSeriesTypeConfig<'heatmap'> = {
   identifierSerializer,
   identifierCleaner,
   getItemAtPosition,
+  getItemWithData,
   keyboardFocusHandler,
   descriptionGetter,
   isHighlightedCreator: createIsHighlighted,

--- a/packages/x-charts-pro/src/Heatmap/useHeatmapProps.ts
+++ b/packages/x-charts-pro/src/Heatmap/useHeatmapProps.ts
@@ -67,6 +67,7 @@ export function useHeatmapProps(props: UseHeatmapProps) {
     highlightedItem,
     onHighlightChange,
     disableKeyboardNavigation,
+    experimentalFeatures,
     borderRadius,
     hideLegend,
   } = props;
@@ -140,6 +141,7 @@ export function useHeatmapProps(props: UseHeatmapProps) {
       highlightedItem,
       onHighlightChange,
       disableKeyboardNavigation,
+      experimentalFeatures,
       onItemClick,
       plugins: HEATMAP_PLUGINS,
     };

--- a/packages/x-charts-pro/src/LineChartPro/LineChartPro.tsx
+++ b/packages/x-charts-pro/src/LineChartPro/LineChartPro.tsx
@@ -222,6 +222,7 @@ LineChartPro.propTypes /* remove-proptypes */ = {
    */
   experimentalFeatures: PropTypes.shape({
     enablePositionBasedPointerInteraction: PropTypes.bool,
+    keyboardActivation: PropTypes.bool,
   }),
   /**
    * Option to display a cartesian grid in the background.

--- a/packages/x-charts-pro/src/PieChartPro/PieChartPro.tsx
+++ b/packages/x-charts-pro/src/PieChartPro/PieChartPro.tsx
@@ -157,7 +157,9 @@ PieChartPro.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.object,
+  experimentalFeatures: PropTypes.shape({
+    keyboardActivation: PropTypes.bool,
+  }),
   /**
    * The height of the chart in px. If not defined, it takes the height of the parent element.
    */

--- a/packages/x-charts-pro/src/RadarChartPro/RadarChartPro.tsx
+++ b/packages/x-charts-pro/src/RadarChartPro/RadarChartPro.tsx
@@ -155,7 +155,9 @@ RadarChartPro.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.object,
+  experimentalFeatures: PropTypes.shape({
+    keyboardActivation: PropTypes.bool,
+  }),
   /**
    * The height of the chart in px. If not defined, it takes the height of the parent element.
    */

--- a/packages/x-charts-pro/src/SankeyChart/SankeyChart.tsx
+++ b/packages/x-charts-pro/src/SankeyChart/SankeyChart.tsx
@@ -116,7 +116,9 @@ SankeyChart.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.object,
+  experimentalFeatures: PropTypes.shape({
+    keyboardActivation: PropTypes.bool,
+  }),
   /**
    * The height of the chart in px. If not defined, it takes the height of the parent element.
    */

--- a/packages/x-charts-pro/src/SankeyChart/SankeyDataProvider.tsx
+++ b/packages/x-charts-pro/src/SankeyChart/SankeyDataProvider.tsx
@@ -67,7 +67,9 @@ SankeyDataProvider.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.object,
+  experimentalFeatures: PropTypes.shape({
+    keyboardActivation: PropTypes.bool,
+  }),
   /**
    * The height of the chart in px. If not defined, it takes the height of the parent element.
    */

--- a/packages/x-charts-pro/src/SankeyChart/SankeyPlot.tsx
+++ b/packages/x-charts-pro/src/SankeyChart/SankeyPlot.tsx
@@ -3,6 +3,8 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { styled } from '@mui/material/styles';
+import { useRegisterItemActivation } from '@mui/x-charts/internals';
+import type { ChartsActivationEvent } from '@mui/x-charts/models';
 import type { SankeyLinkIdentifierWithData, SankeyNodeIdentifierWithData } from './sankey.types';
 import { useSankeyLayout, useSankeySeries } from '../hooks/useSankeySeries';
 import { useUtilityClasses } from './sankeyClasses';
@@ -27,7 +29,7 @@ export interface SankeyPlotProps {
    * @param {SankeyNodeIdentifierWithData} node The sankey node identifier.
    */
   onNodeClick?: (
-    event: React.MouseEvent<SVGElement, MouseEvent>,
+    event: ChartsActivationEvent<SVGElement>,
     node: SankeyNodeIdentifierWithData,
   ) => void;
   /**
@@ -36,7 +38,7 @@ export interface SankeyPlotProps {
    * @param {SankeyLinkIdentifierWithData} link The sankey link identifier.
    */
   onLinkClick?: (
-    event: React.MouseEvent<SVGElement, MouseEvent>,
+    event: ChartsActivationEvent<SVGElement>,
     link: SankeyLinkIdentifierWithData,
   ) => void;
 }
@@ -56,6 +58,47 @@ function SankeyPlot(props: SankeyPlotProps) {
 
   const sankeySeries = useSankeySeries()[0];
   const layout = useSankeyLayout();
+
+  useRegisterItemActivation(
+    { type: 'sankey' },
+    (onNodeClick || onLinkClick) &&
+      ((event, item) => {
+        if (item.subType === 'node') {
+          const node = layout?.nodes?.find((candidate) => candidate.id === item.nodeId);
+
+          if (!onNodeClick || !node) {
+            return;
+          }
+
+          onNodeClick(event, {
+            type: 'sankey',
+            seriesId: item.seriesId,
+            subType: 'node',
+            nodeId: node.id,
+            node,
+          });
+          return;
+        }
+
+        const link = layout?.links?.find(
+          (candidate) =>
+            candidate.source.id === item.sourceId && candidate.target.id === item.targetId,
+        );
+
+        if (!onLinkClick || !link) {
+          return;
+        }
+
+        onLinkClick(event, {
+          type: 'sankey',
+          seriesId: item.seriesId,
+          subType: 'link',
+          sourceId: link.source.id,
+          targetId: link.target.id,
+          link,
+        });
+      }),
+  );
 
   if (!sankeySeries) {
     throw new Error(

--- a/packages/x-charts-pro/src/ScatterChartPro/ScatterChartPro.tsx
+++ b/packages/x-charts-pro/src/ScatterChartPro/ScatterChartPro.tsx
@@ -225,6 +225,7 @@ ScatterChartPro.propTypes /* remove-proptypes */ = {
    * Options to enable features planned for the next major.
    */
   experimentalFeatures: PropTypes.shape({
+    keyboardActivation: PropTypes.bool,
     progressiveRendering: PropTypes.bool,
   }),
   /**

--- a/packages/x-charts-pro/src/tests/keyboardActivation.test.tsx
+++ b/packages/x-charts-pro/src/tests/keyboardActivation.test.tsx
@@ -1,0 +1,105 @@
+import { createRenderer } from '@mui/internal-test-utils';
+import { vi } from 'vitest';
+import { FunnelChart } from '@mui/x-charts-pro/FunnelChart';
+import { Heatmap } from '@mui/x-charts-pro/Heatmap';
+import { SankeyChart } from '@mui/x-charts-pro/SankeyChart';
+
+describe('keyboard item activation - pro charts', () => {
+  const { render } = createRenderer();
+
+  const config = {
+    height: 100,
+    width: 100,
+    margin: 0,
+    skipAnimation: true,
+    hideLegend: true,
+  } as const;
+
+  it('should fire onItemClick with the focused funnel section', async () => {
+    const onItemClick = vi.fn();
+    const { user } = render(
+      <FunnelChart
+        {...config}
+        series={[{ id: 'A', data: [{ value: 200 }, { value: 100 }] }]}
+        onItemClick={onItemClick}
+        experimentalFeatures={{ keyboardActivation: true }}
+      />,
+    );
+
+    await user.keyboard('{Tab}');
+    await user.keyboard('[ArrowRight]');
+    await user.keyboard('[Enter]');
+
+    expect(onItemClick.mock.calls.length).to.equal(1);
+    expect(onItemClick.mock.lastCall?.[1]).to.deep.equal({
+      type: 'funnel',
+      seriesId: 'A',
+      dataIndex: 0,
+    });
+  });
+
+  it('should fire onItemClick with the focused heatmap cell', async () => {
+    const onItemClick = vi.fn();
+    const { user } = render(
+      <Heatmap
+        {...config}
+        xAxis={[{ data: ['A', 'B'] }]}
+        yAxis={[{ data: ['X', 'Y'] }]}
+        series={[
+          {
+            id: 'S',
+            data: [
+              [0, 0, 1],
+              [0, 1, 2],
+              [1, 0, 3],
+              [1, 1, 4],
+            ],
+          },
+        ]}
+        onItemClick={onItemClick}
+        experimentalFeatures={{ keyboardActivation: true }}
+      />,
+    );
+
+    await user.keyboard('{Tab}');
+    await user.keyboard('[ArrowRight]');
+    await user.keyboard('[Enter]');
+
+    expect(onItemClick.mock.calls.length).to.equal(1);
+    expect(onItemClick.mock.lastCall?.[1]).to.deep.equal({
+      type: 'heatmap',
+      seriesId: 'S',
+      xIndex: 0,
+      yIndex: 0,
+      value: 1,
+    });
+  });
+
+  it('should fire onNodeClick with the focused sankey node', async () => {
+    const onNodeClick = vi.fn();
+    const { user } = render(
+      <SankeyChart
+        height={100}
+        width={100}
+        margin={0}
+        series={{
+          data: {
+            links: [
+              { source: 'a', target: 'b', value: 5 },
+              { source: 'b', target: 'c', value: 5 },
+            ],
+          },
+        }}
+        onNodeClick={onNodeClick}
+        experimentalFeatures={{ keyboardActivation: true }}
+      />,
+    );
+
+    await user.keyboard('{Tab}');
+    await user.keyboard('[ArrowRight]');
+    await user.keyboard('[Enter]');
+
+    expect(onNodeClick.mock.calls.length).to.equal(1);
+    expect(onNodeClick.mock.lastCall?.[1].subType).to.equal('node');
+  });
+});

--- a/packages/x-charts/src/BarChart/BarChart.tsx
+++ b/packages/x-charts/src/BarChart/BarChart.tsx
@@ -228,7 +228,9 @@ BarChart.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.object,
+  experimentalFeatures: PropTypes.shape({
+    keyboardActivation: PropTypes.bool,
+  }),
   /**
    * Option to display a cartesian grid in the background.
    */
@@ -400,7 +402,7 @@ BarChart.propTypes /* remove-proptypes */ = {
   onHighlightedAxisChange: PropTypes.func,
   /**
    * Callback fired when a bar item is clicked.
-   * @param {MouseEvent | React.MouseEvent<SVGElement, MouseEvent>} event The event source of the callback.
+   * @param {ChartsActivationEvent | ChartsActivationEvent<SVGElement>} event The event source of the callback.
    *        It is a native MouseEvent for `svg-batch` renderer and a React MouseEvent for `svg-single` renderer.
    * @param {BarItemIdentifier} barItemIdentifier The bar item identifier.
    */

--- a/packages/x-charts/src/BarChart/BarPlot.tsx
+++ b/packages/x-charts/src/BarChart/BarPlot.tsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { styled } from '@mui/material/styles';
 import type { BarElementSlotProps, BarElementSlots } from './BarElement';
-import type { BarItemIdentifier } from '../models';
+import type { BarItemIdentifier, ChartsActivationEvent } from '../models';
 import { useDrawingArea, useXAxes, useYAxes } from '../hooks';
 import type { BarLabelSlotProps, BarLabelSlots } from './BarLabel/BarLabelItem';
 import { BarLabelPlot } from './BarLabel/BarLabelPlot';
@@ -33,10 +33,10 @@ export interface BarPlotProps {
   skipAnimation?: boolean;
   /**
    * Callback fired when a bar item is clicked.
-   * @param {MouseEvent} event The event source of the callback.
+   * @param {ChartsActivationEvent} event The event source of the callback.
    * @param {BarItemIdentifier} barItemIdentifier The bar item identifier.
    */
-  onItemClick?(event: MouseEvent, barItemIdentifier: BarItemIdentifier): void;
+  onItemClick?(event: ChartsActivationEvent, barItemIdentifier: BarItemIdentifier): void;
   /**
    * Defines the border radius of the bar element.
    */
@@ -144,7 +144,7 @@ BarPlot.propTypes /* remove-proptypes */ = {
   className: PropTypes.string,
   /**
    * Callback fired when a bar item is clicked.
-   * @param {MouseEvent | React.MouseEvent<SVGElement, MouseEvent>} event The event source of the callback.
+   * @param {ChartsActivationEvent | ChartsActivationEvent<SVGElement>} event The event source of the callback.
    *        It is a native MouseEvent for `svg-batch` renderer and a React MouseEvent for `svg-single` renderer.
    * @param {BarItemIdentifier} barItemIdentifier The bar item identifier.
    */

--- a/packages/x-charts/src/BarChart/BatchBarPlot/BatchBarPlot.tsx
+++ b/packages/x-charts/src/BarChart/BatchBarPlot/BatchBarPlot.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import type { BarItemIdentifier } from '../../models';
+import type { BarItemIdentifier, ChartsActivationEvent } from '../../models';
 import type { ProcessedBarSeriesData } from '../types';
 import { useUtilityClasses } from '../barClasses';
 import type { IndividualBarPlotProps } from '../IndividualBarPlot';
@@ -17,7 +17,7 @@ import { createPath, useCreateBarPaths } from './useCreateBarPaths';
 import { BarGroup } from './BarGroup';
 
 interface BatchBarPlotProps extends Omit<IndividualBarPlotProps, 'onItemClick'> {
-  onItemClick?: (event: MouseEvent, barItemIdentifier: BarItemIdentifier) => void;
+  onItemClick?: (event: ChartsActivationEvent, barItemIdentifier: BarItemIdentifier) => void;
 }
 
 export function BatchBarPlot({

--- a/packages/x-charts/src/BarChart/IndividualBarPlot.tsx
+++ b/packages/x-charts/src/BarChart/IndividualBarPlot.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import type { BarPlotSlotProps, BarPlotSlots } from './BarPlot';
-import type { BarItemIdentifier } from '../models';
+import type { BarItemIdentifier, ChartsActivationEvent } from '../models';
 import { BarElement } from './BarElement';
 import type { MaskData, ProcessedBarSeriesData } from './types';
 import { useUtilityClasses } from './barClasses';
@@ -12,7 +12,7 @@ export interface IndividualBarPlotProps {
   masksData: MaskData[];
   borderRadius?: number;
   skipAnimation?: boolean;
-  onItemClick?: (event: MouseEvent, barItemIdentifier: BarItemIdentifier) => void;
+  onItemClick?: (event: ChartsActivationEvent, barItemIdentifier: BarItemIdentifier) => void;
   slotProps?: BarPlotSlotProps;
   slots?: BarPlotSlots;
 }

--- a/packages/x-charts/src/BarChart/useRegisterItemClickHandlers.ts
+++ b/packages/x-charts/src/BarChart/useRegisterItemClickHandlers.ts
@@ -10,13 +10,16 @@ import { useChartsContext } from '../context/ChartsProvider';
 import { getChartPoint } from '../internals/getChartPoint';
 import { useStore } from '../internals/store/useStore';
 import { selectorBarItemAtPosition } from '../internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxisPosition.selectors';
+import { useRegisterItemActivation } from '../internals/useRegisterItemActivation';
+import type { ChartsActivationEvent } from '../models/events';
 
 /**
  * Hook that registers pointer event handlers for chart item clicking.
  * @param onItemClick Callback for item click events.
  */
 export function useRegisterItemClickHandlers(
-  onItemClick: ((event: MouseEvent, barItemIdentifier: BarItemIdentifier) => void) | undefined,
+  onItemClick:
+    ((event: ChartsActivationEvent, barItemIdentifier: BarItemIdentifier) => void) | undefined,
 ) {
   const { instance } =
     useChartsContext<
@@ -24,6 +27,17 @@ export function useRegisterItemClickHandlers(
     >();
   const chartsLayerContainerRef = useChartsLayerContainerRef();
   const store = useStore<[UseChartCartesianAxisSignature, UseChartHighlightSignature<'bar'>]>();
+
+  useRegisterItemActivation(
+    { type: 'bar' },
+    onItemClick &&
+      ((event, item) =>
+        onItemClick(event, {
+          type: 'bar',
+          seriesId: item.seriesId,
+          dataIndex: item.dataIndex,
+        })),
+  );
 
   React.useEffect(() => {
     const element = chartsLayerContainerRef.current;

--- a/packages/x-charts/src/ChartsContainer/ChartsContainer.tsx
+++ b/packages/x-charts/src/ChartsContainer/ChartsContainer.tsx
@@ -123,7 +123,9 @@ ChartsContainer.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.any,
+  experimentalFeatures: PropTypes.shape({
+    keyboardActivation: PropTypes.bool,
+  }),
   /**
    * The height of the chart in px. If not defined, it takes the height of the parent element.
    */
@@ -281,7 +283,7 @@ ChartsContainer.propTypes /* remove-proptypes */ = {
   /**
    * Callback fired when clicking close to an item.
    * This is only available for scatter plot for now.
-   * @param {MouseEvent} event Mouse event caught at the svg level
+   * @param {ChartsActivationEvent} event Event caught at the svg level
    * @param {ScatterItemIdentifier} scatterItemIdentifier Identify which item got clicked
    */
   onItemClick: PropTypes.func,

--- a/packages/x-charts/src/ChartsDataProvider/ChartsDataProvider.tsx
+++ b/packages/x-charts/src/ChartsDataProvider/ChartsDataProvider.tsx
@@ -106,7 +106,9 @@ ChartsDataProvider.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.any,
+  experimentalFeatures: PropTypes.shape({
+    keyboardActivation: PropTypes.bool,
+  }),
   /**
    * The height of the chart in px. If not defined, it takes the height of the parent element.
    */

--- a/packages/x-charts/src/ChartsRadialDataProvider/ChartsRadialDataProvider.tsx
+++ b/packages/x-charts/src/ChartsRadialDataProvider/ChartsRadialDataProvider.tsx
@@ -91,7 +91,9 @@ ChartsRadialDataProvider.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.any,
+  experimentalFeatures: PropTypes.shape({
+    keyboardActivation: PropTypes.bool,
+  }),
   /**
    * The height of the chart in px. If not defined, it takes the height of the parent element.
    */

--- a/packages/x-charts/src/LineChart/AreaPlot.tsx
+++ b/packages/x-charts/src/LineChart/AreaPlot.tsx
@@ -6,11 +6,12 @@ import clsx from 'clsx';
 import { AreaElement } from './AreaElement';
 import type { AreaElementProps, AreaElementSlotProps, AreaElementSlots } from './AreaElement';
 import type { LineItemClickIdentifier } from '../models/seriesType/line';
+import type { ChartsActivationEvent } from '../models/events';
 import { useSkipAnimation } from '../hooks/useSkipAnimation';
 import { useXAxes, useYAxes } from '../hooks/useAxis';
 import { useInternalIsZoomInteracting } from '../internals/plugins/featurePlugins/useChartCartesianAxis/useInternalIsZoomInteracting';
 import { useAreaPlotData } from './useAreaPlotData';
-import { useLineItemClickHandler } from './useLineItemClickHandler';
+import { LINE_ACTIVATION_PRIORITY, useLineItemClickHandler } from './useLineItemClickHandler';
 import { ANIMATION_DURATION_MS, ANIMATION_TIMING_FUNCTION } from '../internals/animation/animation';
 import { lineClasses, useUtilityClasses } from './lineClasses';
 
@@ -24,11 +25,11 @@ export interface AreaPlotProps
     Pick<AreaElementProps, 'slots' | 'slotProps' | 'skipAnimation'> {
   /**
    * Callback fired when a line area item is clicked.
-   * @param {React.MouseEvent<SVGPathElement, MouseEvent>} event The event source of the callback.
+   * @param {ChartsActivationEvent<SVGElement>} event The event source of the callback.
    * @param {LineItemClickIdentifier} lineItemIdentifier The line item identifier.
    */
   onItemClick?: (
-    event: React.MouseEvent<SVGElement, MouseEvent>,
+    event: ChartsActivationEvent<SVGElement>,
     lineItemIdentifier: LineItemClickIdentifier,
   ) => void;
 }
@@ -76,7 +77,7 @@ function AreaPlot(props: AreaPlotProps) {
 
   const completedData = useAggregatedData();
   const classes = useUtilityClasses();
-  const onAreaItemClick = useLineItemClickHandler(onItemClick);
+  const onAreaItemClick = useLineItemClickHandler(onItemClick, LINE_ACTIVATION_PRIORITY.area);
 
   return (
     <AreaPlotRoot className={clsx(classes.areaPlot, className)} {...other}>
@@ -107,7 +108,7 @@ AreaPlot.propTypes /* remove-proptypes */ = {
   // ----------------------------------------------------------------------
   /**
    * Callback fired when a line area item is clicked.
-   * @param {React.MouseEvent<SVGPathElement, MouseEvent>} event The event source of the callback.
+   * @param {ChartsActivationEvent<SVGElement>} event The event source of the callback.
    * @param {LineItemClickIdentifier} lineItemIdentifier The line item identifier.
    */
   onItemClick: PropTypes.func,

--- a/packages/x-charts/src/LineChart/AreaPlot.tsx
+++ b/packages/x-charts/src/LineChart/AreaPlot.tsx
@@ -77,7 +77,16 @@ function AreaPlot(props: AreaPlotProps) {
 
   const completedData = useAggregatedData();
   const classes = useUtilityClasses();
-  const onAreaItemClick = useLineItemClickHandler(onItemClick, LINE_ACTIVATION_PRIORITY.area);
+
+  // The area is drawn only for series that enable it, so a series without an area declines and
+  // activation falls through to the line.
+  const isAreaRendered = ({ seriesId }: LineItemClickIdentifier) =>
+    completedData.some((series) => series.seriesId === seriesId && !!series.area);
+  const onAreaItemClick = useLineItemClickHandler(
+    onItemClick,
+    LINE_ACTIVATION_PRIORITY.area,
+    isAreaRendered,
+  );
 
   return (
     <AreaPlotRoot className={clsx(classes.areaPlot, className)} {...other}>

--- a/packages/x-charts/src/LineChart/LineChart.tsx
+++ b/packages/x-charts/src/LineChart/LineChart.tsx
@@ -261,6 +261,7 @@ LineChart.propTypes /* remove-proptypes */ = {
    */
   experimentalFeatures: PropTypes.shape({
     enablePositionBasedPointerInteraction: PropTypes.bool,
+    keyboardActivation: PropTypes.bool,
   }),
   /**
    * Option to display a cartesian grid in the background.

--- a/packages/x-charts/src/LineChart/LinePlot.tsx
+++ b/packages/x-charts/src/LineChart/LinePlot.tsx
@@ -6,11 +6,12 @@ import clsx from 'clsx';
 import { LineElement } from './LineElement';
 import type { LineElementProps, LineElementSlotProps, LineElementSlots } from './LineElement';
 import type { LineItemClickIdentifier } from '../models/seriesType/line';
+import type { ChartsActivationEvent } from '../models/events';
 import { useSkipAnimation } from '../hooks/useSkipAnimation';
 import { useXAxes, useYAxes } from '../hooks';
 import { useInternalIsZoomInteracting } from '../internals/plugins/featurePlugins/useChartCartesianAxis/useInternalIsZoomInteracting';
 import { useLinePlotData } from './useLinePlotData';
-import { useLineItemClickHandler } from './useLineItemClickHandler';
+import { LINE_ACTIVATION_PRIORITY, useLineItemClickHandler } from './useLineItemClickHandler';
 import { ANIMATION_DURATION_MS, ANIMATION_TIMING_FUNCTION } from '../internals/animation/animation';
 import { lineClasses, useUtilityClasses } from './lineClasses';
 
@@ -24,11 +25,11 @@ export interface LinePlotProps
     Pick<LineElementProps, 'slots' | 'slotProps' | 'skipAnimation'> {
   /**
    * Callback fired when a line item is clicked.
-   * @param {React.MouseEvent<SVGPathElement, MouseEvent>} event The event source of the callback.
+   * @param {ChartsActivationEvent<SVGElement>} event The event source of the callback.
    * @param {LineItemClickIdentifier} lineItemIdentifier The line item identifier.
    */
   onItemClick?: (
-    event: React.MouseEvent<SVGElement, MouseEvent>,
+    event: ChartsActivationEvent<SVGElement>,
     lineItemIdentifier: LineItemClickIdentifier,
   ) => void;
 }
@@ -75,7 +76,7 @@ function LinePlot(props: LinePlotProps) {
 
   const completedData = useAggregatedData();
   const classes = useUtilityClasses();
-  const onLineItemClick = useLineItemClickHandler(onItemClick);
+  const onLineItemClick = useLineItemClickHandler(onItemClick, LINE_ACTIVATION_PRIORITY.line);
 
   return (
     <LinePlotRoot className={clsx(classes.linePlot, className)} {...other}>
@@ -106,7 +107,7 @@ LinePlot.propTypes /* remove-proptypes */ = {
   // ----------------------------------------------------------------------
   /**
    * Callback fired when a line item is clicked.
-   * @param {React.MouseEvent<SVGPathElement, MouseEvent>} event The event source of the callback.
+   * @param {ChartsActivationEvent<SVGElement>} event The event source of the callback.
    * @param {LineItemClickIdentifier} lineItemIdentifier The line item identifier.
    */
   onItemClick: PropTypes.func,

--- a/packages/x-charts/src/LineChart/MarkPlot.tsx
+++ b/packages/x-charts/src/LineChart/MarkPlot.tsx
@@ -6,6 +6,8 @@ import clsx from 'clsx';
 import type { WithDataAttributes } from '@mui/utils/types';
 import { useSkipAnimation } from '../hooks/useSkipAnimation';
 import type { LineItemClickIdentifier } from '../models/seriesType/line';
+import type { ChartsActivationEvent } from '../models/events';
+import { LINE_ACTIVATION_PRIORITY, useRegisterLineItemActivation } from './useLineItemClickHandler';
 import { CircleMarkElement } from './CircleMarkElement';
 import { MarkElement } from './MarkElement';
 import type { MarkElementProps } from './MarkElement';
@@ -42,11 +44,11 @@ export interface MarkPlotProps
   slotProps?: MarkPlotSlotProps;
   /**
    * Callback fired when a line mark item is clicked.
-   * @param {React.MouseEvent<SVGPathElement, MouseEvent>} event The event source of the callback.
+   * @param {ChartsActivationEvent<SVGElement>} event The event source of the callback.
    * @param {LineItemClickIdentifier} lineItemIdentifier The line mark item identifier.
    */
   onItemClick?: (
-    event: React.MouseEvent<SVGElement, MouseEvent>,
+    event: ChartsActivationEvent<SVGElement>,
     lineItemIdentifier: LineItemClickIdentifier,
   ) => void;
 }
@@ -77,6 +79,8 @@ function MarkPlot(props: MarkPlotProps) {
   } = props;
   const isZoomInteracting = useInternalIsZoomInteracting();
   const skipAnimation = useSkipAnimation(isZoomInteracting || inSkipAnimation);
+
+  useRegisterLineItemActivation(onItemClick, LINE_ACTIVATION_PRIORITY.mark);
 
   const { xAxis } = useXAxes();
   const { yAxis } = useYAxes();
@@ -150,7 +154,7 @@ MarkPlot.propTypes /* remove-proptypes */ = {
   // ----------------------------------------------------------------------
   /**
    * Callback fired when a line mark item is clicked.
-   * @param {React.MouseEvent<SVGPathElement, MouseEvent>} event The event source of the callback.
+   * @param {ChartsActivationEvent<SVGElement>} event The event source of the callback.
    * @param {LineItemClickIdentifier} lineItemIdentifier The line mark item identifier.
    */
   onItemClick: PropTypes.func,

--- a/packages/x-charts/src/LineChart/MarkPlot.tsx
+++ b/packages/x-charts/src/LineChart/MarkPlot.tsx
@@ -100,7 +100,6 @@ function MarkPlot(props: MarkPlotProps) {
     return rep;
   }, [xAxisHighlightIndexes]);
 
-
   const completedData = useMarkPlotData(xAxis, yAxis);
 
   // A mark is activatable only where it is actually rendered, so a hidden mark falls through to the

--- a/packages/x-charts/src/LineChart/MarkPlot.tsx
+++ b/packages/x-charts/src/LineChart/MarkPlot.tsx
@@ -1,26 +1,26 @@
 'use client';
+import { styled } from '@mui/material/styles';
+import type { WithDataAttributes } from '@mui/utils/types';
+import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import * as React from 'react';
-import { styled } from '@mui/material/styles';
-import clsx from 'clsx';
-import type { WithDataAttributes } from '@mui/utils/types';
-import { useSkipAnimation } from '../hooks/useSkipAnimation';
-import type { LineItemClickIdentifier } from '../models/seriesType/line';
-import type { ChartsActivationEvent } from '../models/events';
-import { LINE_ACTIVATION_PRIORITY, useRegisterLineItemActivation } from './useLineItemClickHandler';
-import { CircleMarkElement } from './CircleMarkElement';
-import { MarkElement } from './MarkElement';
-import type { MarkElementProps } from './MarkElement';
-import { useItemHighlightStateGetter, useXAxes, useYAxes } from '../hooks';
-import { useInternalIsZoomInteracting } from '../internals/plugins/featurePlugins/useChartCartesianAxis/useInternalIsZoomInteracting';
-import { selectorChartsHighlightXAxisIndex } from '../internals/plugins/featurePlugins/useChartCartesianAxis';
-import type { UseChartCartesianAxisSignature } from '../internals/plugins/featurePlugins/useChartCartesianAxis';
-import type { AxisId } from '../models/axis';
-import type { UseChartBrushSignature } from '../internals/plugins/featurePlugins/useChartBrush';
 import { useChartsContext } from '../context/ChartsProvider';
-import { useMarkPlotData } from './useMarkPlotData';
-import { useUtilityClasses } from './lineClasses';
+import { useItemHighlightStateGetter, useXAxes, useYAxes } from '../hooks';
+import { useSkipAnimation } from '../hooks/useSkipAnimation';
+import type { UseChartBrushSignature } from '../internals/plugins/featurePlugins/useChartBrush';
+import type { UseChartCartesianAxisSignature } from '../internals/plugins/featurePlugins/useChartCartesianAxis';
+import { selectorChartsHighlightXAxisIndex } from '../internals/plugins/featurePlugins/useChartCartesianAxis';
+import { useInternalIsZoomInteracting } from '../internals/plugins/featurePlugins/useChartCartesianAxis/useInternalIsZoomInteracting';
+import type { AxisId } from '../models/axis';
 import type { MarkPropsOverrides } from '../models/chartsSlotsComponentsProps';
+import type { ChartsActivationEvent } from '../models/events';
+import type { LineItemClickIdentifier } from '../models/seriesType/line';
+import { CircleMarkElement } from './CircleMarkElement';
+import { useUtilityClasses } from './lineClasses';
+import type { MarkElementProps } from './MarkElement';
+import { MarkElement } from './MarkElement';
+import { LINE_ACTIVATION_PRIORITY, useRegisterLineItemActivation } from './useLineItemClickHandler';
+import { useMarkPlotData } from './useMarkPlotData';
 
 export interface MarkPlotSlots {
   mark?: React.JSXElementConstructor<MarkElementProps & MarkPropsOverrides>;
@@ -80,8 +80,6 @@ function MarkPlot(props: MarkPlotProps) {
   const isZoomInteracting = useInternalIsZoomInteracting();
   const skipAnimation = useSkipAnimation(isZoomInteracting || inSkipAnimation);
 
-  useRegisterLineItemActivation(onItemClick, LINE_ACTIVATION_PRIORITY.mark);
-
   const { xAxis } = useXAxes();
   const { yAxis } = useYAxes();
 
@@ -102,7 +100,20 @@ function MarkPlot(props: MarkPlotProps) {
     return rep;
   }, [xAxisHighlightIndexes]);
 
+
   const completedData = useMarkPlotData(xAxis, yAxis);
+
+  // A mark is activatable only where it is actually rendered, so a hidden mark falls through to the
+  // line, then the area, matching what a pointer would hit.
+  const isMarkRendered = ({ seriesId, dataIndex }: LineItemClickIdentifier) =>
+    completedData.some(
+      (series) =>
+        series.seriesId === seriesId &&
+        !series.hidden &&
+        series.marks.some((mark) => mark.index === dataIndex),
+    );
+  useRegisterLineItemActivation(onItemClick, LINE_ACTIVATION_PRIORITY.mark, isMarkRendered);
+
   const classes = useUtilityClasses();
 
   return (

--- a/packages/x-charts/src/LineChart/useLineItemClickHandler.ts
+++ b/packages/x-charts/src/LineChart/useLineItemClickHandler.ts
@@ -7,6 +7,38 @@ import { getChartPoint } from '../internals/getChartPoint';
 import { getAxisIndex } from '../internals/plugins/featurePlugins/useChartCartesianAxis/getAxisValue';
 import type { LineItemClickIdentifier } from '../models/seriesType/line';
 import type { SeriesId } from '../models/seriesType/common';
+import type { ChartsActivationEvent } from '../models/events';
+import { useRegisterItemActivation } from '../internals/useRegisterItemActivation';
+
+/**
+ * Priorities matching the pointer hit-testing order: marks sit above lines, lines above areas.
+ * The topmost callback a pointer would reach is the one keyboard activation fires.
+ */
+export const LINE_ACTIVATION_PRIORITY = { mark: 2, line: 1, area: 0 };
+
+/**
+ * Registers <kbd>Enter</kbd>/<kbd>Space</kbd> activation of the focused line item.
+ */
+export function useRegisterLineItemActivation(
+  onItemClick:
+    | ((
+        event: ChartsActivationEvent<SVGElement>,
+        lineItemIdentifier: LineItemClickIdentifier,
+      ) => void)
+    | undefined,
+  priority: number,
+) {
+  useRegisterItemActivation(
+    { type: 'line', priority },
+    onItemClick &&
+      ((event, item) =>
+        onItemClick(event, {
+          type: 'line',
+          seriesId: item.seriesId,
+          dataIndex: item.dataIndex,
+        })),
+  );
+}
 
 /**
  * Creates a click handler for line and area paths that enriches the item
@@ -17,11 +49,16 @@ import type { SeriesId } from '../models/seriesType/common';
  * fired when the click position cannot be associated with a data point.
  */
 export function useLineItemClickHandler(
-  onItemClick?: (
-    event: React.MouseEvent<SVGElement, MouseEvent>,
-    lineItemIdentifier: LineItemClickIdentifier,
-  ) => void,
+  onItemClick:
+    | ((
+        event: ChartsActivationEvent<SVGElement>,
+        lineItemIdentifier: LineItemClickIdentifier,
+      ) => void)
+    | undefined,
+  priority: number,
 ): ((event: React.MouseEvent<SVGElement, MouseEvent>, seriesId: SeriesId) => void) | undefined {
+  useRegisterLineItemActivation(onItemClick, priority);
+
   const chartsLayerContainerRef = useChartsLayerContainerRef();
   const { xAxis: xAxes, xAxisIds } = useXAxes();
   const seriesData = useLineSeriesContext();

--- a/packages/x-charts/src/LineChart/useLineItemClickHandler.ts
+++ b/packages/x-charts/src/LineChart/useLineItemClickHandler.ts
@@ -75,8 +75,13 @@ export function useLineItemClickHandler(
       ) => void)
     | undefined,
   priority: number,
+  /**
+   * Declines items the caller does not render, so activation falls through to the next handler.
+   * The area plot uses it to defer when the series has no area drawn.
+   */
+  canActivate?: (item: LineItemClickIdentifier) => boolean,
 ): ((event: React.MouseEvent<SVGElement, MouseEvent>, seriesId: SeriesId) => void) | undefined {
-  useRegisterLineItemActivation(onItemClick, priority);
+  useRegisterLineItemActivation(onItemClick, priority, canActivate);
 
   const chartsLayerContainerRef = useChartsLayerContainerRef();
   const { xAxis: xAxes, xAxisIds } = useXAxes();

--- a/packages/x-charts/src/LineChart/useLineItemClickHandler.ts
+++ b/packages/x-charts/src/LineChart/useLineItemClickHandler.ts
@@ -27,9 +27,28 @@ export function useRegisterLineItemActivation(
       ) => void)
     | undefined,
   priority: number,
+  /**
+   * Declines items the caller does not render, so activation falls through to the next handler.
+   * Used by the mark plot: a mark that is not shown should defer to the line, then the area.
+   */
+  canActivate?: (item: LineItemClickIdentifier) => boolean,
 ) {
-  useRegisterItemActivation(
-    { type: 'line', priority },
+  useRegisterItemActivation<'line'>(
+    {
+      type: 'line',
+      priority,
+      canActivate:
+        canActivate &&
+        ((item) => {
+          // The dispatcher matches the `line` type before calling this, so the item is a line item.
+          const lineItem = item as LineItemClickIdentifier;
+          return canActivate({
+            type: 'line',
+            seriesId: lineItem.seriesId,
+            dataIndex: lineItem.dataIndex,
+          });
+        }),
+    },
     onItemClick &&
       ((event, item) =>
         onItemClick(event, {

--- a/packages/x-charts/src/PieChart/PieArcPlot.tsx
+++ b/packages/x-charts/src/PieChart/PieArcPlot.tsx
@@ -12,6 +12,8 @@ import type {
   PieItemIdentifier,
 } from '../models/seriesType/pie';
 import { useTransformData } from './dataTransform/useTransformData';
+import { useRegisterItemActivation } from '../internals/useRegisterItemActivation';
+import type { ChartsActivationEvent } from '../models/events';
 import type { PieArcPropsOverrides } from '../models/chartsSlotsComponentsProps';
 
 export interface PieArcPlotSlots {
@@ -50,12 +52,12 @@ export interface PieArcPlotProps
   slotProps?: PieArcPlotSlotProps;
   /**
    * Callback fired when a pie item is clicked.
-   * @param {React.MouseEvent<SVGPathElement, MouseEvent>} event The event source of the callback.
+   * @param {ChartsActivationEvent<SVGPathElement>} event The event source of the callback.
    * @param {PieItemIdentifier} pieItemIdentifier The pie item identifier.
    * @param {DefaultizedPieValueType} item The pie item.
    */
   onItemClick?: (
-    event: React.MouseEvent<SVGPathElement, MouseEvent>,
+    event: ChartsActivationEvent<SVGPathElement>,
     pieItemIdentifier: PieItemIdentifier,
     item: DefaultizedPieValueType,
   ) => void;
@@ -98,6 +100,20 @@ function PieArcPlot(props: PieArcPlotProps) {
     faded,
     data,
   });
+
+  useRegisterItemActivation(
+    { type: 'pie', seriesId },
+    onItemClick &&
+      ((event, focusedItem) => {
+        const item = transformedData[focusedItem.dataIndex];
+
+        if (item === undefined) {
+          return;
+        }
+
+        onItemClick(event, { type: 'pie', seriesId, dataIndex: focusedItem.dataIndex }, item);
+      }),
+  );
 
   if (data.length === 0) {
     return null;
@@ -201,7 +217,7 @@ PieArcPlot.propTypes /* remove-proptypes */ = {
   innerRadius: PropTypes.number,
   /**
    * Callback fired when a pie item is clicked.
-   * @param {React.MouseEvent<SVGPathElement, MouseEvent>} event The event source of the callback.
+   * @param {ChartsActivationEvent<SVGPathElement>} event The event source of the callback.
    * @param {PieItemIdentifier} pieItemIdentifier The pie item identifier.
    * @param {DefaultizedPieValueType} item The pie item.
    */

--- a/packages/x-charts/src/PieChart/PieChart.tsx
+++ b/packages/x-charts/src/PieChart/PieChart.tsx
@@ -204,7 +204,9 @@ PieChart.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.object,
+  experimentalFeatures: PropTypes.shape({
+    keyboardActivation: PropTypes.bool,
+  }),
   /**
    * The height of the chart in px. If not defined, it takes the height of the parent element.
    */

--- a/packages/x-charts/src/PieChart/PiePlot.tsx
+++ b/packages/x-charts/src/PieChart/PiePlot.tsx
@@ -118,7 +118,7 @@ PiePlot.propTypes /* remove-proptypes */ = {
   className: PropTypes.string,
   /**
    * Callback fired when a pie item is clicked.
-   * @param {React.MouseEvent<SVGPathElement, MouseEvent>} event The event source of the callback.
+   * @param {ChartsActivationEvent<SVGPathElement>} event The event source of the callback.
    * @param {PieItemIdentifier} pieItemIdentifier The pie item identifier.
    * @param {DefaultizedPieValueType} item The pie item.
    */

--- a/packages/x-charts/src/RadarChart/RadarChart.tsx
+++ b/packages/x-charts/src/RadarChart/RadarChart.tsx
@@ -168,7 +168,9 @@ RadarChart.propTypes /* remove-proptypes */ = {
   /**
    * Options to enable features planned for the next major.
    */
-  experimentalFeatures: PropTypes.object,
+  experimentalFeatures: PropTypes.shape({
+    keyboardActivation: PropTypes.bool,
+  }),
   /**
    * The height of the chart in px. If not defined, it takes the height of the parent element.
    */

--- a/packages/x-charts/src/RadarChart/RadarSeriesPlot/RadarSeriesArea.tsx
+++ b/packages/x-charts/src/RadarChart/RadarSeriesPlot/RadarSeriesArea.tsx
@@ -10,6 +10,10 @@ import { useInteractionAllItemProps } from './useInteractionAllItemProps';
 import type { SeriesId, HighlightItemIdentifierWithType } from '../../models/seriesType';
 import type { HighlightState } from '../../hooks/useItemHighlightState';
 import { useRadarRotationIndex } from './useRadarRotationIndex';
+import {
+  RADAR_ACTIVATION_PRIORITY,
+  useRegisterRadarItemActivation,
+} from './useRegisterRadarItemActivation';
 
 interface GetPathPropsParams {
   seriesId: SeriesId;
@@ -48,6 +52,9 @@ function RadarSeriesArea(props: RadarSeriesAreaProps) {
   const getHighlightState = useItemHighlightStateGetter<'radar'>();
 
   const classes = useUtilityClasses(inClasses);
+
+  useRegisterRadarItemActivation(seriesId, onItemClick, RADAR_ACTIVATION_PRIORITY.area);
+
   return (
     <React.Fragment>
       {seriesCoordinates?.map(({ seriesId: id, points, color, fillArea, hidden }, seriesIndex) => {
@@ -99,7 +106,7 @@ RadarSeriesArea.propTypes /* remove-proptypes */ = {
   className: PropTypes.string,
   /**
    * Callback fired when an area is clicked.
-   * @param {React.MouseEvent<SVGPathElement, MouseEvent>} event The event source of the callback.
+   * @param {ChartsActivationEvent<SVGElement>} event The event source of the callback.
    * @param {RadarItemIdentifier} radarItemIdentifier The radar item identifier.
    */
   onItemClick: PropTypes.func,

--- a/packages/x-charts/src/RadarChart/RadarSeriesPlot/RadarSeriesMarks.tsx
+++ b/packages/x-charts/src/RadarChart/RadarSeriesPlot/RadarSeriesMarks.tsx
@@ -8,6 +8,10 @@ import { useItemHighlightStateGetter } from '../../hooks/useItemHighlightStateGe
 import type { SeriesId } from '../../models/seriesType/common';
 import type { HighlightItemIdentifierWithType } from '../../models';
 import type { HighlightState } from '../../hooks/useItemHighlightState';
+import {
+  RADAR_ACTIVATION_PRIORITY,
+  useRegisterRadarItemActivation,
+} from './useRegisterRadarItemActivation';
 
 interface GetCirclePropsParams {
   seriesId: SeriesId;
@@ -43,6 +47,8 @@ function RadarSeriesMarks(props: RadarSeriesMarksProps) {
 
   const classes = useUtilityClasses(inClasses);
   const getHighlightState = useItemHighlightStateGetter();
+
+  useRegisterRadarItemActivation(seriesId, onItemClick, RADAR_ACTIVATION_PRIORITY.mark);
 
   return (
     <React.Fragment>
@@ -94,7 +100,7 @@ RadarSeriesMarks.propTypes /* remove-proptypes */ = {
   className: PropTypes.string,
   /**
    * Callback fired when a mark is clicked.
-   * @param {React.MouseEvent<SVGPathElement, MouseEvent>} event The event source of the callback.
+   * @param {ChartsActivationEvent<SVGElement>} event The event source of the callback.
    * @param {RadarItemIdentifier} radarItemIdentifier The radar item identifier.
    */
   onItemClick: PropTypes.func,

--- a/packages/x-charts/src/RadarChart/RadarSeriesPlot/RadarSeriesPlot.types.ts
+++ b/packages/x-charts/src/RadarChart/RadarSeriesPlot/RadarSeriesPlot.types.ts
@@ -1,6 +1,7 @@
 import type * as React from 'react';
 import type { RadarClasses } from '../radarClasses';
 import type { RadarItemIdentifier } from '../../models/seriesType/radar';
+import type { ChartsActivationEvent } from '../../models/events';
 
 interface CommonRadarSeriesPlotProps {
   /**
@@ -39,11 +40,11 @@ export interface RadarSeriesMarksProps
   extends CommonRadarSeriesPlotProps, React.SVGAttributes<SVGCircleElement> {
   /**
    * Callback fired when a mark is clicked.
-   * @param {React.MouseEvent<SVGPathElement, MouseEvent>} event The event source of the callback.
+   * @param {ChartsActivationEvent<SVGElement>} event The event source of the callback.
    * @param {RadarItemIdentifier} radarItemIdentifier The radar item identifier.
    */
   onItemClick?: (
-    event: React.MouseEvent<SVGElement, MouseEvent>,
+    event: ChartsActivationEvent<SVGElement>,
     radarItemIdentifier: RadarClickIdentifier,
   ) => void;
 }
@@ -52,11 +53,11 @@ export interface RadarSeriesAreaProps
   extends CommonRadarSeriesPlotProps, React.SVGAttributes<SVGPathElement> {
   /**
    * Callback fired when an area is clicked.
-   * @param {React.MouseEvent<SVGPathElement, MouseEvent>} event The event source of the callback.
+   * @param {ChartsActivationEvent<SVGElement>} event The event source of the callback.
    * @param {RadarItemIdentifier} radarItemIdentifier The radar item identifier.
    */
   onItemClick?: (
-    event: React.MouseEvent<SVGElement, MouseEvent>,
+    event: ChartsActivationEvent<SVGElement>,
     radarItemIdentifier: RadarClickIdentifier,
   ) => void;
 }

--- a/packages/x-charts/src/RadarChart/RadarSeriesPlot/useRegisterRadarItemActivation.ts
+++ b/packages/x-charts/src/RadarChart/RadarSeriesPlot/useRegisterRadarItemActivation.ts
@@ -1,0 +1,36 @@
+'use client';
+import { useRegisterItemActivation } from '../../internals/useRegisterItemActivation';
+import type { SeriesId } from '../../models/seriesType/common';
+import type { RadarItemIdentifier } from '../../models/seriesType/radar';
+import type { ChartsActivationEvent } from '../../models/events';
+
+/**
+ * Priorities matching the pointer hit-testing order: marks sit above areas.
+ * The topmost callback a pointer would reach is the one keyboard activation fires.
+ */
+export const RADAR_ACTIVATION_PRIORITY = { mark: 2, area: 1 };
+
+/**
+ * Registers <kbd>Enter</kbd>/<kbd>Space</kbd> activation of the focused radar item.
+ */
+export function useRegisterRadarItemActivation(
+  seriesId: SeriesId | undefined,
+  onItemClick:
+    | ((
+        event: ChartsActivationEvent<SVGElement>,
+        radarItemIdentifier: Required<RadarItemIdentifier>,
+      ) => void)
+    | undefined,
+  priority: number,
+) {
+  useRegisterItemActivation(
+    { type: 'radar', seriesId, priority },
+    onItemClick &&
+      ((event, item) =>
+        onItemClick(event, {
+          type: 'radar',
+          seriesId: item.seriesId,
+          dataIndex: item.dataIndex,
+        })),
+  );
+}

--- a/packages/x-charts/src/RadarChart/experimentalFeatures.test.tsx
+++ b/packages/x-charts/src/RadarChart/experimentalFeatures.test.tsx
@@ -1,0 +1,20 @@
+import { createRenderer } from '@mui/internal-test-utils';
+import { RadarChart } from '@mui/x-charts/RadarChart';
+
+describe('<RadarChart /> - experimentalFeatures', () => {
+  const { render } = createRenderer();
+
+  it('should not forward experimentalFeatures to the DOM', async () => {
+    const { container } = render(
+      <RadarChart
+        height={100}
+        width={100}
+        series={[{ id: 'A', data: [1, 2, 3] }]}
+        radar={{ metrics: ['M1', 'M2', 'M3'] }}
+        experimentalFeatures={{}}
+      />,
+    );
+
+    expect(container.querySelector('[experimentalfeatures]')).to.equal(null);
+  });
+});

--- a/packages/x-charts/src/RadarChart/useRadarChartProps.ts
+++ b/packages/x-charts/src/RadarChart/useRadarChartProps.ts
@@ -44,6 +44,7 @@ export const useRadarChartProps = (props: RadarChartProps) => {
     onAreaClick,
     onMarkClick,
     disableKeyboardNavigation,
+    experimentalFeatures,
     className,
     ...other
   } = props;
@@ -62,6 +63,7 @@ export const useRadarChartProps = (props: RadarChartProps) => {
     skipAnimation,
     onAxisClick,
     disableKeyboardNavigation,
+    experimentalFeatures,
     plugins: RADAR_PLUGINS,
   };
 

--- a/packages/x-charts/src/ScatterChart/Scatter.tsx
+++ b/packages/x-charts/src/ScatterChart/Scatter.tsx
@@ -19,6 +19,8 @@ import type { ColorGetter } from '../internals/plugins/corePlugins/useChartSerie
 import type { ScatterSizeGetter } from './seriesConfig/getMarkerSize';
 import { useUtilityClasses } from './scatterClasses';
 import type { ScatterClasses } from './scatterClasses';
+import { useRegisterItemActivation } from '../internals/useRegisterItemActivation';
+import type { ChartsActivationEvent } from '../models/events';
 import { useScatterPlotData } from './useScatterPlotData';
 import { useChartsContext } from '../context/ChartsProvider';
 import type { UseChartTooltipSignature } from '../internals/plugins/featurePlugins/useChartTooltip';
@@ -45,11 +47,11 @@ export interface ScatterProps {
   sizeGetter: ScatterSizeGetter;
   /**
    * Callback fired when clicking on a scatter item.
-   * @param {MouseEvent} event Mouse event recorded on the `<svg/>` element.
+   * @param {ChartsActivationEvent<SVGElement>} event Event recorded on the `<svg/>` element.
    * @param {ScatterItemIdentifier} scatterItemIdentifier The scatter item identifier.
    */
   onItemClick?: (
-    event: React.MouseEvent<SVGElement, MouseEvent>,
+    event: ChartsActivationEvent<SVGElement>,
     scatterItemIdentifier: ScatterItemIdentifier,
   ) => void;
   classes?: Partial<ScatterClasses>;
@@ -120,6 +122,17 @@ function Scatter(props: ScatterProps) {
 
   const classes = useUtilityClasses({ classes: inClasses });
 
+  useRegisterItemActivation(
+    { type: 'scatter', seriesId: series.id },
+    onItemClick &&
+      ((event, item) =>
+        onItemClick(event, {
+          type: 'scatter',
+          seriesId: series.id,
+          dataIndex: item.dataIndex,
+        })),
+  );
+
   return (
     <g data-series={series.id} className={classes.series}>
       {scatterPlotData.map((dataPoint) => {
@@ -175,7 +188,7 @@ Scatter.propTypes /* remove-proptypes */ = {
   colorGetter: PropTypes.func.isRequired,
   /**
    * Callback fired when clicking on a scatter item.
-   * @param {MouseEvent} event Mouse event recorded on the `<svg/>` element.
+   * @param {ChartsActivationEvent<SVGElement>} event Event recorded on the `<svg/>` element.
    * @param {ScatterItemIdentifier} scatterItemIdentifier The scatter item identifier.
    */
   onItemClick: PropTypes.func,

--- a/packages/x-charts/src/ScatterChart/ScatterChart.tsx
+++ b/packages/x-charts/src/ScatterChart/ScatterChart.tsx
@@ -268,6 +268,7 @@ ScatterChart.propTypes /* remove-proptypes */ = {
    * Options to enable features planned for the next major.
    */
   experimentalFeatures: PropTypes.shape({
+    keyboardActivation: PropTypes.bool,
     progressiveRendering: PropTypes.bool,
   }),
   /**

--- a/packages/x-charts/src/ScatterChart/async/ScatterAsync.tsx
+++ b/packages/x-charts/src/ScatterChart/async/ScatterAsync.tsx
@@ -12,6 +12,7 @@ import type { UseProgressiveRenderingSignature } from '../../internals/plugins/f
 import { selectorChartZoomIsInteracting } from '../../internals/plugins/featurePlugins/useChartCartesianAxis';
 import type { UseChartCartesianAxisSignature } from '../../internals/plugins/featurePlugins/useChartCartesianAxis';
 import { selectorScatterSeriesRenderData } from './scatterRenderData.selectors';
+import { useRegisterItemActivation } from '../../internals/useRegisterItemActivation';
 
 /** Per-series points sampled while interacting; the rest fills in on settle. */
 const INTERACTION_POINT_BUDGET = 2000;
@@ -49,6 +50,17 @@ function ScatterAsync(props: ScatterProps) {
   // `count` (total points) is constant across zoom/pan, so the sampled set is
   // stable while panning.
   const interactionStep = getInteractionStep(count, nBatches, INTERACTION_POINT_BUDGET);
+
+  useRegisterItemActivation(
+    { type: 'scatter', seriesId: series.id },
+    onItemClick &&
+      ((event, item) =>
+        onItemClick(event, {
+          type: 'scatter',
+          seriesId: series.id,
+          dataIndex: item.dataIndex,
+        })),
+  );
 
   const batches: React.ReactNode[] = [];
   for (let b = 0; b < mountedBatches; b += 1) {

--- a/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
+++ b/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
@@ -431,6 +431,7 @@ SparkLineChart.propTypes /* remove-proptypes */ = {
    */
   experimentalFeatures: PropTypes.shape({
     enablePositionBasedPointerInteraction: PropTypes.bool,
+    keyboardActivation: PropTypes.bool,
     progressiveRendering: PropTypes.bool,
   }),
   /**
@@ -691,7 +692,7 @@ SparkLineChart.propTypes /* remove-proptypes */ = {
   /**
    * Callback fired when clicking close to an item.
    * This is only available for scatter plot for now.
-   * @param {MouseEvent} event Mouse event caught at the svg level
+   * @param {ChartsActivationEvent} event Event caught at the svg level
    * @param {ScatterItemIdentifier} scatterItemIdentifier Identify which item got clicked
    */
   onItemClick: PropTypes.func,

--- a/packages/x-charts/src/internals/index.ts
+++ b/packages/x-charts/src/internals/index.ts
@@ -91,6 +91,7 @@ export * from './scaleGuards';
 export * from './findMinMax';
 export * from './commonNextFocusItem';
 export { createCommonKeyboardFocusHandler } from './createCommonKeyboardFocusHandler';
+export { useRegisterItemActivation } from './useRegisterItemActivation';
 export { getSeriesColorFn } from './getSeriesColorFn';
 export { resolveColorProcessor } from './resolveColorProcessor';
 export { processLineLikeSeries } from './processLineLikeSeries';

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartExperimentalFeature/useChartExperimentalFeature.types.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartExperimentalFeature/useChartExperimentalFeature.types.ts
@@ -1,6 +1,14 @@
 import type { ChartPluginSignature } from '../../models';
 import type { ChartSeriesType } from '../../../../models/seriesType/config';
 
+interface CommonExperimentalFeatures {
+  /**
+   * Enables activating the keyboard-focused item with <kbd>Enter</kbd> or <kbd>Space</kbd>,
+   * firing `onItemClick` and `onAxisClick` as a pointer click would.
+   */
+  keyboardActivation?: boolean;
+}
+
 interface LineExperimentalFeatures {
   /**
    * Enables pointer-based interaction detection for line and area series.
@@ -31,7 +39,8 @@ interface ScatterExperimentalFeatures {
 }
 
 export type ChartExperimentalFeatures<SeriesType extends ChartSeriesType = ChartSeriesType> =
-  ('line' extends SeriesType ? LineExperimentalFeatures : {}) &
+  CommonExperimentalFeatures &
+    ('line' extends SeriesType ? LineExperimentalFeatures : {}) &
     ('scatter' extends SeriesType ? ScatterExperimentalFeatures : {});
 
 export interface UseChartExperimentalFeaturesParameters<

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/getItemWithData.types.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/getItemWithData.types.ts
@@ -1,0 +1,19 @@
+import type {
+  SeriesItemIdentifierWithType,
+  FocusedItemIdentifier,
+} from '../../../../../models/seriesType';
+import type { ChartState } from '../../../models/chart';
+import type { ChartSeriesType } from '../../../../../models/seriesType/config';
+import type { ChartSeriesTypeRequiredPlugins } from './seriesConfig.types';
+
+/**
+ * Completes an item identifier with the data a pointer click would provide, so keyboard activation
+ * emits the same payload as `getItemAtPosition`.
+ * @param {ChartState} state The chart state.
+ * @param {FocusedItemIdentifier<SeriesType>} identifier The identifier to complete.
+ * @returns {SeriesItemIdentifierWithType<SeriesType>} The identifier with its click data.
+ */
+export type GetItemWithData<SeriesType extends ChartSeriesType> = (
+  state: ChartState<ChartSeriesTypeRequiredPlugins<SeriesType>>,
+  identifier: FocusedItemIdentifier<SeriesType>,
+) => SeriesItemIdentifierWithType<SeriesType>;

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/index.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/index.ts
@@ -11,5 +11,6 @@ export * from './getSeriesWithDefaultValues.types';
 export * from './identifierSerializer.types';
 export * from './identifierCleaner.types';
 export * from './getItemAtPosition.types';
+export * from './getItemWithData.types';
 export * from './descriptionGetter.types';
 export * from './TooltipContent.types';

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/seriesConfig.types.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartSeriesConfig/types/seriesConfig.types.ts
@@ -18,6 +18,7 @@ import type { KeyboardFocusHandler } from '../../../featurePlugins/useChartKeybo
 import type { IdentifierSerializer } from './identifierSerializer.types';
 import type { IdentifierCleaner } from './identifierCleaner.types';
 import type { GetItemAtPosition } from './getItemAtPosition.types';
+import type { GetItemWithData } from './getItemWithData.types';
 import type { DescriptionGetter } from './descriptionGetter.types';
 import type { UseChartCartesianAxisSignature } from '../../../featurePlugins/useChartCartesianAxis';
 import type { UseChartPolarAxisSignature } from '../../../featurePlugins/useChartPolarAxis';
@@ -64,6 +65,11 @@ export type ChartSeriesTypeConfig<SeriesType extends ChartSeriesType> = {
    */
   identifierCleaner: IdentifierCleaner<SeriesType>;
   getItemAtPosition?: GetItemAtPosition<SeriesType>;
+  /**
+   * Completes a focused item identifier with the data a pointer click provides.
+   * Used by keyboard activation to emit the same payload as a click.
+   */
+  getItemWithData?: GetItemWithData<SeriesType>;
   /**
    * Optional sampling strategy used to render large datasets. When set and sampling is enabled,
    * the series is reduced to a zoom-appropriate level of detail before rendering.

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartClosestPoint/useChartClosestPoint.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartClosestPoint/useChartClosestPoint.ts
@@ -17,6 +17,7 @@ import {
 } from '../useChartCartesianAxis';
 import { selectorChartSeriesProcessed } from '../../corePlugins/useChartSeries/useChartSeries.selectors';
 import { findClosestPoints } from './findClosestPoints';
+import type { ChartsActivationEvent } from '../../../../models/events';
 
 type ClosestPoint = { dataIndex: number; seriesId: SeriesId; edgeDistance: number; radius: number };
 
@@ -258,6 +259,25 @@ export const useChartClosestPoint: ChartPlugin<UseChartClosestPointSignature> = 
     defaultYAxisId,
     store,
   ]);
+
+  React.useEffect(() => {
+    if (!onItemClick || !instance.registerItemActivationHandler) {
+      return undefined;
+    }
+
+    return instance.registerItemActivationHandler({ type: 'scatter' }, (event, item) => {
+      if (item.type !== 'scatter') {
+        return;
+      }
+
+      // The callback only describes the pointer event unless the user augments the types.
+      onItemClick(event as unknown as ChartsActivationEvent, {
+        type: 'scatter',
+        seriesId: item.seriesId,
+        dataIndex: item.dataIndex,
+      });
+    });
+  }, [instance, onItemClick]);
 
   // Instance implementation
   const enableVoronoiCallback = useEventCallback(() => {

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartClosestPoint/useChartClosestPoint.types.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartClosestPoint/useChartClosestPoint.types.ts
@@ -7,6 +7,8 @@ import type { UseChartHighlightSignature } from '../useChartHighlight';
 import type { UseChartInteractionSignature } from '../useChartInteraction';
 import type { UseChartTooltipSignature } from '../useChartTooltip';
 import type { UseChartZAxisSignature } from '../useChartZAxis';
+import type { UseChartKeyboardNavigationSignature } from '../useChartKeyboardNavigation';
+import type { ChartsActivationEvent } from '../../../../models/events';
 
 export interface UseChartVoronoiInstance {
   /**
@@ -43,10 +45,13 @@ export interface UseChartVoronoiParameters {
   /**
    * Callback fired when clicking close to an item.
    * This is only available for scatter plot for now.
-   * @param {MouseEvent} event Mouse event caught at the svg level
+   * @param {ChartsActivationEvent} event Event caught at the svg level
    * @param {ScatterItemIdentifier} scatterItemIdentifier Identify which item got clicked
    */
-  onItemClick?: (event: MouseEvent, scatterItemIdentifier: ScatterItemIdentifier) => void;
+  onItemClick?: (
+    event: ChartsActivationEvent,
+    scatterItemIdentifier: ScatterItemIdentifier,
+  ) => void;
 }
 
 export type UseChartVoronoiDefaultizedParameters = Pick<
@@ -66,5 +71,6 @@ export type UseChartClosestPointSignature<SeriesType extends ChartSeriesType = C
       UseChartHighlightSignature<SeriesType>,
       UseChartTooltipSignature,
       UseChartZAxisSignature,
+      UseChartKeyboardNavigationSignature,
     ];
   }>;

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartItemClick/useChartItemClick.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartItemClick/useChartItemClick.ts
@@ -1,9 +1,11 @@
 'use client';
+import * as React from 'react';
 import type { ChartPlugin } from '../../models';
 import type { ChartSeriesType } from '../../../../models/seriesType/config';
 import type { UseChartItemClickSignature } from './useChartItemClick.types';
 import type { SeriesItemIdentifierWithType } from '../../../../models/seriesType';
 import { getChartPoint } from '../../../getChartPoint';
+import type { ChartsActivationEvent } from '../../../../models/events';
 
 export const useChartItemClick: ChartPlugin<UseChartItemClickSignature<any>> = ({
   params,
@@ -11,6 +13,24 @@ export const useChartItemClick: ChartPlugin<UseChartItemClickSignature<any>> = (
   instance,
 }) => {
   const { onItemClick } = params;
+
+  React.useEffect(() => {
+    if (!onItemClick || !instance.registerItemActivationHandler) {
+      return undefined;
+    }
+
+    return instance.registerItemActivationHandler({}, (event, item) => {
+      const seriesTypeConfig = store.state.seriesConfig.config[item.type];
+      // @ts-ignore The type inference for store.state does not support generic yet
+      const itemWithData = seriesTypeConfig?.getItemWithData?.(store.state, item);
+
+      // The callback only describes the pointer event unless the user augments the types.
+      onItemClick(
+        event as unknown as ChartsActivationEvent<HTMLDivElement>,
+        (itemWithData ?? item) as SeriesItemIdentifierWithType<ChartSeriesType>,
+      );
+    });
+  }, [instance, onItemClick, store]);
 
   if (!onItemClick) {
     return { instance: {} };

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartItemClick/useChartItemClick.types.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartItemClick/useChartItemClick.types.ts
@@ -2,16 +2,18 @@ import type { ChartPluginSignature } from '../../models';
 import type { ChartSeriesType } from '../../../../models/seriesType/config';
 import type { SeriesItemIdentifierWithType } from '../../../../models/seriesType';
 import type { ChartSeriesTypeRequiredPlugins } from '../../corePlugins/useChartSeriesConfig';
+import type { UseChartKeyboardNavigationSignature } from '../useChartKeyboardNavigation';
+import type { ChartsActivationEvent } from '../../../../models/events';
 
 export interface UseChartItemClickParameters<SeriesType extends ChartSeriesType = ChartSeriesType> {
   /**
    * The callback fired when an item is clicked.
    *
-   * @param {React.MouseEvent<HTMLDivElement, MouseEvent>} event The click event.
+   * @param {ChartsActivationEvent<HTMLDivElement>} event The click event.
    * @param {SeriesItemIdentifierWithType<SeriesType>} item The clicked item.
    */
   onItemClick?: (
-    event: React.MouseEvent<HTMLDivElement, MouseEvent>,
+    event: ChartsActivationEvent<HTMLDivElement>,
     item: SeriesItemIdentifierWithType<SeriesType>,
   ) => void;
 }
@@ -28,4 +30,5 @@ export type UseChartItemClickSignature<SeriesType extends ChartSeriesType = Char
     defaultizedParams: UseChartItemClickParameters<SeriesType>;
     instance: UseChartItemClickInstance;
     dependencies: ChartSeriesTypeRequiredPlugins<SeriesType>;
+    optionalDependencies: [UseChartKeyboardNavigationSignature];
   }>;

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/index.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/index.ts
@@ -1,4 +1,9 @@
 export { useChartKeyboardNavigation } from './useChartKeyboardNavigation';
 export * from './useChartKeyboardNavigation.selectors';
-export type { UseChartKeyboardNavigationSignature } from './useChartKeyboardNavigation.types';
+export type {
+  UseChartKeyboardNavigationSignature,
+  ItemActivationHandler,
+  ItemActivationScope,
+} from './useChartKeyboardNavigation.types';
+export { isItemActivationKey } from './itemActivation';
 export type * from './keyboardFocusHandler.types';

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/itemActivation.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/itemActivation.ts
@@ -1,0 +1,60 @@
+import type { FocusedItemIdentifier } from '../../../../models/seriesType';
+import type { ChartSeriesType } from '../../../../models/seriesType/config';
+import type {
+  ItemActivationHandler,
+  ItemActivationScope,
+} from './useChartKeyboardNavigation.types';
+
+export type ItemActivationRegistration = {
+  scope: ItemActivationScope;
+  handler: ItemActivationHandler;
+};
+
+export function isItemActivationKey(event: KeyboardEvent): boolean {
+  return event.key === 'Enter' || event.key === ' ';
+}
+
+function getScopeSpecificity(
+  scope: ItemActivationScope,
+  item: FocusedItemIdentifier<ChartSeriesType>,
+): number | null {
+  if (scope.type !== undefined && scope.type !== item.type) {
+    return null;
+  }
+
+  if (scope.seriesId !== undefined && (!('seriesId' in item) || scope.seriesId !== item.seriesId)) {
+    return null;
+  }
+
+  return (scope.type === undefined ? 0 : 1) + (scope.seriesId === undefined ? 0 : 1);
+}
+
+/**
+ * Returns the handler matching the item with the most specific scope, the highest priority
+ * breaking ties, or `null` when none matches.
+ */
+export function findItemActivationHandler(
+  registrations: Iterable<ItemActivationRegistration>,
+  item: FocusedItemIdentifier<ChartSeriesType>,
+): ItemActivationHandler | null {
+  let bestHandler: ItemActivationHandler | null = null;
+  let bestSpecificity = -1;
+  let bestPriority = -1;
+
+  for (const registration of registrations) {
+    const specificity = getScopeSpecificity(registration.scope, item);
+    const priority = registration.scope.priority ?? 0;
+
+    if (
+      specificity !== null &&
+      (specificity > bestSpecificity ||
+        (specificity === bestSpecificity && priority > bestPriority))
+    ) {
+      bestHandler = registration.handler;
+      bestSpecificity = specificity;
+      bestPriority = priority;
+    }
+  }
+
+  return bestHandler;
+}

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/itemActivation.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/itemActivation.ts
@@ -47,6 +47,7 @@ export function findItemActivationHandler(
 
     if (
       specificity !== null &&
+      (registration.scope.canActivate === undefined || registration.scope.canActivate(item)) &&
       (specificity > bestSpecificity ||
         (specificity === bestSpecificity && priority > bestPriority))
     ) {

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardActivation.test.tsx
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardActivation.test.tsx
@@ -1,0 +1,205 @@
+import { createRenderer } from '@mui/internal-test-utils/createRenderer';
+import { vi } from 'vitest';
+import { BarChart } from '@mui/x-charts/BarChart';
+import { LineChart } from '@mui/x-charts/LineChart';
+import { PieChart } from '@mui/x-charts/PieChart';
+import { ScatterChart } from '@mui/x-charts/ScatterChart';
+import { RadarChart } from '@mui/x-charts/RadarChart';
+
+describe('keyboard item activation', () => {
+  const { render } = createRenderer();
+
+  const barConfig = {
+    height: 100,
+    width: 100,
+    margin: 0,
+    skipAnimation: true,
+  } as const;
+
+  it('should not fire onItemClick when the experimental feature is off', async () => {
+    const onItemClick = vi.fn();
+    const { user } = render(
+      <BarChart {...barConfig} series={[{ id: 'A', data: [50, 100] }]} onItemClick={onItemClick} />,
+    );
+
+    await user.keyboard('{Tab}');
+    await user.keyboard('[ArrowRight]');
+    await user.keyboard('[Enter]');
+
+    expect(onItemClick.mock.calls.length).to.equal(0);
+  });
+
+  it('should fire onItemClick with the focused bar on Enter and Space', async () => {
+    const onItemClick = vi.fn();
+    const { user } = render(
+      <BarChart
+        {...barConfig}
+        series={[{ id: 'A', data: [50, 100] }]}
+        onItemClick={onItemClick}
+        experimentalFeatures={{ keyboardActivation: true }}
+      />,
+    );
+
+    await user.keyboard('{Tab}');
+    await user.keyboard('[ArrowRight]');
+    await user.keyboard('[Enter]');
+
+    expect(onItemClick.mock.calls.length).to.equal(1);
+    expect(onItemClick.mock.lastCall?.[1]).to.deep.equal({
+      type: 'bar',
+      seriesId: 'A',
+      dataIndex: 0,
+    });
+
+    await user.keyboard('[ArrowRight]');
+    await user.keyboard('[Space]');
+
+    expect(onItemClick.mock.calls.length).to.equal(2);
+    expect(onItemClick.mock.lastCall?.[1]).to.deep.equal({
+      type: 'bar',
+      seriesId: 'A',
+      dataIndex: 1,
+    });
+  });
+
+  it('should fall back to onAreaClick when it is the only line callback', async () => {
+    const onAreaClick = vi.fn();
+    const { user } = render(
+      <LineChart
+        {...barConfig}
+        series={[{ id: 'A', data: [50, 100], area: true }]}
+        onAreaClick={onAreaClick}
+        experimentalFeatures={{ keyboardActivation: true }}
+      />,
+    );
+
+    await user.keyboard('{Tab}');
+    await user.keyboard('[ArrowRight]');
+    await user.keyboard('[Enter]');
+
+    expect(onAreaClick.mock.calls.length).to.equal(1);
+  });
+
+  it('should fall back to onAreaClick when it is the only radar callback', async () => {
+    const onAreaClick = vi.fn();
+    const { user } = render(
+      <RadarChart
+        {...barConfig}
+        series={[{ id: 'A', data: [50, 100, 20] }]}
+        radar={{ metrics: ['M1', 'M2', 'M3'] }}
+        onAreaClick={onAreaClick}
+        experimentalFeatures={{ keyboardActivation: true }}
+      />,
+    );
+
+    await user.keyboard('{Tab}');
+    await user.keyboard('[ArrowRight]');
+    await user.keyboard('[Enter]');
+
+    expect(onAreaClick.mock.calls.length).to.equal(1);
+  });
+
+  it('should fire onMarkClick once for a line chart rendering area, line and marks', async () => {
+    const onItemClick = vi.fn();
+    const { user } = render(
+      <LineChart
+        {...barConfig}
+        series={[{ id: 'A', data: [50, 100], area: true }]}
+        onAreaClick={onItemClick}
+        onLineClick={onItemClick}
+        onMarkClick={onItemClick}
+        experimentalFeatures={{ keyboardActivation: true }}
+      />,
+    );
+
+    await user.keyboard('{Tab}');
+    await user.keyboard('[ArrowRight]');
+    await user.keyboard('[Enter]');
+
+    expect(onItemClick.mock.calls.length).to.equal(1);
+    expect(onItemClick.mock.lastCall?.[1]).to.deep.equal({
+      type: 'line',
+      seriesId: 'A',
+      dataIndex: 0,
+    });
+  });
+
+  it('should fire onItemClick with the pie item as third argument', async () => {
+    const onItemClick = vi.fn();
+    const { user } = render(
+      <PieChart
+        {...barConfig}
+        series={[{ id: 'A', data: [{ value: 10 }, { value: 20 }] }]}
+        onItemClick={onItemClick}
+        experimentalFeatures={{ keyboardActivation: true }}
+      />,
+    );
+
+    await user.keyboard('{Tab}');
+    await user.keyboard('[ArrowRight]');
+    await user.keyboard('[Enter]');
+
+    expect(onItemClick.mock.calls.length).to.equal(1);
+    expect(onItemClick.mock.lastCall?.[1]).to.deep.equal({
+      type: 'pie',
+      seriesId: 'A',
+      dataIndex: 0,
+    });
+    expect(onItemClick.mock.lastCall?.[2].value).to.equal(10);
+  });
+
+  it('should fire onItemClick with the focused scatter point', async () => {
+    const onItemClick = vi.fn();
+    const { user } = render(
+      <ScatterChart
+        {...barConfig}
+        series={[
+          {
+            id: 'A',
+            data: [
+              { x: 1, y: 1, id: 'p1' },
+              { x: 2, y: 2, id: 'p2' },
+            ],
+          },
+        ]}
+        onItemClick={onItemClick}
+        experimentalFeatures={{ keyboardActivation: true }}
+      />,
+    );
+
+    await user.keyboard('{Tab}');
+    await user.keyboard('[ArrowRight]');
+    await user.keyboard('[Enter]');
+
+    expect(onItemClick.mock.calls.length).to.equal(1);
+    expect(onItemClick.mock.lastCall?.[1]).to.deep.equal({
+      type: 'scatter',
+      seriesId: 'A',
+      dataIndex: 0,
+    });
+  });
+
+  it('should fire onItemClick with the focused radar item', async () => {
+    const onItemClick = vi.fn();
+    const { user } = render(
+      <RadarChart
+        {...barConfig}
+        series={[{ id: 'A', data: [50, 100, 20] }]}
+        radar={{ metrics: ['M1', 'M2', 'M3'] }}
+        onMarkClick={onItemClick}
+        experimentalFeatures={{ keyboardActivation: true }}
+      />,
+    );
+
+    await user.keyboard('{Tab}');
+    await user.keyboard('[ArrowRight]');
+    await user.keyboard('[Enter]');
+
+    expect(onItemClick.mock.calls.length).to.equal(1);
+    expect(onItemClick.mock.lastCall?.[1]).to.deep.equal({
+      type: 'radar',
+      seriesId: 'A',
+      dataIndex: 0,
+    });
+  });
+});

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardActivation.test.tsx
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardActivation.test.tsx
@@ -1,4 +1,4 @@
-import { createRenderer } from '@mui/internal-test-utils/createRenderer';
+import { createRenderer, fireEvent } from '@mui/internal-test-utils/createRenderer';
 import { vi } from 'vitest';
 import { BarChart } from '@mui/x-charts/BarChart';
 import { LineChart } from '@mui/x-charts/LineChart';
@@ -27,6 +27,29 @@ describe('keyboard item activation', () => {
     await user.keyboard('[Enter]');
 
     expect(onItemClick.mock.calls.length).to.equal(0);
+  });
+
+  it('should ignore the auto-repeat keydown while the key is held down', async () => {
+    const onItemClick = vi.fn();
+    const { user } = render(
+      <BarChart
+        {...barConfig}
+        series={[{ id: 'A', data: [50, 100] }]}
+        onItemClick={onItemClick}
+        experimentalFeatures={{ keyboardActivation: true }}
+      />,
+    );
+
+    await user.keyboard('{Tab}');
+    await user.keyboard('[ArrowRight]');
+
+    const target = document.activeElement!;
+    // The browser marks every keydown after the first as a repeat while the key is held.
+    fireEvent.keyDown(target, { key: 'Enter', repeat: true });
+    expect(onItemClick.mock.calls.length).to.equal(0);
+
+    fireEvent.keyDown(target, { key: 'Enter' });
+    expect(onItemClick.mock.calls.length).to.equal(1);
   });
 
   it('should fire onItemClick with the focused bar on Enter and Space', async () => {

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardActivation.test.tsx
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardActivation.test.tsx
@@ -112,6 +112,43 @@ describe('keyboard item activation', () => {
     });
   });
 
+  it('should not fire onAreaClick when the area is disabled', async () => {
+    const onAreaClick = vi.fn();
+    const { user } = render(
+      <LineChart
+        {...barConfig}
+        series={[{ id: 'A', data: [50, 100], area: false, showMark: false }]}
+        onAreaClick={onAreaClick}
+        experimentalFeatures={{ keyboardActivation: true }}
+      />,
+    );
+
+    await user.keyboard('{Tab}');
+    await user.keyboard('[ArrowRight]');
+    await user.keyboard('[Enter]');
+
+    // No area is drawn, so a pointer could not click it and neither can the keyboard.
+    expect(onAreaClick.mock.calls.length).to.equal(0);
+  });
+
+  it('should fire onAreaClick when the area is enabled', async () => {
+    const onAreaClick = vi.fn();
+    const { user } = render(
+      <LineChart
+        {...barConfig}
+        series={[{ id: 'A', data: [50, 100], area: true, showMark: false }]}
+        onAreaClick={onAreaClick}
+        experimentalFeatures={{ keyboardActivation: true }}
+      />,
+    );
+
+    await user.keyboard('{Tab}');
+    await user.keyboard('[ArrowRight]');
+    await user.keyboard('[Enter]');
+
+    expect(onAreaClick.mock.calls.length).to.equal(1);
+  });
+
   it('should fire onMarkClick when marks are shown', async () => {
     const onMarkClick = vi.fn();
     const onLineClick = vi.fn();

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardActivation.test.tsx
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardActivation.test.tsx
@@ -85,6 +85,54 @@ describe('keyboard item activation', () => {
     });
   });
 
+  it('should skip onMarkClick and fall back to onLineClick when marks are hidden', async () => {
+    const onMarkClick = vi.fn();
+    const onLineClick = vi.fn();
+    const { user } = render(
+      <LineChart
+        {...barConfig}
+        series={[{ id: 'A', data: [50, 100], showMark: false }]}
+        onMarkClick={onMarkClick}
+        onLineClick={onLineClick}
+        experimentalFeatures={{ keyboardActivation: true }}
+      />,
+    );
+
+    await user.keyboard('{Tab}');
+    await user.keyboard('[ArrowRight]');
+    await user.keyboard('[Enter]');
+
+    // The mark is not rendered, so a pointer could not click it; activation falls through to the line.
+    expect(onMarkClick.mock.calls.length).to.equal(0);
+    expect(onLineClick.mock.calls.length).to.equal(1);
+    expect(onLineClick.mock.lastCall?.[1]).to.deep.equal({
+      type: 'line',
+      seriesId: 'A',
+      dataIndex: 0,
+    });
+  });
+
+  it('should fire onMarkClick when marks are shown', async () => {
+    const onMarkClick = vi.fn();
+    const onLineClick = vi.fn();
+    const { user } = render(
+      <LineChart
+        {...barConfig}
+        series={[{ id: 'A', data: [50, 100], showMark: true }]}
+        onMarkClick={onMarkClick}
+        onLineClick={onLineClick}
+        experimentalFeatures={{ keyboardActivation: true }}
+      />,
+    );
+
+    await user.keyboard('{Tab}');
+    await user.keyboard('[ArrowRight]');
+    await user.keyboard('[Enter]');
+
+    expect(onMarkClick.mock.calls.length).to.equal(1);
+    expect(onLineClick.mock.calls.length).to.equal(0);
+  });
+
   it('should fall back to onAreaClick when it is the only line callback', async () => {
     const onAreaClick = vi.fn();
     const { user } = render(

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.selectors.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.selectors.ts
@@ -1,6 +1,7 @@
 import { createSelector, createSelectorMemoized } from '@mui/x-internals/store';
 import { fastObjectShallowCompare } from '@mui/x-internals/fastObjectShallowCompare';
 import type { ChartOptionalRootSelector } from '../../utils/selectors';
+import type { ChartState } from '../../models/chart';
 import type { UseChartKeyboardNavigationSignature } from './useChartKeyboardNavigation.types';
 import { selectorChartSeriesProcessed } from '../../corePlugins/useChartSeries';
 import type { ProcessedSeries } from '../../corePlugins/useChartSeries';
@@ -50,6 +51,17 @@ export const selectorChartsFocusedOrToFocusedItem = createSelector(
 export const selectorChartsIsKeyboardNavigationEnabled = createSelector(
   selectKeyboardNavigation,
   (keyboardNavigationState) => !!keyboardNavigationState?.enabled,
+);
+
+const selectKeyboardActivationFeature = (
+  state: ChartState<[], [UseChartKeyboardNavigationSignature]>,
+) => state.experimentalFeatures?.keyboardActivation;
+
+export const selectorChartsIsKeyboardActivationEnabled = createSelector(
+  selectKeyboardNavigation,
+  selectKeyboardActivationFeature,
+  (keyboardNavigationState, keyboardActivation) =>
+    keyboardActivation === true && !!keyboardNavigationState?.enabled,
 );
 
 /**

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.ts
@@ -4,9 +4,16 @@ import useEnhancedEffect from '@mui/utils/useEnhancedEffect';
 import { selectorChartDefaultizedSeries } from '../../corePlugins/useChartSeries/useChartSeries.selectors';
 import { selectorChartSeriesConfig } from '../../corePlugins/useChartSeriesConfig';
 import type { ChartPlugin } from '../../models';
-import type { UseChartKeyboardNavigationSignature } from './useChartKeyboardNavigation.types';
+import type {
+  ItemActivationHandler,
+  ItemActivationScope,
+  UseChartKeyboardNavigationSignature,
+} from './useChartKeyboardNavigation.types';
 import type { ChartSeriesType } from '../../../../models/seriesType/config';
 import type { FocusedItemUpdater } from './keyboardFocusHandler.types';
+import { findItemActivationHandler, isItemActivationKey } from './itemActivation';
+import type { ItemActivationRegistration } from './itemActivation';
+import { selectorChartsIsKeyboardActivationEnabled } from './useChartKeyboardNavigation.selectors';
 
 export const useChartKeyboardNavigation: ChartPlugin<UseChartKeyboardNavigationSignature> = ({
   params,
@@ -14,6 +21,24 @@ export const useChartKeyboardNavigation: ChartPlugin<UseChartKeyboardNavigationS
   instance,
 }) => {
   const { chartsLayerContainerRef } = instance;
+
+  const activationRegistrationsRef = React.useRef(new Map<number, ItemActivationRegistration>());
+  const nextRegistrationIdRef = React.useRef(0);
+
+  const registerItemActivationHandler = React.useCallback(
+    (scope: ItemActivationScope, handler: ItemActivationHandler) => {
+      const registrationId = nextRegistrationIdRef.current;
+      nextRegistrationIdRef.current += 1;
+
+      const registrations = activationRegistrationsRef.current;
+      registrations.set(registrationId, { scope, handler });
+
+      return () => {
+        registrations.delete(registrationId);
+      };
+    },
+    [],
+  );
 
   React.useEffect(() => {
     const element = chartsLayerContainerRef.current;
@@ -53,6 +78,29 @@ export const useChartKeyboardNavigation: ChartPlugin<UseChartKeyboardNavigationS
           },
         });
       }
+    }
+
+    function activationHandler(event: KeyboardEvent) {
+      if (!isItemActivationKey(event) || !selectorChartsIsKeyboardActivationEnabled(store.state)) {
+        return;
+      }
+
+      const focusedItem = store.state.keyboardNavigation.item;
+      if (focusedItem === null || !store.state.keyboardNavigation.isFocused) {
+        return;
+      }
+
+      const handler = findItemActivationHandler(
+        activationRegistrationsRef.current.values(),
+        focusedItem,
+      );
+
+      if (handler === null) {
+        return;
+      }
+
+      event.preventDefault();
+      handler(event, focusedItem);
     }
 
     function keyboardHandler(event: KeyboardEvent) {
@@ -98,10 +146,12 @@ export const useChartKeyboardNavigation: ChartPlugin<UseChartKeyboardNavigationS
       }
     }
 
+    element.addEventListener('keydown', activationHandler);
     element.addEventListener('keydown', keyboardHandler);
     element.addEventListener('focusout', removeFocus);
     element.addEventListener('focusin', restoreFocus);
     return () => {
+      element.removeEventListener('keydown', activationHandler);
       element.removeEventListener('keydown', keyboardHandler);
       element.removeEventListener('focusout', removeFocus);
       element.removeEventListener('focusin', restoreFocus);
@@ -115,7 +165,7 @@ export const useChartKeyboardNavigation: ChartPlugin<UseChartKeyboardNavigationS
     });
   }, [store, params.disableKeyboardNavigation]);
 
-  return {};
+  return { instance: { registerItemActivationHandler } };
 };
 
 useChartKeyboardNavigation.getInitialState = (params) => ({

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.ts
@@ -84,7 +84,12 @@ export const useChartKeyboardNavigation: ChartPlugin<UseChartKeyboardNavigationS
     }
 
     function activationHandler(event: KeyboardEvent) {
-      if (!isItemActivationKey(event) || !selectorChartsIsKeyboardActivationEnabled(store.state)) {
+      // Ignore the auto-repeat while the key is held: a pointer click does not repeat either.
+      if (
+        event.repeat ||
+        !isItemActivationKey(event) ||
+        !selectorChartsIsKeyboardActivationEnabled(store.state)
+      ) {
         return;
       }
 

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.types.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.types.ts
@@ -2,10 +2,47 @@ import type { ChartPluginSignature } from '../../models';
 import type { UseChartInteractionSignature } from '../useChartInteraction';
 import type { UseChartCartesianAxisSignature } from '../useChartCartesianAxis';
 import type { UseChartHighlightSignature } from '../useChartHighlight';
-import type { FocusedItemIdentifier } from '../../../../models/seriesType';
+import type { FocusedItemIdentifier, SeriesId } from '../../../../models/seriesType';
 import type { ChartSeriesType } from '../../../../models/seriesType/config';
 
-export interface UseChartKeyboardNavigationInstance {}
+/**
+ * Called when the focused item is activated with the keyboard.
+ * @param {KeyboardEvent} event The keyboard event that triggered the activation.
+ * @param {FocusedItemIdentifier<ChartSeriesType>} item The activated item.
+ */
+export type ItemActivationHandler = (
+  event: KeyboardEvent,
+  item: FocusedItemIdentifier<ChartSeriesType>,
+) => void;
+
+/**
+ * The items a handler covers. An empty scope covers every item.
+ */
+export interface ItemActivationScope {
+  type?: ChartSeriesType;
+  seriesId?: SeriesId;
+  /**
+   * Breaks ties between handlers covering the same items, highest first.
+   * Mirrors pointer hit-testing, where marks sit above lines, and lines above areas.
+   * @default 0
+   */
+  priority?: number;
+}
+
+export interface UseChartKeyboardNavigationInstance {
+  /**
+   * Registers a handler triggered when the focused item is activated with the keyboard.
+   * Only the handler with the most specific matching scope runs, so plots sharing a series
+   * do not fire the callback twice.
+   * @param {ItemActivationScope} scope The items the handler covers.
+   * @param {ItemActivationHandler} handler The handler to call on activation.
+   * @returns {() => void} A cleanup function unregistering the handler.
+   */
+  registerItemActivationHandler: (
+    scope: ItemActivationScope,
+    handler: ItemActivationHandler,
+  ) => () => void;
+}
 
 export interface UseChartKeyboardNavigationState {
   keyboardNavigation: {

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.types.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.types.ts
@@ -27,6 +27,14 @@ export interface ItemActivationScope {
    * @default 0
    */
   priority?: number;
+  /**
+   * When set, the handler is a candidate only for items it returns `true` for. Lets a plot decline
+   * an item a pointer could not reach — e.g. a line mark that is not rendered — so activation falls
+   * through to the next handler.
+   * @param {FocusedItemIdentifier<ChartSeriesType>} item The focused item.
+   * @returns {boolean} Whether the handler can activate this item.
+   */
+  canActivate?: (item: FocusedItemIdentifier<ChartSeriesType>) => boolean;
 }
 
 export interface UseChartKeyboardNavigationInstance {

--- a/packages/x-charts/src/internals/useRegisterItemActivation.ts
+++ b/packages/x-charts/src/internals/useRegisterItemActivation.ts
@@ -1,0 +1,47 @@
+'use client';
+import * as React from 'react';
+import useEventCallback from '@mui/utils/useEventCallback';
+import { useChartsContext } from '../context/ChartsProvider';
+import type {
+  ItemActivationHandler,
+  UseChartKeyboardNavigationSignature,
+} from './plugins/featurePlugins/useChartKeyboardNavigation';
+import type { ChartSeriesType } from '../models/seriesType/config';
+import type { SeriesId } from '../models/seriesType/common';
+import type { FocusedItemIdentifier } from '../models/seriesType';
+
+/**
+ * Registers a handler fired when the keyboard-focused item is activated with <kbd>Enter</kbd> or
+ * <kbd>Space</kbd>. It is a no-op when the `keyboardActivation` experimental feature is off.
+ *
+ * Scope the registration as tightly as the caller knows: when several plots handle the same item,
+ * the most specific scope wins, `priority` breaks ties, and the handler runs once.
+ *
+ * The handler receives the `KeyboardEvent`, typed as `any` because the click callbacks it forwards
+ * to only describe the pointer event unless the user augments `keyboardActivationOverride`.
+ *
+ * @param scope The items covered by the handler. Omit `seriesId` to cover a whole series type.
+ * @param handler The handler to call on activation, or `undefined` to register nothing.
+ */
+export function useRegisterItemActivation<SeriesType extends ChartSeriesType = ChartSeriesType>(
+  scope: { type?: SeriesType; seriesId?: SeriesId; priority?: number },
+  handler: ((event: any, item: FocusedItemIdentifier<SeriesType>) => void) | undefined,
+) {
+  const { instance } = useChartsContext<[], [UseChartKeyboardNavigationSignature]>();
+  const { type, seriesId, priority } = scope;
+
+  const hasHandler = handler !== undefined;
+  const stableHandler = useEventCallback<Parameters<ItemActivationHandler>, void>((event, item) =>
+    handler?.(event, item as FocusedItemIdentifier<SeriesType>),
+  );
+
+  const registerItemActivationHandler = instance.registerItemActivationHandler;
+
+  React.useEffect(() => {
+    if (!hasHandler || !registerItemActivationHandler) {
+      return undefined;
+    }
+
+    return registerItemActivationHandler({ type, seriesId, priority }, stableHandler);
+  }, [registerItemActivationHandler, hasHandler, type, seriesId, priority, stableHandler]);
+}

--- a/packages/x-charts/src/internals/useRegisterItemActivation.ts
+++ b/packages/x-charts/src/internals/useRegisterItemActivation.ts
@@ -15,7 +15,8 @@ import type { FocusedItemIdentifier } from '../models/seriesType';
  * <kbd>Space</kbd>. It is a no-op when the `keyboardActivation` experimental feature is off.
  *
  * Scope the registration as tightly as the caller knows: when several plots handle the same item,
- * the most specific scope wins, `priority` breaks ties, and the handler runs once.
+ * the most specific scope wins, `priority` breaks ties, `canActivate` can decline an item, and the
+ * handler runs once.
  *
  * The handler receives the `KeyboardEvent`, typed as `any` because the click callbacks it forwards
  * to only describe the pointer event unless the user augments `keyboardActivationOverride`.
@@ -24,15 +25,25 @@ import type { FocusedItemIdentifier } from '../models/seriesType';
  * @param handler The handler to call on activation, or `undefined` to register nothing.
  */
 export function useRegisterItemActivation<SeriesType extends ChartSeriesType = ChartSeriesType>(
-  scope: { type?: SeriesType; seriesId?: SeriesId; priority?: number },
+  scope: {
+    type?: SeriesType;
+    seriesId?: SeriesId;
+    priority?: number;
+    canActivate?: (item: FocusedItemIdentifier<SeriesType>) => boolean;
+  },
   handler: ((event: any, item: FocusedItemIdentifier<SeriesType>) => void) | undefined,
 ) {
   const { instance } = useChartsContext<[], [UseChartKeyboardNavigationSignature]>();
-  const { type, seriesId, priority } = scope;
+  const { type, seriesId, priority, canActivate } = scope;
 
   const hasHandler = handler !== undefined;
   const stableHandler = useEventCallback<Parameters<ItemActivationHandler>, void>((event, item) =>
     handler?.(event, item as FocusedItemIdentifier<SeriesType>),
+  );
+
+  const hasCanActivate = canActivate !== undefined;
+  const stableCanActivate = useEventCallback((item: FocusedItemIdentifier<ChartSeriesType>) =>
+    canActivate ? canActivate(item as FocusedItemIdentifier<SeriesType>) : true,
   );
 
   const registerItemActivationHandler = instance.registerItemActivationHandler;
@@ -42,6 +53,18 @@ export function useRegisterItemActivation<SeriesType extends ChartSeriesType = C
       return undefined;
     }
 
-    return registerItemActivationHandler({ type, seriesId, priority }, stableHandler);
-  }, [registerItemActivationHandler, hasHandler, type, seriesId, priority, stableHandler]);
+    return registerItemActivationHandler(
+      { type, seriesId, priority, canActivate: hasCanActivate ? stableCanActivate : undefined },
+      stableHandler,
+    );
+  }, [
+    registerItemActivationHandler,
+    hasHandler,
+    type,
+    seriesId,
+    priority,
+    hasCanActivate,
+    stableCanActivate,
+    stableHandler,
+  ]);
 }

--- a/packages/x-charts/src/models/events.ts
+++ b/packages/x-charts/src/models/events.ts
@@ -1,0 +1,17 @@
+import type * as React from 'react';
+import type { HasProperty } from '@mui/x-internals/types';
+import type { ChartsTypeFeatureFlags } from './featureFlags';
+
+/**
+ * The event a click callback receives.
+ *
+ * It only describes the pointer event by default. Add
+ * `import type {} from '@mui/x-charts/moduleAugmentation/keyboardActivation'` to also get the
+ * `KeyboardEvent` fired by the `keyboardActivation` experimental feature.
+ */
+export type ChartsActivationEvent<Element = never> =
+  | ([Element] extends [never] ? MouseEvent : React.MouseEvent<Element, MouseEvent>)
+  | (HasProperty<ChartsTypeFeatureFlags, 'keyboardActivationOverride'> extends true
+      ? // @ts-ignore this property is added through module augmentation
+        ChartsTypeFeatureFlags['keyboardActivationOverride']
+      : never);

--- a/packages/x-charts/src/models/index.ts
+++ b/packages/x-charts/src/models/index.ts
@@ -2,6 +2,7 @@ export * from './seriesType';
 export * from './stacking';
 export * from './slots';
 export * from './featureFlags';
+export type { ChartsActivationEvent } from './events';
 export * from './chartsSlotsComponentsProps';
 export type {
   AxisConfig,

--- a/packages/x-charts/src/moduleAugmentation/barChartBatchRendererOnItemClick.ts
+++ b/packages/x-charts/src/moduleAugmentation/barChartBatchRendererOnItemClick.ts
@@ -1,16 +1,15 @@
-import type * as React from 'react';
-import type { BarItemIdentifier } from '../models';
+import type { BarItemIdentifier, ChartsActivationEvent } from '../models';
 
 declare module '@mui/x-charts/BarChart' {
   export interface BarPlotProps {
     /**
      * Callback fired when a bar item is clicked.
-     * @param {MouseEvent | React.MouseEvent<SVGElement, MouseEvent>} event The event source of the callback.
+     * @param {ChartsActivationEvent | ChartsActivationEvent<SVGElement>} event The event source of the callback.
      *        It is a native MouseEvent for `svg-batch` renderer and a React MouseEvent for `svg-single` renderer.
      * @param {BarItemIdentifier} barItemIdentifier The bar item identifier.
      */
     onItemClick?(
-      event: MouseEvent | React.MouseEvent<SVGElement, MouseEvent>,
+      event: ChartsActivationEvent | ChartsActivationEvent<SVGElement>,
       barItemIdentifier: BarItemIdentifier,
     ): void;
   }

--- a/packages/x-charts/src/moduleAugmentation/keyboardActivation.ts
+++ b/packages/x-charts/src/moduleAugmentation/keyboardActivation.ts
@@ -1,0 +1,8 @@
+declare module '@mui/x-charts/models' {
+  interface ChartsTypeFeatureFlags {
+    keyboardActivationOverride: KeyboardEvent;
+  }
+}
+
+// Required to make this file into a module
+export default {};

--- a/scripts/x-charts-premium.exports.json
+++ b/scripts/x-charts-premium.exports.json
@@ -112,6 +112,7 @@
   { "name": "ChartDrawingArea", "kind": "TypeAlias" },
   { "name": "ChartPremiumApi", "kind": "TypeAlias" },
   { "name": "ChartProApi", "kind": "TypeAlias" },
+  { "name": "ChartsActivationEvent", "kind": "TypeAlias" },
   { "name": "ChartsAxis", "kind": "Function" },
   { "name": "ChartsAxisClasses", "kind": "Interface" },
   { "name": "ChartsAxisClassKey", "kind": "TypeAlias" },

--- a/scripts/x-charts-pro.exports.json
+++ b/scripts/x-charts-pro.exports.json
@@ -99,6 +99,7 @@
   { "name": "ChartImageExportOptions", "kind": "Interface" },
   { "name": "ChartPrintExportOptions", "kind": "Interface" },
   { "name": "ChartProApi", "kind": "TypeAlias" },
+  { "name": "ChartsActivationEvent", "kind": "TypeAlias" },
   { "name": "ChartsAxis", "kind": "Function" },
   { "name": "ChartsAxisClasses", "kind": "Interface" },
   { "name": "ChartsAxisClassKey", "kind": "TypeAlias" },

--- a/scripts/x-charts.exports.json
+++ b/scripts/x-charts.exports.json
@@ -77,6 +77,7 @@
   { "name": "ChartBaseToggleButtonGroupProps", "kind": "TypeAlias" },
   { "name": "ChartBaseToggleButtonProps", "kind": "TypeAlias" },
   { "name": "ChartDrawingArea", "kind": "TypeAlias" },
+  { "name": "ChartsActivationEvent", "kind": "TypeAlias" },
   { "name": "ChartsAxis", "kind": "Function" },
   { "name": "ChartsAxisClasses", "kind": "Interface" },
   { "name": "ChartsAxisClassKey", "kind": "TypeAlias" },


### PR DESCRIPTION
Part of #23208 (which this replaces, together with the axis PR linked below).
Depends on #23216 — its one-file fix is included here until it merges.

## Summary

Charts let keyboard users move focus between items with the arrow keys, but there was no way to activate the focused item, so `onItemClick` and friends were mouse-only ([WCAG 2.1 SC 2.1.1](https://www.w3.org/WAI/WCAG21/Understanding/keyboard.html), #23148).

This adds a `keyboardActivation` experimental feature, shared by every chart. When enabled, pressing <kbd>Enter</kbd> or <kbd>Space</kbd> on the focused item fires the chart's item click callback with the same payload a pointer click provides.

```jsx
<BarChart
  experimentalFeatures={{ keyboardActivation: true }}
  onItemClick={(event, item) => {}}
/>
```

Axis activation (`onAxisClick`) is a separate PR, linked below.

### How it works

- `useChartKeyboardNavigation` gains `registerItemActivationHandler(scope, handler)` and dispatches <kbd>Enter</kbd>/<kbd>Space</kbd> to the registered handler whose scope (`type` + `seriesId`) matches the focused item most specifically.
- Each place that already wires a click callback registers its own handler through `useRegisterItemActivation`, so payloads are built by the code that owns them rather than by faking DOM events.
- When several handlers cover the same item, `priority` breaks the tie in pointer hit-testing order, so a line chart fires `onMarkClick`, then `onLineClick`, then `onAreaClick`, and never more than one. Radar does the same for marks over areas; Sankey picks `onNodeClick` or `onLinkClick` from the focused element.
- Heatmap goes through the generic `useChartItemClick` plugin, so a `getItemWithData` series-config entry completes the identifier exactly as `getItemAtPosition` does for a pointer click.

Covered: bar, line, pie, scatter, radar, funnel, heatmap, sankey, range bar, and map.

### Types

The click callbacks keep their current types, so nothing breaks. `ChartsActivationEvent` resolves to the pointer event alone unless `ChartsTypeFeatureFlags.keyboardActivationOverride` is declared, following the `seriesValuesOverride` pattern:

```ts
import type {} from '@mui/x-charts/moduleAugmentation/keyboardActivation';
```

Verified both ways: with the augmentation absent, existing handlers — annotated `(event: MouseEvent, …)`, inferred handlers reading `event.clientX`, and `React.MouseEvent<SVGPathElement>` ones — still compile; with it, `event instanceof KeyboardEvent` narrows.

Both become the default in v10 (#23214).
