### PR TITLE
[charts] Fix GestureManager event listener leak on chart unmount

### DIFF
--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartInteractionListener/useChartInteractionListener.test.tsx
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartInteractionListener/useChartInteractionListener.test.tsx
@@ -1,0 +1,110 @@
+import * as React from 'react';
+import { createRenderer } from '@mui/internal-test-utils';
+import { BarChart } from '@mui/x-charts/BarChart';
+
+// Attached by the internal PointerManager / KeyboardManager that GestureManager owns.
+const DOCUMENT_EVENTS = [
+  'pointerdown',
+  'pointermove',
+  'pointerup',
+  'pointercancel',
+  'forceCancel',
+  'blur',
+  'contextmenu',
+];
+const WINDOW_EVENTS = ['keydown', 'keyup', 'blur'];
+
+type ListenerCall = { type: string; callback: unknown };
+
+/**
+ * Records `addEventListener` / `removeEventListener` traffic on a target.
+ *
+ * Not `sinon.spy`: in jsdom `window === globalThis`, where `addEventListener` is an accessor
+ * property that sinon refuses to wrap. Patching the descriptor directly works both for that
+ * accessor and for the inherited method on `document`.
+ */
+function trackListeners(target: EventTarget, types: string[]) {
+  const added: ListenerCall[] = [];
+  const removed: ListenerCall[] = [];
+
+  const patch = (name: 'addEventListener' | 'removeEventListener', log: ListenerCall[]) => {
+    const original = Object.getOwnPropertyDescriptor(target, name);
+    const originalFn = (target as any)[name] as Function;
+
+    Object.defineProperty(target, name, {
+      configurable: true,
+      writable: true,
+      value: function trackedListener(
+        this: EventTarget,
+        type: string,
+        callback: unknown,
+        options: unknown,
+      ) {
+        if (types.includes(type)) {
+          log.push({ type, callback });
+        }
+        return originalFn.call(this, type, callback, options);
+      },
+    });
+
+    return () => {
+      if (original) {
+        Object.defineProperty(target, name, original);
+      } else {
+        delete (target as any)[name];
+      }
+    };
+  };
+
+  const restoreAdd = patch('addEventListener', added);
+  const restoreRemove = patch('removeEventListener', removed);
+
+  return {
+    restore() {
+      restoreAdd();
+      restoreRemove();
+    },
+    /** Event types added but never removed with a matching (type, callback) pair. */
+    leakedTypes() {
+      return added
+        .filter((a) => !removed.some((r) => r.type === a.type && r.callback === a.callback))
+        .map(({ type }) => type);
+    },
+  };
+}
+
+describe('useChartInteractionListener', () => {
+  const { render } = createRenderer();
+
+  it('should remove every document and window listener when the chart unmounts', () => {
+    const chart = (
+      <BarChart
+        height={300}
+        width={300}
+        skipAnimation
+        series={[{ data: [10, 20] }]}
+        xAxis={[{ data: ['A', 'B'] }]}
+      />
+    );
+
+    // The first mount also performs one-time global setup unrelated to charts (MUI's
+    // focus-visible handlers, React's `selectionchange`), which is intentionally never torn
+    // down. Warm that up first so the measured cycle only sees chart-owned listeners.
+    render(chart).unmount();
+
+    const documentListeners = trackListeners(document, DOCUMENT_EVENTS);
+    const windowListeners = trackListeners(window, WINDOW_EVENTS);
+
+    try {
+      render(chart).unmount();
+
+      expect({
+        document: documentListeners.leakedTypes(),
+        window: windowListeners.leakedTypes(),
+      }).to.deep.equal({ document: [], window: [] });
+    } finally {
+      documentListeners.restore();
+      windowListeners.restore();
+    }
+  });
+});

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartInteractionListener/useChartInteractionListener.test.tsx
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartInteractionListener/useChartInteractionListener.test.tsx
@@ -1,74 +1,61 @@
 import * as React from 'react';
+import { onTestFinished } from 'vitest';
 import { createRenderer } from '@mui/internal-test-utils';
 import { BarChart } from '@mui/x-charts/BarChart';
 
-// Attached by the internal PointerManager / KeyboardManager that GestureManager owns.
-const DOCUMENT_EVENTS = [
-  'pointerdown',
-  'pointermove',
-  'pointerup',
-  'pointercancel',
-  'forceCancel',
-  'blur',
-  'contextmenu',
-];
-const WINDOW_EVENTS = ['keydown', 'keyup', 'blur'];
-
-type ListenerCall = { type: string; callback: unknown };
+type Listener = { type: string; callback: unknown };
 
 /**
- * Records `addEventListener` / `removeEventListener` traffic on a target.
- *
- * Not `sinon.spy`: in jsdom `window === globalThis`, where `addEventListener` is an accessor
- * property that sinon refuses to wrap. Patching the descriptor directly works both for that
- * accessor and for the inherited method on `document`.
+ * Listeners currently registered on `target`, to assert a mount/unmount cycle leaves none behind.
+ * Patches the descriptor rather than using `sinon.spy`: in jsdom `window === globalThis`, where
+ * `addEventListener` is an accessor property that sinon refuses to wrap.
  */
