### PR TITLE
[charts] Fix `slotProps.legend.position` and `direction` in `RadarChart`

### DIFF
--- a/packages/x-charts/src/RadarChart/RadarChart.test.tsx
+++ b/packages/x-charts/src/RadarChart/RadarChart.test.tsx
@@ -27,6 +27,36 @@ describe('<RadarChart />', () => {
     refInstanceof: window.HTMLDivElement,
   }));
 
+  describe('legend', () => {
+    const getGridTemplateAreas = (container: HTMLElement) =>
+      window
+        .getComputedStyle(container.firstElementChild!)
+        .gridTemplateAreas.replace(/\s+/g, ' ')
+        .trim();
+
+    it('should place the legend at the bottom when slotProps.legend.position is bottom', () => {
+      const { container } = render(
+        <RadarChart
+          {...radarConfig}
+          slotProps={{ legend: { position: { vertical: 'bottom', horizontal: 'center' } } }}
+        />,
+      );
+
+      expect(getGridTemplateAreas(container)).to.equal('"chart" "legend"');
+    });
+
+    it('should place the legend on the side when slotProps.legend.direction is vertical', () => {
+      const { container } = render(
+        <RadarChart
+          {...radarConfig}
+          slotProps={{ legend: { direction: 'vertical', position: { horizontal: 'start' } } }}
+        />,
+      );
+
+      expect(getGridTemplateAreas(container)).to.equal('"legend chart"');
+    });
+  });
+
   it('should render "No Data" overlay when series prop is an empty array', () => {
     render(<RadarChart height={100} width={100} series={[]} radar={{ metrics: [] }} />);
 

--- a/packages/x-charts/src/RadarChart/useRadarChartProps.ts
+++ b/packages/x-charts/src/RadarChart/useRadarChartProps.ts
@@ -80,6 +80,8 @@ export const useRadarChartProps = (props: RadarChartProps) => {
 
   const chartsWrapperProps: Omit<ChartsWrapperProps, 'children'> = {
     sx,
+    legendPosition: props.slotProps?.legend?.position,
+    legendDirection: props.slotProps?.legend?.direction,
     hideLegend: props.hideLegend ?? false,
     className,
   };


### PR DESCRIPTION
Fixes #23251

`useRadarChartProps` built `chartsWrapperProps` without `legendPosition`/`legendDirection`, so `ChartsWrapper` always fell back to the default grid layout (legend on top) and `slotProps.legend.position` / `slotProps.legend.direction` had no effect on `RadarChart`.

Every other chart already forwards those two props (`BarChart`, `LineChart`, `ScatterChart`, `PieChart`, `FunnelChart`, `Heatmap`); radar was the only one missing them.

Computed `grid-template-areas` with `slotProps={{ legend: { position: { vertical: 'bottom' } } }}`:

| | before | after |
| --- | --- | --- |
| `RadarChart` | `"legend" "chart"` | `"chart" "legend"` |

`RadarChartPro` is fixed as well since it shares the same hook.
