### PR TITLE
[pickers] Associate the day cells with their week day column header

### DIFF
--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.test.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.test.tsx
@@ -884,25 +884,18 @@ describe('<DateRangeCalendar />', () => {
     });
   });
 
-  // A screen reader announces the column header only when the column changes,
-  // so the description is what makes the week day audible on a vertical move.
-  it('should describe the day cells of every calendar with their week day header', () => {
+  it('should give every calendar its own week day headers', () => {
     render(<DateRangeCalendar calendars={2} referenceDate={adapterToUse.date('2018-01-01')} />);
 
-    // January 7th and February 4th 2018 are Sundays, the first column of their grid.
-    const grids = ['January 2018', 'February 2018'].map((month) => ({
-      sunday: getPickerDay(month === 'January 2018' ? '7' : '4', month),
-      firstHeader: within(screen.getByRole('grid', { name: month })).getAllByRole(
+    ['January 2018', 'February 2018'].forEach((month) => {
+      const headers = within(screen.getByRole('grid', { name: month })).getAllByRole(
         'columnheader',
-      )[0],
-    }));
+      );
 
-    grids.forEach(({ sunday, firstHeader }) => {
-      expect(sunday).to.have.attribute('aria-describedby', firstHeader.id);
-      expect(firstHeader).toHaveAccessibleName('Sunday');
+      expect(headers).to.have.length(7);
+      expect(headers[0]).toHaveAccessibleName('Sunday');
+      expect(headers[0]).to.have.attribute('aria-colindex', '1');
     });
-    // Each grid owns its week day headers.
-    expect(grids[0].firstHeader.id).not.to.equal(grids[1].firstHeader.id);
   });
 
   describe('Performance', () => {

--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.test.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.test.tsx
@@ -865,8 +865,8 @@ describe('<DateRangeCalendar />', () => {
       expect(grid.querySelectorAll(`.${dayClasses.fillerCell}`)).to.have.length(4);
     });
 
-    // The week number is a `rowheader` taking the first position of the row, so a cell without
-    // an explicit column index would be off by one.
+    // The week number is a `rowheader` taking the first column, so a cell without an explicit
+    // column index would be off by one.
     it('should keep the column index of the day they replace', () => {
       render(<DateRangeCalendar calendars={1} displayWeekNumber referenceDate={referenceDate} />);
 
@@ -879,9 +879,26 @@ describe('<DateRangeCalendar />', () => {
           .getAllByRole('gridcell')
           .map((cell) => cell.getAttribute('aria-colindex'));
 
-        expect(columnIndexes).to.deep.equal(['1', '2', '3', '4', '5', '6', '7']);
+        expect(columnIndexes).to.deep.equal(['2', '3', '4', '5', '6', '7', '8']);
       });
     });
+  });
+
+  // A screen reader announces the column header only when the column changes,
+  // so the description is what makes the week day audible on a vertical move.
+  it('should describe the day cells of every calendar with their week day', () => {
+    render(<DateRangeCalendar calendars={2} referenceDate={adapterToUse.date('2018-01-01')} />);
+
+    // January 7th and February 4th 2018 are Sundays, the first column of their grid.
+    const januarySunday = getPickerDay('7');
+    const februarySunday = getPickerDay('4', 'February 2018');
+
+    expect(januarySunday).toHaveAccessibleDescription('Sunday');
+    expect(februarySunday).toHaveAccessibleDescription('Sunday');
+    // Each grid owns its week day headers.
+    expect(januarySunday.getAttribute('aria-describedby')).not.to.equal(
+      februarySunday.getAttribute('aria-describedby'),
+    );
   });
 
   describe('Performance', () => {

--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.test.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.test.tsx
@@ -886,19 +886,23 @@ describe('<DateRangeCalendar />', () => {
 
   // A screen reader announces the column header only when the column changes,
   // so the description is what makes the week day audible on a vertical move.
-  it('should describe the day cells of every calendar with their week day', () => {
+  it('should describe the day cells of every calendar with their week day header', () => {
     render(<DateRangeCalendar calendars={2} referenceDate={adapterToUse.date('2018-01-01')} />);
 
     // January 7th and February 4th 2018 are Sundays, the first column of their grid.
-    const januarySunday = getPickerDay('7');
-    const februarySunday = getPickerDay('4', 'February 2018');
+    const grids = ['January 2018', 'February 2018'].map((month) => ({
+      sunday: getPickerDay(month === 'January 2018' ? '7' : '4', month),
+      firstHeader: within(screen.getByRole('grid', { name: month })).getAllByRole(
+        'columnheader',
+      )[0],
+    }));
 
-    expect(januarySunday).toHaveAccessibleDescription('Sunday');
-    expect(februarySunday).toHaveAccessibleDescription('Sunday');
+    grids.forEach(({ sunday, firstHeader }) => {
+      expect(sunday).to.have.attribute('aria-describedby', firstHeader.id);
+      expect(firstHeader).toHaveAccessibleName('Sunday');
+    });
     // Each grid owns its week day headers.
-    expect(januarySunday.getAttribute('aria-describedby')).not.to.equal(
-      februarySunday.getAttribute('aria-describedby'),
-    );
+    expect(grids[0].firstHeader.id).not.to.equal(grids[1].firstHeader.id);
   });
 
   describe('Performance', () => {

--- a/packages/x-date-pickers/src/DateCalendar/DayCalendar.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/DayCalendar.tsx
@@ -523,7 +523,7 @@ export function DayCalendar(inProps: DayCalendarProps) {
       role="grid"
       aria-labelledby={gridLabelId}
       aria-colcount={columnIndexOffset + 7}
-      aria-rowcount={loading ? 1 : weeksToDisplay.length + 1}
+      aria-rowcount={weeksToDisplay.length + 1}
       className={classes.root}
     >
       <PickerCalendarDayHeader role="row" aria-rowindex={1} className={classes.header}>

--- a/packages/x-date-pickers/src/DateCalendar/DayCalendar.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/DayCalendar.tsx
@@ -1,7 +1,6 @@
 'use client';
 import * as React from 'react';
 import useEventCallback from '@mui/utils/useEventCallback';
-import useId from '@mui/utils/useId';
 import Typography from '@mui/material/Typography';
 import useSlotProps from '@mui/utils/useSlotProps';
 import { useRtl } from '@mui/system/RtlProvider';
@@ -370,10 +369,8 @@ export function DayCalendar(inProps: DayCalendarProps) {
   const now = useNow(timezone);
   const classes = useUtilityClasses(classesProp);
   const isRtl = useRtl();
-  const id = useId();
   // The week number is a `rowheader`, so it takes the first column of the grid.
   const columnIndexOffset = displayWeekNumber ? 1 : 0;
-  const getWeekDayLabelId = (dayIndex: number) => `${id}-week-day-${dayIndex}`;
 
   const isDateDisabled = useIsDateDisabled({
     shouldDisableDate,
@@ -544,7 +541,6 @@ export function DayCalendar(inProps: DayCalendarProps) {
         {getWeekdays(adapter, now).map((weekday, i) => (
           <PickerCalendarWeekDayLabel
             key={i.toString()}
-            id={getWeekDayLabelId(i)}
             variant="caption"
             role="columnheader"
             aria-colindex={columnIndexOffset + i + 1}
@@ -611,9 +607,6 @@ export function DayCalendar(inProps: DayCalendarProps) {
                     isDateDisabled={isDateDisabled}
                     currentMonthNumber={currentMonthNumber}
                     aria-colindex={columnIndexOffset + dayIndex + 1}
-                    // A screen reader announces the column header only when the column changes,
-                    // so the description is what makes the week day audible on a vertical move.
-                    aria-describedby={getWeekDayLabelId(dayIndex)}
                   />
                 ))}
               </PickerCalendarWeek>

--- a/packages/x-date-pickers/src/DateCalendar/DayCalendar.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/DayCalendar.tsx
@@ -2,7 +2,6 @@
 import * as React from 'react';
 import useEventCallback from '@mui/utils/useEventCallback';
 import useId from '@mui/utils/useId';
-import visuallyHidden from '@mui/utils/visuallyHidden';
 import Typography from '@mui/material/Typography';
 import useSlotProps from '@mui/utils/useSlotProps';
 import { useRtl } from '@mui/system/RtlProvider';
@@ -549,11 +548,10 @@ export function DayCalendar(inProps: DayCalendarProps) {
             variant="caption"
             role="columnheader"
             aria-colindex={columnIndexOffset + i + 1}
+            aria-label={adapter.format(weekday, 'weekday')}
             className={classes.weekDayLabel}
           >
-            <span aria-hidden="true">{dayOfWeekFormatter(weekday)}</span>
-            {/* The day cells describe themselves with this text, an `aria-label` would not be read. */}
-            <span style={visuallyHidden}>{adapter.format(weekday, 'weekday')}</span>
+            {dayOfWeekFormatter(weekday)}
           </PickerCalendarWeekDayLabel>
         ))}
       </PickerCalendarDayHeader>

--- a/packages/x-date-pickers/src/DateCalendar/DayCalendar.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/DayCalendar.tsx
@@ -1,6 +1,8 @@
 'use client';
 import * as React from 'react';
 import useEventCallback from '@mui/utils/useEventCallback';
+import useId from '@mui/utils/useId';
+import visuallyHidden from '@mui/utils/visuallyHidden';
 import Typography from '@mui/material/Typography';
 import useSlotProps from '@mui/utils/useSlotProps';
 import { useRtl } from '@mui/system/RtlProvider';
@@ -369,6 +371,10 @@ export function DayCalendar(inProps: DayCalendarProps) {
   const now = useNow(timezone);
   const classes = useUtilityClasses(classesProp);
   const isRtl = useRtl();
+  const id = useId();
+  // The week number is a `rowheader`, so it takes the first column of the grid.
+  const columnIndexOffset = displayWeekNumber ? 1 : 0;
+  const getWeekDayLabelId = (dayIndex: number) => `${id}-week-day-${dayIndex}`;
 
   const isDateDisabled = useIsDateDisabled({
     shouldDisableDate,
@@ -517,12 +523,19 @@ export function DayCalendar(inProps: DayCalendarProps) {
   }, [currentMonth, fixedWeekNumber, adapter]);
 
   return (
-    <PickerCalendarDayRoot role="grid" aria-labelledby={gridLabelId} className={classes.root}>
-      <PickerCalendarDayHeader role="row" className={classes.header}>
+    <PickerCalendarDayRoot
+      role="grid"
+      aria-labelledby={gridLabelId}
+      aria-colcount={columnIndexOffset + 7}
+      aria-rowcount={loading ? 1 : weeksToDisplay.length + 1}
+      className={classes.root}
+    >
+      <PickerCalendarDayHeader role="row" aria-rowindex={1} className={classes.header}>
         {displayWeekNumber && (
           <PickerCalendarWeekNumberLabel
             variant="caption"
             role="columnheader"
+            aria-colindex={1}
             aria-label={translations.calendarWeekNumberHeaderLabel}
             className={classes.weekNumberLabel}
           >
@@ -532,12 +545,15 @@ export function DayCalendar(inProps: DayCalendarProps) {
         {getWeekdays(adapter, now).map((weekday, i) => (
           <PickerCalendarWeekDayLabel
             key={i.toString()}
+            id={getWeekDayLabelId(i)}
             variant="caption"
             role="columnheader"
-            aria-label={adapter.format(weekday, 'weekday')}
+            aria-colindex={columnIndexOffset + i + 1}
             className={classes.weekDayLabel}
           >
-            {dayOfWeekFormatter(weekday)}
+            <span aria-hidden="true">{dayOfWeekFormatter(weekday)}</span>
+            {/* The day cells describe themselves with this text, an `aria-label` would not be read. */}
+            <span style={visuallyHidden}>{adapter.format(weekday, 'weekday')}</span>
           </PickerCalendarWeekDayLabel>
         ))}
       </PickerCalendarDayHeader>
@@ -567,14 +583,14 @@ export function DayCalendar(inProps: DayCalendarProps) {
                 role="row"
                 key={`week-${week[0]}`}
                 className={classes.weekContainer}
-                // fix issue of announcing row 1 as row 2
-                // caused by week day labels row
-                aria-rowindex={index + 1}
+                // The week day labels row is the first row of the grid.
+                aria-rowindex={index + 2}
               >
                 {displayWeekNumber && (
                   <PickerCalendarWeekNumber
                     className={classes.weekNumber}
                     role="rowheader"
+                    aria-colindex={1}
                     aria-label={translations.calendarWeekNumberAriaLabelText(
                       adapter.getWeekNumber(week[0]),
                     )}
@@ -596,8 +612,10 @@ export function DayCalendar(inProps: DayCalendarProps) {
                     onDaySelect={handleDaySelect}
                     isDateDisabled={isDateDisabled}
                     currentMonthNumber={currentMonthNumber}
-                    // fix issue of announcing column 1 as column 2 when `displayWeekNumber` is enabled
-                    aria-colindex={dayIndex + 1}
+                    aria-colindex={columnIndexOffset + dayIndex + 1}
+                    // A screen reader announces the column header only when the column changes,
+                    // so the description is what makes the week day audible on a vertical move.
+                    aria-describedby={getWeekDayLabelId(dayIndex)}
                   />
                 ))}
               </PickerCalendarWeek>

--- a/packages/x-date-pickers/src/DateCalendar/PickersSlideTransition.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/PickersSlideTransition.tsx
@@ -138,7 +138,12 @@ export function PickersSlideTransition(inProps: SlideTransitionProps) {
   const classes = useUtilityClasses(classesProp, ownerState);
   const theme = useTheme();
   if (reduceAnimations) {
-    return <div className={clsx(classes.root, className)}>{children}</div>;
+    // `role="none"` keeps the day rows owned by the calendar grid.
+    return (
+      <div role="none" className={clsx(classes.root, className)}>
+        {children}
+      </div>
+    );
   }
 
   const transitionClasses = {

--- a/packages/x-date-pickers/src/DateCalendar/tests/DateCalendar.test.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/tests/DateCalendar.test.tsx
@@ -176,18 +176,23 @@ describe('<DateCalendar />', () => {
 
     // A screen reader announces the column header only when the column changes,
     // so the description is what makes the week day audible on a vertical move.
-    it('should describe the day cells with their week day', () => {
+    it('should describe the day cells with their week day header', () => {
       render(<DateCalendar referenceDate={referenceDate} />);
 
       const grid = screen.getByRole('grid', { name: 'January 2018' });
+      const headers = within(grid).getAllByRole('columnheader');
 
-      // January 7th 2018 is a Sunday, the first column of the grid.
-      expect(within(grid).getByRole('gridcell', { name: '7' })).toHaveAccessibleDescription(
-        'Sunday',
+      // January 7th 2018 is a Sunday and January 13th is a Saturday.
+      expect(within(grid).getByRole('gridcell', { name: '7' })).to.have.attribute(
+        'aria-describedby',
+        headers[0].id,
       );
-      expect(within(grid).getByRole('gridcell', { name: '13' })).toHaveAccessibleDescription(
-        'Saturday',
+      expect(within(grid).getByRole('gridcell', { name: '13' })).to.have.attribute(
+        'aria-describedby',
+        headers[6].id,
       );
+      expect(headers[0]).toHaveAccessibleName('Sunday');
+      expect(headers[6]).toHaveAccessibleName('Saturday');
     });
   });
 

--- a/packages/x-date-pickers/src/DateCalendar/tests/DateCalendar.test.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/tests/DateCalendar.test.tsx
@@ -115,10 +115,14 @@ describe('<DateCalendar />', () => {
       render(<DateCalendar referenceDate={referenceDate} />);
 
       const grid = screen.getByRole('grid', { name: 'January 2018' });
+      const headers = within(grid).getAllByRole('columnheader');
       const headerIndexes = getColumnIndexes(grid, 'columnheader');
 
       expect(grid).to.have.attribute('aria-colcount', '7');
       expect(headerIndexes).to.deep.equal(['1', '2', '3', '4', '5', '6', '7']);
+      // The header carries the week day a screen reader announces on a column change.
+      expect(headers[0]).toHaveAccessibleName('Sunday');
+      expect(headers[6]).toHaveAccessibleName('Saturday');
 
       const weeks = within(within(grid).getByRole('rowgroup')).getAllByRole('row');
       expect(weeks).to.have.length(5);
@@ -172,27 +176,6 @@ describe('<DateCalendar />', () => {
 
       expect(grid).to.have.attribute('aria-rowcount', '6');
       expect(rowIndexes).to.deep.equal(['1', '2', '3', '4', '5', '6']);
-    });
-
-    // A screen reader announces the column header only when the column changes,
-    // so the description is what makes the week day audible on a vertical move.
-    it('should describe the day cells with their week day header', () => {
-      render(<DateCalendar referenceDate={referenceDate} />);
-
-      const grid = screen.getByRole('grid', { name: 'January 2018' });
-      const headers = within(grid).getAllByRole('columnheader');
-
-      // January 7th 2018 is a Sunday and January 13th is a Saturday.
-      expect(within(grid).getByRole('gridcell', { name: '7' })).to.have.attribute(
-        'aria-describedby',
-        headers[0].id,
-      );
-      expect(within(grid).getByRole('gridcell', { name: '13' })).to.have.attribute(
-        'aria-describedby',
-        headers[6].id,
-      );
-      expect(headers[0]).toHaveAccessibleName('Sunday');
-      expect(headers[6]).toHaveAccessibleName('Saturday');
     });
   });
 

--- a/packages/x-date-pickers/src/DateCalendar/tests/DateCalendar.test.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/tests/DateCalendar.test.tsx
@@ -177,6 +177,16 @@ describe('<DateCalendar />', () => {
       expect(grid).to.have.attribute('aria-rowcount', '6');
       expect(rowIndexes).to.deep.equal(['1', '2', '3', '4', '5', '6']);
     });
+
+    // `aria-rowcount` describes the whole grid, including the rows absent from the DOM.
+    it('should keep the row count while loading', () => {
+      render(<DateCalendar loading referenceDate={referenceDate} />);
+
+      const grid = screen.getByRole('grid', { name: 'January 2018' });
+
+      expect(grid).to.have.attribute('aria-rowcount', '6');
+      expect(within(grid).queryByRole('rowgroup')).to.equal(null);
+    });
   });
 
   it('should render column header according to dayOfWeekFormatter', () => {

--- a/packages/x-date-pickers/src/DateCalendar/tests/DateCalendar.test.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/tests/DateCalendar.test.tsx
@@ -103,21 +103,91 @@ describe('<DateCalendar />', () => {
     expect(disabledDays.length).to.equal(31);
   });
 
-  // The week number is a `rowheader` taking the first position of the row, so a cell without
-  // an explicit column index would be off by one.
-  it('should keep the column index of the days replaced by a filler cell', () => {
-    render(<DateCalendar displayWeekNumber referenceDate={adapterToUse.date('2018-01-01')} />);
+  describe('grid semantics', () => {
+    const referenceDate = adapterToUse.date('2018-01-01');
 
-    const grid = screen.getByRole('grid', { name: 'January 2018' });
-    const weeks = within(within(grid).getByRole('rowgroup')).getAllByRole('row');
-
-    expect(weeks).to.have.length(5);
-    weeks.forEach((week) => {
-      const columnIndexes = within(week)
-        .getAllByRole('gridcell')
+    const getColumnIndexes = (container: HTMLElement, role: 'columnheader' | 'gridcell') =>
+      within(container)
+        .getAllByRole(role)
         .map((cell) => cell.getAttribute('aria-colindex'));
 
-      expect(columnIndexes).to.deep.equal(['1', '2', '3', '4', '5', '6', '7']);
+    it('should give the day cells the column index of their week day header', () => {
+      render(<DateCalendar referenceDate={referenceDate} />);
+
+      const grid = screen.getByRole('grid', { name: 'January 2018' });
+      const headerIndexes = getColumnIndexes(grid, 'columnheader');
+
+      expect(grid).to.have.attribute('aria-colcount', '7');
+      expect(headerIndexes).to.deep.equal(['1', '2', '3', '4', '5', '6', '7']);
+
+      const weeks = within(within(grid).getByRole('rowgroup')).getAllByRole('row');
+      expect(weeks).to.have.length(5);
+      weeks.forEach((week) => {
+        expect(getColumnIndexes(week, 'gridcell')).to.deep.equal(headerIndexes);
+      });
+    });
+
+    // The week number is a `rowheader` taking the first column, so the days start on the second one.
+    it('should offset the column indexes when the week number is displayed', () => {
+      render(<DateCalendar displayWeekNumber referenceDate={referenceDate} />);
+
+      const grid = screen.getByRole('grid', { name: 'January 2018' });
+
+      expect(grid).to.have.attribute('aria-colcount', '8');
+      expect(getColumnIndexes(grid, 'columnheader')).to.deep.equal([
+        '1',
+        '2',
+        '3',
+        '4',
+        '5',
+        '6',
+        '7',
+        '8',
+      ]);
+
+      const weeks = within(within(grid).getByRole('rowgroup')).getAllByRole('row');
+      expect(weeks).to.have.length(5);
+      weeks.forEach((week) => {
+        expect(within(week).getByRole('rowheader')).to.have.attribute('aria-colindex', '1');
+        // The filler cells keep the column index of the day they replace.
+        expect(getColumnIndexes(week, 'gridcell')).to.deep.equal([
+          '2',
+          '3',
+          '4',
+          '5',
+          '6',
+          '7',
+          '8',
+        ]);
+      });
+    });
+
+    it('should number the week rows after the week day header row', () => {
+      render(<DateCalendar referenceDate={referenceDate} />);
+
+      const grid = screen.getByRole('grid', { name: 'January 2018' });
+      const rowIndexes = within(grid)
+        .getAllByRole('row')
+        .map((row) => row.getAttribute('aria-rowindex'));
+
+      expect(grid).to.have.attribute('aria-rowcount', '6');
+      expect(rowIndexes).to.deep.equal(['1', '2', '3', '4', '5', '6']);
+    });
+
+    // A screen reader announces the column header only when the column changes,
+    // so the description is what makes the week day audible on a vertical move.
+    it('should describe the day cells with their week day', () => {
+      render(<DateCalendar referenceDate={referenceDate} />);
+
+      const grid = screen.getByRole('grid', { name: 'January 2018' });
+
+      // January 7th 2018 is a Sunday, the first column of the grid.
+      expect(within(grid).getByRole('gridcell', { name: '7' })).toHaveAccessibleDescription(
+        'Sunday',
+      );
+      expect(within(grid).getByRole('gridcell', { name: '13' })).toHaveAccessibleDescription(
+        'Saturday',
+      );
     });
   });
 

--- a/packages/x-date-pickers/src/DateCalendar/tests/localization.DateCalendar.test.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/tests/localization.DateCalendar.test.tsx
@@ -1,5 +1,5 @@
 import { screen, createRenderer } from '@mui/internal-test-utils';
-import { DateCalendar, dayCalendarClasses } from '@mui/x-date-pickers/DateCalendar';
+import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import type { AdapterName } from 'test/utils/pickers';
 import { createPickerRenderer, availableAdapters } from 'test/utils/pickers';
@@ -45,17 +45,13 @@ describe('<DateCalendar /> - localization', () => {
             </LocalizationProvider>,
           );
 
-          expect(document.querySelector(`.${dayCalendarClasses.weekDayLabel}`)!.ariaLabel).to.equal(
-            'Sunday',
-          );
+          expect(screen.getAllByRole('columnheader')[0]).toHaveAccessibleName('Sunday');
 
           setProps({
             adapterLocale: adapterName === 'date-fns' ? fr : 'fr',
           });
 
-          expect(document.querySelector(`.${dayCalendarClasses.weekDayLabel}`)!.ariaLabel).to.equal(
-            'lundi',
-          );
+          expect(screen.getAllByRole('columnheader')[0]).toHaveAccessibleName('lundi');
         });
       });
     });

--- a/packages/x-date-pickers/src/DateCalendar/tests/localization.DateCalendar.test.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/tests/localization.DateCalendar.test.tsx
@@ -1,5 +1,5 @@
 import { screen, createRenderer } from '@mui/internal-test-utils';
-import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
+import { DateCalendar, dayCalendarClasses } from '@mui/x-date-pickers/DateCalendar';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import type { AdapterName } from 'test/utils/pickers';
 import { createPickerRenderer, availableAdapters } from 'test/utils/pickers';
@@ -45,13 +45,17 @@ describe('<DateCalendar /> - localization', () => {
             </LocalizationProvider>,
           );
 
-          expect(screen.getAllByRole('columnheader')[0]).toHaveAccessibleName('Sunday');
+          expect(document.querySelector(`.${dayCalendarClasses.weekDayLabel}`)!.ariaLabel).to.equal(
+            'Sunday',
+          );
 
           setProps({
             adapterLocale: adapterName === 'date-fns' ? fr : 'fr',
           });
 
-          expect(screen.getAllByRole('columnheader')[0]).toHaveAccessibleName('lundi');
+          expect(document.querySelector(`.${dayCalendarClasses.weekDayLabel}`)!.ariaLabel).to.equal(
+            'lundi',
+          );
         });
       });
     });


### PR DESCRIPTION
### Summary

The day cells of `DateCalendar` and `DateRangeCalendar` had no usable relationship with their week day `columnheader`, so a screen reader never announced the week day of the focused day. #23326 fixed one cause, the filler cells that left the accessibility tree. The grid geometry itself was still incoherent.

`aria-colindex` is the position of a cell in the total set of columns of the grid. A `rowheader` is a cell, so it occupies a column, exactly like a `<th scope="row">` occupies column 1 of a native table row.

With `displayWeekNumber`, the header row rendered 8 cells: the week number `columnheader` plus 7 week day `columnheader` elements, occupying columns 1 to 8. Each week row also rendered 8 cells: the week number `rowheader` plus 7 `gridcell` elements. But the day cells declared `aria-colindex` 1 to 7 and the `rowheader` declared nothing. So Monday and the week number both claimed column 1, every day cell pointed at the header of the previous day, and the last week day header owned no cell.

The row indices had the same defect. The week rows declared `aria-rowindex={index + 1}`, so the first week claimed row 1, the row the week day header already occupied.

Both offsets come from #7589, which made the first day announce as column 1 and the first week as row 1. That reads better in isolation, but it breaks the mapping the header association depends on. A screen reader that announces "column 2" for Monday is correct when a week number column precedes it.

### Changes

`DayCalendar` derives a single offset from `displayWeekNumber` and uses it on every cell:

- The week day `columnheader` elements declare `aria-colindex`, so they line up with the cells below them.
- The week number `columnheader` and `rowheader` declare column 1.
- The day cells shift by the week number column.
- The week day header row declares `aria-rowindex="1"` and the week rows start at 2.
- The grid declares `aria-colcount` and `aria-rowcount`.

`PickersSlideTransition` adds `role="none"` to the `div` of its `reduceAnimations` branch. The animated branch already sets it. Without it the `rowgroup` is not a child of the `grid` in the accessibility tree, so the users who ask for reduced motion got a broken grid.

### Testing

NVDA on Chrome reads the week day and the week number correctly with these changes, on both calendars.

An earlier iteration also described each day cell with its week day header, to make the week day audible on a vertical move as well. NVDA then read the week day twice, once from the column header on a column change and once from the description, so the description is not part of this PR.

The two column index assertions added in #23326 now expect columns 2 to 8 with `displayWeekNumber`, for the reason described above. New tests cover the column indices of the headers and the cells, the row indices, the counts, and the week day header of each grid of a `DateRangeCalendar`.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
