### PR TITLE
[tree view] Ignore `keepExistingSelection` when `multiSelect` is `false`

### DIFF
--- a/packages/x-tree-view-pro/src/internals/plugins/lazyLoading/TreeViewLazyLoadingPlugin.test.tsx
+++ b/packages/x-tree-view-pro/src/internals/plugins/lazyLoading/TreeViewLazyLoadingPlugin.test.tsx
@@ -99,6 +99,62 @@ describeTreeView<RichTreeViewProStore<any, any>>(
         expect(view.getAllTreeItemIds()).to.deep.equal(['1', '1-1']);
       });
 
+      it('should not update the selection when expanding a selected item in single selection', async () => {
+        const onSelectedItemsChange = spy();
+        const onItemSelectionToggle = spy();
+
+        const view = render({
+          items: [{ id: '1', childrenCount: 1 }],
+          dataSource: {
+            getChildrenCount: (item) => item?.childrenCount as number,
+            getTreeItems: mockFetchData,
+          },
+          defaultSelectedItems: '1',
+          onSelectedItemsChange,
+          onItemSelectionToggle,
+        });
+
+        act(() => {
+          view.apiRef.current.setItemExpansion({
+            event: {} as any,
+            itemId: '1',
+            shouldBeExpanded: true,
+          });
+        });
+        await awaitMockFetch();
+
+        expect(view.isItemExpanded('1')).to.equal(true);
+        expect(view.isItemSelected('1')).to.equal(true);
+        expect(onSelectedItemsChange.callCount).to.equal(0);
+        expect(onItemSelectionToggle.callCount).to.equal(0);
+      });
+
+      it('should propagate the selection to the lazy loaded children when expanding a selected item', async () => {
+        const view = render({
+          items: [{ id: '1', childrenCount: 1 }],
+          dataSource: {
+            getChildrenCount: (item) => item?.childrenCount as number,
+            getTreeItems: mockFetchData,
+          },
+          multiSelect: true,
+          defaultSelectedItems: ['1'],
+          selectionPropagation: { descendants: true, parents: false },
+        });
+
+        act(() => {
+          view.apiRef.current.setItemExpansion({
+            event: {} as any,
+            itemId: '1',
+            shouldBeExpanded: true,
+          });
+        });
+        await awaitMockFetch();
+
+        expect(view.isItemExpanded('1')).to.equal(true);
+        expect(view.isItemSelected('1')).to.equal(true);
+        expect(view.isItemSelected('1-1')).to.equal(true);
+      });
+
       it('should not load children if item has no children', async () => {
         const view = render({
           items: [{ id: '1', childrenCount: 0 }],

--- a/packages/x-tree-view-pro/src/internals/plugins/lazyLoading/TreeViewLazyLoadingPlugin.test.tsx
+++ b/packages/x-tree-view-pro/src/internals/plugins/lazyLoading/TreeViewLazyLoadingPlugin.test.tsx
@@ -129,6 +129,34 @@ describeTreeView<RichTreeViewProStore<any, any>>(
         expect(onItemSelectionToggle.callCount).to.equal(0);
       });
 
+      it('should not update the selection when expanding a selected item without descendants propagation', async () => {
+        const onSelectedItemsChange = spy();
+
+        const view = render({
+          items: [{ id: '1', childrenCount: 1 }],
+          dataSource: {
+            getChildrenCount: (item) => item?.childrenCount as number,
+            getTreeItems: mockFetchData,
+          },
+          multiSelect: true,
+          defaultSelectedItems: ['1'],
+          onSelectedItemsChange,
+        });
+
+        act(() => {
+          view.apiRef.current.setItemExpansion({
+            event: {} as any,
+            itemId: '1',
+            shouldBeExpanded: true,
+          });
+        });
+        await awaitMockFetch();
+
+        expect(view.isItemExpanded('1')).to.equal(true);
+        expect(view.getSelectedTreeItems()).to.deep.equal(['1']);
+        expect(onSelectedItemsChange.callCount).to.equal(0);
+      });
+
       it('should propagate the selection to the lazy loaded children when expanding a selected item', async () => {
         const view = render({
           items: [{ id: '1', childrenCount: 1 }],

--- a/packages/x-tree-view-pro/src/internals/plugins/lazyLoading/TreeViewLazyLoadingPlugin.ts
+++ b/packages/x-tree-view-pro/src/internals/plugins/lazyLoading/TreeViewLazyLoadingPlugin.ts
@@ -116,6 +116,7 @@ export class TreeViewLazyLoadingPlugin<R extends TreeViewValidItem<R>> {
       });
       if (
         selectionSelectors.isMultiSelectEnabled(this.store.state) &&
+        selectionSelectors.propagationRules(this.store.state).descendants &&
         selectionSelectors.isItemSelected(this.store.state, eventParameters.itemId)
       ) {
         // make sure selection propagation works correctly

--- a/packages/x-tree-view-pro/src/internals/plugins/lazyLoading/TreeViewLazyLoadingPlugin.ts
+++ b/packages/x-tree-view-pro/src/internals/plugins/lazyLoading/TreeViewLazyLoadingPlugin.ts
@@ -114,7 +114,10 @@ export class TreeViewLazyLoadingPlugin<R extends TreeViewValidItem<R>> {
         shouldBeExpanded: true,
         event,
       });
-      if (selectionSelectors.isItemSelected(this.store.state, eventParameters.itemId)) {
+      if (
+        selectionSelectors.isMultiSelectEnabled(this.store.state) &&
+        selectionSelectors.isItemSelected(this.store.state, eventParameters.itemId)
+      ) {
         // make sure selection propagation works correctly
         this.store.selection.setItemSelection({
           event,

--- a/packages/x-tree-view/src/internals/plugins/selection/TreeViewSelectionPlugin.test.tsx
+++ b/packages/x-tree-view/src/internals/plugins/selection/TreeViewSelectionPlugin.test.tsx
@@ -1247,6 +1247,53 @@ describeTreeView<TreeViewAnyStore>(
 
           expect(view.isItemSelected('1')).to.equal(true);
         });
+
+        it('should ignore keepExistingSelection and only select the new item', () => {
+          const onSelectedItemsChange = spy();
+
+          const view = render({
+            items: [{ id: '1' }, { id: '2' }],
+            defaultSelectedItems: '1',
+            onSelectedItemsChange,
+          });
+
+          act(() => {
+            view.apiRef.current.setItemSelection({
+              itemId: '2',
+              event: {} as any,
+              keepExistingSelection: true,
+            });
+          });
+
+          expect(view.isItemSelected('1')).to.equal(false);
+          expect(view.isItemSelected('2')).to.equal(true);
+          expect(onSelectedItemsChange.lastCall.args[1]).to.equal('2');
+        });
+
+        it('should keep the model as an item id when re-selecting a selected item with keepExistingSelection', () => {
+          const onSelectedItemsChange = spy();
+          const onItemSelectionToggle = spy();
+
+          const view = render({
+            items: [{ id: '1' }, { id: '2' }],
+            defaultSelectedItems: '1',
+            onSelectedItemsChange,
+            onItemSelectionToggle,
+          });
+
+          act(() => {
+            view.apiRef.current.setItemSelection({
+              itemId: '1',
+              event: {} as any,
+              keepExistingSelection: true,
+              shouldBeSelected: true,
+            });
+          });
+
+          expect(view.isItemSelected('1')).to.equal(true);
+          expect(onSelectedItemsChange.lastCall.args[1]).to.equal('1');
+          expect(onItemSelectionToggle.callCount).to.equal(0);
+        });
       });
 
       describe('multi selection', () => {

--- a/packages/x-tree-view/src/internals/plugins/selection/TreeViewSelectionPlugin.ts
+++ b/packages/x-tree-view/src/internals/plugins/selection/TreeViewSelectionPlugin.ts
@@ -150,7 +150,7 @@ export class TreeViewSelectionPlugin<Multiple extends boolean | undefined> {
 
     let newSelected: TreeViewSelectionValue<boolean>;
     const isMultiSelectEnabled = selectionSelectors.isMultiSelectEnabled(this.store.state);
-    if (keepExistingSelection) {
+    if (keepExistingSelection && isMultiSelectEnabled) {
       const oldSelected = selectionSelectors.selectedItems(this.store.state);
       const isSelectedBefore = selectionSelectors.isItemSelected(this.store.state, itemId);
       if (isSelectedBefore && (shouldBeSelected === false || shouldBeSelected == null)) {


### PR DESCRIPTION
Fixes #23236

`setItemSelection` built the new model from the `selectedItems` selector when `keepExistingSelection` was `true`, and that selector always normalizes to an array. In single selection this turned the selection model into an array, so `onSelectedItemsChange` received `['item-1']` instead of `'item-1'` and `onItemSelectionToggle` received an array as its `itemId` argument — contradicting the documented single-select signature.

`keepExistingSelection` is now ignored when `multiSelect` is `false`, which matches its documented contract ("only relevant when `multiSelect` is `true`") and fixes both the lazy loading path and the public `apiRef.current.setItemSelection({ keepExistingSelection: true })` path.

The lazy loading plugin also passed `keepExistingSelection: true` unconditionally when re-applying the selection of an expanded item. That re-selection only exists so selection propagation covers the newly loaded children, and propagation is a multi select feature, so it is now skipped in single selection — removing the spurious `onSelectedItemsChange` call on expansion.