### PR TITLE
[tree view] Do not render items removed from the `items` prop

### DIFF
--- a/packages/x-tree-view/src/RichTreeView/RichTreeView.test.tsx
+++ b/packages/x-tree-view/src/RichTreeView/RichTreeView.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createRenderer, screen } from '@mui/internal-test-utils';
+import { createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
 import { RichTreeView, richTreeViewClasses as classes } from '@mui/x-tree-view/RichTreeView';
 import { describeConformance } from 'test/utils/describeConformance';
 
@@ -19,5 +19,39 @@ describe('<RichTreeView />', () => {
     render(<RichTreeView id="test-id" items={[{ id: '1', label: 'Item 1' }]} />);
 
     expect(screen.getByRole('tree')).to.have.attribute('id', 'test-id');
+  });
+
+  it('should not render an item that is no longer in the items prop', () => {
+    const renderedItemIds: string[] = [];
+
+    function TestCase() {
+      const [items, setItems] = React.useState([
+        { id: '1', label: 'Item 1', children: [{ id: '1.1', label: 'Item 1.1' }] },
+      ]);
+
+      return (
+        <React.Fragment>
+          <button onClick={() => setItems([{ id: '1', label: 'Item 1', children: [] }])}>
+            remove
+          </button>
+          <RichTreeView
+            items={items}
+            defaultExpandedItems={['1']}
+            slotProps={{
+              item: (ownerState) => {
+                renderedItemIds.push(ownerState.itemId);
+                return {};
+              },
+            }}
+          />
+        </React.Fragment>
+      );
+    }
+
+    render(<TestCase />);
+    renderedItemIds.length = 0;
+    fireEvent.click(screen.getByText('remove'));
+
+    expect(renderedItemIds).not.to.contain('1.1');
   });
 });

--- a/packages/x-tree-view/src/internals/MinimalTreeViewStore/MinimalTreeViewStore.ts
+++ b/packages/x-tree-view/src/internals/MinimalTreeViewStore/MinimalTreeViewStore.ts
@@ -13,11 +13,7 @@ import type {
   MinimalTreeViewState,
 } from './MinimalTreeViewStore.types';
 import type { TreeViewValidItem } from '../../models';
-import {
-  createMinimalInitialState,
-  createTreeViewDefaultId,
-  deriveStateFromParameters,
-} from './MinimalTreeViewStore.utils';
+import { createMinimalInitialState, deriveStateFromParameters } from './MinimalTreeViewStore.utils';
 import { TimeoutManager } from './TimeoutManager';
 import { TreeViewKeyboardNavigationPlugin } from '../plugins/keyboardNavigation';
 import { TreeViewFocusPlugin } from '../plugins/focus/TreeViewFocusPlugin';
@@ -191,8 +187,8 @@ export class MinimalTreeViewStore<
     updateModel(newMinimalState, 'expandedItems', 'defaultExpandedItems');
     updateModel(newMinimalState, 'selectedItems', 'defaultSelectedItems');
 
