### PR TITLE
[DataGrid] Do not ellipsize non-text cell content

### DIFF
--- a/docs/pages/x/api/data-grid/data-grid-premium.json
+++ b/docs/pages/x/api/data-grid/data-grid-premium.json
@@ -1827,6 +1827,12 @@
       "isGlobal": false
     },
     {
+      "key": "cell--element",
+      "className": "MuiDataGridPremium-cell--element",
+      "description": "Styles applied to the cell element if its content is not text.",
+      "isGlobal": false
+    },
+    {
       "key": "cell--fillPreview",
       "className": "MuiDataGridPremium-cell--fillPreview",
       "description": "Styles applied to the cell element when it is in the fill preview range.",

--- a/docs/pages/x/api/data-grid/data-grid-premium.json
+++ b/docs/pages/x/api/data-grid/data-grid-premium.json
@@ -1827,12 +1827,6 @@
       "isGlobal": false
     },
     {
-      "key": "cell--element",
-      "className": "MuiDataGridPremium-cell--element",
-      "description": "Styles applied to the cell element if its content is not text.",
-      "isGlobal": false
-    },
-    {
       "key": "cell--fillPreview",
       "className": "MuiDataGridPremium-cell--fillPreview",
       "description": "Styles applied to the cell element when it is in the fill preview range.",
@@ -1866,6 +1860,12 @@
       "key": "cell--flex",
       "className": "MuiDataGridPremium-cell--flex",
       "description": "Styles applied to the cell element in flex display mode.",
+      "isGlobal": false
+    },
+    {
+      "key": "cell--nonText",
+      "className": "MuiDataGridPremium-cell--nonText",
+      "description": "Styles applied to the cell element if its content is not text.",
       "isGlobal": false
     },
     {

--- a/docs/pages/x/api/data-grid/data-grid-pro.json
+++ b/docs/pages/x/api/data-grid/data-grid-pro.json
@@ -1369,6 +1369,12 @@
       "isGlobal": false
     },
     {
+      "key": "cell--element",
+      "className": "MuiDataGridPro-cell--element",
+      "description": "Styles applied to the cell element if its content is not text.",
+      "isGlobal": false
+    },
+    {
       "key": "cell--fillPreview",
       "className": "MuiDataGridPro-cell--fillPreview",
       "description": "Styles applied to the cell element when it is in the fill preview range.",

--- a/docs/pages/x/api/data-grid/data-grid-pro.json
+++ b/docs/pages/x/api/data-grid/data-grid-pro.json
@@ -1369,12 +1369,6 @@
       "isGlobal": false
     },
     {
-      "key": "cell--element",
-      "className": "MuiDataGridPro-cell--element",
-      "description": "Styles applied to the cell element if its content is not text.",
-      "isGlobal": false
-    },
-    {
       "key": "cell--fillPreview",
       "className": "MuiDataGridPro-cell--fillPreview",
       "description": "Styles applied to the cell element when it is in the fill preview range.",
@@ -1408,6 +1402,12 @@
       "key": "cell--flex",
       "className": "MuiDataGridPro-cell--flex",
       "description": "Styles applied to the cell element in flex display mode.",
+      "isGlobal": false
+    },
+    {
+      "key": "cell--nonText",
+      "className": "MuiDataGridPro-cell--nonText",
+      "description": "Styles applied to the cell element if its content is not text.",
       "isGlobal": false
     },
     {

--- a/docs/pages/x/api/data-grid/data-grid.json
+++ b/docs/pages/x/api/data-grid/data-grid.json
@@ -1197,6 +1197,12 @@
       "isGlobal": false
     },
     {
+      "key": "cell--element",
+      "className": "MuiDataGrid-cell--element",
+      "description": "Styles applied to the cell element if its content is not text.",
+      "isGlobal": false
+    },
+    {
       "key": "cell--fillPreview",
       "className": "MuiDataGrid-cell--fillPreview",
       "description": "Styles applied to the cell element when it is in the fill preview range.",

--- a/docs/pages/x/api/data-grid/data-grid.json
+++ b/docs/pages/x/api/data-grid/data-grid.json
@@ -1197,12 +1197,6 @@
       "isGlobal": false
     },
     {
-      "key": "cell--element",
-      "className": "MuiDataGrid-cell--element",
-      "description": "Styles applied to the cell element if its content is not text.",
-      "isGlobal": false
-    },
-    {
       "key": "cell--fillPreview",
       "className": "MuiDataGrid-cell--fillPreview",
       "description": "Styles applied to the cell element when it is in the fill preview range.",
@@ -1236,6 +1230,12 @@
       "key": "cell--flex",
       "className": "MuiDataGrid-cell--flex",
       "description": "Styles applied to the cell element in flex display mode.",
+      "isGlobal": false
+    },
+    {
+      "key": "cell--nonText",
+      "className": "MuiDataGrid-cell--nonText",
+      "description": "Styles applied to the cell element if its content is not text.",
       "isGlobal": false
     },
     {

--- a/docs/translations/api-docs/data-grid/data-grid-premium/data-grid-premium.json
+++ b/docs/translations/api-docs/data-grid/data-grid-premium/data-grid-premium.json
@@ -1160,6 +1160,11 @@
       "nodeName": "the cell element",
       "conditions": "the cell is in edit mode"
     },
