### PR TITLE
[fields] Keep the selected section on blank space clicks

### DIFF
--- a/packages/x-date-pickers/src/DateField/tests/selection.DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/selection.DateField.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { spy } from 'sinon';
 import { DateField } from '@mui/x-date-pickers/DateField';
-import { fireEvent, screen } from '@mui/internal-test-utils';
+import { createEvent, fireEvent, screen } from '@mui/internal-test-utils';
 import {
   createPickerRenderer,
   expectFieldValue,
@@ -167,6 +167,57 @@ describe('<DateField /> - Selection', () => {
       expect(getCleanedSelectedContent()).to.equal('');
     });
 
+    it('should prevent the default mousedown behavior when clicking the field padding', () => {
+      // The padding belongs to the field root, outside the sections container.
+      // Without `preventDefault` the browser blurs the focused section, and the
+      // field visibly blurs and focuses again. The blur itself is a browser
+      // default action, so only real pointer input reproduces it -- the e2e
+      // suite covers that, and this locks the mechanism everywhere.
+      const view = renderWithProps({});
+      const fieldRoot = view.getSectionsContainer().parentElement!;
+
+      const event = createEvent.mouseDown(fieldRoot);
+      fireEvent(fieldRoot, event);
+
+      expect(event.defaultPrevented).to.equal(true);
+    });
+
+    it('should not prevent the default mousedown behavior when clicking an adornment button', () => {
+      // The adornments own their focus behavior: preventing the default here
+      // would stop the button from taking the focus on click.
+      renderWithProps({
+        clearable: true,
+        defaultValue: adapterToUse.date('2022-04-11'),
+        // The ripple would start on mousedown and update state outside `act`.
+        slotProps: { clearButton: { disableRipple: true } },
+      });
+      const clearButton = screen.getByRole('button', { name: 'Clear' });
+
+      const event = createEvent.mouseDown(clearButton);
+      fireEvent(clearButton, event);
+
+      expect(event.defaultPrevented).to.equal(false);
+    });
+
+    it('should not prevent the default mousedown behavior when clicking a non-interactive adornment', () => {
+      // The blank space check is the field root itself, not "anything that is
+      // not a section". A consumer adornment stays untouched even when it
+      // renders nothing focusable.
+      renderWithProps({
+        slotProps: {
+          textField: {
+            slotProps: { input: { startAdornment: <span data-testid="adornment">@</span> } },
+          },
+        },
+      } as any);
+      const adornment = screen.getByTestId('adornment');
+
+      const event = createEvent.mouseDown(adornment);
+      fireEvent(adornment, event);
+
+      expect(event.defaultPrevented).to.equal(false);
+    });
+
     it('should forward mousedown to a userland `onMouseDown` consumer', () => {
       const consumer = spy();
       const view = renderWithProps({ onMouseDown: consumer });
@@ -275,6 +326,77 @@ describe('<DateField /> - Selection', () => {
       fireEvent.click(sectionsContainer, { clientX });
 
       expect(getCleanedSelectedContent()).to.equal('DD');
+    });
+  });
+
+  // The sections container stretches to fill the field, so the area after the
+  // last section is blank space that belongs to no section.
+  // Browser-only, because JSDOM rects are 0x0: no click point can ever fall
+  // outside the sections there. Events are dispatched with `fireEvent` on real
+  // layout, like the closest-section test above. That covers the selection
+  // logic; the `preventDefault` that stops Chromium from delegating focus on a
+  // trusted click needs real pointer input, and is covered in `test/e2e`.
+  describe.skipIf(isJSDOM)('Click on the blank space after the last section', () => {
+    const getLastSectionRight = (sectionsContainer: HTMLElement) => {
+      const sections = sectionsContainer.querySelectorAll<HTMLElement>('[data-sectionindex]');
+      return sections[sections.length - 1].getBoundingClientRect().right;
+    };
+
+    const clickAt = (sectionsContainer: HTMLElement, clientX: number) => {
+      fireEvent.mouseDown(sectionsContainer, { clientX });
+      fireEvent.click(sectionsContainer, { clientX });
+    };
+
+    const clickBlankSpace = (sectionsContainer: HTMLElement) => {
+      const containerRight = sectionsContainer.getBoundingClientRect().right;
+      // Without blank space well clear of the tolerance band, every assertion
+      // below would pass vacuously.
+      expect(containerRight).to.be.greaterThan(getLastSectionRight(sectionsContainer) + 16);
+
+      clickAt(sectionsContainer, containerRight - 2);
+    };
+
+    it('should select the first section when the field is not focused', () => {
+      const view = renderWithProps({});
+
+      clickBlankSpace(view.getSectionsContainer());
+
+      expect(getCleanedSelectedContent()).to.equal('MM');
+    });
+
+    it('should keep the selected section when the field is already focused', async () => {
+      const onSelectedSectionsChange = spy();
+      const view = renderWithProps({ onSelectedSectionsChange });
+      await view.selectSection('day');
+      onSelectedSectionsChange.resetHistory();
+
+      clickBlankSpace(view.getSectionsContainer());
+
+      expect(getCleanedSelectedContent()).to.equal('DD');
+      expect(onSelectedSectionsChange.callCount).to.equal(0);
+    });
+
+    it('should select the last section when clicking just inside its right edge', () => {
+      // Pins the boundary of the blank space: the last rendered character still
+      // selects the year.
+      const view = renderWithProps({});
+      const sectionsContainer = view.getSectionsContainer();
+
+      clickAt(sectionsContainer, getLastSectionRight(sectionsContainer) - 1);
+
+      expect(getCleanedSelectedContent()).to.equal('YYYY');
+    });
+
+    it('should select the last section when the click misses it by less than the tolerance', async () => {
+      // A sloppy click a couple of pixels past the year still means the year,
+      // rather than a blank space click that would leave the day selected.
+      const view = renderWithProps({});
+      await view.selectSection('day');
+      const sectionsContainer = view.getSectionsContainer();
+
+      clickAt(sectionsContainer, getLastSectionRight(sectionsContainer) + 2);
+
+      expect(getCleanedSelectedContent()).to.equal('YYYY');
     });
   });
 

--- a/packages/x-date-pickers/src/DateField/tests/selection.DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/selection.DateField.test.tsx
@@ -168,11 +168,8 @@ describe('<DateField /> - Selection', () => {
     });
 
     it('should prevent the default mousedown behavior when clicking the field padding', () => {
-      // The padding belongs to the field root, outside the sections container.
-      // Without `preventDefault` the browser blurs the focused section, and the
-      // field visibly blurs and focuses again. The blur itself is a browser
-      // default action, so only real pointer input reproduces it -- the e2e
-      // suite covers that, and this locks the mechanism everywhere.
+      // Without it the browser blurs the focused section. The blur is a default
+      // action, so only the e2e suite reproduces it; this locks the mechanism.
       const view = renderWithProps({});
       const fieldRoot = view.getSectionsContainer().parentElement!;
 
@@ -183,8 +180,7 @@ describe('<DateField /> - Selection', () => {
     });
 
     it('should not prevent the default mousedown behavior when clicking an adornment button', () => {
-      // The adornments own their focus behavior: preventing the default here
-      // would stop the button from taking the focus on click.
+      // Preventing it would stop the button from taking the focus on click.
       renderWithProps({
         clearable: true,
         defaultValue: adapterToUse.date('2022-04-11'),
@@ -200,9 +196,8 @@ describe('<DateField /> - Selection', () => {
     });
 
     it('should not prevent the default mousedown behavior when clicking a non-interactive adornment', () => {
-      // The blank space check is the field root itself, not "anything that is
-      // not a section". A consumer adornment stays untouched even when it
-      // renders nothing focusable.
+      // The blank space check is the field root itself, not "not a section", so
+      // an adornment stays untouched even when it renders nothing focusable.
       renderWithProps({
         slotProps: {
           textField: {
@@ -329,13 +324,8 @@ describe('<DateField /> - Selection', () => {
     });
   });
 
-  // The sections container stretches to fill the field, so the area after the
-  // last section is blank space that belongs to no section.
-  // Browser-only, because JSDOM rects are 0x0: no click point can ever fall
-  // outside the sections there. Events are dispatched with `fireEvent` on real
-  // layout, like the closest-section test above. That covers the selection
-  // logic; the `preventDefault` that stops Chromium from delegating focus on a
-  // trusted click needs real pointer input, and is covered in `test/e2e`.
+  // Browser-only: JSDOM rects are 0x0, so no click point falls outside the
+  // sections. `test/e2e` covers what needs trusted input.
   describe.skipIf(isJSDOM)('Click on the blank space after the last section', () => {
     const getLastSectionRight = (sectionsContainer: HTMLElement) => {
       const sections = sectionsContainer.querySelectorAll<HTMLElement>('[data-sectionindex]');
@@ -349,8 +339,7 @@ describe('<DateField /> - Selection', () => {
 
     const clickBlankSpace = (sectionsContainer: HTMLElement) => {
       const containerRight = sectionsContainer.getBoundingClientRect().right;
-      // Without blank space well clear of the tolerance band, every assertion
-      // below would pass vacuously.
+      // Guards against a vacuous pass: clear of the tolerance band.
       expect(containerRight).to.be.greaterThan(getLastSectionRight(sectionsContainer) + 16);
 
       clickAt(sectionsContainer, containerRight - 2);
@@ -377,8 +366,7 @@ describe('<DateField /> - Selection', () => {
     });
 
     it('should select the last section when clicking just inside its right edge', () => {
-      // Pins the boundary of the blank space: the last rendered character still
-      // selects the year.
+      // Pins the boundary: the last rendered character still selects the year.
       const view = renderWithProps({});
       const sectionsContainer = view.getSectionsContainer();
 
@@ -388,8 +376,7 @@ describe('<DateField /> - Selection', () => {
     });
 
     it('should select the last section when the click misses it by less than the tolerance', async () => {
-      // A sloppy click a couple of pixels past the year still means the year,
-      // rather than a blank space click that would leave the day selected.
+      // A sloppy click 2px past the year means the year, not blank space.
       const view = renderWithProps({});
       await view.selectSection('day');
       const sectionsContainer = view.getSectionsContainer();

--- a/packages/x-date-pickers/src/PickersTextField/PickersInputBase/PickersInputBase.tsx
+++ b/packages/x-date-pickers/src/PickersTextField/PickersInputBase/PickersInputBase.tsx
@@ -188,8 +188,6 @@ const PickersInputBaseActiveBar = styled('div', {
 })<{ ownerState: { sectionOffsets: number[] } }>(({ theme, ownerState }) => ({
   display: 'none',
   position: 'absolute',
-  // Decorative: it must not become the target of a click on the field padding.
-  pointerEvents: 'none',
   height: 2,
   bottom: 2,
   borderTopLeftRadius: 2,

--- a/packages/x-date-pickers/src/PickersTextField/PickersInputBase/PickersInputBase.tsx
+++ b/packages/x-date-pickers/src/PickersTextField/PickersInputBase/PickersInputBase.tsx
@@ -188,6 +188,8 @@ const PickersInputBaseActiveBar = styled('div', {
 })<{ ownerState: { sectionOffsets: number[] } }>(({ theme, ownerState }) => ({
   display: 'none',
   position: 'absolute',
+  // Decorative: it must not become the target of a click on the field padding.
+  pointerEvents: 'none',
   height: 2,
   bottom: 2,
   borderTopLeftRadius: 2,

--- a/packages/x-date-pickers/src/internals/hooks/useField/useFieldRootProps.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useFieldRootProps.ts
@@ -240,14 +240,10 @@ export function useFieldRootProps(
       return;
     }
     const target = event.target as Element;
-    // `sectionListRoot` is the sections container, a descendant of the
-    // InputBase root that owns this handler.
     const sectionListRoot = domGetters.getRoot();
     const isInsideSectionList = sectionListRoot.contains(target);
-    // Outside the sections container, only the field root itself is ours: it is
-    // the target when the click lands on the field padding, because everything
-    // else in the field is a child element. The adornments keep their own
-    // behavior, whether or not they render something focusable.
+    // Only the field root is ours outside the sections container: it is the
+    // target of a padding click. The adornments keep their own behavior.
     if (!isInsideSectionList && target !== event.currentTarget) {
       return;
     }
@@ -255,14 +251,10 @@ export function useFieldRootProps(
       ? target.closest<HTMLElement>('[data-sectionindex]')
       : null;
 
-    // Blank space is the field padding, plus the area past the rendered
-    // sections in the container that stretches to fill the field. Mimic the
-    // native date input: select the first section when the click enters the
-    // field, and keep the current section for every later click.
-    // `preventDefault` is what keeps the section. It stops the browser from
-    // blurring the focused section when the click lands on a target that
-    // cannot take the focus, and it stops Chromium from delegating the focus
-    // to the nearest section once the `WebkitUserModify` gate lifts.
+    // Blank space is the field padding and the area past the sections. Mimic
+    // the native date input: first section on entry, keep it afterwards.
+    // `preventDefault` is what keeps it, by stopping both the browser blur and
+    // Chromium's focus delegation.
     const isBlankSpaceClick =
       sectionElement == null &&
       (!isInsideSectionList || isPointOutsideSections(sectionListRoot, event.clientX));
@@ -389,17 +381,15 @@ export function useFieldRootProps(
 }
 
 /**
- * Slop, in pixels, added to each side of the sections. It is under half a digit
- * at the default font size, so a click that just misses the outermost section
- * still selects it instead of counting as a click on the blank space.
+ * Slop on each side of the sections, so a click that just misses the outermost
+ * one still selects it. Under half a digit at the default font size.
  */
 const BLANK_SPACE_TOLERANCE = 4;
 
 /**
- * Returns `true` when `clientX` sits past the rendered sections on either side,
- * in the blank space the sections container fills but no section occupies.
- * Only the horizontal axis is tested: a click in the container's vertical
- * padding still belongs to the section it sits above or below.
+ * Returns `true` when `clientX` sits past the sections on either side.
+ * Horizontal only: a click in the container's vertical padding still belongs to
+ * the section above or below it.
  */
 function isPointOutsideSections(root: HTMLElement, clientX: number): boolean {
   const sections = root.querySelectorAll<HTMLElement>('[data-sectionindex]');

--- a/packages/x-date-pickers/src/internals/hooks/useField/useFieldRootProps.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useFieldRootProps.ts
@@ -240,18 +240,44 @@ export function useFieldRootProps(
       return;
     }
     const target = event.target as Element;
-    // `sectionListRoot` is the sections container (a descendant of the
-    // InputBase root that owns this handler). The guard rejects clicks on
-    // sibling adornments (open / clear buttons, etc.) which have their own
-    // behavior and must not get intercepted here.
+    // `sectionListRoot` is the sections container, a descendant of the
+    // InputBase root that owns this handler.
     const sectionListRoot = domGetters.getRoot();
-    if (!sectionListRoot.contains(target)) {
+    const isInsideSectionList = sectionListRoot.contains(target);
+    // Outside the sections container, only the field root itself is ours: it is
+    // the target when the click lands on the field padding, because everything
+    // else in the field is a child element. The adornments keep their own
+    // behavior, whether or not they render something focusable.
+    if (!isInsideSectionList && target !== event.currentTarget) {
       return;
     }
+    const sectionElement = isInsideSectionList
+      ? target.closest<HTMLElement>('[data-sectionindex]')
+      : null;
+
+    // Blank space is the field padding, plus the area past the rendered
+    // sections in the container that stretches to fill the field. Mimic the
+    // native date input: select the first section when the click enters the
+    // field, and keep the current section for every later click.
+    // `preventDefault` is what keeps the section. It stops the browser from
+    // blurring the focused section when the click lands on a target that
+    // cannot take the focus, and it stops Chromium from delegating the focus
+    // to the nearest section once the `WebkitUserModify` gate lifts.
+    const isBlankSpaceClick =
+      sectionElement == null &&
+      (!isInsideSectionList || isPointOutsideSections(sectionListRoot, event.clientX));
+    if (isBlankSpaceClick) {
+      event.preventDefault();
+      if (!focused) {
+        setFocused(true);
+        setSelectedSections(sectionOrder.startIndex);
+      }
+      return;
+    }
+
     // Prefer the visually-containing section (matches Chromium's
     // delegation + section container `onClick`), fall back to the
-    // closest-by-distance section for padding / past-last-section clicks.
-    const sectionElement = target.closest<HTMLElement>('[data-sectionindex]');
+    // closest-by-distance section for clicks on the container padding.
     const parsedIndex = sectionElement
       ? Number(sectionElement.dataset.sectionindex)
       : findClosestSectionIndexToPoint(sectionListRoot, event.clientX);
@@ -360,6 +386,36 @@ export function useFieldRootProps(
     contentEditable: parsedSelectedSections === 'all',
     tabIndex: internalPropsWithDefaults.disabled || parsedSelectedSections === 0 ? -1 : 0, // TODO: Try to set to undefined when there is a section selected.
   };
+}
+
+/**
+ * Slop, in pixels, added to each side of the sections. It is under half a digit
+ * at the default font size, so a click that just misses the outermost section
+ * still selects it instead of counting as a click on the blank space.
+ */
+const BLANK_SPACE_TOLERANCE = 4;
+
+/**
+ * Returns `true` when `clientX` sits past the rendered sections on either side,
+ * in the blank space the sections container fills but no section occupies.
+ * Only the horizontal axis is tested: a click in the container's vertical
+ * padding still belongs to the section it sits above or below.
+ */
+function isPointOutsideSections(root: HTMLElement, clientX: number): boolean {
+  const sections = root.querySelectorAll<HTMLElement>('[data-sectionindex]');
+  if (sections.length === 0) {
+    return false;
+  }
+
+  let left = Infinity;
+  let right = -Infinity;
+  for (let i = 0; i < sections.length; i += 1) {
+    const rect = sections[i].getBoundingClientRect();
+    left = Math.min(left, rect.left);
+    right = Math.max(right, rect.right);
+  }
+
+  return clientX < left - BLANK_SPACE_TOLERANCE || clientX > right + BLANK_SPACE_TOLERANCE;
 }
 
 /**

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -13,6 +13,7 @@ import {
   type Locator,
 } from '@playwright/test';
 import { pickersSectionListClasses } from '@mui/x-date-pickers/PickersSectionList';
+import { pickersOutlinedInputClasses } from '@mui/x-date-pickers/PickersTextField';
 
 function sleep(timeoutMS: number): Promise<void> {
   return new Promise((resolve) => {
@@ -748,6 +749,49 @@ async function initializeEnvironment(
           await page.getByRole('button', { name: 'Clear' }).click();
 
           expect(await page.evaluate(() => document.activeElement?.textContent)).to.equal('MM');
+        });
+
+        it('should keep the selected section when clicking the blank space after the last section', async () => {
+          // Needs trusted pointer input: without the `preventDefault` on
+          // mousedown, Chromium delegates the focus to the nearest section and
+          // the click on the blank space steals the selection.
+          await renderFixture('DatePicker/BasicDesktopDatePicker');
+
+          await page.getByRole('spinbutton', { name: 'Day' }).click();
+
+          const container = (await page
+            .locator(`.${pickersSectionListClasses.root}`)
+            .boundingBox())!;
+          const year = (await page.getByRole('spinbutton', { name: 'Year' }).boundingBox())!;
+          // Without blank space to click, the assertion below would pass vacuously.
+          expect(container.x + container.width).to.be.greaterThan(year.x + year.width + 16);
+
+          await page.mouse.click(
+            container.x + container.width - 2,
+            container.y + container.height / 2,
+          );
+
+          expect(await page.evaluate(() => document.activeElement?.textContent)).to.equal('DD');
+        });
+
+        it('should keep the selected section when clicking the padding of the field', async () => {
+          // The padding sits inside the field root but outside the sections
+          // container. Without the `preventDefault` on mousedown, the browser
+          // blurs the section, and the field visibly blurs and focuses again.
+          await renderFixture('DatePicker/BasicDesktopDatePicker');
+
+          await page.getByRole('spinbutton', { name: 'Day' }).click();
+
+          const root = (await page.locator(`.${pickersOutlinedInputClasses.root}`).boundingBox())!;
+          const container = (await page
+            .locator(`.${pickersSectionListClasses.root}`)
+            .boundingBox())!;
+          // Without padding to click, the assertion below would pass vacuously.
+          expect(container.x).to.be.greaterThan(root.x + 8);
+
+          await page.mouse.click(root.x + 4, root.y + root.height / 2);
+
+          expect(await page.evaluate(() => document.activeElement?.textContent)).to.equal('DD');
         });
 
         it('should correctly select a day in a calendar with "AdapterMomentJalaali"', async () => {

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -752,9 +752,8 @@ async function initializeEnvironment(
         });
 
         it('should keep the selected section when clicking the blank space after the last section', async () => {
-          // Needs trusted pointer input: without the `preventDefault` on
-          // mousedown, Chromium delegates the focus to the nearest section and
-          // the click on the blank space steals the selection.
+          // Needs trusted input: Chromium delegates the focus to the nearest
+          // section without the `preventDefault` on mousedown.
           await renderFixture('DatePicker/BasicDesktopDatePicker');
 
           await page.getByRole('spinbutton', { name: 'Day' }).click();
@@ -775,9 +774,8 @@ async function initializeEnvironment(
         });
 
         it('should keep the selected section when clicking the padding of the field', async () => {
-          // The padding sits inside the field root but outside the sections
-          // container. Without the `preventDefault` on mousedown, the browser
-          // blurs the section, and the field visibly blurs and focuses again.
+          // Needs trusted input: the browser blurs the section without the
+          // `preventDefault` on mousedown, so the field flashes.
           await renderFixture('DatePicker/BasicDesktopDatePicker');
 
           await page.getByRole('spinbutton', { name: 'Day' }).click();


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/23304

## Problem

The sections container stretches to fill the field, so a click after the last section lands on it. #22285 sent that click to the section whose horizontal center is closest, on the premise that it matched the native date input. The benchmark in the issue shows the premise was wrong: the native input selects the first section on the first click, and Chrome keeps the current section on every later click in the empty area.

That also left no way to tell a click on the trailing blank space from a click on the year, so a controlled `selectedSections` could not keep the first section selected.

## Changes

- A click on the blank space selects the first section when it enters the field, and keeps the current section afterwards. This matches Chrome.
- A 4px tolerance extends the sections on both sides, so a click that just misses the outermost section still selects it. Without it, a sloppy click 2px past the year does nothing at all.
- The field padding now follows the same rule. It sits inside the field root but outside the sections container, so the mousedown handler used to return early there and never called `preventDefault`. The browser then blurred the focused section, and the field visibly blurred and focused again, coming back on the first section rather than the one the user had. Outside the sections container the handler only claims the field root itself, which is the target of a click on the padding, so the adornments keep their own focus behavior.

Clicks on the container padding and on separator gaps still resolve to the closest section. Only the area past the rendered sections changes.

## Testing

Each test was confirmed to fail without its fix.

- `selection.DateField.test.tsx`, browser only, since jsdom rects are 0x0 and no click point can fall outside the sections there: first click selects the first section, a later click keeps the current one, the boundary and the tolerance band both select the year.
- `selection.DateField.test.tsx`, jsdom and browser: a mousedown on the field padding is default prevented, and a mousedown on an adornment is not, for both a button and a non-interactive adornment.
- `test/e2e/index.test.ts`: the blur and the Chromium focus delegation are browser default actions, so only trusted pointer input reproduces them. Two tests cover the blank space and the padding with real clicks.
