### PR TITLE
[DateRangePicker] Keep the range highlight opaque for disabled days

### DIFF
--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.test.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.test.tsx
@@ -780,6 +780,36 @@ describe('<DateRangeCalendar />', () => {
     });
   });
 
+  describe('disabled days styling', () => {
+    const value: [PickerValidDate, PickerValidDate] = [
+      adapterToUse.date('2018-01-01'),
+      adapterToUse.date('2018-01-10'),
+    ];
+
+    it('should not dim the days when only some dates of the range are disabled', () => {
+      render(
+        <DateRangeCalendar
+          value={value}
+          shouldDisableDate={(date) => [5, 10].includes(adapterToUse.getDate(date))}
+        />,
+      );
+
+      // Inside the range.
+      const disabledDay = getPickerDay('5');
+      expect(disabledDay).to.have.attribute('disabled');
+      expect(disabledDay).to.have.style('opacity', '1');
+      // End of the range.
+      expect(getPickerDay('10')).to.have.style('opacity', '1');
+    });
+
+    it('should dim the days when the whole calendar is disabled', () => {
+      render(<DateRangeCalendar value={value} disabled />);
+
+      expect(getPickerDay('5')).to.have.style('opacity', '0.6');
+      expect(getPickerDay('10')).to.have.style('opacity', '0.6');
+    });
+  });
+
   it('prop: calendars - should render the provided amount of calendars', () => {
     render(<DateRangeCalendar calendars={3} />);
 

--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
@@ -25,6 +25,7 @@ import {
   useControlledValue,
   useViews,
   usePickerPrivateContext,
+  PickerPrivateContext,
   areDatesEqual,
   useApplyDefaultValuesToDateValidationProps,
 } from '@mui/x-date-pickers/internals';
@@ -304,7 +305,21 @@ const DateRangeCalendar = React.forwardRef(function DateRangeCalendar(
     timezone,
   });
 
-  const { ownerState: pickersOwnerState } = usePickerPrivateContext();
+  const pickerPrivateContext = usePickerPrivateContext();
+
+  // The calendar can be rendered on its own, in which case the Picker context knows nothing about its `disabled` prop.
+  const privateContextValue = React.useMemo(
+    () =>
+      disabled && !pickerPrivateContext.ownerState.isPickerDisabled
+        ? {
+            ...pickerPrivateContext,
+            ownerState: { ...pickerPrivateContext.ownerState, isPickerDisabled: true },
+          }
+        : pickerPrivateContext,
+    [pickerPrivateContext, disabled],
+  );
+
+  const pickersOwnerState = privateContextValue.ownerState;
   const ownerState: DateRangeCalendarOwnerState = {
     ...pickersOwnerState,
     isDraggingDay: isDragging,
@@ -583,57 +598,59 @@ const DateRangeCalendar = React.forwardRef(function DateRangeCalendar(
   }, [focusedView, setFocusedView, view]);
 
   return (
-    <DateRangeCalendarRoot
-      ref={ref}
-      className={clsx(classes.root, className)}
-      ownerState={ownerState}
-      {...other}
-    >
-      <Watermark packageInfo={packageInfo} />
-      {calendarMonths.map((monthIndex) => {
-        const month = visibleMonths[monthIndex];
-        const labelId = `${id}-grid-${monthIndex}-label`;
+    <PickerPrivateContext.Provider value={privateContextValue}>
+      <DateRangeCalendarRoot
+        ref={ref}
+        className={clsx(classes.root, className)}
+        ownerState={ownerState}
+        {...other}
+      >
+        <Watermark packageInfo={packageInfo} />
+        {calendarMonths.map((monthIndex) => {
+          const month = visibleMonths[monthIndex];
+          const labelId = `${id}-grid-${monthIndex}-label`;
 
-        return (
-          <DateRangeCalendarMonthContainer key={monthIndex} className={classes.monthContainer}>
-            <CalendarHeader
-              {...calendarHeaderProps}
-              month={month}
-              monthIndex={monthIndex}
-              labelId={labelId}
-            />
-            <DayCalendarForRange
-              className={classes.dayCalendar}
-              {...calendarState}
-              {...baseDateValidationProps}
-              {...commonViewProps}
-              onMonthSwitchingAnimationEnd={onMonthSwitchingAnimationEnd}
-              onFocusedDayChange={(focusedDate) =>
-                setVisibleDate({ target: focusedDate, reason: 'cell-interaction' })
-              }
-              reduceAnimations={reduceAnimations}
-              selectedDays={value}
-              onSelectedDaysChange={handleSelectedDayChange}
-              currentMonth={month}
-              TransitionProps={CalendarTransitionProps}
-              shouldDisableDate={wrappedShouldDisableDate}
-              hasFocus={hasFocus}
-              onFocusedViewChange={(isViewFocused) => setFocusedView('day', isViewFocused)}
-              showDaysOutsideCurrentMonth={calendars === 1 && showDaysOutsideCurrentMonth}
-              dayOfWeekFormatter={dayOfWeekFormatter}
-              loading={loading}
-              renderLoading={renderLoading}
-              slots={slotsForDayCalendar}
-              slotProps={slotPropsForDayCalendar}
-              fixedWeekNumber={fixedWeekNumber}
-              displayWeekNumber={displayWeekNumber}
-              timezone={timezone}
-              gridLabelId={labelId}
-            />
-          </DateRangeCalendarMonthContainer>
-        );
-      })}
-    </DateRangeCalendarRoot>
+          return (
+            <DateRangeCalendarMonthContainer key={monthIndex} className={classes.monthContainer}>
+              <CalendarHeader
+                {...calendarHeaderProps}
+                month={month}
+                monthIndex={monthIndex}
+                labelId={labelId}
+              />
+              <DayCalendarForRange
+                className={classes.dayCalendar}
+                {...calendarState}
+                {...baseDateValidationProps}
+                {...commonViewProps}
+                onMonthSwitchingAnimationEnd={onMonthSwitchingAnimationEnd}
+                onFocusedDayChange={(focusedDate) =>
+                  setVisibleDate({ target: focusedDate, reason: 'cell-interaction' })
+                }
+                reduceAnimations={reduceAnimations}
+                selectedDays={value}
+                onSelectedDaysChange={handleSelectedDayChange}
+                currentMonth={month}
+                TransitionProps={CalendarTransitionProps}
+                shouldDisableDate={wrappedShouldDisableDate}
+                hasFocus={hasFocus}
+                onFocusedViewChange={(isViewFocused) => setFocusedView('day', isViewFocused)}
+                showDaysOutsideCurrentMonth={calendars === 1 && showDaysOutsideCurrentMonth}
+                dayOfWeekFormatter={dayOfWeekFormatter}
+                loading={loading}
+                renderLoading={renderLoading}
+                slots={slotsForDayCalendar}
+                slotProps={slotPropsForDayCalendar}
+                fixedWeekNumber={fixedWeekNumber}
+                displayWeekNumber={displayWeekNumber}
+                timezone={timezone}
+                gridLabelId={labelId}
+              />
+            </DateRangeCalendarMonthContainer>
+          );
+        })}
+      </DateRangeCalendarRoot>
+    </PickerPrivateContext.Provider>
   );
 }) as DateRangeCalendarComponent;
 

--- a/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.test.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.test.tsx
@@ -149,6 +149,27 @@ describe('<DateRangePickerDay />', () => {
       expect(container.firstChild).to.have.style('opacity', '1');
     });
 
+    it('should use the disabled text color outside of the current month', () => {
+      const theme = createTheme({
+        palette: { text: { disabled: 'rgb(1, 2, 3)', secondary: 'rgb(4, 5, 6)' } },
+      });
+
+      const { container } = render(
+        <ThemeProvider theme={theme}>
+          <DateRangePickerDay
+            {...disabledDayProps}
+            day={adapterToUse.date('2018-02-01')}
+            outsideCurrentMonth
+            showDaysOutsideCurrentMonth
+            isStartOfHighlighting={false}
+            isEndOfHighlighting={false}
+          />
+        </ThemeProvider>,
+      );
+
+      expect(container.firstChild).to.have.style('color', 'rgb(1, 2, 3)');
+    });
+
     it('should not dim the day at the edge of the selected range', () => {
       const { container } = render(
         <DateRangePickerDay

--- a/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.test.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.test.tsx
@@ -122,6 +122,48 @@ describe('<DateRangePickerDay />', () => {
     });
   });
 
+  describe('disabled day', () => {
+    const disabledDayProps = {
+      onDaySelect: () => {},
+      outsideCurrentMonth: false,
+      disabled: true,
+      isHighlighting: true,
+      isPreviewing: false,
+      isStartOfPreviewing: false,
+      isEndOfPreviewing: false,
+      isFirstVisibleCell: false,
+      isLastVisibleCell: false,
+    };
+
+    it('should not dim the day inside the selected range', () => {
+      const { container } = render(
+        <DateRangePickerDay
+          {...disabledDayProps}
+          day={adapterToUse.date('2018-01-15')}
+          isStartOfHighlighting={false}
+          isEndOfHighlighting={false}
+        />,
+      );
+
+      expect(container.firstChild).to.have.class(classes.insideSelection);
+      expect(container.firstChild).to.have.style('opacity', '1');
+    });
+
+    it('should not dim the day at the edge of the selected range', () => {
+      const { container } = render(
+        <DateRangePickerDay
+          {...disabledDayProps}
+          day={adapterToUse.date('2018-01-15')}
+          isStartOfHighlighting
+          isEndOfHighlighting={false}
+        />,
+      );
+
+      expect(container.firstChild).to.have.class(classes.selectionStart);
+      expect(container.firstChild).to.have.style('opacity', '1');
+    });
+  });
+
   describe('filler cell', () => {
     it('should stay hidden when it is disabled and inside the selected range', () => {
       const { container } = render(

--- a/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.tsx
@@ -300,8 +300,8 @@ const DateRangePickerDayRoot = styled(ButtonBase, {
         ...selectedDayStyles(theme),
       },
     },
-    // A day disabled on its own (`shouldDisableDate`, `minDate`, ...) only dims itself.
-    // Dimming the whole cell would also dim the `::before` range highlight and leave gaps in the range.
+    // A day disabled on its own (`shouldDisableDate`, `minDate`, ...) only dims its text.
+    // Dimming the cell would also dim the `::before` range highlight and leave gaps in the range.
     {
       props: {
         isDaySelected: true,
@@ -310,10 +310,6 @@ const DateRangePickerDayRoot = styled(ButtonBase, {
         isPickerDisabled: false,
       },
       style: {
-        backgroundColor: theme.alpha(
-          (theme.vars || theme).palette.primary.main,
-          DISABLED_DAY_OPACITY,
-        ),
         color: theme.alpha(
           (theme.vars || theme).palette.primary.contrastText,
           DISABLED_DAY_OPACITY,

--- a/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.tsx
@@ -20,10 +20,7 @@ import type {
   DateRangePickerDayClasses,
   DateRangePickerDayClassKey,
 } from './dateRangePickerDayClasses';
-import {
-  dateRangePickerDayClasses,
-  getDateRangePickerDayUtilityClass,
-} from './dateRangePickerDayClasses';
+import { getDateRangePickerDayUtilityClass } from './dateRangePickerDayClasses';
 
 const useUtilityClasses = (
   ownerState: DateRangePickerDayOwnerState,
@@ -110,16 +107,9 @@ const selectedDayStyles = (theme: Theme) => ({
     willChange: 'background-color',
     backgroundColor: (theme.vars || theme).palette.primary.dark,
   },
-  [`&.${dateRangePickerDayClasses.disabled}`]: {
-    opacity: 0.6,
-  },
 });
 
-const insideSelectionStyle = () => ({
-  [`&.${dateRangePickerDayClasses.disabled}`]: {
-    opacity: 0.6,
-  },
-});
+const DISABLED_DAY_OPACITY = 0.6;
 
 const DateRangePickerDayRoot = styled(ButtonBase, {
   name: 'MuiDateRangePickerDay',
@@ -302,13 +292,45 @@ const DateRangePickerDayRoot = styled(ButtonBase, {
         '::before': {
           ...highlightStyles(theme),
         },
-        ...insideSelectionStyle(),
       },
     },
     {
       props: { isDaySelected: true, isDayInsideSelection: false },
       style: {
         ...selectedDayStyles(theme),
+      },
+    },
+    // A day disabled on its own (`shouldDisableDate`, `minDate`, ...) only dims itself.
+    // Dimming the whole cell would also dim the `::before` range highlight and leave gaps in the range.
+    {
+      props: {
+        isDaySelected: true,
+        isDayInsideSelection: false,
+        isDayDisabled: true,
+        isPickerDisabled: false,
+      },
+      style: {
+        backgroundColor: theme.alpha(
+          (theme.vars || theme).palette.primary.main,
+          DISABLED_DAY_OPACITY,
+        ),
+        color: theme.alpha(
+          (theme.vars || theme).palette.primary.contrastText,
+          DISABLED_DAY_OPACITY,
+        ),
+      },
+    },
+    // When the whole Picker is disabled, the range is dimmed as a whole.
+    {
+      props: { isDaySelected: true, isDayDisabled: true, isPickerDisabled: true },
+      style: {
+        opacity: DISABLED_DAY_OPACITY,
+      },
+    },
+    {
+      props: { isDayInsideSelection: true, isDayDisabled: true, isPickerDisabled: true },
+      style: {
+        opacity: DISABLED_DAY_OPACITY,
       },
     },
     {

--- a/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.tsx
@@ -184,6 +184,14 @@ const DateRangePickerDayRoot = styled(ButtonBase, {
   },
   variants: [
     {
+      props: { isDayOutsideMonth: true },
+      style: {
+        color: (theme.vars || theme).palette.text.secondary,
+      },
+    },
+    // Must come after `isDayOutsideMonth` so that a disabled day outside the current month
+    // uses the disabled text color.
+    {
       props: { isDayDisabled: true },
       style: {
         color: (theme.vars || theme).palette.text.disabled,
@@ -196,12 +204,6 @@ const DateRangePickerDayRoot = styled(ButtonBase, {
         // and results in unexpected relationships between week day and day columns.
         opacity: 0,
         pointerEvents: 'none',
-      },
-    },
-    {
-      props: { isDayOutsideMonth: true },
-      style: {
-        color: (theme.vars || theme).palette.text.secondary,
       },
     },
     {

--- a/packages/x-date-pickers/src/PickerDay/PickerDay.test.tsx
+++ b/packages/x-date-pickers/src/PickerDay/PickerDay.test.tsx
@@ -1,6 +1,8 @@
+import * as React from 'react';
 import { spy } from 'sinon';
 import { screen } from '@mui/internal-test-utils';
 import ButtonBase from '@mui/material/ButtonBase';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { PickerDay, pickerDayClasses as classes } from '@mui/x-date-pickers/PickerDay';
 import { adapterToUse, createPickerRenderer } from 'test/utils/pickers';
 import { describeConformance } from 'test/utils/describeConformance';
@@ -87,5 +89,27 @@ describe('<PickerDay />', () => {
     const day = screen.getByRole('button');
     expect(day).to.have.text('2 (free)');
     expect(day).toHaveAccessibleName('2 (free)');
+  });
+
+  it('should use the disabled text color for a disabled day outside the current month', () => {
+    const theme = createTheme({
+      palette: { text: { disabled: 'rgb(1, 2, 3)', secondary: 'rgb(4, 5, 6)' } },
+    });
+
+    render(
+      <ThemeProvider theme={theme}>
+        <PickerDay
+          day={adapterToUse.date('2020-02-02')}
+          onDaySelect={() => {}}
+          outsideCurrentMonth
+          showDaysOutsideCurrentMonth
+          isFirstVisibleCell={false}
+          isLastVisibleCell={false}
+          disabled
+        />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByRole('button')).to.have.style('color', 'rgb(1, 2, 3)');
   });
 });

--- a/packages/x-date-pickers/src/PickerDay/PickerDay.tsx
+++ b/packages/x-date-pickers/src/PickerDay/PickerDay.tsx
@@ -107,6 +107,14 @@ const PickerDayRoot = styled(ButtonBase, {
       },
     },
     {
+      props: { isDayOutsideMonth: true },
+      style: {
+        color: (theme.vars || theme).palette.text.secondary,
+      },
+    },
+    // Must come after `isDayOutsideMonth` so that a disabled day outside the current month
+    // uses the disabled text color.
+    {
       props: { isDayDisabled: true },
       style: {
         color: (theme.vars || theme).palette.text.disabled,
@@ -119,12 +127,6 @@ const PickerDayRoot = styled(ButtonBase, {
         // and results in unexpected relationships between week day and day columns.
         opacity: 0,
         pointerEvents: 'none',
-      },
-    },
-    {
-      props: { isDayOutsideMonth: true },
-      style: {
-        color: (theme.vars || theme).palette.text.secondary,
       },
     },
     {

--- a/packages/x-date-pickers/src/internals/index.ts
+++ b/packages/x-date-pickers/src/internals/index.ts
@@ -19,8 +19,8 @@ export type {
   PickerFieldUISlotsFromContext,
   PickerFieldUISlotPropsFromContext,
 } from './components/PickerFieldUI';
-export { PickerProvider } from './components/PickerProvider';
-export type { PickerContextValue } from './components/PickerProvider';
+export { PickerProvider, PickerPrivateContext } from './components/PickerProvider';
+export type { PickerContextValue, PickerPrivateContextValue } from './components/PickerProvider';
 export { PickersModalDialog } from './components/PickersModalDialog';
 export type {
   PickersModalDialogSlots,

--- a/test/regressions/pickers/DateRangeCalendarDisabled.tsx
+++ b/test/regressions/pickers/DateRangeCalendarDisabled.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import dayjs, { Dayjs } from 'dayjs';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { DateRangeCalendar } from '@mui/x-date-pickers-pro/DateRangeCalendar';
+
+// A fully disabled calendar dims the selected range as a whole, unlike a calendar
+// where only some dates are disabled (see DateRangeCalendarDisabledDays).
+const value: [Dayjs, Dayjs] = [dayjs('2026-09-14'), dayjs('2026-10-30')];
+
+export default function DateRangeCalendarDisabled() {
+  return (
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
+      <DateRangeCalendar calendars={2} value={value} disabled />
+    </LocalizationProvider>
+  );
+}

--- a/test/regressions/pickers/DateRangeCalendarDisabledDaysOutsideMonth.tsx
+++ b/test/regressions/pickers/DateRangeCalendarDisabledDaysOutsideMonth.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import dayjs, { Dayjs } from 'dayjs';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { DateRangeCalendar } from '@mui/x-date-pickers-pro/DateRangeCalendar';
+
+// With `showDaysOutsideCurrentMonth`, a disabled day outside the current month
+// must use the disabled text color like any other disabled day.
+const value: [Dayjs, Dayjs] = [dayjs('2026-09-14'), dayjs('2026-09-25')];
+
+const isWeekend = (date: Dayjs) => {
+  const day = date.day();
+  return day === 0 || day === 6;
+};
+
+export default function DateRangeCalendarDisabledDaysOutsideMonth() {
+  return (
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
+      <DateRangeCalendar
+        calendars={1}
+        value={value}
+        shouldDisableDate={isWeekend}
+        showDaysOutsideCurrentMonth
+      />
+    </LocalizationProvider>
+  );
+}

--- a/test/regressions/pickers/DateRangeCalendarSingleDisabledDay.tsx
+++ b/test/regressions/pickers/DateRangeCalendarSingleDisabledDay.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import dayjs, { Dayjs } from 'dayjs';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { DateRangeCalendar } from '@mui/x-date-pickers-pro/DateRangeCalendar';
+
+// A single day disabled in the middle of a week must only dim its own text:
+// the range highlight has to stay continuous around it.
+const value: [Dayjs, Dayjs] = [dayjs('2026-09-14'), dayjs('2026-09-25')];
+
+const disabledDay = dayjs('2026-09-16');
+
+export default function DateRangeCalendarSingleDisabledDay() {
+  return (
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
+      <DateRangeCalendar
+        calendars={1}
+        value={value}
+        shouldDisableDate={(date) => date.isSame(disabledDay, 'day')}
+      />
+    </LocalizationProvider>
+  );
+}


### PR DESCRIPTION
Follow-up to the visual discussion in #23293.

A day disabled through `shouldDisableDate` (or `minDate` / `maxDate` / ...) dimmed the whole cell with `opacity: 0.6`. Since the cell also paints the range highlight through its `::before` pseudo-element, the highlight got dimmed too and the selected range showed lighter gaps wherever a day was disabled.

This implements option 2 from https://github.com/mui/mui-x/pull/23293#issuecomment-5192718678:

- **certain dates disabled** (2b): only the text of the disabled day is dimmed, background colors are left alone. The range highlight stays at full strength, and so does the primary background of a disabled range edge. This matches v8, where the highlight was a separate element and never picked up the disabled opacity.
- **entire range disabled** (2a): the range keeps being dimmed as a whole with `opacity: 0.6`, as it is today.

`DateRangeCalendar` now propagates its own `disabled` prop through the Picker private context, so a standalone `<DateRangeCalendar disabled />` gets the 2a treatment instead of looking like a calendar with a lot of individually disabled days.

The `DateRangeCalendarDisabledDays` regression test covers the first case and a new `DateRangeCalendarDisabled` one covers the second, so Argos shows both.

cc @noraleonte @LukasTy: the rounded corners at the start/end of a month raised in the same thread are untouched here, they deserve their own PR.