+    "cell--element": {
+      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the cell element",
+      "conditions": "its content is not text"
+    },
     "cell--fillPreview": {
       "description": "Styles applied to {{nodeName}} when {{conditions}}.",
       "nodeName": "the cell element",

--- a/docs/translations/api-docs/data-grid/data-grid-premium/data-grid-premium.json
+++ b/docs/translations/api-docs/data-grid/data-grid-premium/data-grid-premium.json
@@ -1160,11 +1160,6 @@
       "nodeName": "the cell element",
       "conditions": "the cell is in edit mode"
     },
-    "cell--element": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the cell element",
-      "conditions": "its content is not text"
-    },
     "cell--fillPreview": {
       "description": "Styles applied to {{nodeName}} when {{conditions}}.",
       "nodeName": "the cell element",
@@ -1193,6 +1188,11 @@
     "cell--flex": {
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the cell element in flex display mode"
+    },
+    "cell--nonText": {
+      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the cell element",
+      "conditions": "its content is not text"
     },
     "cell--pinnedLeft": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",

--- a/docs/translations/api-docs/data-grid/data-grid-pro/data-grid-pro.json
+++ b/docs/translations/api-docs/data-grid/data-grid-pro/data-grid-pro.json
@@ -956,6 +956,11 @@
       "nodeName": "the cell element",
       "conditions": "the cell is in edit mode"
     },
+    "cell--element": {
+      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the cell element",
+      "conditions": "its content is not text"
+    },
     "cell--fillPreview": {
       "description": "Styles applied to {{nodeName}} when {{conditions}}.",
       "nodeName": "the cell element",

--- a/docs/translations/api-docs/data-grid/data-grid-pro/data-grid-pro.json
+++ b/docs/translations/api-docs/data-grid/data-grid-pro/data-grid-pro.json
@@ -956,11 +956,6 @@
       "nodeName": "the cell element",
       "conditions": "the cell is in edit mode"
     },
-    "cell--element": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the cell element",
-      "conditions": "its content is not text"
-    },
     "cell--fillPreview": {
       "description": "Styles applied to {{nodeName}} when {{conditions}}.",
       "nodeName": "the cell element",
@@ -989,6 +984,11 @@
     "cell--flex": {
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the cell element in flex display mode"
+    },
+    "cell--nonText": {
+      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the cell element",
+      "conditions": "its content is not text"
     },
     "cell--pinnedLeft": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",

--- a/docs/translations/api-docs/data-grid/data-grid/data-grid.json
+++ b/docs/translations/api-docs/data-grid/data-grid/data-grid.json
@@ -758,11 +758,6 @@
       "nodeName": "the cell element",
       "conditions": "the cell is in edit mode"
     },
