### PR TITLE
[pickers] Fix day shift when editing dates predating timezone standardization

### DIFF
--- a/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.test.tsx
+++ b/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.test.tsx
@@ -69,6 +69,58 @@ describe('<AdapterDayjs />', () => {
       expect(adapter.getTimezone(resolvedDate)).to.equal('system');
       expect(adapter.isSameDay(resolvedDate, dayjs(TEST_DATE_ISO_STRING))).to.equal(true);
     });
+
+    // `Asia/Kolkata` is used because the affected zones depend on the system timezone, and the tests
+    // run with `TZ=UTC`. See https://github.com/mui/mui-x/issues/23163
+    describe('Dates predating the timezone standardization', () => {
+      const adapter = new AdapterDayjs();
+      // The wall clock of this date in `Asia/Kolkata` is `2026-08-06 01:41`.
+      const getDate = () => adapter.date('2026-08-05T20:11:00Z', 'Asia/Kolkata') as Dayjs;
+
+      it('setYear: should only change the year', () => {
+        expect(
+          adapter.formatByString(adapter.setYear(getDate(), 202), 'YYYY-MM-DD HH:mm'),
+        ).to.equal('0202-08-06 01:41');
+      });
+
+      it('setMonth: should only change the month', () => {
+        expect(
+          adapter.formatByString(
+            adapter.setMonth(adapter.setYear(getDate(), 202), 2),
+            'YYYY-MM-DD HH:mm',
+          ),
+        ).to.equal('0202-03-06 01:41');
+      });
+
+      it('addYears: should keep the day of the month', () => {
+        expect(
+          adapter.formatByString(
+            adapter.addYears(adapter.setYear(getDate(), 202), 1),
+            'YYYY-MM-DD HH:mm',
+          ),
+        ).to.equal('0203-08-06 01:41');
+      });
+
+      it('addMonths: should keep the day of the month', () => {
+        expect(
+          adapter.formatByString(
+            adapter.addMonths(adapter.setYear(getDate(), 202), 1),
+            'YYYY-MM-DD HH:mm',
+          ),
+        ).to.equal('0202-09-06 01:41');
+      });
+
+      it('setMonth: should still clamp the day of the month on a shorter month', () => {
+        const endOfJanuary = adapter.setDate(
+          adapter.setMonth(adapter.setYear(getDate(), 202), 0),
+          31,
+        );
+
+        expect(adapter.formatByString(adapter.setMonth(endOfJanuary, 1), 'YYYY-MM-DD')).to.equal(
+          '0202-02-28',
+        );
+      });
+    });
   });
 
   describe('Adapter localization', () => {

--- a/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.test.tsx
+++ b/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.test.tsx
@@ -120,6 +120,19 @@ describe('<AdapterDayjs />', () => {
           '0202-02-28',
         );
       });
+
+      it('setYear: should support years that do not round-trip through the ISO format', () => {
+        const result = adapter.setYear(getDate(), 10000);
+
+        expect(adapter.isValid(result)).to.equal(true);
+        expect(adapter.formatByString(result, 'MM-DD HH:mm')).to.equal('08-06 01:41');
+      });
+
+      it('setYear: should keep an invalid date invalid', () => {
+        expect(adapter.isValid(adapter.setYear(adapter.getInvalidDate() as Dayjs, 2020))).to.equal(
+          false,
+        );
+      });
     });
   });
 

