### PR TITLE
[docs] Replace README peer dependency lists with an npm install command

### DIFF
--- a/packages/x-charts-premium/README.md
+++ b/packages/x-charts-premium/README.md
@@ -8,17 +8,7 @@ It's part of [MUI X](https://mui.com/x/), an open-core extension of our Core li
 Install the package in your project directory with:
 
 ```bash
-npm install @mui/x-charts-premium
-```
-
-This component has the following peer dependencies that you need to install as well.
-
-```json
-"peerDependencies": {
-  "@mui/material": "^7.3.0 || ^9.0.0",
-  "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-  "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-},
+npm install @mui/x-charts-premium @mui/material @emotion/react @emotion/styled
 ```
 
 ## Documentation

--- a/packages/x-charts-premium/README.md
+++ b/packages/x-charts-premium/README.md
@@ -15,7 +15,7 @@ This component has the following peer dependencies that you need to install as w
 
 ```json
 "peerDependencies": {
-  "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
+  "@mui/material": "^7.3.0 || ^9.0.0",
   "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
   "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
 },

--- a/packages/x-charts-pro/README.md
+++ b/packages/x-charts-pro/README.md
@@ -8,17 +8,7 @@ It's part of [MUI X](https://mui.com/x/), an open-core extension of our Core li
 Install the package in your project directory with:
 
 ```bash
-npm install @mui/x-charts-pro
-```
-
-This component has the following peer dependencies that you need to install as well.
-
-```json
-"peerDependencies": {
-  "@mui/material": "^7.3.0 || ^9.0.0",
-  "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-  "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-},
+npm install @mui/x-charts-pro @mui/material @emotion/react @emotion/styled
 ```
 
 ## Documentation

--- a/packages/x-charts-pro/README.md
+++ b/packages/x-charts-pro/README.md
@@ -15,7 +15,7 @@ This component has the following peer dependencies that you need to install as w
 
 ```json
 "peerDependencies": {
-  "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
+  "@mui/material": "^7.3.0 || ^9.0.0",
   "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
   "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
 },

--- a/packages/x-charts/README.md
+++ b/packages/x-charts/README.md
@@ -8,17 +8,7 @@ It's part of [MUI X](https://mui.com/x/), an open-core extension of our Core li
 Install the package in your project directory with:
 
 ```bash
-npm install @mui/x-charts
-```
-
-This component has the following peer dependencies that you need to install as well.
-
-```json
-"peerDependencies": {
-  "@mui/material": "^7.3.0 || ^9.0.0",
-  "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-  "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-},
+npm install @mui/x-charts @mui/material @emotion/react @emotion/styled
 ```
 
 ## Documentation

--- a/packages/x-charts/README.md
+++ b/packages/x-charts/README.md
@@ -15,7 +15,7 @@ This component has the following peer dependencies that you need to install as w
 
 ```json
 "peerDependencies": {
-  "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
+  "@mui/material": "^7.3.0 || ^9.0.0",
   "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
   "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
 },

--- a/packages/x-chat/README.md
+++ b/packages/x-chat/README.md
@@ -12,17 +12,7 @@ It's part of [MUI X](https://mui.com/x/), an open-core extension of our Core li
 Install the package in your project directory with:
 
 ```bash
-npm install @mui/x-chat
-```
-
-This component has the following peer dependencies that you need to install as well.
-
-```json
-"peerDependencies": {
-  "@mui/material": "^7.3.0 || ^9.0.0",
-  "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-  "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-}
+npm install @mui/x-chat @mui/material @emotion/react @emotion/styled
 ```
 
 ## Documentation

--- a/packages/x-chat/README.md
+++ b/packages/x-chat/README.md
@@ -19,10 +19,7 @@ This component has the following peer dependencies that you need to install as w
 
 ```json
 "peerDependencies": {
-  "@emotion/react": "^11.9.0",
-  "@emotion/styled": "^11.8.1",
-  "@mui/material": "^7.3.0 || ^9.0.0-beta.0 || ^9.0.0",
-  "@mui/system": "^7.3.0 || ^9.0.0-beta.1",
+  "@mui/material": "^7.3.0 || ^9.0.0",
   "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
   "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
 }

