### PR TITLE
[test] Fix act warnings in the data source filter tests

### DIFF
--- a/packages/x-data-grid-pro/src/tests/dataSource.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/dataSource.DataGridPro.test.tsx
@@ -12,7 +12,7 @@ import type {
   GridLogicOperator,
 } from '@mui/x-data-grid-pro';
 import { spy } from 'sinon';
-import { getRow, sleep } from 'test/utils/helperFn';
+import { actSleep, getRow } from 'test/utils/helperFn';
 import { TestCache } from '@mui/x-data-grid/internals';
 
 describe('<DataGridPro /> - Data source', () => {
@@ -99,7 +99,7 @@ describe('<DataGridPro /> - Data source', () => {
       });
 
       await upsertFilterItem({ id: 2, field: 'id', operator: 'contains' });
-      await sleep(50);
+      await actSleep(50);
 
       expect(fetchRowsSpy.callCount).to.equal(2);
       expect(fetchRowsSpy.lastCall.args[0].filterModel.items).to.have.length(1);
@@ -143,7 +143,7 @@ describe('<DataGridPro /> - Data source', () => {
       await act(async () => {
         apiRef.current!.setFilterLogicOperator('or' as GridLogicOperator);
       });
-      await sleep(50);
+      await actSleep(50);
 
       expect(fetchRowsSpy.callCount).to.equal(2);
     });
@@ -163,7 +163,7 @@ describe('<DataGridPro /> - Data source', () => {
       await act(async () => {
         apiRef.current!.setFilterLogicOperator('or' as GridLogicOperator);
       });
-      await sleep(50);
+      await actSleep(50);
       expect(fetchRowsSpy.callCount).to.equal(2);
 
       await upsertFilterItem({ id: 2, field: 'id', operator: 'contains', value: '2' });

--- a/packages/x-data-grid-pro/src/tests/dataSourceLazyLoader.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/dataSourceLazyLoader.DataGridPro.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useMockServer } from '@mui/x-data-grid-generator';
 import { act, createRenderer, waitFor, within } from '@mui/internal-test-utils';
-import { getCell, getRow, sleep } from 'test/utils/helperFn';
+import { actSleep, getCell, getRow } from 'test/utils/helperFn';
 import type { RefObject } from '@mui/x-internals/types';
 import { DataGridPro, useGridApiRef, GRID_ROOT_GROUP_ID } from '@mui/x-data-grid-pro';
 import type {
@@ -169,7 +169,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
       });
 
       await upsertFilterItem({ id: 1, field: 'id', operator: 'contains' });
-      await sleep(50);
+      await actSleep(50);
 
       expect(fetchRowsSpy.callCount).to.equal(1);
     });

--- a/packages/x-data-grid-pro/src/tests/dataSourceTreeData.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/dataSourceTreeData.DataGridPro.test.tsx
@@ -12,7 +12,7 @@ import type {
   GridGroupNode,
 } from '@mui/x-data-grid-pro';
 import { spy } from 'sinon';
-import { getCell, getRow, sleep } from 'test/utils/helperFn';
+import { actSleep, getCell, getRow } from 'test/utils/helperFn';
 import { isJSDOM } from 'test/utils/skipIf';
 
 const dataSetOptions = {
@@ -180,7 +180,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
       await act(async () => {
         apiRef.current!.upsertFilterItem({ id: 1, field: 'name', operator: 'contains' });
       });
-      await sleep(50);
+      await actSleep(50);
 
       expect(fetchRowsSpy.callCount).to.equal(1);
     });

--- a/packages/x-data-grid/src/tests/dataSource.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/dataSource.DataGrid.test.tsx
@@ -13,7 +13,7 @@ import type {
   GridGetRowsResponse,
 } from '@mui/x-data-grid';
 import { spy } from 'sinon';
-import { getCell, sleep } from 'test/utils/helperFn';
+import { actSleep, getCell } from 'test/utils/helperFn';
 import { getKeyDefault } from '../hooks/features/dataSource/cache';
 import { TestCache } from '../internals/utils';
 
@@ -235,7 +235,7 @@ describe('<DataGrid /> - Data source', () => {
       await renderAndWaitForInitialFetch();
 
       await upsertFilterItem({ id: 1, field: 'id', operator: 'contains' });
-      await sleep(50);
+      await actSleep(50);
 
       expect(fetchRowsSpy.callCount).to.equal(1);
     });
