### PR TITLE
[charts] Fix axis clicks being discarded on slight pointer movement

### DIFF
--- a/packages/x-charts/src/BarChart/checkClickEvent.test.tsx
+++ b/packages/x-charts/src/BarChart/checkClickEvent.test.tsx
@@ -85,44 +85,47 @@ describe('BarChart - click event', () => {
 
     // Regression test for https://github.com/mui/mui-x/issues/20364
     // A click with a small pointer drift should still be handled and not discarded as a pan.
-    it.skipIf(isJSDOM)('should fire when the pointer drifts slightly between press and release', async () => {
-      const onAxisClick = vi.fn();
-      const { user, container } = render(
-        <div
-          style={{
-            width: 400,
-            height: 400,
-          }}
-        >
-          <BarChart
-            {...config}
-            series={[
-              { dataKey: 'v1', id: 's1' },
-              { dataKey: 'v2', id: 's2' },
-            ]}
-            xAxis={[{ dataKey: 'x' }]}
-            onAxisClick={onAxisClick}
-          />
-        </div>,
-      );
-      const layerContainer = container.querySelector<HTMLElement>(
-        `.${chartsSvgLayerClasses.root}`,
-      )!.parentElement!;
+    it.skipIf(isJSDOM)(
+      'should fire when the pointer drifts slightly between press and release',
+      async () => {
+        const onAxisClick = vi.fn();
+        const { user, container } = render(
+          <div
+            style={{
+              width: 400,
+              height: 400,
+            }}
+          >
+            <BarChart
+              {...config}
+              series={[
+                { dataKey: 'v1', id: 's1' },
+                { dataKey: 'v2', id: 's2' },
+              ]}
+              xAxis={[{ dataKey: 'x' }]}
+              onAxisClick={onAxisClick}
+            />
+          </div>,
+        );
+        const layerContainer = container.querySelector<HTMLElement>(
+          `.${chartsSvgLayerClasses.root}`,
+        )!.parentElement!;
 
-      // Press, drift a few pixels (within the tap's maxDistance), then release.
-      await user.pointer([
-        { keys: '[MouseLeft>]', target: layerContainer, coords: { clientX: 150, clientY: 60 } },
-        { target: layerContainer, coords: { clientX: 154, clientY: 62 } },
-        { keys: '[/MouseLeft]', target: layerContainer, coords: { clientX: 154, clientY: 62 } },
-      ]);
+        // Press, drift a few pixels (within the tap's maxDistance), then release.
+        await user.pointer([
+          { keys: '[MouseLeft>]', target: layerContainer, coords: { clientX: 150, clientY: 60 } },
+          { target: layerContainer, coords: { clientX: 154, clientY: 62 } },
+          { keys: '[/MouseLeft]', target: layerContainer, coords: { clientX: 154, clientY: 62 } },
+        ]);
 
-      expect(onAxisClick).toHaveBeenCalledTimes(1);
-      expect(onAxisClick.mock.lastCall?.[1]).to.deep.equal({
-        dataIndex: 0,
-        axisValue: 'A',
-        seriesValues: { s1: 4, s2: 2 },
-      });
-    });
+        expect(onAxisClick).toHaveBeenCalledTimes(1);
+        expect(onAxisClick.mock.lastCall?.[1]).to.deep.equal({
+          dataIndex: 0,
+          axisValue: 'A',
+          seriesValues: { s1: 4, s2: 2 },
+        });
+      },
+    );
 
     // can't do Pointer event with JSDom https://github.com/jsdom/jsdom/issues/2527
     it.skipIf(isJSDOM)(

--- a/packages/x-charts/src/BarChart/checkClickEvent.test.tsx
+++ b/packages/x-charts/src/BarChart/checkClickEvent.test.tsx
@@ -83,6 +83,47 @@ describe('BarChart - click event', () => {
       });
     });
 
+    // Regression test for https://github.com/mui/mui-x/issues/20364
+    // A click with a small pointer drift should still be handled and not discarded as a pan.
+    it.skipIf(isJSDOM)('should fire when the pointer drifts slightly between press and release', async () => {
+      const onAxisClick = vi.fn();
+      const { user, container } = render(
+        <div
+          style={{
+            width: 400,
+            height: 400,
+          }}
+        >
+          <BarChart
+            {...config}
+            series={[
+              { dataKey: 'v1', id: 's1' },
+              { dataKey: 'v2', id: 's2' },
+            ]}
+            xAxis={[{ dataKey: 'x' }]}
+            onAxisClick={onAxisClick}
+          />
+        </div>,
+      );
+      const layerContainer = container.querySelector<HTMLElement>(
+        `.${chartsSvgLayerClasses.root}`,
+      )!.parentElement!;
+
+      // Press, drift a few pixels (within the tap's maxDistance), then release.
+      await user.pointer([
+        { keys: '[MouseLeft>]', target: layerContainer, coords: { clientX: 150, clientY: 60 } },
+        { target: layerContainer, coords: { clientX: 154, clientY: 62 } },
+        { keys: '[/MouseLeft]', target: layerContainer, coords: { clientX: 154, clientY: 62 } },
+      ]);
+
+      expect(onAxisClick).toHaveBeenCalledTimes(1);
+      expect(onAxisClick.mock.lastCall?.[1]).to.deep.equal({
+        dataIndex: 0,
+        axisValue: 'A',
+        seriesValues: { s1: 4, s2: 2 },
+      });
+    });
+
     // can't do Pointer event with JSDom https://github.com/jsdom/jsdom/issues/2527
     it.skipIf(isJSDOM)(
       'should provide the right context as second argument with layout="horizontal"',

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartInteractionListener/useChartInteractionListener.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartInteractionListener/useChartInteractionListener.ts
@@ -64,7 +64,10 @@ export const useChartInteractionListener: ChartPlugin<UseChartInteractionListene
           }),
           new TapGesture({
             name: 'tap',
-            preventIf: ['pan', 'zoomPinch', 'zoomPan'],
+            // `pan` is intentionally omitted: it has `threshold: 0`, so any pointer drift during a
+            // click activates it and would cancel the tap, discarding the click. The tap's own
+            // `maxDistance` already discriminates a click from a drag. See https://github.com/mui/mui-x/issues/20364
+            preventIf: ['zoomPinch', 'zoomPan'],
           }),
           new PressGesture({
             name: 'quickPress',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request). 


## Description
Some axis clicks did nothing. If you clicked on the axis and your pointer moved even a pixel between press and release, `onAxisClick` never fired. Only perfectly still clicks worked, which is why it looked random.

The tap gesture listed pan in its `preventIf`, and pan has `threshold: 0`, so it activates on the first pixel of movement. Any small drift during a click counted as a pan and cancelled the tap.

The pan gesture here is only used for the highlight-follow interaction, not zoom (zoom uses `zoomPan`, which stays in `preventIf`). So I removed pan from the tap's `preventIf`. The tap already has its own `maxDistance` of about `10px` to tell a click from a drag, and that is exactly the check we want. Clicks with small drift now register, real drags still don't. 

## Testing
Added a browser test that presses, moves a few pixels, then releases, and checks that onAxisClick fires. It fails before this change and passes after.

Closes #20364