--- a/packages/x-chat/package.json
+++ b/packages/x-chat/package.json
@@ -58,8 +58,8 @@
   "peerDependencies": {
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",
-    "@mui/material": "^7.3.0 || ^9.0.0-beta.0 || ^9.0.0",
-    "@mui/system": "^7.3.0 || ^9.0.0-beta.1",
+    "@mui/material": "^7.3.0 || ^9.0.0",
+    "@mui/system": "^7.3.0 || ^9.0.0",
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
   },

--- a/packages/x-data-grid-premium/README.md
+++ b/packages/x-data-grid-premium/README.md
@@ -8,17 +8,7 @@ It's part of [MUI X](https://mui.com/x/), an open-core extension of our Core li
 Install the package in your project directory with:
 
 ```bash
-npm install @mui/x-data-grid-premium
-```
-
-This component has the following peer dependencies that you need to install as well.
-
-```json
-"peerDependencies": {
-  "@mui/material": "^7.3.0 || ^9.0.0",
-  "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-  "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-},
+npm install @mui/x-data-grid-premium @mui/material @emotion/react @emotion/styled
 ```
 
 ## Documentation

--- a/packages/x-data-grid-premium/README.md
+++ b/packages/x-data-grid-premium/README.md
@@ -15,7 +15,7 @@ This component has the following peer dependencies that you need to install as w
 
 ```json
 "peerDependencies": {
-  "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
+  "@mui/material": "^7.3.0 || ^9.0.0",
   "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
   "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
 },

--- a/packages/x-data-grid-pro/README.md
+++ b/packages/x-data-grid-pro/README.md
@@ -15,7 +15,7 @@ This component has the following peer dependencies that you need to install as w
 
 ```json
 "peerDependencies": {
-  "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
+  "@mui/material": "^7.3.0 || ^9.0.0",
   "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
   "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
 },

--- a/packages/x-data-grid-pro/README.md
+++ b/packages/x-data-grid-pro/README.md
@@ -8,17 +8,7 @@ It's part of [MUI X](https://mui.com/x/), an open-core extension of our Core li
 Install the package in your project directory with:
 
 ```bash
-npm install @mui/x-data-grid-pro
-```
-
-This component has the following peer dependencies that you need to install as well.
-
-```json
-"peerDependencies": {
-  "@mui/material": "^7.3.0 || ^9.0.0",
-  "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-  "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-},
+npm install @mui/x-data-grid-pro @mui/material @emotion/react @emotion/styled
 ```
 
 ## Documentation

--- a/packages/x-data-grid/README.md
+++ b/packages/x-data-grid/README.md
@@ -8,17 +8,7 @@ It's part of [MUI X](https://mui.com/x/), an open-core extension of our Core li
 Install the package in your project directory with:
 
 ```bash
-npm install @mui/x-data-grid
-```
-
-This component has the following peer dependencies that you need to install as well.
-
-```json
-"peerDependencies": {
-  "@mui/material": "^7.3.0 || ^9.0.0",
-  "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-  "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-},
+npm install @mui/x-data-grid @mui/material @emotion/react @emotion/styled
 ```
 
 ## Documentation

--- a/packages/x-data-grid/README.md
+++ b/packages/x-data-grid/README.md
@@ -15,7 +15,7 @@ This component has the following peer dependencies that you need to install as w
 
 ```json
 "peerDependencies": {
-  "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
+  "@mui/material": "^7.3.0 || ^9.0.0",
   "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
   "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
 },

--- a/packages/x-date-pickers-pro/README.md
+++ b/packages/x-date-pickers-pro/README.md
@@ -37,7 +37,7 @@ This component has the following peer dependencies that you need to install as w
 
 ```json
 "peerDependencies": {
-  "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
+  "@mui/material": "^7.3.0 || ^9.0.0",
   "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
   "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
 },

--- a/packages/x-date-pickers-pro/README.md
+++ b/packages/x-date-pickers-pro/README.md
@@ -8,7 +8,7 @@ It's part of [MUI X](https://mui.com/x/), an open-core extension of our Core li
 Install the package in your project directory with:
 
 ```bash
-npm install @mui/x-date-pickers-pro
+npm install @mui/x-date-pickers-pro @mui/material @emotion/react @emotion/styled
 ```
 
 Then install the date library of your choice (if not already installed).
@@ -31,16 +31,6 @@ npm install luxon
 
 # or moment
 npm install moment
