### PR TITLE
[codemod] Remove unused `@babel/core` and `@babel/traverse` dependencies

### DIFF
--- a/packages/x-codemod/package.json
+++ b/packages/x-codemod/package.json
@@ -29,9 +29,7 @@
     "url": "https://opencollective.com/mui-org"
   },
   "dependencies": {
-    "@babel/core": "catalog:",
     "@babel/runtime": "catalog:",
-    "@babel/traverse": "catalog:",
     "@mui/x-internals": "workspace:^",
     "jscodeshift": "catalog:",
     "yargs": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1196,15 +1196,9 @@ importers:
 
   packages/x-codemod:
     dependencies:
-      '@babel/core':
-        specifier: 'catalog:'
-        version: 7.29.7(supports-color@10.2.2)
       '@babel/runtime':
         specifier: 'catalog:'
         version: 7.29.7
-      '@babel/traverse':
-        specifier: 'catalog:'
-        version: 7.29.7(supports-color@10.2.2)
       '@mui/x-internals':
         specifier: workspace:^
         version: link:../x-internals/build


### PR DESCRIPTION
`@mui/x-codemod` has declared `@babel/core` and `@babel/traverse` as runtime dependencies since the package was introduced in #6876, but neither has ever been used.

- `git log -S"@babel/core"` and `git log -S"@babel/traverse"` over the entire history of `packages/x-codemod/src` return no commits at all, so neither was imported and later dropped -- they were simply never referenced.
- Nothing pulls them in transitively either. `jscodeshift` resolves its own `@babel/core`, and its only peer dependency is `@babel/preset-env`, declared optional.
- `@babel/runtime` stays: the built output requires `@babel/runtime/helpers/*`. `@mui/x-internals` stays too, it is used by a type-only import in `src/types.ts`.

## Why now

This is worth doing ahead of the Babel 8 bump in #23132. Under that PR the catalog resolves these two to `@babel/core@8.0.1` and `@babel/traverse@8.0.4`, both of which declare `engines.node: ^22.18.0 || >=24.11.0`. That contradicts this package's own `engines.node` of `>=20.19`, so users on Node 20.19-22.17 or 24.0-24.10 running `npx @mui/x-codemod` -- the documented migration path -- would hit it.

Verified by packing the package with the Babel 8 versions and installing it on Node 22.17.1:

- default npm config: `EBADENGINE` warnings for `@babel/core@8.0.1`, `@babel/traverse@8.0.4` and their transitive Babel 8 packages; the install still completes
- with `engine-strict=true` in `.npmrc`: the install fails outright with exit code 1

The two dependencies were also shipping duplication. `@babel/core@8` was hoisted to the top level and used by nothing, while `jscodeshift` nested its own `@babel/core@7` that does the actual work. Dropping them takes a fresh consumer install from 121 packages / 84M to 116 packages / 27M.

## Testing

- `pnpm test:unit --project "x-codemod" --run`: 275 tests passed across 92 files
- `pnpm --filter "@mui/x-codemod" run typescript`: clean
- eslint, prettier and `pnpm dedupe --check`: clean
- built the package, packed it, installed the tarball on Node 22.17.1 and ran `v8.0.0/data-grid/rename-package` against a fixture: install exits 0 with zero engine warnings, and the codemod output is unchanged (`1 ok`, `LicenseInfo` correctly moved to `@mui/x-license`)
