### PR TITLE
[DateRangePicker] Fix disabled filler cells showing the range highlight

### DIFF
--- a/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.test.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.test.tsx
@@ -121,4 +121,30 @@ describe('<DateRangePickerDay />', () => {
       expect(container4.firstChild).to.have.style('opacity', '0.4');
     });
   });
+
+  describe('filler cell', () => {
+    it('should stay hidden when it is disabled and inside the selected range', () => {
+      const { container } = render(
+        <DateRangePickerDay
+          day={adapterToUse.date('2018-02-01')}
+          onDaySelect={() => {}}
+          outsideCurrentMonth
+          disabled
+          isHighlighting
+          isPreviewing={false}
+          isStartOfPreviewing={false}
+          isEndOfPreviewing={false}
+          isStartOfHighlighting={false}
+          isEndOfHighlighting={false}
+          isFirstVisibleCell={false}
+          isLastVisibleCell={false}
+        />,
+      );
+
+      expect(container.firstChild).to.have.class(classes.fillerCell);
+      expect(container.firstChild).not.to.have.class(classes.selected);
+      expect(container.firstChild).not.to.have.class(classes.insideSelection);
+      expect(container.firstChild).to.have.style('opacity', '0');
+    });
+  });
 });

--- a/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.tsx
@@ -450,23 +450,30 @@ const DateRangePickerDayRaw = React.forwardRef(function DateRangePickerDay(
     showDaysOutsideCurrentMonth,
   });
 
+  const isDayFillerCell =
+    isDayFillerCellProp ?? (outsideCurrentMonth && !showDaysOutsideCurrentMonth);
+
   const ownerState: DateRangePickerDayOwnerState = {
     ...pickerDayOwnerState,
     // Properties that the Base UI implementation will have
-    isDaySelectionStart: isStartOfHighlighting,
-    isDaySelectionEnd: isEndOfHighlighting,
-    isDayInsideSelection: isHighlighting && !isStartOfHighlighting && !isEndOfHighlighting,
-    isDaySelected: isVisuallySelected ?? (isHighlighting || Boolean(selected)),
-    isDayPreviewed: isPreviewing,
-    isDayPreviewStart: isStartOfPreviewing,
-    isDayPreviewEnd: isEndOfPreviewing,
-    isDayInsidePreview: isPreviewing && !isStartOfPreviewing && !isEndOfPreviewing,
+    // A filler cell is visually hidden, it must never pick up any selection or preview styling.
+    isDaySelectionStart: !isDayFillerCell && isStartOfHighlighting,
+    isDaySelectionEnd: !isDayFillerCell && isEndOfHighlighting,
+    isDayInsideSelection:
+      !isDayFillerCell && isHighlighting && !isStartOfHighlighting && !isEndOfHighlighting,
+    isDaySelected:
+      !isDayFillerCell && (isVisuallySelected ?? (isHighlighting || Boolean(selected))),
+    isDayPreviewed: !isDayFillerCell && isPreviewing,
+    isDayPreviewStart: !isDayFillerCell && isStartOfPreviewing,
+    isDayPreviewEnd: !isDayFillerCell && isEndOfPreviewing,
+    isDayInsidePreview:
+      !isDayFillerCell && isPreviewing && !isStartOfPreviewing && !isEndOfPreviewing,
     // Properties specific to the MUI implementation (some might be removed in the next major)
     isDayStartOfMonth: adapter.isSameDay(day, adapter.startOfMonth(day)),
     isDayEndOfMonth: adapter.isSameDay(day, adapter.endOfMonth(day)),
     isDayFirstVisibleCell: isFirstVisibleCell,
     isDayLastVisibleCell: isLastVisibleCell,
-    isDayFillerCell: isDayFillerCellProp ?? (outsideCurrentMonth && !showDaysOutsideCurrentMonth),
+    isDayFillerCell,
     isDayDraggable: Boolean(draggable),
   };
 

--- a/test/regressions/pickers/DateRangeCalendarDisabledDays.tsx
+++ b/test/regressions/pickers/DateRangeCalendarDisabledDays.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import dayjs, { Dayjs } from 'dayjs';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { DateRangeCalendar } from '@mui/x-date-pickers-pro/DateRangeCalendar';
+
+// September 2026 ends on a Wednesday, so its grid is padded with filler cells for
+// October 1 to October 3. October 3 is a Saturday, so it is a disabled filler cell
+// inside the selected range: it must stay invisible instead of rendering the range
+// highlight without a day number.
+// See https://github.com/mui/mui-x/issues/23289
+const value: [Dayjs, Dayjs] = [dayjs('2026-09-14'), dayjs('2026-10-30')];
+
+const isWeekend = (date: Dayjs) => {
+  const day = date.day();
+  return day === 0 || day === 6;
+};
+
+export default function DateRangeCalendarDisabledDays() {
+  return (
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
+      <DateRangeCalendar calendars={2} value={value} shouldDisableDate={isWeekend} />
+    </LocalizationProvider>
+  );
+}


### PR DESCRIPTION
Fixes #23289

A filler cell (a day of the neighbouring month rendered to pad the grid) is hidden with `opacity: 0`. The disabled styling of the selection variants (`&.Mui-disabled { opacity: 0.6 }`) is a compound selector, so it has a higher specificity and won over that rule. A filler cell that was both disabled (through `shouldDisableDate`) and inside the selected range was therefore painted as a range-highlighted cell with no day number, leaving a visual gap in the row.

Filler cells no longer receive any selection or preview owner state, which restores the behavior v8 had through `shouldRenderHighlight = isHighlighting && !outsideCurrentMonth`. That guard was dropped in #21739 when `DateRangePickerDay2` replaced `DateRangePickerDay`.

### Before

<img width="644" alt="before" src="https://github.com/user-attachments/assets/20ae6304-54ba-4c1b-8dc7-d35500571a0e" />

### After

<img width="633" alt="after" src="https://github.com/user-attachments/assets/ea22a3ed-320b-41d2-aa0c-649ad3235ef7" />