-```
-
-This component has the following peer dependencies that you need to install as well.
-
-```json
-"peerDependencies": {
-  "@mui/material": "^7.3.0 || ^9.0.0",
-  "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-  "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-},
 ```
 
 After completing the installation, you have to set the `dateAdapter` prop of the `LocalizationProvider` accordingly.

--- a/packages/x-date-pickers/README.md
+++ b/packages/x-date-pickers/README.md
@@ -8,7 +8,7 @@ It's part of [MUI X](https://mui.com/x/), an open-core extension of our Core li
 Install the package in your project directory with:
 
 ```bash
-npm install @mui/x-date-pickers
+npm install @mui/x-date-pickers @mui/material @emotion/react @emotion/styled
 ```
 
 Then install the date library of your choice (if not already installed).
@@ -31,16 +31,6 @@ npm install luxon
 
 # or moment
 npm install moment
-```
-
-This component has the following peer dependencies that you need to install as well.
-
-```json
-"peerDependencies": {
-  "@mui/material": "^7.3.0 || ^9.0.0",
-  "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-  "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-},
 ```
 
 After completing the installation, you have to set the `dateAdapter` prop of the `LocalizationProvider` accordingly.

--- a/packages/x-date-pickers/README.md
+++ b/packages/x-date-pickers/README.md
@@ -37,7 +37,7 @@ This component has the following peer dependencies that you need to install as w
 
 ```json
 "peerDependencies": {
-  "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
+  "@mui/material": "^7.3.0 || ^9.0.0",
   "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
   "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
 },

--- a/packages/x-scheduler-internals-premium/README.md
+++ b/packages/x-scheduler-internals-premium/README.md
@@ -11,15 +11,6 @@ Install the package in your project directory with:
 npm install @mui/x-scheduler-internals-premium
 ```
 
