### PR TITLE
[docs] Redirect the renamed Event Timeline views page

### DIFF
--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -86,4 +86,5 @@
 /x/api/charts/chart-data-provider/ /x/api/charts/charts-data-provider/ 301
 /x/api/charts/chart-data-provider-pro/ /x/api/charts/charts-data-provider-pro/ 301
 /x/api/charts/chart-data-provider-premium/ /x/api/charts/charts-data-provider-premium/ 301
+/x/react-scheduler/event-timeline/views/ /x/react-scheduler/event-timeline/presets/ 301
 # Proxies


### PR DESCRIPTION
#22130 renamed `/x/react-scheduler/event-timeline/views/` to `.../presets/` without a redirect, so the old URL 404s.

The only remaining links to it are on `mui.com/pricing/` ("Timeline views" and "Zoom in/out" in the pricing table), which lives in `mui/material-ui` and needs a separate fix. This redirect covers external links to the old URL.