-function trackListeners(target: EventTarget, types: string[]) {
-  const added: ListenerCall[] = [];
-  const removed: ListenerCall[] = [];
+function trackListeners(target: EventTarget) {
+  const active: Listener[] = [];
 
-  const patch = (name: 'addEventListener' | 'removeEventListener', log: ListenerCall[]) => {
-    const original = Object.getOwnPropertyDescriptor(target, name);
+  const patch = (
+    name: 'addEventListener' | 'removeEventListener',
+    onCall: (listener: Listener) => void,
+  ) => {
+    const descriptor = Object.getOwnPropertyDescriptor(target, name);
     const originalFn = (target as any)[name] as Function;
 
     Object.defineProperty(target, name, {
       configurable: true,
-      writable: true,
-      value: function trackedListener(
-        this: EventTarget,
-        type: string,
-        callback: unknown,
-        options: unknown,
-      ) {
-        if (types.includes(type)) {
-          log.push({ type, callback });
-        }
-        return originalFn.call(this, type, callback, options);
+      value: (type: string, callback: unknown, options: unknown) => {
+        onCall({ type, callback });
+        return originalFn.call(target, type, callback, options);
       },
     });
 
     return () => {
-      if (original) {
-        Object.defineProperty(target, name, original);
+      if (descriptor) {
+        Object.defineProperty(target, name, descriptor);
       } else {
         delete (target as any)[name];
       }
     };
   };
 
-  const restoreAdd = patch('addEventListener', added);
-  const restoreRemove = patch('removeEventListener', removed);
+  const restores = [
+    patch('addEventListener', (listener) => active.push(listener)),
+    patch('removeEventListener', ({ type, callback }) => {
+      const index = active.findIndex(
+        (listener) => listener.type === type && listener.callback === callback,
+      );
+      if (index !== -1) {
+        active.splice(index, 1);
+      }
+    }),
+  ];
 
   return {
     restore() {
-      restoreAdd();
-      restoreRemove();
+      restores.forEach((restore) => restore());
     },
-    /** Event types added but never removed with a matching (type, callback) pair. */
+    /** Types added without a matching `removeEventListener(type, callback)`. */
     leakedTypes() {
-      return added
-        .filter((a) => !removed.some((r) => r.type === a.type && r.callback === a.callback))
-        .map(({ type }) => type);
+      return active.map(({ type }) => type);
     },
   };
 }
@@ -87,24 +74,22 @@ describe('useChartInteractionListener', () => {
       />
     );
 
-    // The first mount also performs one-time global setup unrelated to charts (MUI's
-    // focus-visible handlers, React's `selectionchange`), which is intentionally never torn
-    // down. Warm that up first so the measured cycle only sees chart-owned listeners.
+    // Warm-up: the first mount installs one-time globals (focus-visible, `selectionchange`)
+    // that are intentionally never torn down.
     render(chart).unmount();
 
-    const documentListeners = trackListeners(document, DOCUMENT_EVENTS);
-    const windowListeners = trackListeners(window, WINDOW_EVENTS);
-
-    try {
-      render(chart).unmount();
-
-      expect({
-        document: documentListeners.leakedTypes(),
-        window: windowListeners.leakedTypes(),
-      }).to.deep.equal({ document: [], window: [] });
-    } finally {
+    const documentListeners = trackListeners(document);
+    const windowListeners = trackListeners(window);
+    onTestFinished(() => {
       documentListeners.restore();
       windowListeners.restore();
-    }
+    });
+
+    render(chart).unmount();
+
+    expect({
+      document: documentListeners.leakedTypes(),
+      window: windowListeners.leakedTypes(),
+    }).to.deep.equal({ document: [], window: [] });
   });
 });

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartInteractionListener/useChartInteractionListener.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartInteractionListener/useChartInteractionListener.ts
@@ -92,8 +92,13 @@ export const useChartInteractionListener: ChartPlugin<UseChartInteractionListene
     gestureManager.registerElement(['pan', 'move', 'tap', 'quickPress', 'brush'], svg);
 
     return () => {
-      // Cleanup gesture manager
-      gestureManager.unregisterAllGestures(svg);
+      // Cleanup gesture manager. `destroy()` unregisters every element's gestures like
+      // `unregisterAllGestures()` does, and is additionally the only path that removes the
+      // document/window listeners owned by the internal PointerManager and KeyboardManager.
+      gestureManager.destroy();
+      // The manager is unusable once destroyed, so drop it and let the next mount build a
+      // fresh one. Reusing a destroyed manager loses its gesture templates.
+      gestureManagerRef.current = null;
     };
   }, [chartsLayerContainerRef, gestureManagerRef]);
 


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