-    if (this.state.providedTreeId !== parameters.id || this.state.treeId === undefined) {
-      newMinimalState.treeId = createTreeViewDefaultId();
+    if (this.state.treeId !== parameters.defaultId) {
+      newMinimalState.treeId = parameters.defaultId;
     }
 
     if (

--- a/packages/x-tree-view/src/internals/MinimalTreeViewStore/MinimalTreeViewStore.ts
+++ b/packages/x-tree-view/src/internals/MinimalTreeViewStore/MinimalTreeViewStore.ts
@@ -45,6 +45,9 @@ export class MinimalTreeViewStore<
 
   private mapper: TreeViewParametersToStateMapper<R, Multiple, State, Parameters>;
 
+  // Set when `applyParametersDuringRender` updated the state without notifying the subscribers.
+  private hasRenderUpdate = false;
+
   // Owns the store's teardown. Declared first so the resources below register
   // against it during field initialization; disposed by `useDisposable` on
   // unmount (see `[disposeSymbol]`). `public` so plugins can register their own
@@ -116,6 +119,33 @@ export class MinimalTreeViewStore<
    * Updates the state of the Tree View based on the new parameters provided to the root component.
    */
   public updateStateFromParameters(parameters: Parameters) {
+    this.update(this.buildStateFromParameters(parameters));
+    this.parameters = parameters;
+  }
+
+  // Applies the new parameters during render, without notifying the subscribers.
+  public applyParametersDuringRender(parameters: Parameters) {
+    const newState = this.buildStateFromParameters(parameters);
+    for (const key in newState) {
+      if (!Object.is(this.state[key], newState[key])) {
+        this.state = { ...this.state, ...newState };
+        this.hasRenderUpdate = true;
+        break;
+      }
+    }
+
+    this.parameters = parameters;
+  }
+
+  // Notifies the subscribers of the state applied by `applyParametersDuringRender`.
+  public flushRenderUpdate = () => {
+    if (this.hasRenderUpdate) {
+      this.hasRenderUpdate = false;
+      this.setState(this.state);
+    }
+  };
+
+  private buildStateFromParameters(parameters: Parameters) {
     const updateModel: TreeViewModelUpdater<State, Parameters> = (
       mutableNewState,
       controlledProp,
@@ -172,14 +202,7 @@ export class MinimalTreeViewStore<
       Object.assign(newMinimalState, TreeViewItemsPlugin.buildItemsStateIfNeeded(parameters));
     }
 
-    const newState = this.mapper.updateStateFromParameters(
-      newMinimalState,
-      parameters,
-      updateModel,
-    );
-
-    this.update(newState);
-    this.parameters = parameters;
+    return this.mapper.updateStateFromParameters(newMinimalState, parameters, updateModel);
   }
 
   /**

--- a/packages/x-tree-view/src/internals/MinimalTreeViewStore/MinimalTreeViewStore.types.ts
+++ b/packages/x-tree-view/src/internals/MinimalTreeViewStore/MinimalTreeViewStore.types.ts
@@ -91,6 +91,10 @@ export interface MinimalTreeViewParameters<
    */
   isRtl: boolean;
   /**
+   * The id used to build the id attributes of the items when the `id` parameter is not provided.
+   */
+  defaultId: string | undefined;
+  /**
    * Whether the items should be focusable when disabled.
    * @default false
    */

--- a/packages/x-tree-view/src/internals/MinimalTreeViewStore/MinimalTreeViewStore.utils.ts
+++ b/packages/x-tree-view/src/internals/MinimalTreeViewStore/MinimalTreeViewStore.utils.ts
@@ -47,12 +47,18 @@ function applyModelInitialValue<T>(
   return fallback;
 }
 
+let globalTreeViewDefaultId = 0;
+export const createTreeViewDefaultId = () => {
+  globalTreeViewDefaultId += 1;
+  return `mui-tree-view-${globalTreeViewDefaultId}`;
+};
+
 export function createMinimalInitialState<
   R extends TreeViewValidItem<R>,
   Multiple extends boolean | undefined,
 >(parameters: MinimalTreeViewParameters<R, Multiple>): MinimalTreeViewState<R, Multiple> {
   return {
-    treeId: undefined,
+    treeId: createTreeViewDefaultId(),
     focusedItemId: null,
     ...deriveStateFromParameters(parameters),
     ...TreeViewItemsPlugin.buildItemsStateIfNeeded(parameters),
@@ -68,9 +74,3 @@ export function createMinimalInitialState<
     ),
   };
 }
-
-let globalTreeViewDefaultId = 0;
-export const createTreeViewDefaultId = () => {
-  globalTreeViewDefaultId += 1;
-  return `mui-tree-view-${globalTreeViewDefaultId}`;
-};

--- a/packages/x-tree-view/src/internals/MinimalTreeViewStore/MinimalTreeViewStore.utils.ts
+++ b/packages/x-tree-view/src/internals/MinimalTreeViewStore/MinimalTreeViewStore.utils.ts
@@ -47,18 +47,12 @@ function applyModelInitialValue<T>(
   return fallback;
 }
 
-let globalTreeViewDefaultId = 0;
-export const createTreeViewDefaultId = () => {
-  globalTreeViewDefaultId += 1;
-  return `mui-tree-view-${globalTreeViewDefaultId}`;
-};
-
 export function createMinimalInitialState<
   R extends TreeViewValidItem<R>,
   Multiple extends boolean | undefined,
 >(parameters: MinimalTreeViewParameters<R, Multiple>): MinimalTreeViewState<R, Multiple> {
   return {
-    treeId: createTreeViewDefaultId(),
+    treeId: parameters.defaultId,
     focusedItemId: null,
     ...deriveStateFromParameters(parameters),
     ...TreeViewItemsPlugin.buildItemsStateIfNeeded(parameters),

--- a/packages/x-tree-view/src/internals/TreeViewProvider/TreeViewProvider.types.ts
+++ b/packages/x-tree-view/src/internals/TreeViewProvider/TreeViewProvider.types.ts
@@ -20,6 +20,8 @@ export type TreeViewStoreInContext<TStore extends TreeViewAnyStore> = Omit<
   | 'update'
   | 'set'
   | 'updateStateFromParameters'
+  | 'applyParametersDuringRender'
+  | 'flushRenderUpdate'
   | 'disposables'
   | typeof disposeSymbol
   | 'mountEffect'

--- a/packages/x-tree-view/src/internals/hooks/useTreeViewStore.ts
+++ b/packages/x-tree-view/src/internals/hooks/useTreeViewStore.ts
@@ -1,4 +1,5 @@
 'use client';
+import * as React from 'react';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useOnMount } from '@base-ui/utils/useOnMount';
 import { useDisposable } from '@mui/x-internals/useDisposable';
@@ -22,12 +23,20 @@ export function useTreeViewStore<TStore extends TreeViewAnyStore>(
   parameters: UseTreeViewStoreParameters<TStore>,
 ): TStore {
   const isRtl = useRtl();
-  const store = useDisposable(() => new StoreClass({ ...parameters, isRtl }));
-
-  useIsoLayoutEffect(
-    () => store.updateStateFromParameters({ ...parameters, isRtl }),
-    [store, isRtl, parameters],
+  const storeParameters = React.useMemo(
+    () => ({ ...parameters, isRtl }) as TStore['parameters'],
+    [parameters, isRtl],
   );
+  const store = useDisposable(() => new StoreClass(storeParameters));
+
+  // Derived during render so that the items rendered in this pass match `parameters.items`.
+  if (store.parameters !== storeParameters) {
+    store.applyParametersDuringRender(storeParameters);
+  }
+
+  useIsoLayoutEffect(() => {
+    store.flushRenderUpdate();
+  });
 
   // Mount-time side effects (e.g. kicking off lazy-loading fetches). The store is
   // created during render by `useDisposable`, so these can't run in the factory.

--- a/packages/x-tree-view/src/internals/hooks/useTreeViewStore.ts
+++ b/packages/x-tree-view/src/internals/hooks/useTreeViewStore.ts
@@ -4,6 +4,7 @@ import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useOnMount } from '@base-ui/utils/useOnMount';
 import { useDisposable } from '@mui/x-internals/useDisposable';
 import { useRtl } from '@mui/system/RtlProvider';
+import useId from '@mui/utils/useId';
 import type { TreeViewAnyStore } from '../models';
 
 interface ValidTreeViewStoreConstructor<TStore extends TreeViewAnyStore> {
@@ -12,7 +13,7 @@ interface ValidTreeViewStoreConstructor<TStore extends TreeViewAnyStore> {
 
 export type UseTreeViewStoreParameters<TStore extends TreeViewAnyStore> = Omit<
   Parameters<TStore['updateStateFromParameters']>[0],
-  'isRtl'
+  'isRtl' | 'defaultId'
 >;
 
 /**
@@ -23,9 +24,10 @@ export function useTreeViewStore<TStore extends TreeViewAnyStore>(
   parameters: UseTreeViewStoreParameters<TStore>,
 ): TStore {
   const isRtl = useRtl();
+  const defaultId = useId();
   const storeParameters = React.useMemo(
-    () => ({ ...parameters, isRtl }) as TStore['parameters'],
-    [parameters, isRtl],
+    () => ({ ...parameters, isRtl, defaultId }) as TStore['parameters'],
+    [parameters, isRtl, defaultId],
   );
   const store = useDisposable(() => new StoreClass(storeParameters));
 

--- a/test/utils/tree-view/fakeContextValue.ts
+++ b/test/utils/tree-view/fakeContextValue.ts
@@ -5,7 +5,11 @@ import { TreeViewContextValue } from '@mui/x-tree-view/internals/TreeViewProvide
 export const getFakeContextValue = (
   parameters: UseTreeViewStoreParameters<SimpleTreeViewStore<any>> = {},
 ): TreeViewContextValue<SimpleTreeViewStore<any>> => {
-  const store = new SimpleTreeViewStore({ ...parameters, isRtl: false });
+  const store = new SimpleTreeViewStore({
+    ...parameters,
+    isRtl: false,
+    defaultId: 'mui-tree-view-test',
+  });
 
   return {
     store,


### PR DESCRIPTION
Fixes #23331

## Changes

The Tree View store was synced from the root component's props inside a layout effect, so on the render where `props.items` changes the tree still renders the previous set of items. The store catches up after commit and schedules a second render with the correct set.

Nothing flickers on screen because a layout effect runs before paint, but the item slot does render with ids that are no longer in `props.items`. A `slotProps.item` callback that looks the item up in the user's own data, as shown in [Using additional props](https://mui.com/x/common-concepts/custom-components/#using-additional-props), then receives an id it cannot resolve and throws. It also costs a wasted render pass of the subtree on every `items` change.

The state derived from the parameters is now computed during render, so the items rendered in that pass always match `props.items`.

- `MinimalTreeViewStore.applyParametersDuringRender` applies the new state without notifying the subscribers, since React does not allow scheduling updates on other components while rendering. `flushRenderUpdate` notifies in a layout effect, which only matters for the subscribers that bailed out of that render.
- The default `treeId` now comes from `useId` and is passed to the store through the parameters. It used to be generated by the first sync, which no longer runs on mount. This also removes a full re-render of every item right after mount.
- `@mui/x-internals/store` is untouched, so no other package is affected.

Repro of the reported behavior, before the fix, logging the ids the item slot is rendered with after the child is removed:

`['1', '1', '1.1', '1.1', '1', '1']`

The first pass is the stale one, doubled by StrictMode. After the fix, `1.1` is gone.

## Testing

Added a regression test in `RichTreeView.test.tsx`. It lives there rather than in the `describeTreeView` suites because that harness supplies its own `slotProps.item`, and the stale pass is only observable when the callback identity changes on each render. When it does not, `RichTreeViewItem` bails out of the re-render through `React.memo` and the test would pass without the fix.

`x-tree-view` and `x-tree-view-pro` suites pass, including the focus, keyboard navigation and memoization tests that depend on when the items state is applied.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).