### PR TITLE
[tree view] Use `useId` for the default tree id

### DIFF
--- a/packages/x-tree-view/src/internals/MinimalTreeViewStore/MinimalTreeViewStore.ts
+++ b/packages/x-tree-view/src/internals/MinimalTreeViewStore/MinimalTreeViewStore.ts
@@ -13,11 +13,7 @@ import type {
   MinimalTreeViewState,
 } from './MinimalTreeViewStore.types';
 import type { TreeViewValidItem } from '../../models';
-import {
-  createMinimalInitialState,
-  createTreeViewDefaultId,
-  deriveStateFromParameters,
-} from './MinimalTreeViewStore.utils';
+import { createMinimalInitialState, deriveStateFromParameters } from './MinimalTreeViewStore.utils';
 import { TimeoutManager } from './TimeoutManager';
 import { TreeViewKeyboardNavigationPlugin } from '../plugins/keyboardNavigation';
 import { TreeViewFocusPlugin } from '../plugins/focus/TreeViewFocusPlugin';
@@ -161,8 +157,8 @@ export class MinimalTreeViewStore<
     updateModel(newMinimalState, 'expandedItems', 'defaultExpandedItems');
     updateModel(newMinimalState, 'selectedItems', 'defaultSelectedItems');
 
-    if (this.state.providedTreeId !== parameters.id || this.state.treeId === undefined) {
-      newMinimalState.treeId = createTreeViewDefaultId();
+    if (this.state.treeId !== parameters.defaultId) {
+      newMinimalState.treeId = parameters.defaultId;
     }
 
     if (

--- a/packages/x-tree-view/src/internals/MinimalTreeViewStore/MinimalTreeViewStore.types.ts
+++ b/packages/x-tree-view/src/internals/MinimalTreeViewStore/MinimalTreeViewStore.types.ts
@@ -87,6 +87,10 @@ export interface MinimalTreeViewParameters<
   Multiple extends boolean | undefined,
 > {
   /**
+   * The id used to build the id attributes of the items when the `id` parameter is not provided.
+   */
+  defaultId: string | undefined;
+  /**
    * Whether the layout is right-to-left.
    */
   isRtl: boolean;

--- a/packages/x-tree-view/src/internals/MinimalTreeViewStore/MinimalTreeViewStore.utils.ts
+++ b/packages/x-tree-view/src/internals/MinimalTreeViewStore/MinimalTreeViewStore.utils.ts
@@ -52,7 +52,7 @@ export function createMinimalInitialState<
   Multiple extends boolean | undefined,
 >(parameters: MinimalTreeViewParameters<R, Multiple>): MinimalTreeViewState<R, Multiple> {
   return {
-    treeId: undefined,
+    treeId: parameters.defaultId,
     focusedItemId: null,
     ...deriveStateFromParameters(parameters),
     ...TreeViewItemsPlugin.buildItemsStateIfNeeded(parameters),
@@ -68,9 +68,3 @@ export function createMinimalInitialState<
     ),
   };
 }
-
-let globalTreeViewDefaultId = 0;
-export const createTreeViewDefaultId = () => {
-  globalTreeViewDefaultId += 1;
-  return `mui-tree-view-${globalTreeViewDefaultId}`;
-};

--- a/packages/x-tree-view/src/internals/hooks/useTreeViewStore.ts
+++ b/packages/x-tree-view/src/internals/hooks/useTreeViewStore.ts
@@ -3,6 +3,7 @@ import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useOnMount } from '@base-ui/utils/useOnMount';
 import { useDisposable } from '@mui/x-internals/useDisposable';
 import { useRtl } from '@mui/system/RtlProvider';
+import useId from '@mui/utils/useId';
 import type { TreeViewAnyStore } from '../models';
 
 interface ValidTreeViewStoreConstructor<TStore extends TreeViewAnyStore> {
@@ -11,7 +12,7 @@ interface ValidTreeViewStoreConstructor<TStore extends TreeViewAnyStore> {
 
 export type UseTreeViewStoreParameters<TStore extends TreeViewAnyStore> = Omit<
   Parameters<TStore['updateStateFromParameters']>[0],
-  'isRtl'
+  'isRtl' | 'defaultId'
 >;
 
 /**
@@ -22,11 +23,12 @@ export function useTreeViewStore<TStore extends TreeViewAnyStore>(
   parameters: UseTreeViewStoreParameters<TStore>,
 ): TStore {
   const isRtl = useRtl();
-  const store = useDisposable(() => new StoreClass({ ...parameters, isRtl }));
+  const defaultId = useId();
+  const store = useDisposable(() => new StoreClass({ ...parameters, isRtl, defaultId }));
 
   useIsoLayoutEffect(
-    () => store.updateStateFromParameters({ ...parameters, isRtl }),
-    [store, isRtl, parameters],
+    () => store.updateStateFromParameters({ ...parameters, isRtl, defaultId }),
+    [store, isRtl, defaultId, parameters],
   );
 
   // Mount-time side effects (e.g. kicking off lazy-loading fetches). The store is

--- a/test/utils/tree-view/fakeContextValue.ts
+++ b/test/utils/tree-view/fakeContextValue.ts
@@ -5,7 +5,11 @@ import { TreeViewContextValue } from '@mui/x-tree-view/internals/TreeViewProvide
 export const getFakeContextValue = (
   parameters: UseTreeViewStoreParameters<SimpleTreeViewStore<any>> = {},
 ): TreeViewContextValue<SimpleTreeViewStore<any>> => {
-  const store = new SimpleTreeViewStore({ ...parameters, isRtl: false });
+  const store = new SimpleTreeViewStore({
+    ...parameters,
+    isRtl: false,
+    defaultId: 'mui-tree-view-test',
+  });
 
   return {
     store,


### PR DESCRIPTION
Split out of #23337 at @noraleonte's request.

## Changes

`treeId` starts as `undefined` and is only generated by the first `updateStateFromParameters`, which runs in a layout effect after mount. Until then `treeItemIdAttribute` resolves to `-<itemId>`, so:

- two Tree Views on the same page emit the same item ids in the server output and in the first client render
- every item re-renders right after mount when the real id arrives

The default id now comes from `useId` and is passed to the store through the parameters, the same way `isRtl` already is. It is stable from the first render, unique per instance, and consistent between server and client. `createTreeViewDefaultId` and its module-global counter are gone.

`useId` is `@mui/utils/useId`, which is what the Data Grid uses. It delegates to React's `useId` on React 18+, and falls back to a post-mount id on React 17, which matches the current behaviour there.

No public API change.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).


## Changelog

No public API change. The generated `id` attribute on the root and on each Tree Item
changes format (`mui-tree-view-<n>-<itemId>` → `<useId>-<itemId>`); it was never a
public contract and was already non-deterministic, but hardcoded selectors need updating.
