### PR TITLE
[DataGrid] Fix unhandled rejection when unmounting mid-autosize

### DIFF
--- a/packages/x-data-grid-pro/src/tests/columns.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/columns.DataGridPro.test.tsx
@@ -648,6 +648,24 @@ describe('<DataGridPro /> - Columns', () => {
       });
     });
 
+    // Regression test for https://github.com/mui/mui-x/issues/23298
+    it('should not reject when the grid unmounts while autosizing', async () => {
+      const { unmount } = render(<Test rows={rows} columns={columns} />);
+
+      let error: unknown;
+      await act(async () => {
+        // Not awaited on purpose: the grid unmounts while `autosizeColumns` is suspended on
+        // its internal `await`, which nulls the root element ref.
+        const promise = apiRef.current!.autosizeColumns().catch((err) => {
+          error = err;
+        });
+        unmount();
+        await promise;
+      });
+
+      expect(error).to.equal(undefined);
+    });
+
     // Regression test for https://github.com/mui/mui-x/issues/22505
     it('should wait for all rows to be rendered on mount when rows fit the viewport', async () => {
       const shortValue = 'Nike';

--- a/packages/x-data-grid/src/hooks/features/columnResize/useGridColumnResize.tsx
+++ b/packages/x-data-grid/src/hooks/features/columnResize/useGridColumnResize.tsx
@@ -812,6 +812,11 @@ export const useGridColumnResize = (
         if (!props.disableVirtualization && options.disableColumnVirtualization) {
           apiRef.current.unstable_setColumnVirtualization(false);
           await columnVirtualizationDisabled();
+
+          // The grid may have unmounted while awaiting, which nulls the root element ref.
+          if (!apiRef.current.rootElementRef?.current) {
+            return;
+          }
         }
 
         const widthByField = extractColumnWidths(apiRef, options, columns);


### PR DESCRIPTION
Fixes #23298

## Problem

`autosizeColumns` null-checks the root element only *before* its one `await`:

```js
const root = apiRef.current.rootElementRef?.current;
if (!root) { return; }               // pre-await guard
...
await columnVirtualizationDisabled();
const widthByField = extractColumnWidths(apiRef, options, columns);
```

`extractColumnWidths` then re-dereferences the root unguarded (`apiRef.current.rootElementRef!.current!` followed by `root.classList.add(...)`). If the grid unmounts during the await, React has already nulled `rootElementRef.current` and this throws:

```
TypeError: Cannot read properties of null (reading 'classList')
```

`DEFAULT_GRID_AUTOSIZE_OPTIONS.disableColumnVirtualization` is `true`, so the `autosizeOnMount` path always takes the awaiting branch. That call site is fire-and-forget, so the rejection escapes to `window.unhandledrejection` where apps have no way to catch it. Reported from production telemetry on apps that render grids inside collapsible sections, where mount-then-quick-unmount is a routine user gesture.

## Fix

Re-check the root after the await and bail out silently, matching what the pre-await guard already does. A grid that unmounted mid-autosize has no observable autosize outcome to lose. The guard also covers the sibling unguarded dereferences inside `extractColumnWidths` (`titleContainer.children`, the `findGridCells` / `findGridHeader` container refs).

The `finally` block still runs, so column virtualization is restored and `isAutosizingRef` is reset.

The double-click-separator call site passes `disableColumnVirtualization: false`, so it never awaits and was never affected.

I did not add a blanket `.catch()` in `runAutosize`: it would swallow genuine errors and make future bugs on this path invisible.

## Test

Added a regression test in `columns.DataGridPro.test.tsx` that unmounts the grid while `autosizeColumns` is suspended on its internal await. Without the fix it fails with exactly the reported `TypeError: Cannot read properties of null (reading 'classList')`.