### PR TITLE
[docs] Remove unused adapter-dependencies.json

### DIFF
--- a/docs/src/modules/utils/adapter-dependencies.json
+++ b/docs/src/modules/utils/adapter-dependencies.json
@@ -1,9 +1,0 @@
-{
-  "date-fns": "4.1.0",
-  "date-fns-jalali": "4.1.0-0",
-  "dayjs": "1.11.13",
-  "luxon": "3.6.1",
-  "moment": "2.30.1",
-  "moment-hijri": "3.0.0",
-  "moment-jalaali": "0.10.4"
-}


### PR DESCRIPTION
Remove `docs/src/modules/utils/adapter-dependencies.json`. Nothing reads it.

## Why

https://github.com/mui/mui-x/pull/18446 made the pickers adapter versions dynamic. It added `getPickerAdapterDeps.ts`, which resolves each version from the installed `package.json`, and it deleted both this JSON file and `scripts/buildPickerAdapterDeps.ts`.

https://github.com/mui/mui-x/pull/17447 restored the file two weeks later. That PR only refined the charts overview page, so the file came back from a stale branch merge.

## Evidence

- The only consumer is `docs/next.config.ts`, which calls `getPickerAdapterDeps()` and passes the result through the `PICKERS_ADAPTERS_DEPS` env var. No code path reads the JSON file.
- The values were also stale: `date-fns` 4.1.0 vs 4.4.0 installed, `dayjs` 1.11.13 vs 1.11.21, `luxon` 3.6.1 vs 3.7.2.

## Testing

`pnpm test:unit --project "docs*" --run` passes (26 tests, 3 files).

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