-    "cell--element": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the cell element",
-      "conditions": "its content is not text"
-    },
     "cell--fillPreview": {
       "description": "Styles applied to {{nodeName}} when {{conditions}}.",
       "nodeName": "the cell element",
@@ -791,6 +786,11 @@
     "cell--flex": {
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the cell element in flex display mode"
+    },
+    "cell--nonText": {
+      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the cell element",
+      "conditions": "its content is not text"
     },
     "cell--pinnedLeft": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",

--- a/docs/translations/api-docs/data-grid/data-grid/data-grid.json
+++ b/docs/translations/api-docs/data-grid/data-grid/data-grid.json
@@ -758,6 +758,11 @@
       "nodeName": "the cell element",
       "conditions": "the cell is in edit mode"
     },
+    "cell--element": {
+      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the cell element",
+      "conditions": "its content is not text"
+    },
     "cell--fillPreview": {
       "description": "Styles applied to {{nodeName}} when {{conditions}}.",
       "nodeName": "the cell element",

--- a/packages/x-data-grid/src/components/cell/GridCell.tsx
+++ b/packages/x-data-grid/src/components/cell/GridCell.tsx
@@ -432,6 +432,10 @@ const GridCell = forwardRef<HTMLDivElement, GridCellProps>(function GridCell(pro
     title = valueString;
   }
 
+  if (children != null && typeof children !== 'string' && typeof children !== 'number') {
+    classNames.push(gridClasses['cell--element']);
+  }
+
   const draggableEventHandlers = disableDragEvents
     ? null
     : {

--- a/packages/x-data-grid/src/components/cell/GridCell.tsx
+++ b/packages/x-data-grid/src/components/cell/GridCell.tsx
@@ -432,9 +432,10 @@ const GridCell = forwardRef<HTMLDivElement, GridCellProps>(function GridCell(pro
     title = valueString;
   }
 
-  if (children != null && typeof children !== 'string' && typeof children !== 'number') {
-    classNames.push(gridClasses['cell--element']);
-    classNames.push(rootClasses?.['cell--element']);
+  // Primitives are rendered as text or not at all, only objects can overflow as an element.
+  if (typeof children === 'object' && children !== null) {
+    classNames.push(gridClasses['cell--nonText']);
+    classNames.push(rootClasses?.['cell--nonText']);
   }
 
   const draggableEventHandlers = disableDragEvents

--- a/packages/x-data-grid/src/components/cell/GridCell.tsx
+++ b/packages/x-data-grid/src/components/cell/GridCell.tsx
@@ -434,6 +434,7 @@ const GridCell = forwardRef<HTMLDivElement, GridCellProps>(function GridCell(pro
 
   if (children != null && typeof children !== 'string' && typeof children !== 'number') {
     classNames.push(gridClasses['cell--element']);
+    classNames.push(rootClasses?.['cell--element']);
   }
 
   const draggableEventHandlers = disableDragEvents

--- a/packages/x-data-grid/src/components/containers/GridRootStyles.ts
+++ b/packages/x-data-grid/src/components/containers/GridRootStyles.ts
@@ -558,10 +558,6 @@ export const GridRootStyles = styled('div', {
       overflow: 'hidden',
       whiteSpace: 'nowrap',
       textOverflow: 'ellipsis',
-      // Avoids painting a clipped "…" next to overflowing widget content.
-      [`&.${c['cell--element']}`]: {
-        textOverflow: 'clip',
-      },
       '&.Mui-selected': selectedStyles,
     },
     /* Default range border styles using box-shadow to avoid layout shift */
@@ -705,6 +701,10 @@ export const GridRootStyles = styled('div', {
       display: 'flex',
       alignItems: 'center',
       lineHeight: 'inherit',
+    },
+    // Kept at the same specificity as the cell rule so that users can restore the ellipsis.
+    [`& .${c['cell--nonText']}`]: {
+      textOverflow: 'clip',
     },
     [`& .${c['cell--textLeft']}`]: {
       textAlign: 'left',

--- a/packages/x-data-grid/src/components/containers/GridRootStyles.ts
+++ b/packages/x-data-grid/src/components/containers/GridRootStyles.ts
@@ -558,6 +558,10 @@ export const GridRootStyles = styled('div', {
       overflow: 'hidden',
       whiteSpace: 'nowrap',
       textOverflow: 'ellipsis',
+      // Avoids painting a clipped "…" next to overflowing widget content.
+      [`&.${c['cell--element']}`]: {
+        textOverflow: 'clip',
+      },
       '&.Mui-selected': selectedStyles,
     },
     /* Default range border styles using box-shadow to avoid layout shift */

--- a/packages/x-data-grid/src/constants/gridClasses.ts
+++ b/packages/x-data-grid/src/constants/gridClasses.ts
@@ -108,13 +108,13 @@ export interface GridClasses {
    */
   'cell--editing': string;
   /**
-   * Styles applied to the cell element if its content is not text.
-   */
-  'cell--element': string;
-  /**
    * Styles applied to the cell element in flex display mode.
    */
   'cell--flex': string;
+  /**
+   * Styles applied to the cell element if its content is not text.
+   */
+  'cell--nonText': string;
   /**
    * Styles applied to the cell element if `align="center"`.
    */
@@ -1088,8 +1088,8 @@ export const gridClassesOverrides = {
     'cell',
     'cell--editable',
     'cell--editing',
-    'cell--element',
     'cell--flex',
+    'cell--nonText',
     'cell--pinnedLeft',
     'cell--pinnedRight',
     'cell--rangeBottom',

--- a/packages/x-data-grid/src/constants/gridClasses.ts
+++ b/packages/x-data-grid/src/constants/gridClasses.ts
@@ -108,6 +108,10 @@ export interface GridClasses {
    */
   'cell--editing': string;
   /**
+   * Styles applied to the cell element if its content is not text.
+   */
+  'cell--element': string;
+  /**
    * Styles applied to the cell element in flex display mode.
    */
   'cell--flex': string;
@@ -1084,6 +1088,7 @@ export const gridClassesOverrides = {
     'cell',
     'cell--editable',
     'cell--editing',
+    'cell--element',
     'cell--flex',
     'cell--pinnedLeft',
     'cell--pinnedRight',

--- a/packages/x-data-grid/src/tests/cells.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/cells.DataGrid.test.tsx
@@ -145,7 +145,7 @@ describe('<DataGrid /> - Cells', () => {
 
     it('should flag the cell when renderCell returns an element', () => {
       renderCellColumn({ field: 'brand', renderCell: () => <button type="button">Edit</button> });
-      expect(getCell(0, 0)).to.have.class(gridClasses['cell--element']);
+      expect(getCell(0, 0)).to.have.class(gridClasses['cell--nonText']);
     });
 
     it('should append the custom class passed through the classes prop', () => {
@@ -155,7 +155,7 @@ describe('<DataGrid /> - Cells', () => {
             autoHeight={isJSDOM}
             columns={[{ field: 'brand', renderCell: () => <button type="button">Edit</button> }]}
             rows={[{ id: 1, brand: 'Nike' }]}
-            classes={{ 'cell--element': 'foobar' }}
+            classes={{ 'cell--nonText': 'foobar' }}
           />
         </div>,
       );
@@ -164,12 +164,36 @@ describe('<DataGrid /> - Cells', () => {
 
     it('should not flag the cell when renderCell returns text', () => {
       renderCellColumn({ field: 'brand', renderCell: ({ value }) => value });
-      expect(getCell(0, 0)).not.to.have.class(gridClasses['cell--element']);
+      expect(getCell(0, 0)).not.to.have.class(gridClasses['cell--nonText']);
     });
 
     it('should not flag the cell when the value is rendered by default', () => {
       renderCellColumn({ field: 'brand' });
-      expect(getCell(0, 0)).not.to.have.class(gridClasses['cell--element']);
+      expect(getCell(0, 0)).not.to.have.class(gridClasses['cell--nonText']);
+    });
+
+    it('should not flag the cell when renderCell returns `null`', () => {
+      renderCellColumn({ field: 'brand', renderCell: () => null });
+      expect(getCell(0, 0)).not.to.have.class(gridClasses['cell--nonText']);
+    });
+
+    it('should not flag the cell when renderCell returns `false`', () => {
+      renderCellColumn({ field: 'brand', renderCell: () => false });
+      expect(getCell(0, 0)).not.to.have.class(gridClasses['cell--nonText']);
+    });
+
+    it.skipIf(isJSDOM)('should let the user restore the ellipsis on the cell', () => {
+      render(
+        <div style={{ width: 300, height: 300 }}>
+          <DataGrid
+            autoHeight={isJSDOM}
+            columns={[{ field: 'brand', renderCell: () => <button type="button">Edit</button> }]}
+            rows={[{ id: 1, brand: 'Nike' }]}
+            sx={{ [`& .${gridClasses.cell}`]: { textOverflow: 'ellipsis' } }}
+          />
+        </div>,
+      );
+      expect(window.getComputedStyle(getCell(0, 0)).textOverflow).to.equal('ellipsis');
     });
 
     it.skipIf(isJSDOM)('should not ellipsize element content', () => {

--- a/packages/x-data-grid/src/tests/cells.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/cells.DataGrid.test.tsx
@@ -148,6 +148,20 @@ describe('<DataGrid /> - Cells', () => {
       expect(getCell(0, 0)).to.have.class(gridClasses['cell--element']);
     });
 
+    it('should append the custom class passed through the classes prop', () => {
+      render(
+        <div style={{ width: 300, height: 300 }}>
+          <DataGrid
+            autoHeight={isJSDOM}
+            columns={[{ field: 'brand', renderCell: () => <button type="button">Edit</button> }]}
+            rows={[{ id: 1, brand: 'Nike' }]}
+            classes={{ 'cell--element': 'foobar' }}
+          />
+        </div>,
+      );
+      expect(getCell(0, 0)).to.have.class('foobar');
+    });
+
     it('should not flag the cell when renderCell returns text', () => {
       renderCellColumn({ field: 'brand', renderCell: ({ value }) => value });
       expect(getCell(0, 0)).not.to.have.class(gridClasses['cell--element']);

--- a/packages/x-data-grid/src/tests/cells.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/cells.DataGrid.test.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { spy } from 'sinon';
 import { createRenderer, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
-import { DataGrid, renderLongTextCell } from '@mui/x-data-grid';
-import type { GridApi, GridValueFormatter } from '@mui/x-data-grid';
+import { DataGrid, gridClasses, renderLongTextCell } from '@mui/x-data-grid';
+import type { GridApi, GridColDef, GridValueFormatter } from '@mui/x-data-grid';
 import { getCell, openLongTextEditPopup, openLongTextViewPopup } from 'test/utils/helperFn';
 import { getBasicGridData } from '@mui/x-data-grid-generator';
 import { isJSDOM } from 'test/utils/skipIf';
@@ -131,6 +131,42 @@ describe('<DataGrid /> - Cells', () => {
       </div>,
     );
     expect(getCell(0, 0)).to.have.text('');
+  });
+
+  // See https://github.com/mui/mui-x/issues/23332
+  describe('text overflow', () => {
+    function renderCellColumn(column: GridColDef) {
+      render(
+        <div style={{ width: 300, height: 300 }}>
+          <DataGrid autoHeight={isJSDOM} columns={[column]} rows={[{ id: 1, brand: 'Nike' }]} />
+        </div>,
+      );
+    }
+
+    it('should flag the cell when renderCell returns an element', () => {
+      renderCellColumn({ field: 'brand', renderCell: () => <button type="button">Edit</button> });
+      expect(getCell(0, 0)).to.have.class(gridClasses['cell--element']);
+    });
+
+    it('should not flag the cell when renderCell returns text', () => {
+      renderCellColumn({ field: 'brand', renderCell: ({ value }) => value });
+      expect(getCell(0, 0)).not.to.have.class(gridClasses['cell--element']);
+    });
+
+    it('should not flag the cell when the value is rendered by default', () => {
+      renderCellColumn({ field: 'brand' });
+      expect(getCell(0, 0)).not.to.have.class(gridClasses['cell--element']);
+    });
+
+    it.skipIf(isJSDOM)('should not ellipsize element content', () => {
+      renderCellColumn({ field: 'brand', renderCell: () => <button type="button">Edit</button> });
+      expect(window.getComputedStyle(getCell(0, 0)).textOverflow).to.equal('clip');
+    });
+
+    it.skipIf(isJSDOM)('should ellipsize text content', () => {
+      renderCellColumn({ field: 'brand' });
+      expect(window.getComputedStyle(getCell(0, 0)).textOverflow).to.equal('ellipsis');
+    });
   });
 
   // See https://github.com/mui/mui-x/issues/22831


### PR DESCRIPTION
Closes #23332

## Problem

`.MuiDataGrid-cell` sets `text-overflow: ellipsis`. That property does not only affect text: per the CSS Overflow spec it also applies to overflowing **atomic inlines** (`inline-block`, `inline-flex`, `img`).

A MUI `IconButton` is `inline-flex`, so when a `renderCell` widget is wider than the cell content box the browser paints a literal `…` after it, which `overflow: hidden` then slices in half. The result is a column of stray half-dots beside every row.

It only shows up in a narrow band of column widths, which is why it reads as a rendering glitch rather than as truncation. Reproducing the reporter's case (a 36px `IconButton`, cell padding `0 10px`) in Chromium:

| column width | 44 | 46 | 48 | 50 | 52 | 54 | 56 | 58 |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| painted ellipsis | none | none | sliver | `..` | `...` | `...` | none | none |

At 56px the content box is exactly 36px, so the widget stops overflowing and the artifact disappears. Below 48px the ellipsis is pushed past the clip edge and disappears again.

## Fix

Ellipsis is meaningful for truncated text, not for widget content. This turns it off for non-text content and changes nothing else:

- `GridCell` adds a new `cell--element` class when the resolved children is neither a string nor a number.
- `GridRootStyles` nests `text-overflow: clip` under that class inside the existing `.cell` block.

`text-overflow` is paint-only (the spec states that ellipsing must not affect layout), so this touches no layout, no vertical alignment, no column autosizing and adds no DOM node. The perf win from #12013, which removed the `.cellContent` wrapper, is preserved.

Cells still ellipsize when `renderCell` returns a string or a number, and when the value is rendered by default. `display: 'flex'` columns are unaffected, since a flex cell already ignores `text-overflow`.

## Behavior change worth calling out

`renderCell: () => <span>{longText}</span>`, an inline element child, loses the cell level ellipsis and is hard clipped instead. This is the only regression class and it cannot be avoided without measuring the DOM, since React cannot distinguish a span of text from a widget.

It matches the guidance already in the v6 to v7 migration guide, which tells users to bring their own wrapper for element content:

```tsx
{
  display: 'flex',
  renderCell: ({ value }) => (
    <div style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{value}</div>
  ),
}
```

Block level children never received the cell ellipsis in the first place, so nothing regresses there. That includes the built in `treeDataGroupingCell` and `groupingCriteriaCell`, which are both `display: flex`.

## Notes on the approach

Two heavier alternatives were considered and rejected:

- Auto applying `display: 'flex'` when the content is an element. This was proposed during the review of #12013 and set aside in favour of the explicit `display` prop. It silently re-centers every existing `renderCell` column, so the visual blast radius is large.
- Making the cell a flex container and wrapping strings in a span, as in #21731. That reintroduces the DOM node #12013 removed, and the author of that PR reported regressions in flash animations, left aligned content and chart content.

## Testing

Five cases added to `cells.DataGrid.test.tsx`, covering element content, `renderCell` returning text, and the default text cell. Two of them are browser only and assert the resolved `getComputedStyle(cell).textOverflow` is `clip` for element content and `ellipsis` for text.

## Changelog

Cells rendering a custom widget through `renderCell` no longer paint a clipped text ellipsis next to overflowing content. The ellipsis is now applied only to text content.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
