### PR TITLE
[pickers] Prevent focus restoration from reopening picker

### DIFF
--- a/packages/x-date-pickers/src/DesktopDatePicker/tests/keepOpenDuringFieldFocus.clickFieldDoesNotClose.DesktopDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/tests/keepOpenDuringFieldFocus.clickFieldDoesNotClose.DesktopDatePicker.test.tsx
@@ -51,7 +51,7 @@ describe('DesktopDatePicker keepOpenDuringFieldFocus - clicking field should not
       expect(monthSection).toHaveFocus();
       expect(onOpen.callCount).to.equal(1);
     });
-    expect(screen.queryByRole('dialog')).to.equal(null);
+    await waitFor(() => expect(screen.queryByRole('dialog')).to.equal(null));
 
     await user.click(screen.getByRole('button', { name: 'Before picker' }));
     await user.tab();

--- a/packages/x-date-pickers/src/DesktopDatePicker/tests/keepOpenDuringFieldFocus.clickFieldDoesNotClose.DesktopDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/tests/keepOpenDuringFieldFocus.clickFieldDoesNotClose.DesktopDatePicker.test.tsx
@@ -1,6 +1,13 @@
-import { screen } from '@mui/internal-test-utils';
+import * as React from 'react';
+import { spy } from 'sinon';
+import { screen, waitFor } from '@mui/internal-test-utils';
 import { DesktopDatePicker } from '@mui/x-date-pickers/DesktopDatePicker';
-import { createPickerRenderer, getFieldSectionsContainer, openPicker } from 'test/utils/pickers';
+import {
+  adapterToUse,
+  createPickerRenderer,
+  getFieldSectionsContainer,
+  openPicker,
+} from 'test/utils/pickers';
 
 describe('DesktopDatePicker keepOpenDuringFieldFocus - clicking field should not close', () => {
   const { render } = createPickerRenderer();
@@ -18,5 +25,37 @@ describe('DesktopDatePicker keepOpenDuringFieldFocus - clicking field should not
     const popper = screen.queryByRole('dialog') ?? screen.queryByRole('tooltip');
     expect(popper).not.to.equal(null);
     expect(popper).toBeVisible();
+  });
+
+  it('does not reopen after selecting a date and restoring focus to the field', async () => {
+    const onOpen = spy();
+    const { user } = render(
+      <React.Fragment>
+        <button type="button">Before picker</button>
+        <DesktopDatePicker
+          defaultValue={adapterToUse.date('2018-01-01')}
+          keepOpenDuringFieldFocus
+          onOpen={onOpen}
+        />
+      </React.Fragment>,
+    );
+
+    const field = getFieldSectionsContainer();
+    await user.click(field);
+    expect(onOpen.callCount).to.equal(1);
+    const monthSection = screen.getByRole('spinbutton', { name: 'Month' });
+
+    await user.click(screen.getByRole('gridcell', { name: '2' }));
+
+    await waitFor(() => {
+      expect(monthSection).toHaveFocus();
+      expect(onOpen.callCount).to.equal(1);
+    });
+    expect(screen.queryByRole('dialog')).to.equal(null);
+
+    await user.click(screen.getByRole('button', { name: 'Before picker' }));
+    await user.tab();
+
+    expect(screen.getByRole('dialog')).toBeVisible();
   });
 });

--- a/packages/x-date-pickers/src/internals/components/PickerFieldUI.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickerFieldUI.tsx
@@ -17,6 +17,7 @@ import { useFieldOwnerState } from '../hooks/useFieldOwnerState';
 import { usePickerTranslations } from '../../hooks';
 import { ClearIcon as MuiClearIcon } from '../../icons';
 import { useNullablePickerContext } from '../hooks/useNullablePickerContext';
+import { usePickerPrivateContext } from '../hooks/usePickerPrivateContext';
 import type { UseFieldReturnValue, UseFieldProps } from '../hooks/useField';
 import type { PickersTextFieldProps } from '../../PickersTextField';
 import { PickersTextField } from '../../PickersTextField';
@@ -414,6 +415,7 @@ export function useFieldTextFieldProps<TProps extends UseFieldOwnerStateParamete
   const { ref, externalForwardedProps, slotProps } = parameters;
   const pickerFieldUIContext = React.useContext(PickerFieldUIContext);
   const pickerContext = useNullablePickerContext();
+  const { isRestoringFocusRef } = usePickerPrivateContext();
   const ownerState = useFieldOwnerState(externalForwardedProps);
 
   // TODO v10: remove