## Changelog

Charts no longer leak 10 `document` / `window` event listeners each time they unmount.

## The problem

`useChartInteractionListener` builds a `GestureManager` on mount, but its effect cleanup only calls `unregisterAllGestures(svg)`. That destroys the element-bound gesture clones (removing listeners from the SVG) and clears `elementGestureMap` — it never touches the manager's `PointerManager` or `KeyboardManager`, both of which attach listeners in their constructors:

- `document`: `pointerdown`, `pointermove`, `pointerup`, `pointercancel`, `forceCancel`, `blur`, `contextmenu`
- `window`: `keydown`, `keyup`, `blur`

`GestureManager.destroy()` is the only path that reaches `pointerManager.destroy()` and `keyboardManager.destroy()`, where those `removeEventListener` calls live. So every chart mount permanently adds 10 listeners.

They aren't inert, either: `handlePointerEvent` still fires on every `pointermove` over the document, allocating a `PointerData` and doing a `Map.set` before notifying an empty handler set. The cost grows linearly with the number of chart mounts in a session.

Closes #23282

## The fix

```diff
     return () => {
-      // Cleanup gesture manager
-      gestureManager.unregisterAllGestures(svg);
+      // Cleanup gesture manager. `destroy()` unregisters every element's gestures like
+      // `unregisterAllGestures()` does, and is additionally the only path that removes the
+      // document/window listeners owned by the internal PointerManager and KeyboardManager.
+      gestureManager.destroy();
+      // The manager is unusable once destroyed, so drop it and let the next mount build a
+      // fresh one. Reusing a destroyed manager loses its gesture templates.
+      gestureManagerRef.current = null;
     };
```

Two notes on why it is shaped this way.

**Nulling the ref is load-bearing.** `destroy()` clears `gestureTemplates`, so a later mount that reused the ref would hit `registerSingleGesture`'s `Gesture template "pan" not found.` path and silently lose every gesture. Under `<StrictMode>` that happens immediately, on the first mount. Applying `destroy()` without the null makes the new test — and other chart tests — fail via `vitest-fail-on-console`, so this half is covered rather than assumed.

**Ordering against the zoom plugin is safe.** The pro zoom/brush plugins register through `registerGestures`, whose cleanup calls `gestureManager.removeGestures(names)`. React runs effect cleanups in declaration order, so the core plugin's `destroy()` runs first. Post-destroy, `elementGestureMap` is empty (the `forEach` is a no-op) and `gestureTemplates.delete` is a no-op, so nothing throws. The `x-charts-pro` Chromium suite below exercises real pan/zoom gestures and confirms it.

An alternative fix would be to make `PointerManager` / `KeyboardManager` genuinely shared, which is what `PointerManager`'s docstring ("This singleton class…") and its `destroy()` comment ("resets the singleton instance") already claim. That is a larger behavioural change, so this PR takes the minimal route — happy to go the other way if you'd prefer.

## Test

The new `useChartInteractionListener.test.tsx` asserts that every `document` / `window` listener a chart adds is removed with a matching `(type, callback)` pair on unmount.

Two implementation details that would otherwise look arbitrary:

- It patches the `addEventListener` descriptors directly rather than using `sinon.spy`. In jsdom `window === globalThis`, where `addEventListener` is an accessor property that sinon refuses to wrap (`TypeError: Attempted to wrap undefined property addEventListener as function`).
- It renders and unmounts once before measuring. The first mount also performs one-time global setup unrelated to charts — MUI's focus-visible `focus`/`blur` handlers, React's `selectionchange` — which is intentionally never torn down. Without the warm-up the assertion picks up a spurious `blur`, and the outcome depends on what else ran first in the worker (`isolate: false`).

Failure output before the fix:

```
AssertionError: expected { …(2) } to deeply equal { document: [], window: [] }

  {
-   "document": [],
-   "window": [],
+   "document": [
+     "pointerdown", "pointermove", "pointerup", "pointercancel",
+     "forceCancel", "blur", "contextmenu",
+   ],
+   "window": [ "keydown", "keyup", "blur" ],
  }
```

## Verification

Red on master and green with the fix, in both jsdom and Chromium. Full suites with the fix applied:

| Suite | Result |
| --- | --- |
| jsdom `x-charts` | 593 passed, 122 skipped (101 files) |
| jsdom `x-charts-pro` + `x-charts-premium` | 238 passed, 99 skipped (39 files) |
| chromium `x-charts` | 704 passed, 10 skipped (106 files) |
| chromium `x-charts-pro` | 256 passed (36 files) |

The Chromium `x-charts-pro` run covers `LineChartPro.zoom.test.tsx` (including *should pan on press and drag*) and `ZoomInteractionConfig.test.tsx`, which are the gesture paths most at risk from destroying the manager.

`prettier`, `eslint`, and `tsgo` typecheck are clean on both changed files.
