### PR TITLE
[pickers] Keep the gridcell role and the column index on filler cells

### DIFF
--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.test.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.test.tsx
@@ -853,6 +853,16 @@ describe('<DateRangeCalendar />', () => {
     });
   });
 
+  it('should expose the filler cells as grid cells', () => {
+    render(<DateRangeCalendar calendars={1} referenceDate={adapterToUse.date('2018-01-01')} />);
+
+    const grid = screen.getByRole('grid', { name: 'January 2018' });
+
+    // Every week of the grid must expose as many cells as the grid has column headers.
+    expect(within(grid).getAllByRole('gridcell')).to.have.length(35);
+    expect(grid.querySelectorAll(`.${dayClasses.fillerCell}`)).to.have.length(4);
+  });
+
   describe('Performance', () => {
     it('should only render the new start day when selecting a start day without a previously selected start day', () => {
       const RenderCount = spy((props) => <DateRangePickerDay {...props} />);

--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.test.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.test.tsx
@@ -853,14 +853,35 @@ describe('<DateRangeCalendar />', () => {
     });
   });
 
-  it('should expose the filler cells as grid cells', () => {
-    render(<DateRangeCalendar calendars={1} referenceDate={adapterToUse.date('2018-01-01')} />);
+  describe('filler cells', () => {
+    const referenceDate = adapterToUse.date('2018-01-01');
 
-    const grid = screen.getByRole('grid', { name: 'January 2018' });
+    it('should be exposed as grid cells', () => {
+      render(<DateRangeCalendar calendars={1} referenceDate={referenceDate} />);
 
-    // Every week of the grid must expose as many cells as the grid has column headers.
-    expect(within(grid).getAllByRole('gridcell')).to.have.length(35);
-    expect(grid.querySelectorAll(`.${dayClasses.fillerCell}`)).to.have.length(4);
+      const grid = screen.getByRole('grid', { name: 'January 2018' });
+
+      expect(within(grid).getAllByRole('gridcell')).to.have.length(35);
+      expect(grid.querySelectorAll(`.${dayClasses.fillerCell}`)).to.have.length(4);
+    });
+
+    // The week number is a `rowheader` taking the first position of the row, so a cell without
+    // an explicit column index would be off by one.
+    it('should keep the column index of the day they replace', () => {
+      render(<DateRangeCalendar calendars={1} displayWeekNumber referenceDate={referenceDate} />);
+
+      const grid = screen.getByRole('grid', { name: 'January 2018' });
+      const weeks = within(within(grid).getByRole('rowgroup')).getAllByRole('row');
+
+      expect(weeks).to.have.length(5);
+      weeks.forEach((week) => {
+        const columnIndexes = within(week)
+          .getAllByRole('gridcell')
+          .map((cell) => cell.getAttribute('aria-colindex'));
+
+        expect(columnIndexes).to.deep.equal(['1', '2', '3', '4', '5', '6', '7']);
+      });
+    });
   });
 
   describe('Performance', () => {

--- a/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.test.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.test.tsx
@@ -212,13 +212,14 @@ describe('<DateRangePickerDay />', () => {
       expect(container.firstChild).to.have.style('opacity', '0');
     });
 
-    it('should keep the role it received', () => {
+    it('should keep the role and the column index it received', () => {
       const { container } = render(
         <DateRangePickerDay
           day={adapterToUse.date('2018-02-01')}
           onDaySelect={() => {}}
           outsideCurrentMonth
           role="gridcell"
+          aria-colindex={5}
           isPreviewing={false}
           isStartOfPreviewing={false}
           isEndOfPreviewing={false}
@@ -231,6 +232,7 @@ describe('<DateRangePickerDay />', () => {
 
       expect(container.firstChild).to.have.class(classes.fillerCell);
       expect(container.firstChild).to.have.attribute('role', 'gridcell');
+      expect(container.firstChild).to.have.attribute('aria-colindex', '5');
     });
   });
 

--- a/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.test.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.test.tsx
@@ -211,6 +211,27 @@ describe('<DateRangePickerDay />', () => {
       expect(container.firstChild).not.to.have.class(classes.insideSelection);
       expect(container.firstChild).to.have.style('opacity', '0');
     });
+
+    it('should keep the role it received', () => {
+      const { container } = render(
+        <DateRangePickerDay
+          day={adapterToUse.date('2018-02-01')}
+          onDaySelect={() => {}}
+          outsideCurrentMonth
+          role="gridcell"
+          isPreviewing={false}
+          isStartOfPreviewing={false}
+          isEndOfPreviewing={false}
+          isStartOfHighlighting={false}
+          isEndOfHighlighting={false}
+          isFirstVisibleCell={false}
+          isLastVisibleCell={false}
+        />,
+      );
+
+      expect(container.firstChild).to.have.class(classes.fillerCell);
+      expect(container.firstChild).to.have.attribute('role', 'gridcell');
+    });
   });
 
   // jsdom does not compute styles of pseudo-elements.

--- a/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.tsx
@@ -553,6 +553,7 @@ const DateRangePickerDayRaw = React.forwardRef(function DateRangePickerDay(
     return (
       <DateRangePickerDayRoot
         ref={handleRef}
+        role={other.role}
         ownerState={ownerState}
         className={clsx(classes.root, className)}
         as="div"

--- a/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.tsx
@@ -554,6 +554,7 @@ const DateRangePickerDayRaw = React.forwardRef(function DateRangePickerDay(
       <DateRangePickerDayRoot
         ref={handleRef}
         role={other.role}
+        aria-colindex={other['aria-colindex']}
         ownerState={ownerState}
         className={clsx(classes.root, className)}
         as="div"

--- a/packages/x-date-pickers/src/DateCalendar/tests/DateCalendar.test.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/tests/DateCalendar.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { screen, waitFor } from '@mui/internal-test-utils';
+import { screen, waitFor, within } from '@mui/internal-test-utils';
 import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
 import { PickerDay } from '@mui/x-date-pickers/PickerDay';
 import type { PickerDayProps } from '@mui/x-date-pickers/PickerDay';
@@ -101,6 +101,24 @@ describe('<DateCalendar />', () => {
 
     expect(cells.length).to.equal(35);
     expect(disabledDays.length).to.equal(31);
+  });
+
+  // The week number is a `rowheader` taking the first position of the row, so a cell without
+  // an explicit column index would be off by one.
+  it('should keep the column index of the days replaced by a filler cell', () => {
+    render(<DateCalendar displayWeekNumber referenceDate={adapterToUse.date('2018-01-01')} />);
+
+    const grid = screen.getByRole('grid', { name: 'January 2018' });
+    const weeks = within(within(grid).getByRole('rowgroup')).getAllByRole('row');
+
+    expect(weeks).to.have.length(5);
+    weeks.forEach((week) => {
+      const columnIndexes = within(week)
+        .getAllByRole('gridcell')
+        .map((cell) => cell.getAttribute('aria-colindex'));
+
+      expect(columnIndexes).to.deep.equal(['1', '2', '3', '4', '5', '6', '7']);
+    });
   });
 
   it('should render column header according to dayOfWeekFormatter', () => {

--- a/packages/x-date-pickers/src/PickerDay/PickerDay.test.tsx
+++ b/packages/x-date-pickers/src/PickerDay/PickerDay.test.tsx
@@ -73,6 +73,24 @@ describe('<PickerDay />', () => {
     expect(day).toHaveAccessibleName('2');
   });
 
+  it('should keep the role and the column index a filler cell received', () => {
+    const { container } = render(
+      <PickerDay
+        day={adapterToUse.date('2018-02-01')}
+        onDaySelect={() => {}}
+        outsideCurrentMonth
+        role="gridcell"
+        aria-colindex={5}
+        isFirstVisibleCell={false}
+        isLastVisibleCell={false}
+      />,
+    );
+
+    expect(container.firstChild).to.have.class(classes.fillerCell);
+    expect(container.firstChild).to.have.attribute('role', 'gridcell');
+    expect(container.firstChild).to.have.attribute('aria-colindex', '5');
+  });
+
   it('should render children instead of the day of the month when children prop is present', () => {
     render(
       <PickerDay

--- a/packages/x-date-pickers/src/PickerDay/PickerDay.tsx
+++ b/packages/x-date-pickers/src/PickerDay/PickerDay.tsx
@@ -246,6 +246,7 @@ const PickerDayRaw = React.forwardRef(function PickerDay(
       <PickerDayRoot
         ref={handleRef}
         role={other.role}
+        aria-colindex={other['aria-colindex']}
         ownerState={ownerState}
         className={clsx(classes.root, className)}
         as="div"


### PR DESCRIPTION
### Summary

Filler cells leave the accessibility tree of the day grid, and the cells that stay in it lose their column index.

`DateRangePickerDay` drops the `role` of its filler cells while `PickerDay` keeps it, so the weeks of a `DateRangeCalendar` expose fewer `gridcell` elements than the grid has columns whenever a week is padded with days of the neighbouring month. On top of that, both components drop `aria-colindex`, which `DayCalendar` sets explicitly on every day cell.

Both components render the filler cell through an early return that swaps `ButtonBase` for a plain `div`. `PickerDay` forwards `role={other.role}` there, `DateRangePickerDay` returns without spreading `...other` and without the role. The cell therefore stays in the DOM but leaves the accessibility tree anyway, which defeats the intent of the comment sitting right next to it:

> `// visibility: 'hidden' does not work here as it hides the element from screen readers`
> `// and results in unexpected relationships between week day and day columns.`

With `<DateRangeCalendar calendars={1} referenceDate={dayjs('2018-01-01')} />`, the January 2018 grid renders 35 day roots but only 31 of them reach the accessibility tree, so weeks 1 and 5 expose 6 and 3 cells against 7 columns. The same query on a `DateCalendar` returns all 35.

### The column index

`DayCalendar` compensates for the week number `rowheader` by passing an explicit index to every day:

```tsx
// fix issue of announcing column 1 as column 2 when `displayWeekNumber` is enabled
aria-colindex={dayIndex + 1}
```

The filler branch drops it in both components, so with `displayWeekNumber` a filler falls back to its DOM position and collides with the neighbouring cell:

```
displayWeekNumber, January 2018, before this PR
  row 1  colindex = [none(filler), 2, 3, 4, 5, 6, 7]
  row 5  colindex = [1, 2, 3, 4, none(filler), none(filler), none(filler)]
```

The leading filler is announced as column 2, the same column as January 1, and the trailing fillers land on 6, 7, 8 instead of 5, 6, 7. Without `displayWeekNumber` the inferred position and `dayIndex + 1` are the same number, so the missing attribute is invisible. `DateCalendar` is affected as well, which is why the fix covers `PickerDay` too.

### Why only the `role` and the column index

Spreading the whole `...other` on the filler branch would look symmetric but would be wrong. `DayCalendar` also injects `aria-current` and `aria-selected` into the day slot props, and a filler cell can be today (viewing January while today is February 1) or a selected range endpoint (a range ending February 2 with `calendars={2}`). Those cells would then be announced as current or selected while being invisible, which is the accessibility counterpart of what #23293 fixed visually. Only the attributes that place the cell in the grid are forwarded.

### This is a regression

Before #21739, `DateRangePickerDay` spread `{...other}` into a `styled(PickersDay)`, and v8's `PickersDay` already forwarded the role on its filler branch:

```tsx
if (outsideCurrentMonth && !showDaysOutsideCurrentMonth) {
  return (
    <PickersDayFiller
      className={clsx(classes.root, classes.hiddenDaySpacingFiller, className)}
      ownerState={ownerState}
      role={other.role}
    />
  );
}
```

So the "one cell per column" contract held in v8 and broke in v9 for the range calendar, with the same root cause as #23293 and #23297. The missing `aria-colindex` is older than that and affects `DateCalendar` on `master` too.

### Tests

- `PickerDay.test.tsx` and `DateRangePickerDay.test.tsx`: a filler cell keeps the role and the column index it received.
- `DateRangeCalendar.test.tsx`: the January 2018 grid exposes 35 `gridcell` elements, 4 of them filler cells.
- `DateCalendar.test.tsx` and `DateRangeCalendar.test.tsx`: with `displayWeekNumber`, every week of the January 2018 grid declares the column indexes `1` to `7`.

All four fail without the change and nothing else in the suite is affected. The `prop: showDaysOutsideCurrentMonth` tests were the only ones depending on the missing role, and #23297 already rewrote them to assert on the filler cell classes.

Note that the count of cells per row cannot be compared to the number of column headers with `displayWeekNumber` enabled, since the week number label is itself a `columnheader`: 8 headers against 7 cells. The tests assert the column index sequence instead.

Closes #23325

## Change summary

Filler cells of `PickerDay` and `DateRangePickerDay` keep their `gridcell` role and their `aria-colindex`, so every week of a calendar exposes one cell per column, announced under the right column.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