--- a/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.ts
+++ b/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.ts
@@ -298,6 +298,12 @@ export class AdapterDayjs implements MuiPickersAdapter<string> {
 
     const wallClock = dayjs.utc(value.format('YYYY-MM-DDTHH:mm:ss.SSS'));
 
+    // Years above 9999 don't round-trip through the ISO format, and an invalid value formats to
+    // `Invalid Date`. Both would make the comparison below `NaN`.
+    if (!wallClock.isValid()) {
+      return value;
+    }
+
     // A shorter target month legitimately clamps the day (`Jan 31` + 1 month is `Feb 28`).
     const expectedDayOfMonth = Math.min(Number(reference.format('D')), wallClock.daysInMonth());
     if (wallClock.date() === expectedDayOfMonth) {

--- a/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.ts
+++ b/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.ts
@@ -283,6 +283,30 @@ export class AdapterDayjs implements MuiPickersAdapter<string> {
     return value;
   };
 
+  /**
+   * On dates predating the timezone standardization, IANA falls back on the Local Mean Time of the
+   * location, whose offset is not a round number of minutes (`Asia/Kolkata` is `GMT+05:53:28`).
+   * `dayjs` then moves the day of the month when only the year or the month was meant to change,
+   * and the accessors of the result (`date()`, `daysInMonth()`) disagree with its formatted value,
+   * hence the round-trip through `format`.
+   * See https://github.com/mui/mui-x/issues/23163
+   */
+  private restoreDayOfMonth = (value: Dayjs, reference: Dayjs) => {
+    if (!this.hasUTCPlugin() || this.getTimezone(value) === 'system') {
+      return value;
+    }
+
+    const wallClock = dayjs.utc(value.format('YYYY-MM-DDTHH:mm:ss.SSS'));
+
+    // A shorter target month legitimately clamps the day (`Jan 31` + 1 month is `Feb 28`).
+    const expectedDayOfMonth = Math.min(Number(reference.format('D')), wallClock.daysInMonth());
+    if (wallClock.date() === expectedDayOfMonth) {
+      return value;
+    }
+
+    return value.set('date', expectedDayOfMonth);
+  };
+
   public date = <T extends string | null | undefined>(
     value?: T,
     timezone: PickersTimezone = 'default',
@@ -522,11 +546,11 @@ export class AdapterDayjs implements MuiPickersAdapter<string> {
   };
 
   public addYears = (value: Dayjs, amount: number) => {
-    return this.adjustOffset(value.add(amount, 'year'));
+    return this.adjustOffset(this.restoreDayOfMonth(value.add(amount, 'year'), value));
   };
 
   public addMonths = (value: Dayjs, amount: number) => {
-    return this.adjustOffset(value.add(amount, 'month'));
+    return this.adjustOffset(this.restoreDayOfMonth(value.add(amount, 'month'), value));
   };
 
   public addWeeks = (value: Dayjs, amount: number) => {
@@ -578,11 +602,11 @@ export class AdapterDayjs implements MuiPickersAdapter<string> {
   };
 
   public setYear = (value: Dayjs, year: number) => {
-    return this.adjustOffset(value.set('year', year));
+    return this.adjustOffset(this.restoreDayOfMonth(value.set('year', year), value));
   };
 
   public setMonth = (value: Dayjs, month: number) => {
-    return this.adjustOffset(value.set('month', month));
+    return this.adjustOffset(this.restoreDayOfMonth(value.set('month', month), value));
   };
 
   public setDate = (value: Dayjs, date: number) => {

--- a/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.ts
+++ b/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.ts
@@ -286,13 +286,15 @@ export class AdapterDayjs implements MuiPickersAdapter<string> {
   /**
    * On dates predating the timezone standardization, IANA falls back on the Local Mean Time of the
    * location, whose offset is not a round number of minutes (`Asia/Kolkata` is `GMT+05:53:28`).
-   * `dayjs` then moves the day of the month when only the year or the month was meant to change,
-   * and the accessors of the result (`date()`, `daysInMonth()`) disagree with its formatted value,
-   * hence the round-trip through `format`.
+   * `dayjs` then moves the day of the month when only the year or the month was meant to change.
+   * `daysInMonth()` is unusable on such a value because it derives from the equally broken
+   * `endOf('month')`, hence computing it on a plain UTC value instead.
    * See https://github.com/mui/mui-x/issues/23163
    */
   private restoreDayOfMonth = (value: Dayjs, reference: Dayjs) => {
-    if (!this.hasUTCPlugin() || this.getTimezone(value) === 'system') {
+    const timezone = this.getTimezone(value);
+    // `system` and `UTC` values keep an offset that matches their instant, so they are never affected.
+    if (!this.hasUTCPlugin() || timezone === 'system' || timezone === 'UTC') {
       return value;
     }
 
@@ -305,8 +307,8 @@ export class AdapterDayjs implements MuiPickersAdapter<string> {
     }
 
     // A shorter target month legitimately clamps the day (`Jan 31` + 1 month is `Feb 28`).
-    const expectedDayOfMonth = Math.min(Number(reference.format('D')), wallClock.daysInMonth());
-    if (wallClock.date() === expectedDayOfMonth) {
+    const expectedDayOfMonth = Math.min(reference.date(), wallClock.daysInMonth());
+    if (value.date() === expectedDayOfMonth) {
       return value;
     }
 

--- a/packages/x-date-pickers/src/DateTimeField/tests/timezone.DateTimeField.test.tsx
+++ b/packages/x-date-pickers/src/DateTimeField/tests/timezone.DateTimeField.test.tsx
@@ -4,7 +4,7 @@ import type { DateTime } from 'luxon';
 import { DateTimeField } from '@mui/x-date-pickers/DateTimeField';
 import { createPickerRenderer, expectFieldValue, buildFieldInteractions } from 'test/utils/pickers';
 import { describeAdapters } from 'test/utils/pickers/describeAdapters';
-import type { PickerValue } from '../../internals/models';
+import type { PickerValue } from '@mui/x-date-pickers/internals';
 
 const TIMEZONE_TO_TEST = ['UTC', 'system', 'America/New_York'];
 

--- a/packages/x-date-pickers/src/DateTimeField/tests/timezone.DateTimeField.test.tsx
+++ b/packages/x-date-pickers/src/DateTimeField/tests/timezone.DateTimeField.test.tsx
@@ -1,8 +1,10 @@
+import * as React from 'react';
 import { spy } from 'sinon';
 import type { DateTime } from 'luxon';
 import { DateTimeField } from '@mui/x-date-pickers/DateTimeField';
 import { createPickerRenderer, expectFieldValue, buildFieldInteractions } from 'test/utils/pickers';
 import { describeAdapters } from 'test/utils/pickers/describeAdapters';
+import type { PickerValue } from '../../internals/models';
 
 const TIMEZONE_TO_TEST = ['UTC', 'system', 'America/New_York'];
 
@@ -128,6 +130,48 @@ describe('<DateTimeField /> - Timezone', () => {
       view.setProps({ value: date.setZone('America/Los_Angeles') });
 
       expectFieldValue(view.getSectionsContainer(), '06/18/2020 07:30 AM');
+    });
+  });
+
+  describe('Editing a year in a timezone using Local Mean Time - Dayjs', () => {
+    const { render, adapter } = createPickerRenderer({
+      adapterName: 'dayjs',
+      clockConfig: new Date('2026-08-05T20:11:00Z'),
+    });
+
+    // Each key press publishes a value, so the year goes through `0002`, `0020` and `0202` before
+    // reaching `2020`. On those years `Asia/Kolkata` falls back on its Local Mean Time, which used to
+    // shift the day of the month. The shifted day was written back into the day section and never
+    // recovered. See https://github.com/mui/mui-x/issues/23163
+    it('should not change the day of the month while the year is being typed', async () => {
+      function ControlledField(props: React.ComponentProps<typeof DateTimeField>) {
+        const [value, setValue] = React.useState<PickerValue>(() =>
+          adapter.date(undefined, 'Asia/Kolkata'),
+        );
+
+        return (
+          <DateTimeField
+            {...props}
+            value={value}
+            onChange={(newValue) => setValue(newValue)}
+            format="MM/DD/YYYY HH:mm"
+            timezone="Asia/Kolkata"
+          />
+        );
+      }
+
+      const { renderWithProps } = buildFieldInteractions({
+        render,
+        Component: ControlledField,
+      });
+      const view = renderWithProps({});
+
+      await view.selectSection('month');
+      await view.user.keyboard('03');
+      await view.user.keyboard('03');
+      await view.user.keyboard('2020');
+
+      expectFieldValue(view.getSectionsContainer(), '03/03/2020 01:41');
     });
   });
 });


### PR DESCRIPTION
Fixes #23163

## The bug

Typing a year into a date field publishes a value on every key press, so the year transiently takes ancient values (`0002`, `0020`, `0202`) before reaching the one the user wants. On dates predating the timezone standardization, IANA falls back on the Local Mean Time of the location, whose offset is not a round number of minutes (`Asia/Kolkata` is `GMT+05:53:28`).

On those dates `dayjs` shifts the day of the month when only the year or the month was meant to change:

```js
const value = dayjs.tz('2026-08-05 20:11', 'Asia/Kolkata');
value.set('year', 202).format('MM/DD'); // '08/01' instead of '08/05'
```

The merge only re-applies the sections marked as modified, and the sections are rebuilt from the published value after every key press, which resets that flag. So when the year is edited, only `setYear` runs and nothing restores the day that `dayjs` moved. The shifted day is written back into the day section and never recovers once the year is complete:

```
type 03/03/202  ->  03/01/0202
type the last 0 ->  03/01/2020   <- wrong day, permanently
```

Which timezones are affected depends on the system timezone as well as the `timezone` prop, which is why the issue reports `America/Detroit` while the tests here use `Asia/Kolkata` (the tests run with `TZ=UTC`). The affected years are not exotic either: `1883` and `1900` are hit too, so ordinary birthdate entry can trigger this.

## The fix

`AdapterDayjs` restores the day of the month after `setYear`, `setMonth`, `addYears` and `addMonths`, clamping it when the target month is shorter so `Jan 31` + 1 month stays `Feb 28`.

The accessors of an affected value are unreliable (`daysInMonth()` returns `1`, and `date()` disagrees with `format('DD')`), so the check round-trips through `format` and a plain UTC value. It bails out early for system-timezone values, leaving the non-timezone path untouched.

## Not included

`startOf` and `endOf` are broken on the same dates (`startOf('month')` returns the last day of the previous month, `startOf('day')` returns `23:59`). That needs a different repair than restoring the day of the month, and it affects calendar rendering rather than field editing, so it is worth a separate issue rather than widening this diff.

## Testing

- Adapter tests covering `setYear`, `setMonth`, `addYears`, `addMonths` and the shorter-month clamping.
- A `DateTimeField` test reproducing the report: typing `03/03/2020` in `Asia/Kolkata` now keeps the day.
- All 5 fail without the fix.