@@ -493,8 +495,8 @@ export function useFieldTextFieldProps<TProps extends UseFieldOwnerStateParamete
 
     (textFieldProps as any).onFocus = (event: React.FocusEvent) => {
       prevOnFocus?.(event);
-      // Avoid opening if event was prevented by user code
-      if (!event.isDefaultPrevented() && !isFromOpenButton(event)) {
+      // Avoid opening if event was prevented by user code or caused by focus restoration
+      if (!event.isDefaultPrevented() && !isFromOpenButton(event) && !isRestoringFocusRef.current) {
         pickerContext.setOpen(true);
       }
     };

--- a/packages/x-date-pickers/src/internals/components/PickerPopper/PickerPopper.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickerPopper/PickerPopper.tsx
@@ -349,7 +349,11 @@ export function PickerPopper(inProps: PickerPopperProps) {
   const { children, placement = 'bottom-start', slots, slotProps, classes: classesProp } = props;
 
   const { open, popupRef, reduceAnimations, keepOpenDuringFieldFocus } = usePickerContext();
-  const { ownerState: pickerOwnerState, rootRefObject } = usePickerPrivateContext();
+  const {
+    ownerState: pickerOwnerState,
+    rootRefObject,
+    isRestoringFocusRef,
+  } = usePickerPrivateContext();
   const { dismissViews, getCurrentViewMode, onPopperExited, triggerElement, viewContainerRole } =
     usePickerPrivateContext();
 
@@ -384,11 +388,15 @@ export function PickerPopper(inProps: PickerPopperProps) {
       // avoids issue, where screen reader could fail to announce selected date after selection
       setTimeout(() => {
         if (lastFocusedElementRef.current instanceof HTMLElement) {
+          isRestoringFocusRef.current = true;
           lastFocusedElementRef.current.focus();
+          setTimeout(() => {
+            isRestoringFocusRef.current = false;
+          });
         }
       });
     }
-  }, [open, viewContainerRole, getCurrentViewMode, rootRefObject]);
+  }, [open, viewContainerRole, getCurrentViewMode, rootRefObject, isRestoringFocusRef]);
 
   const classes = useUtilityClasses(classesProp);
 

--- a/packages/x-date-pickers/src/internals/components/PickerProvider.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickerProvider.tsx
@@ -35,6 +35,7 @@ export const PickerPrivateContext = React.createContext<PickerPrivateContextValu
     pickerOrientation: 'portrait',
   },
   rootRefObject: { current: null },
+  isRestoringFocusRef: { current: false },
   labelId: undefined,
   dismissViews: () => {},
   hasUIView: true,
@@ -356,6 +357,10 @@ export interface PickerPrivateContextValue {
    * This is the object counterpart of the `usePickerContext().rootRef` property which can be a function.
    */
   rootRefObject: React.RefObject<HTMLDivElement | null>;
+  /**
+   * Whether the Picker is currently restoring focus after closing the Popper.
+   */
+  isRestoringFocusRef: React.RefObject<boolean>;
   /**
    * The id of the label element.
    */

--- a/packages/x-date-pickers/src/internals/hooks/usePicker/usePicker.tsx
+++ b/packages/x-date-pickers/src/internals/hooks/usePicker/usePicker.tsx
@@ -97,6 +97,7 @@ export const usePicker = <
     null,
   );
   const rootRefObject = React.useRef<HTMLDivElement>(null);
+  const isRestoringFocusRef = React.useRef(false);
   const rootRef = useForkRef(ref, rootRefObject);
 
   const { timezone, state, setOpen, setValue, setValueFromView, value, viewValue } =
@@ -355,6 +356,7 @@ export const usePicker = <
       hasUIView,
       getCurrentViewMode,
       rootRefObject,
+      isRestoringFocusRef,
       labelId,
       triggerElement,
       viewContainerRole,


### PR DESCRIPTION
## Summary

When a desktop picker closes after selecting a date, `PickerPopper` restores focus to the field. With `keepOpenDuringFieldFocus`, that programmatic focus was treated as user focus and immediately reopened the picker.

This change:

- adds a private `isRestoringFocusRef` to the picker context
- marks the focus restoration window in `PickerPopper`
- prevents `PickerFieldUI` from reopening only during that programmatic restoration
- adds regression coverage proving selection stays closed while later keyboard focus still opens the picker

Closes #23089

## Changelog

[pickers] Prevent `keepOpenDuringFieldFocus` from reopening the picker after a selection closes it.

## Testing

- `pnpm test:unit --project "x-date-pickers" --run <affected test files> --maxWorkers=1` — 39 tests passed
- ESLint on the five changed files
- `pnpm --filter "@mui/x-date-pickers" run typescript`
- `pnpm --filter "@mui/x-date-pickers-pro" run typescript`
- Prettier check on the five changed files

> Local environment note: a complete serialized `x-date-pickers` run was also attempted and reported 11 failures in untouched MobileDateTimePicker/YearCalendar paths, primarily 5-second timeouts and Material UI transition `act(...)` warnings. The directly affected suites and static checks above are green.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
