### PR TITLE
[scheduler] Honor `viewConfig` hour limits in the compact day and week views

### DIFF
--- a/packages/x-scheduler-premium/src/compact-day-view-premium/CompactDayViewPremium.types.ts
+++ b/packages/x-scheduler-premium/src/compact-day-view-premium/CompactDayViewPremium.types.ts
@@ -5,6 +5,7 @@ import type {
   EventCalendarSchedulerParametersOverrides,
   CollapsibleResourcesParameterKeys,
 } from '@mui/x-scheduler-internals/use-event-calendar';
+import type { EventCalendarViewConfig } from '@mui/x-scheduler-internals/models';
 import type { EventCalendarLocaleText } from '@mui/x-scheduler/models';
 import type { CompactDayViewProps } from '@mui/x-scheduler/compact-day-view';
 
@@ -21,6 +22,13 @@ export interface StandaloneCompactDayViewPremiumProps<
       | CollapsibleResourcesParameterKeys
     >,
     EventCalendarSchedulerParametersOverrides {
+  /**
+   * Configuration applied to the view, keyed by the view name.
+   * For the `day` view, `startTime` and `endTime` (whole hours between 0 and 24)
+   * limit the hours displayed in the time grid.
+   * @example { day: { startTime: 8, endTime: 20 } }
+   */
+  viewConfig?: Pick<EventCalendarViewConfig, 'day'>;
   /**
    * Set the locale text of the view.
    * You can find all the translation keys supported in [the source](https://github.com/mui/mui-x/blob/HEAD/packages/x-scheduler/src/models/translations.ts)

--- a/packages/x-scheduler-premium/src/compact-week-view-premium/CompactWeekViewPremium.types.ts
+++ b/packages/x-scheduler-premium/src/compact-week-view-premium/CompactWeekViewPremium.types.ts
@@ -5,6 +5,7 @@ import type {
   EventCalendarSchedulerParametersOverrides,
   CollapsibleResourcesParameterKeys,
 } from '@mui/x-scheduler-internals/use-event-calendar';
+import type { EventCalendarViewConfig } from '@mui/x-scheduler-internals/models';
 import type { EventCalendarLocaleText } from '@mui/x-scheduler/models';
 import type { CompactWeekViewProps } from '@mui/x-scheduler/compact-week-view';
 
@@ -21,6 +22,13 @@ export interface StandaloneCompactWeekViewPremiumProps<
       | CollapsibleResourcesParameterKeys
     >,
     EventCalendarSchedulerParametersOverrides {
+  /**
+   * Configuration applied to the view, keyed by the view name.
+   * For the `week` view, `startTime` and `endTime` (whole hours between 0 and 24)
+   * limit the hours displayed in the time grid.
+   * @example { week: { startTime: 8, endTime: 20 } }
+   */
+  viewConfig?: Pick<EventCalendarViewConfig, 'week'>;
   /**
    * Set the locale text of the view.
    * You can find all the translation keys supported in [the source](https://github.com/mui/mui-x/blob/HEAD/packages/x-scheduler/src/models/translations.ts)

--- a/packages/x-scheduler/src/compact-day-view/CompactDayView.tsx
+++ b/packages/x-scheduler/src/compact-day-view/CompactDayView.tsx
@@ -1,6 +1,9 @@
 'use client';
 import * as React from 'react';
+import { useStore } from '@base-ui/utils/store';
 import { useEventCalendarView } from '@mui/x-scheduler-internals/use-event-calendar-view';
+import { useEventCalendarStoreContext } from '@mui/x-scheduler-internals/use-event-calendar-store-context';
+import { eventCalendarViewSelectors } from '@mui/x-scheduler-internals/event-calendar-selectors';
 import type { CompactDayViewProps } from './CompactDayView.types';
 import { CompactDayTimeGrid } from '../internals/components/compact-day-time-grid';
 import { createDayTimeGridViewDefinition } from '../internals/utils/day-time-grid-view-definition';
@@ -15,9 +18,23 @@ export const CompactDayView = React.memo(
     props: CompactDayViewProps,
     forwardedRef: React.ForwardedRef<HTMLDivElement>,
   ) {
+    // Context hooks
+    const store = useEventCalendarStoreContext();
+
     // Feature hooks
     const { days } = useEventCalendarView(COMPACT_DAY_VIEW_DEFINITION);
 
-    return <CompactDayTimeGrid ref={forwardedRef} {...props} days={days} />;
+    // Selector hooks
+    const config = useStore(store, eventCalendarViewSelectors.timeGridConfig, 'day');
+
+    return (
+      <CompactDayTimeGrid
+        ref={forwardedRef}
+        days={days}
+        startTime={config?.startTime}
+        endTime={config?.endTime}
+        {...props}
+      />
+    );
   }),
 );

--- a/packages/x-scheduler/src/compact-day-view/CompactDayView.types.ts
+++ b/packages/x-scheduler/src/compact-day-view/CompactDayView.types.ts
@@ -5,6 +5,7 @@ import type {
   EventCalendarSchedulerParametersOverrides,
   CollapsibleResourcesParameterKeys,
 } from '@mui/x-scheduler-internals/use-event-calendar';
+import type { EventCalendarViewConfig } from '@mui/x-scheduler-internals/models';
 import type { EventCalendarLocaleText } from '../models/translations';
 import type { ExportedDayTimeGridProps } from '../internals/components/day-time-grid/DayTimeGrid.types';
 
@@ -20,6 +21,13 @@ export interface StandaloneCompactDayViewProps<TEvent extends object, TResource 
       | CollapsibleResourcesParameterKeys
     >,
     EventCalendarSchedulerParametersOverrides {
+  /**
+   * Configuration applied to the view, keyed by the view name.
+   * For the `day` view, `startTime` and `endTime` (whole hours between 0 and 24)
+   * limit the hours displayed in the time grid.
+   * @example { day: { startTime: 8, endTime: 20 } }
+   */
+  viewConfig?: Pick<EventCalendarViewConfig, 'day'>;
   /**
    * Set the locale text of the view.
    * You can find all the translation keys supported in [the source](https://github.com/mui/mui-x/blob/HEAD/packages/x-scheduler/src/models/translations.ts)

--- a/packages/x-scheduler/src/compact-day-view/tests/CompactDayView.test.tsx
+++ b/packages/x-scheduler/src/compact-day-view/tests/CompactDayView.test.tsx
@@ -15,12 +15,14 @@ describe('<CompactDayView />', () => {
   function renderWithProviders(
     ui: React.ReactElement,
     events: any[] = [],
+    providerProps: Partial<React.ComponentProps<typeof EventCalendarProvider>> = {},
   ): ReturnType<typeof render> {
     return render(
       <EventCalendarProvider
         events={events}
         resources={[]}
         visibleDate={DEFAULT_TESTING_VISIBLE_DATE}
+        {...providerProps}
       >
         <EventDialogProvider>{ui}</EventDialogProvider>
       </EventCalendarProvider>,
@@ -29,6 +31,10 @@ describe('<CompactDayView />', () => {
 
   function getDayTimeGrid() {
     return document.querySelector<HTMLElement>(`.${eventCalendarClasses.dayTimeGridContainer}`)!;
+  }
+
+  function getTimeAxisCells() {
+    return document.querySelectorAll(`.${eventCalendarClasses.dayTimeGridTimeAxisCell}`);
   }
 
   it('should render 1 day column', () => {
@@ -73,5 +79,45 @@ describe('<CompactDayView />', () => {
       `.${eventCalendarClasses.timeGridEventResizeHandler}`,
     );
     expect(handlers.length).to.equal(2);
+  });
+
+  describe('viewConfig (startTime / endTime)', () => {
+    it('should render the 24 hour rows by default', () => {
+      renderWithProviders(<CompactDayView />);
+
+      expect(getTimeAxisCells()).to.have.length(24);
+    });
+
+    it('should render only the hour rows configured under the `day` key', () => {
+      renderWithProviders(<CompactDayView />, [], {
+        viewConfig: { day: { startTime: 8, endTime: 20 } },
+      });
+
+      expect(getTimeAxisCells()).to.have.length(12);
+    });
+
+    it('should position events relative to the configured window', () => {
+      const event = EventBuilder.new()
+        .title('Compact Event')
+        .span('2025-07-03T14:00:00Z', '2025-07-03T20:00:00Z')
+        .build();
+
+      renderWithProviders(<CompactDayView />, [event], {
+        viewConfig: { day: { startTime: 8, endTime: 20 } },
+      });
+
+      // 14:00 → 20:00 inside the 08:00 → 20:00 window: starts halfway, fills the bottom half.
+      const element = screen.getByRole('button', { name: /Compact Event/ });
+      expect(element.style.getPropertyValue('--y-position')).to.equal('50%');
+      expect(element.style.getPropertyValue('--height')).to.equal('50%');
+    });
+
+    it('should ignore the `week` key', () => {
+      renderWithProviders(<CompactDayView />, [], {
+        viewConfig: { week: { startTime: 8, endTime: 20 } },
+      });
+
+      expect(getTimeAxisCells()).to.have.length(24);
+    });
   });
 });

--- a/packages/x-scheduler/src/compact-week-view/CompactWeekView.tsx
+++ b/packages/x-scheduler/src/compact-week-view/CompactWeekView.tsx
@@ -1,6 +1,9 @@
 'use client';
 import * as React from 'react';
+import { useStore } from '@base-ui/utils/store';
 import { useEventCalendarView } from '@mui/x-scheduler-internals/use-event-calendar-view';
+import { useEventCalendarStoreContext } from '@mui/x-scheduler-internals/use-event-calendar-store-context';
+import { eventCalendarViewSelectors } from '@mui/x-scheduler-internals/event-calendar-selectors';
 import type { CompactWeekViewProps } from './CompactWeekView.types';
 import { CompactDayTimeGrid } from '../internals/components/compact-day-time-grid';
 import { createDayTimeGridViewDefinition } from '../internals/utils/day-time-grid-view-definition';
@@ -15,9 +18,23 @@ export const CompactWeekView = React.memo(
     props: CompactWeekViewProps,
     forwardedRef: React.ForwardedRef<HTMLDivElement>,
   ) {
+    // Context hooks
+    const store = useEventCalendarStoreContext();
+
     // Feature hooks
     const { days } = useEventCalendarView(COMPACT_WEEK_VIEW_DEFINITION);
 
-    return <CompactDayTimeGrid ref={forwardedRef} {...props} days={days} />;
+    // Selector hooks
+    const config = useStore(store, eventCalendarViewSelectors.timeGridConfig, 'week');
+
+    return (
+      <CompactDayTimeGrid
+        ref={forwardedRef}
+        days={days}
+        startTime={config?.startTime}
+        endTime={config?.endTime}
+        {...props}
+      />
+    );
   }),
 );

--- a/packages/x-scheduler/src/compact-week-view/CompactWeekView.types.ts
+++ b/packages/x-scheduler/src/compact-week-view/CompactWeekView.types.ts
@@ -5,6 +5,7 @@ import type {
   EventCalendarSchedulerParametersOverrides,
   CollapsibleResourcesParameterKeys,
 } from '@mui/x-scheduler-internals/use-event-calendar';
+import type { EventCalendarViewConfig } from '@mui/x-scheduler-internals/models';
 import type { EventCalendarLocaleText } from '../models/translations';
 import type { ExportedDayTimeGridProps } from '../internals/components/day-time-grid/DayTimeGrid.types';
 
@@ -20,6 +21,13 @@ export interface StandaloneCompactWeekViewProps<TEvent extends object, TResource
       | CollapsibleResourcesParameterKeys
     >,
     EventCalendarSchedulerParametersOverrides {
+  /**
+   * Configuration applied to the view, keyed by the view name.
+   * For the `week` view, `startTime` and `endTime` (whole hours between 0 and 24)
+   * limit the hours displayed in the time grid.
+   * @example { week: { startTime: 8, endTime: 20 } }
+   */
+  viewConfig?: Pick<EventCalendarViewConfig, 'week'>;
   /**
    * Set the locale text of the view.
    * You can find all the translation keys supported in [the source](https://github.com/mui/mui-x/blob/HEAD/packages/x-scheduler/src/models/translations.ts)

--- a/packages/x-scheduler/src/compact-week-view/tests/CompactWeekView.test.tsx
+++ b/packages/x-scheduler/src/compact-week-view/tests/CompactWeekView.test.tsx
@@ -15,12 +15,14 @@ describe('<CompactWeekView />', () => {
   function renderWithProviders(
     ui: React.ReactElement,
     events: any[] = [],
+    providerProps: Partial<React.ComponentProps<typeof EventCalendarProvider>> = {},
   ): ReturnType<typeof render> {
     return render(
       <EventCalendarProvider
         events={events}
         resources={[]}
         visibleDate={DEFAULT_TESTING_VISIBLE_DATE}
+        {...providerProps}
       >
         <EventDialogProvider>{ui}</EventDialogProvider>
       </EventCalendarProvider>,
@@ -29,6 +31,10 @@ describe('<CompactWeekView />', () => {
 
   function getDayTimeGrid() {
     return document.querySelector<HTMLElement>(`.${eventCalendarClasses.dayTimeGridContainer}`)!;
+  }
+
+  function getTimeAxisCells() {
+    return document.querySelectorAll(`.${eventCalendarClasses.dayTimeGridTimeAxisCell}`);
   }
 
   it('should render 7 day columns', () => {
@@ -52,5 +58,29 @@ describe('<CompactWeekView />', () => {
     expect(headerCells[0].getAttribute('aria-label')).to.match(
       new RegExp(`${expectedFirstDayOfMonth}$`),
     );
+  });
+
+  describe('viewConfig (startTime / endTime)', () => {
+    it('should render the 24 hour rows by default', () => {
+      renderWithProviders(<CompactWeekView />);
+
+      expect(getTimeAxisCells()).to.have.length(24);
+    });
+
+    it('should render only the hour rows configured under the `week` key', () => {
+      renderWithProviders(<CompactWeekView />, [], {
+        viewConfig: { week: { startTime: 8, endTime: 20 } },
+      });
+
+      expect(getTimeAxisCells()).to.have.length(12);
+    });
+
+    it('should ignore the `day` key', () => {
+      renderWithProviders(<CompactWeekView />, [], {
+        viewConfig: { day: { startTime: 8, endTime: 20 } },
+      });
+
+      expect(getTimeAxisCells()).to.have.length(24);
+    });
   });
 });


### PR DESCRIPTION
`CompactDayView` and `CompactWeekView` never read the store's time-grid config, so `viewConfig.day` / `viewConfig.week` silently did nothing on the touch views while `DayView` and `WeekView` honored them. The props already existed and were forwarded all the way down (`CompactDayTimeGrid` spreads `DayTimeGridProps` into `DayTimeGrid`) — the views just never filled them in.

## Changes

- `CompactDayView` / `CompactWeekView` read `eventCalendarViewSelectors.timeGridConfig` and forward `startTime` / `endTime`, mirroring `DayView` / `WeekView` exactly.
- The four standalone prop types (community + premium) re-add the narrowed `viewConfig` they were omitting, matching `StandaloneDayViewProps` / `StandaloneWeekViewProps`.
- Tests extend the existing `renderWithProviders` helper in each file with a provider-props argument instead of duplicating the JSX.

## Out of scope

`CompactThreeDayView` is left as is: `EventCalendarViewConfig` has no `threeDay` key and the view has no non-compact counterpart, so which key it should read is an open API question rather than a bug fix.