-This component has the following peer dependencies that you need to install as well.
-
-```json
-"peerDependencies": {
-  "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-  "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-},
-```
-
 ## Documentation
 
 Visit [https://mui.com/x/react-scheduler/](https://mui.com/x/react-scheduler/) to view the full documentation.

--- a/packages/x-scheduler-internals/README.md
+++ b/packages/x-scheduler-internals/README.md
@@ -11,15 +11,6 @@ Install the package in your project directory with:
 npm install @mui/x-scheduler-internals
 ```
 
-This component has the following peer dependencies that you need to install as well.
-
-```json
-"peerDependencies": {
-  "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-  "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-},
-```
-
 ## Documentation
 
 Visit [https://mui.com/x/react-scheduler/](https://mui.com/x/react-scheduler/) to view the full documentation.

--- a/packages/x-scheduler-premium/README.md
+++ b/packages/x-scheduler-premium/README.md
@@ -8,18 +8,7 @@ It's part of [MUI X](https://mui.com/x/), an open-core extension of our Core li
 Install the package in your project directory with:
 
 ```bash
-npm install @mui/x-scheduler-premium
-```
-
-This component has the following peer dependencies that you need to install as well.
-
-```json
-"peerDependencies": {
-  "@mui/icons-material": "^7.3.0 || ^9.0.0",
-  "@mui/material": "^7.3.0 || ^9.0.0",
-  "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-  "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-},
+npm install @mui/x-scheduler-premium @mui/material @mui/icons-material @emotion/react @emotion/styled
 ```
 
 ## Documentation

--- a/packages/x-scheduler-premium/README.md
+++ b/packages/x-scheduler-premium/README.md
@@ -15,10 +15,8 @@ This component has the following peer dependencies that you need to install as w
 
 ```json
 "peerDependencies": {
-  "@emotion/react": "^11.9.0",
-  "@emotion/styled": "^11.8.1",
+  "@mui/icons-material": "^7.3.0 || ^9.0.0",
   "@mui/material": "^7.3.0 || ^9.0.0",
-  "@mui/system": "^7.3.0 || ^9.0.0",
   "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
   "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
 },

--- a/packages/x-scheduler/README.md
+++ b/packages/x-scheduler/README.md
@@ -15,11 +15,8 @@ This component has the following peer dependencies that you need to install as w
 
 ```json
 "peerDependencies": {
-  "@emotion/react": "^11.9.0",
-  "@emotion/styled": "^11.8.1",
   "@mui/icons-material": "^7.3.0 || ^9.0.0",
   "@mui/material": "^7.3.0 || ^9.0.0",
-  "@mui/system": "^7.3.0 || ^9.0.0",
   "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
   "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
 },

--- a/packages/x-scheduler/README.md
+++ b/packages/x-scheduler/README.md
@@ -8,18 +8,7 @@ It's part of [MUI X](https://mui.com/x/), an open-core extension of our Core li
 Install the package in your project directory with:
 
 ```bash
-npm install @mui/x-scheduler
-```
-
-This component has the following peer dependencies that you need to install as well.
-
-```json
-"peerDependencies": {
-  "@mui/icons-material": "^7.3.0 || ^9.0.0",
-  "@mui/material": "^7.3.0 || ^9.0.0",
-  "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-  "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-},
+npm install @mui/x-scheduler @mui/material @mui/icons-material @emotion/react @emotion/styled
 ```
 
 ## Documentation

--- a/packages/x-tree-view-pro/README.md
+++ b/packages/x-tree-view-pro/README.md
@@ -8,17 +8,7 @@ It's part of [MUI X](https://mui.com/x/), an open-core extension of our Core li
 Install the package in your project directory with:
 
 ```bash
-npm install @mui/x-tree-view-pro
-```
-
-This component has the following peer dependencies that you need to install as well.
-
-```json
-"peerDependencies": {
-  "@mui/material": "^7.3.0 || ^9.0.0",
-  "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-  "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-},
+npm install @mui/x-tree-view-pro @mui/material @emotion/react @emotion/styled
 ```
 
 ## Documentation

--- a/packages/x-tree-view-pro/README.md
+++ b/packages/x-tree-view-pro/README.md
@@ -15,7 +15,7 @@ This component has the following peer dependencies that you need to install as w
 
 ```json
 "peerDependencies": {
-  "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
+  "@mui/material": "^7.3.0 || ^9.0.0",
   "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
   "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
 },

--- a/packages/x-tree-view/README.md
+++ b/packages/x-tree-view/README.md
@@ -8,17 +8,7 @@ It's part of [MUI X](https://mui.com/x/), an open-core extension of our Core li
 Install the package in your project directory with:
 
 ```bash
-npm install @mui/x-tree-view
-```
-
-This component has the following peer dependencies that you need to install as well.
-
-```json
-"peerDependencies": {
-  "@mui/material": "^7.3.0 || ^9.0.0",
-  "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-  "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-},
+npm install @mui/x-tree-view @mui/material @emotion/react @emotion/styled
 ```
 
 ## Documentation

--- a/packages/x-tree-view/README.md
+++ b/packages/x-tree-view/README.md
@@ -15,7 +15,7 @@ This component has the following peer dependencies that you need to install as w
 
 ```json
 "peerDependencies": {
-  "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
+  "@mui/material": "^7.3.0 || ^9.0.0",
   "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
   "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
 },


### PR DESCRIPTION
The `@mui/material` peer dependency was bumped to `^7.3.0 || ^9.0.0` for v9 and the v8 migration guides were updated, but the package READMEs were missed -- ten still advertised the v7-era `^5.15.14 || ^6.0.0 || ^7.0.0` range.

Rather than re-syncing those numbers by hand, this removes the duplication that causes the rot. Following @JCQuintas's review and team discussion, the versioned `peerDependencies` blocks are replaced with a single install command naming the packages, matching the Material UI convention:

```bash
npm install @mui/x-data-grid @mui/material @emotion/react @emotion/styled
```

The npm registry already renders peer dependencies from `package.json`, so the README copy carried maintenance risk without adding information.

### Changes

- Remove the `peerDependencies` JSON block from all 15 package READMEs.
- Extend each install command with the packages a consumer must install explicitly: `@mui/material` and emotion, plus `@mui/icons-material` for the two scheduler packages, which import it directly. `react` and `react-dom` are omitted, as Material UI does, since any React app already has them. `@mui/system` is omitted because it is a regular dependency of `@mui/material` and is installed transitively.
- The scheduler internals packages declare only `react`/`react-dom`, so their install command is unchanged and the block is simply dropped.
- Drop leftover v9 pre-release terms from the x-chat peer ranges (`^9.0.0-beta.0` on `@mui/material`, `^9.0.0-beta.1` on `@mui/system`) so it matches the other 13 packages.

The first commit fixes the stale ranges in place; the second removes the sections entirely. Reviewing the combined diff is easiest.

### Verification

No `peerDependencies` block remains in any package README. All 14 packages declaring a `@mui/material` peer use an identical range with no pre-release terms. Prettier and Vale both pass on the changed files (`0 errors, 0 warnings` across 15 files). `pnpm install --lockfile-only` leaves `pnpm-lock.yaml` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