@@ -244,7 +244,7 @@ describe('<DataGrid /> - Data source', () => {
       await renderAndWaitForInitialFetch();
 
       await upsertFilterItem({ id: 1, field: 'id', operator: 'contains' });
-      await sleep(50);
+      await actSleep(50);
       expect(fetchRowsSpy.callCount).to.equal(1);
 
       await upsertFilterItem({ id: 1, field: 'id', operator: 'contains', value: '1' });
@@ -280,7 +280,7 @@ describe('<DataGrid /> - Data source', () => {
       await act(async () => {
         apiRef.current!.setFilterLogicOperator('or' as GridLogicOperator);
       });
-      await sleep(50);
+      await actSleep(50);
 
       expect(fetchRowsSpy.callCount).to.equal(2);
     });
@@ -291,7 +291,7 @@ describe('<DataGrid /> - Data source', () => {
       await act(async () => {
         apiRef.current!.setQuickFilterValues(['']);
       });
-      await sleep(50);
+      await actSleep(50);
 
       expect(fetchRowsSpy.callCount).to.equal(1);
     });
@@ -312,7 +312,7 @@ describe('<DataGrid /> - Data source', () => {
           quickFilterLogicOperator: 'or' as GridLogicOperator,
         });
       });
-      await sleep(50);
+      await actSleep(50);
 
       expect(fetchRowsSpy.callCount).to.equal(2);
     });

--- a/test/utils/helperFn.ts
+++ b/test/utils/helperFn.ts
@@ -50,6 +50,13 @@ export function microtasks() {
   return act(() => Promise.resolve()) as unknown as Promise<void>;
 }
 
+// `sleep` inside `act`, so updates settling during the wait don't warn about missing `act`.
+export function actSleep(duration: number) {
+  return act(async () => {
+    await sleep(duration);
+  }) as unknown as Promise<void>;
+}
+
 export function spyApi(api: GridApiCommon, methodName: string) {
   const methodKey = methodName as keyof GridApiCommon;
   const privateApi = unwrapPrivateAPI(api);

--- a/test/utils/helperFn.ts
+++ b/test/utils/helperFn.ts
@@ -51,10 +51,10 @@ export function microtasks() {
 }
 
 // `sleep` inside `act`, so updates settling during the wait don't warn about missing `act`.
-export function actSleep(duration: number) {
-  return act(async () => {
+export async function actSleep(duration: number) {
+  await act(async () => {
     await sleep(duration);
-  }) as unknown as Promise<void>;
+  });
 }
 
 export function spyApi(api: GridApiCommon, methodName: string) {


### PR DESCRIPTION
## Summary

Fixes the flakiness seen in [this CI run](https://app.circleci.com/pipelines/github/mui/mui-x/138150/details?workflowId=2da8f5b4-7e8d-42a7-9fb1-3d8aea88fbc0&job=1f21e75b-2d57-49de-87b9-4fe7dbbaf616&buildNumber=895579&jobType=build), where two data source tests failed with `vitest-fail-on-console` on `An update to GridVirtualScroller inside a test was not wrapped in act(...)`:

- `incomplete filter items > should re-fetch when an incomplete item becomes complete`
- `inapplicable filter model changes > should not re-fetch when the logic operator changes without two complete items`

`waitFor(() => expect(fetchRowsSpy.callCount).to.equal(n))` resolves as soon as `getRows` is *called*, not when its response is applied. The tests then `await sleep(50)` outside `act` to prove no further fetch happens, and the in-flight response settles during that window: rows and row count land, the virtualizer updates its dimensions/virtualization stores (`dimensions.ts`, `virtualization.ts`), and React logs the missing-`act` error, which fails the test. On a fast machine the response usually lands inside `waitFor` (already wrapped in `act`), which is why this only shows up on slower CI machines.

Reproduced deterministically by delaying every mock response by 30ms so it always settles inside the `sleep`, which makes both tests fail with the exact CI error; with this change they pass.

Adds an `actSleep` helper next to the existing `microtasks` helper and uses it at the raw `sleep` sites of the data source tests (grid, pro, lazy loader, tree data).