### PR TITLE
[scheduler] Extract linear time interaction engine

### DIFF
--- a/packages/x-scheduler-internals-premium/src/timeline-grid/event-row/useEventRowDropTarget.ts
+++ b/packages/x-scheduler-internals-premium/src/timeline-grid/event-row/useEventRowDropTarget.ts
@@ -1,166 +1,32 @@
 'use client';
-import * as React from 'react';
-import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { useStore } from '@base-ui/utils/store';
-import { useAdapterContext } from '@mui/x-scheduler-internals/use-adapter-context';
 import type { SchedulerResourceId, SchedulerEvent } from '@mui/x-scheduler-internals/models';
-import {
-  useDropTarget,
-  dateToTimelineAxisOffsetMs,
-  timelineAxisOffsetToDate,
-} from '@mui/x-scheduler-internals/internals';
-import { buildIsValidDropTarget } from '@mui/x-scheduler-internals/build-is-valid-drop-target';
-import {
-  EVENT_DRAG_PRECISION_MINUTE,
-  EVENT_DRAG_PRECISION_MS,
-} from '@mui/x-scheduler-internals/constants';
+import { useLinearTimeDropTarget } from '@mui/x-scheduler-internals/internals';
 import type { TimelineGridEventRowContext } from './TimelineGridEventRowContext';
 import { useEventTimelinePremiumStoreContext } from '../../use-event-timeline-premium-store-context';
 import { eventTimelinePremiumPresetSelectors } from '../../event-timeline-premium-selectors';
 
-const isValidDropTarget = buildIsValidDropTarget([
-  'TimelineGridEvent',
-  'TimelineGridEventResizeHandler',
-  'StandaloneEvent',
-]);
+const sources = {
+  move: 'TimelineGridEvent',
+  resize: 'TimelineGridEventResizeHandler',
+  external: 'StandaloneEvent',
+} as const;
 
 export function useEventRowDropTarget(parameters: useEventRowDropTarget.Parameters) {
   const { resourceId, addPropertiesToDroppedEvent } = parameters;
-
-  // Context hooks
-  const adapter = useAdapterContext();
   const store = useEventTimelinePremiumStoreContext();
-
-  // Ref hooks
-  const ref = React.useRef<HTMLDivElement>(null);
-
-  // Selector hooks
   const config = useStore(store, eventTimelinePremiumPresetSelectors.config);
 
-  // Cursor offsets are measured in axis milliseconds: with a trimmed hour window the
-  // hidden hours take no space, so px↔date conversions go through the axis helpers.
-  const collectionDurationMs = config.durationMs;
-
-  const getCursorPositionInElementMs: TimelineGridEventRowContext['getCursorPositionInElementMs'] =
-    useStableCallback(({ input, elementRef }) => {
-      if (!ref.current || !elementRef.current) {
-        return 0;
-      }
-
-      const clientX = input.clientX;
-      const elementPosition = elementRef.current.getBoundingClientRect();
-      const positionX = (clientX - elementPosition.x) / ref.current.offsetWidth;
-
-      // A cursor on (or past) either edge must not map beyond the axis: the offset
-      // would resolve into the day before or after the collection.
-      return Math.min(
-        Math.max(Math.round(collectionDurationMs * positionX), 0),
-        collectionDurationMs,
-      );
-    });
-
-  const getEventDropData: useDropTarget.GetEventDropData = useStableCallback(
-    ({ data, getDataFromInside, getDataFromOutside, input }) => {
-      if (!isValidDropTarget(data)) {
-        return undefined;
-      }
-
-      const cursorOffsetMs = getCursorPositionInElementMs({ input, elementRef: ref });
-
-      const axisOffsetToDate = (offsetMs: number) => {
-        const roundedOffset =
-          Math.round(offsetMs / EVENT_DRAG_PRECISION_MS) * EVENT_DRAG_PRECISION_MS;
-
-        return timelineAxisOffsetToDate(adapter, config, roundedOffset);
-      };
-
-      // Move a Timeline Event within the Timeline
-      if (data.source === 'TimelineGridEvent') {
-        const eventDurationMs = adapter.getTime(data.end) - adapter.getTime(data.start);
-
-        // `cursorOffsetMs - initialCursorPositionInEventMs` reconstructs the *rendered*
-        // start edge plus the drag delta. When the real start hides inside the hidden
-        // hours, the rendered edge is its window-clamped anchor: carry the hidden
-        // remainder over to the new anchor so an unmoved drag maps back to the exact
-        // original dates instead of silently snapping the start to the window edge.
-        const startAnchor = timelineAxisOffsetToDate(
-          adapter,
-          config,
-          dateToTimelineAxisOffsetMs(adapter, config, data.start),
-        );
-        const hiddenRemainderMs = adapter.getTime(data.start) - adapter.getTime(startAnchor);
-
-        const newAnchorDate = axisOffsetToDate(
-          cursorOffsetMs - data.initialCursorPositionInEventMs,
-        );
-        const newStartDate = adapter.addMilliseconds(newAnchorDate, hiddenRemainderMs);
-
-        // The event keeps its real duration even when it spans hidden hours, so the
-        // real start and end both shift by the same amount as their rendered anchors.
-        const newEndDate = adapter.addMilliseconds(newStartDate, eventDurationMs);
-
-        return getDataFromInside(data, newStartDate, newEndDate);
-      }
-
-      // Resize a Timeline Event
-      if (data.source === 'TimelineGridEventResizeHandler') {
-        if (data.side === 'start') {
-          const cursorDate = axisOffsetToDate(cursorOffsetMs - data.initialCursorPositionInEventMs);
-
-          // Ensure the new start date is not after or too close to the end date.
-          const maxStartDate = adapter.addMinutes(data.end, -EVENT_DRAG_PRECISION_MINUTE);
-          const newStartDate = adapter.isBefore(cursorDate, maxStartDate)
-            ? cursorDate
-            : maxStartDate;
-
-          return getDataFromInside(data, newStartDate, data.end);
-        }
-
-        if (data.side === 'end') {
-          // The offset from the grab point to the event end must be measured on the axis:
-          // the real duration would overshoot when the event spans hidden hours.
-          const eventAxisDurationMs =
-            dateToTimelineAxisOffsetMs(adapter, config, data.end) -
-            dateToTimelineAxisOffsetMs(adapter, config, data.start);
-
-          const cursorDate = axisOffsetToDate(
-            cursorOffsetMs - data.initialCursorPositionInEventMs + eventAxisDurationMs,
-          );
-
-          // Ensure the new end date is not before or too close to the start date.
-          const minEndDate = adapter.addMinutes(data.start, EVENT_DRAG_PRECISION_MINUTE);
-          const newEndDate = adapter.isAfter(cursorDate, minEndDate) ? cursorDate : minEndDate;
-
-          return getDataFromInside(data, data.start, newEndDate);
-        }
-      }
-
-      // Move a Standalone Event into the Time Grid
-      if (data.source === 'StandaloneEvent') {
-        // The new event starts at the cursor: cap the offset to the last slot of the
-        // axis so a drop on the exact right edge does not create the event on the day
-        // after the collection, where it would not be rendered at all.
-        const lastStartOffsetMs = collectionDurationMs - EVENT_DRAG_PRECISION_MS;
-        return getDataFromOutside(
-          data,
-          axisOffsetToDate(Math.min(cursorOffsetMs, lastStartOffsetMs)),
-        );
-      }
-
-      return undefined;
-    },
-  );
-
-  useDropTarget({
-    ref,
-    resourceId,
+  return useLinearTimeDropTarget({
+    axis: 'horizontal',
+    timeScale: { type: 'timeline-axis', axis: config },
+    constrainEventToTimeAxis: false,
+    externalDropStart: 'last-slot',
+    sources,
     surfaceType: 'timeline',
-    getEventDropData,
-    isValidDropTarget,
+    resourceId,
     addPropertiesToDroppedEvent,
   });
-
-  return { getCursorPositionInElementMs, ref };
 }
 
 export namespace useEventRowDropTarget {

--- a/packages/x-scheduler-internals/src/calendar-grid/day-cell/useDayCellDropTarget.ts
+++ b/packages/x-scheduler-internals/src/calendar-grid/day-cell/useDayCellDropTarget.ts
@@ -37,6 +37,7 @@ export function useDayCellDropTarget(parameters: useDayCellDropTarget.Parameters
           data,
           offset === 0 ? data.start : adapter.addDays(data.start, offset),
           offset === 0 ? data.end : adapter.addDays(data.end, offset),
+          'drag',
         );
       }
 
@@ -53,7 +54,7 @@ export function useDayCellDropTarget(parameters: useDayCellDropTarget.Parameters
           } else {
             newStart = mergeDateAndTime(adapter, value, data.start);
           }
-          return getDataFromInside(data, newStart, data.end);
+          return getDataFromInside(data, newStart, data.end, 'resize');
         }
 
         if (data.side === 'end') {
@@ -68,7 +69,7 @@ export function useDayCellDropTarget(parameters: useDayCellDropTarget.Parameters
             draggedDay = mergeDateAndTime(adapter, value, data.end);
           }
 
-          return getDataFromInside(data, data.start, draggedDay);
+          return getDataFromInside(data, data.start, draggedDay, 'resize');
         }
       }
 
@@ -82,6 +83,7 @@ export function useDayCellDropTarget(parameters: useDayCellDropTarget.Parameters
           data,
           offset === 0 ? data.start : adapter.addDays(data.start, offset),
           offset === 0 ? data.end : adapter.addDays(data.end, offset),
+          'drag',
         );
       }
 

--- a/packages/x-scheduler-internals/src/calendar-grid/time-column/useTimeDropTarget.ts
+++ b/packages/x-scheduler-internals/src/calendar-grid/time-column/useTimeDropTarget.ts
@@ -1,184 +1,30 @@
 'use client';
-import * as React from 'react';
-import { useStableCallback } from '@base-ui/utils/useStableCallback';
-import { useAdapterContext } from '../../use-adapter-context';
-import type { SchedulerEvent, TemporalSupportedObject } from '../../models';
-import { buildIsValidDropTarget } from '../../build-is-valid-drop-target';
-import type { CalendarGridTimeColumnContext } from './CalendarGridTimeColumnContext';
-import { useDropTarget } from '../../internals/utils/useDropTarget';
-import { clampResizedEventEdge } from '../../internals/utils/resize-utils';
-import { EVENT_DRAG_PRECISION_MINUTE, EVENT_DRAG_PRECISION_MS } from '../../constants';
 import { schedulerEventSelectors } from '../../scheduler-selectors';
+import type { SchedulerEvent, TemporalSupportedObject } from '../../models';
 import { useEventCalendarStoreContext } from '../../use-event-calendar-store-context';
+import { useLinearTimeDropTarget } from '../../internals/utils/useLinearTimeDropTarget';
+import type { CalendarGridTimeColumnContext } from './CalendarGridTimeColumnContext';
 
-const isValidDropTarget = buildIsValidDropTarget([
-  'CalendarGridTimeEvent',
-  'CalendarGridTimeEventResizeHandler',
-  'CalendarGridDayEvent',
-  'StandaloneEvent',
-]);
+const sources = {
+  move: 'CalendarGridTimeEvent',
+  resize: 'CalendarGridTimeEventResizeHandler',
+  fixedDuration: 'CalendarGridDayEvent',
+  external: 'StandaloneEvent',
+} as const;
 
 export function useTimeDropTarget(parameters: useTimeDropTarget.Parameters) {
   const { start, end, addPropertiesToDroppedEvent } = parameters;
-
-  // Context hooks
-  const adapter = useAdapterContext();
   const store = useEventCalendarStoreContext();
 
-  // Ref hooks
-  const ref = React.useRef<HTMLDivElement>(null);
-
-  const collectionStartTimestamp = adapter.getTime(start);
-  const collectionEndTimestamp = adapter.getTime(end);
-  const collectionDurationMs = collectionEndTimestamp - collectionStartTimestamp;
-
-  const getCursorPositionInElementMs: CalendarGridTimeColumnContext['getCursorPositionInElementMs'] =
-    useStableCallback(({ input, elementRef }) => {
-      if (!ref.current || !elementRef.current) {
-        return 0;
-      }
-
-      const clientY = input.clientY;
-      const elementPosition = elementRef.current.getBoundingClientRect();
-      const positionY = (clientY - elementPosition.y) / ref.current.offsetHeight;
-      const clampedPositionY = Math.max(0, Math.min(1, positionY));
-
-      return Math.round(collectionDurationMs * clampedPositionY);
-    });
-
-  const getDateAtPointer: CalendarGridTimeColumnContext['getDateAtPointer'] = useStableCallback(
-    (input) => {
-      // Bail when the column isn't measurable yet — zero height makes `getCursorPositionInElementMs` return NaN.
-      if (!ref.current || ref.current.offsetHeight === 0) {
-        return null;
-      }
-      const offsetMs = getCursorPositionInElementMs({ input, elementRef: ref });
-      const roundedOffsetMs =
-        Math.round(offsetMs / EVENT_DRAG_PRECISION_MS) * EVENT_DRAG_PRECISION_MS;
-      return adapter.addMilliseconds(start, roundedOffsetMs);
-    },
-  );
-
-  const getEventDropData: useDropTarget.GetEventDropData = useStableCallback(
-    ({ data, getDataFromInside, getDataFromOutside, input }) => {
-      if (!isValidDropTarget(data)) {
-        return undefined;
-      }
-
-      const cursorOffsetMs = getCursorPositionInElementMs({ input, elementRef: ref });
-
-      const addOffsetToDate = (date: TemporalSupportedObject, offsetMs: number) => {
-        const roundedOffset =
-          Math.round(offsetMs / EVENT_DRAG_PRECISION_MS) * EVENT_DRAG_PRECISION_MS;
-
-        return adapter.addMilliseconds(date, roundedOffset);
-      };
-
-      // Move a Time Grid Event within the Time Grid
-      if (data.source === 'CalendarGridTimeEvent') {
-        const eventDurationMs = adapter.getTime(data.end) - adapter.getTime(data.start);
-
-        let newStartDate = addOffsetToDate(
-          start,
-          cursorOffsetMs - data.initialCursorPositionInEventMs,
-        );
-
-        // Clamp the event to stay within the time grid bounds
-        if (adapter.isBefore(newStartDate, start)) {
-          newStartDate = start;
-        }
-        const maxStartDate = adapter.addMilliseconds(end, -eventDurationMs);
-        if (adapter.isAfter(newStartDate, maxStartDate)) {
-          newStartDate = maxStartDate;
-        }
-
-        const newEndDate = adapter.addMilliseconds(newStartDate, eventDurationMs);
-
-        return getDataFromInside(data, newStartDate, newEndDate);
-      }
-
-      // Resize a Time Grid Event
-      if (data.source === 'CalendarGridTimeEventResizeHandler') {
-        if (data.side === 'start') {
-          let cursorDate = addOffsetToDate(
-            start,
-            cursorOffsetMs - data.initialCursorPositionInEventMs,
-          );
-
-          // Clamp to the time grid bounds
-          if (adapter.isBefore(cursorDate, start)) {
-            cursorDate = start;
-          }
-
-          // Ensure the new start date is not after or too close to the end date.
-          const { start: newStartDate } = clampResizedEventEdge({
-            adapter,
-            side: 'start',
-            start: data.start,
-            end: data.end,
-            cursorDate,
-            precisionMinute: EVENT_DRAG_PRECISION_MINUTE,
-          });
-
-          return getDataFromInside(data, newStartDate, data.end);
-        }
-
-        if (data.side === 'end') {
-          const eventDurationMs = adapter.getTime(data.end) - adapter.getTime(data.start);
-
-          let cursorDate = addOffsetToDate(
-            start,
-            cursorOffsetMs - data.initialCursorPositionInEventMs + eventDurationMs,
-          );
-
-          // Clamp to the time grid bounds
-          if (adapter.isAfter(cursorDate, end)) {
-            cursorDate = end;
-          }
-
-          // Ensure the new end date is not before or too close to the start date.
-          const { end: newEndDate } = clampResizedEventEdge({
-            adapter,
-            side: 'end',
-            start: data.start,
-            end: data.end,
-            cursorDate,
-            precisionMinute: EVENT_DRAG_PRECISION_MINUTE,
-          });
-
-          return getDataFromInside(data, data.start, newEndDate);
-        }
-      }
-
-      // Move a Day Grid Event into the Time Grid
-      if (data.source === 'CalendarGridDayEvent') {
-        const newStartDate = addOffsetToDate(start, cursorOffsetMs);
-        const newEndDate = adapter.addMinutes(
-          newStartDate,
-          schedulerEventSelectors.defaultEventDuration(store.state),
-        );
-
-        return getDataFromInside(data, newStartDate, newEndDate);
-      }
-
-      // Move a Standalone Event into the Time Grid
-      if (data.source === 'StandaloneEvent') {
-        return getDataFromOutside(data, addOffsetToDate(start, cursorOffsetMs));
-      }
-
-      return undefined;
-    },
-  );
-
-  useDropTarget({
-    ref,
+  return useLinearTimeDropTarget({
+    axis: 'vertical',
+    timeScale: { type: 'continuous', start, end },
+    constrainEventToTimeAxis: true,
+    sources,
     surfaceType: 'time-grid',
-    getEventDropData,
-    isValidDropTarget,
+    getFixedDurationInMinutes: () => schedulerEventSelectors.defaultEventDuration(store.state),
     addPropertiesToDroppedEvent,
   });
-
-  return { getCursorPositionInElementMs, getDateAtPointer, ref };
 }
 
 export namespace useTimeDropTarget {

--- a/packages/x-scheduler-internals/src/internals/utils/index.ts
+++ b/packages/x-scheduler-internals/src/internals/utils/index.ts
@@ -4,6 +4,7 @@ export * from './drag-utils';
 export * from './pointer-utils';
 export * from './dom-utils';
 export * from './useDropTarget';
+export * from './useLinearTimeDropTarget';
 export * from './useEventResizeHandler';
 export * from './resize-utils';
 export * from './useElementPositionInCollection';

--- a/packages/x-scheduler-internals/src/internals/utils/useDropTarget.ts
+++ b/packages/x-scheduler-internals/src/internals/utils/useDropTarget.ts
@@ -56,15 +56,14 @@ export function useDropTarget<Targets extends keyof EventDropDataLookup>(
     if (!ref.current) {
       return undefined;
     }
-    const getDataFromInside: useDropTarget.GetDataFromInside = (data, newStart, newEnd) => {
-      const type =
-        data.source === 'CalendarGridDayEventResizeHandler' ||
-        data.source === 'CalendarGridTimeEventResizeHandler'
-          ? 'internal-resize'
-          : 'internal-drag';
-
+    const getDataFromInside: useDropTarget.GetDataFromInside = (
+      data,
+      newStart,
+      newEnd,
+      interaction,
+    ) => {
       return {
-        type,
+        type: interaction === 'resize' ? 'internal-resize' : 'internal-drag',
         surfaceType,
         start: newStart,
         end: newEnd,
@@ -199,6 +198,7 @@ export namespace useDropTarget {
     data: Exclude<EventDropData, StandaloneEvent.DragData>,
     newStart: TemporalSupportedObject,
     newEnd: TemporalSupportedObject,
+    interaction: 'drag' | 'resize',
   ) => SchedulerOccurrencePlaceholderInternalDragOrResize;
 
   export type GetDataFromOutside = (

--- a/packages/x-scheduler-internals/src/internals/utils/useLinearTimeDropTarget.test.ts
+++ b/packages/x-scheduler-internals/src/internals/utils/useLinearTimeDropTarget.test.ts
@@ -1,0 +1,201 @@
+import { adapter } from 'test/utils/scheduler';
+import { createLinearTimeInteractionEngine } from './useLinearTimeDropTarget';
+
+describe('createLinearTimeInteractionEngine', () => {
+  const rangeStart = adapter.date('2024-01-15T08:00:00', 'default');
+  const rangeEnd = adapter.date('2024-01-15T18:00:00', 'default');
+
+  function createEngine(axis: 'horizontal' | 'vertical', constrainEventToTimeAxis: boolean) {
+    return createLinearTimeInteractionEngine({
+      adapter,
+      axis,
+      timeScale: { type: 'continuous', start: rangeStart, end: rangeEnd },
+      constrainEventToTimeAxis,
+    });
+  }
+
+  describe('pointer position', () => {
+    const collection = { offsetWidth: 800, offsetHeight: 1_000 };
+    const element = {
+      getBoundingClientRect: () => ({ x: 50, y: 100 }),
+    };
+
+    it('should map the horizontal axis to the collection duration', () => {
+      const engine = createEngine('horizontal', false);
+
+      expect(
+        engine.getCursorPositionInElementMs({
+          pointer: { clientX: 250 },
+          element,
+          collection,
+        }),
+      ).to.equal(2.5 * 60 * 60 * 1_000);
+    });
+
+    it('should map the vertical axis to the collection duration', () => {
+      const engine = createEngine('vertical', false);
+
+      expect(
+        engine.getCursorPositionInElementMs({
+          pointer: { clientY: 350 },
+          element,
+          collection,
+        }),
+      ).to.equal(2.5 * 60 * 60 * 1_000);
+    });
+
+    it('should clamp the pointer position to the time axis', () => {
+      const pointer = { clientX: 900 };
+
+      expect(
+        createEngine('horizontal', false).getCursorPositionInElementMs({
+          pointer,
+          element,
+          collection,
+        }),
+      ).to.equal(10 * 60 * 60 * 1_000);
+    });
+  });
+
+  it('should snap dates to the drag precision', () => {
+    const engine = createEngine('horizontal', true);
+
+    expect(engine.getDateAtOffset(83 * 60 * 1_000)).toEqualDateTime(
+      adapter.date('2024-01-15T09:30:00', 'default'),
+    );
+  });
+
+  describe('moving an event', () => {
+    const start = adapter.date('2024-01-15T10:00:00', 'default');
+    const end = adapter.date('2024-01-15T11:00:00', 'default');
+
+    it('should preserve the duration and account for the initial grab position', () => {
+      const engine = createEngine('horizontal', false);
+      const result = engine.getMovedEventRange({
+        start,
+        end,
+        cursorPositionInCollectionMs: 285 * 60 * 1_000,
+        initialCursorPositionInEventMs: 15 * 60 * 1_000,
+      });
+
+      expect(result.start).toEqualDateTime(adapter.date('2024-01-15T12:30:00', 'default'));
+      expect(result.end).toEqualDateTime(adapter.date('2024-01-15T13:30:00', 'default'));
+    });
+
+    it('should keep a moved event inside a bounded range', () => {
+      const engine = createEngine('vertical', true);
+      const beforeStart = engine.getMovedEventRange({
+        start,
+        end,
+        cursorPositionInCollectionMs: 0,
+        initialCursorPositionInEventMs: 30 * 60 * 1_000,
+      });
+      const afterEnd = engine.getMovedEventRange({
+        start,
+        end,
+        cursorPositionInCollectionMs: 10 * 60 * 60 * 1_000,
+        initialCursorPositionInEventMs: 15 * 60 * 1_000,
+      });
+
+      expect(beforeStart.start).toEqualDateTime(rangeStart);
+      expect(beforeStart.end).toEqualDateTime(adapter.date('2024-01-15T09:00:00', 'default'));
+      expect(afterEnd.start).toEqualDateTime(adapter.date('2024-01-15T17:00:00', 'default'));
+      expect(afterEnd.end).toEqualDateTime(rangeEnd);
+    });
+  });
+
+  describe('resizing an event', () => {
+    const start = adapter.date('2024-01-15T10:00:00', 'default');
+    const end = adapter.date('2024-01-15T11:00:00', 'default');
+
+    it('should keep the minimum duration for both edges', () => {
+      const engine = createEngine('horizontal', false);
+      const resizedStart = engine.getResizedEventRange({
+        start,
+        end,
+        side: 'start',
+        cursorPositionInCollectionMs: 210 * 60 * 1_000,
+        initialCursorPositionInEventMs: 0,
+      });
+      const resizedEnd = engine.getResizedEventRange({
+        start,
+        end,
+        side: 'end',
+        cursorPositionInCollectionMs: 60 * 60 * 1_000,
+        initialCursorPositionInEventMs: 0,
+      });
+
+      expect(resizedStart.start).toEqualDateTime(adapter.date('2024-01-15T10:45:00', 'default'));
+      expect(resizedEnd.end).toEqualDateTime(adapter.date('2024-01-15T10:15:00', 'default'));
+    });
+
+    it('should keep resized edges inside a bounded range', () => {
+      const engine = createEngine('vertical', true);
+      const resizedStart = engine.getResizedEventRange({
+        start,
+        end,
+        side: 'start',
+        cursorPositionInCollectionMs: -60 * 60 * 1_000,
+        initialCursorPositionInEventMs: 0,
+      });
+      const resizedEnd = engine.getResizedEventRange({
+        start,
+        end,
+        side: 'end',
+        cursorPositionInCollectionMs: 10 * 60 * 60 * 1_000,
+        initialCursorPositionInEventMs: 0,
+      });
+
+      expect(resizedStart.start).toEqualDateTime(rangeStart);
+      expect(resizedEnd.end).toEqualDateTime(rangeEnd);
+    });
+  });
+
+  describe('piecewise timeline axis', () => {
+    const start = adapter.date('2024-01-15T00:00:00', 'default');
+    const end = adapter.endOfDay(adapter.addDays(start, 1));
+    const engine = createLinearTimeInteractionEngine({
+      adapter,
+      axis: 'horizontal',
+      timeScale: {
+        type: 'timeline-axis',
+        axis: { start, end, dayStartMinute: 8 * 60, dayEndMinute: 20 * 60 },
+      },
+      constrainEventToTimeAxis: false,
+    });
+
+    it('should skip hidden hours when converting an offset to a date', () => {
+      expect(engine.getDateAtOffset(14 * 60 * 60 * 1_000)).toEqualDateTime(
+        adapter.date('2024-01-16T10:00:00', 'default'),
+      );
+    });
+
+    it('should preserve the hidden remainder when moving an event', () => {
+      const eventStart = adapter.date('2024-01-15T07:00:00', 'default');
+      const eventEnd = adapter.date('2024-01-15T09:00:00', 'default');
+      const result = engine.getMovedEventRange({
+        start: eventStart,
+        end: eventEnd,
+        cursorPositionInCollectionMs: 12.5 * 60 * 60 * 1_000,
+        initialCursorPositionInEventMs: 0.5 * 60 * 60 * 1_000,
+      });
+
+      expect(result.start).toEqualDateTime(adapter.date('2024-01-16T07:00:00', 'default'));
+      expect(result.end).toEqualDateTime(adapter.date('2024-01-16T09:00:00', 'default'));
+    });
+
+    it('should use the rendered axis duration when resizing the end', () => {
+      const eventStart = adapter.date('2024-01-15T10:00:00', 'default');
+      const eventEnd = adapter.date('2024-01-16T10:00:00', 'default');
+      const result = engine.getResizedEventRange({
+        start: eventStart,
+        end: eventEnd,
+        side: 'end',
+        cursorPositionInCollectionMs: 2 * 60 * 60 * 1_000,
+        initialCursorPositionInEventMs: 0,
+      });
+
+      expect(result.end).toEqualDateTime(eventEnd);
+    });
+  });
+});

--- a/packages/x-scheduler-internals/src/internals/utils/useLinearTimeDropTarget.ts
+++ b/packages/x-scheduler-internals/src/internals/utils/useLinearTimeDropTarget.ts
@@ -1,0 +1,366 @@
+'use client';
+import * as React from 'react';
+import { useStableCallback } from '@base-ui/utils/useStableCallback';
+import type { EventDropData, EventDropDataLookup } from '../../build-is-valid-drop-target';
+import { EVENT_DRAG_PRECISION_MINUTE, EVENT_DRAG_PRECISION_MS } from '../../constants';
+import type {
+  EventSurfaceType,
+  SchedulerEvent,
+  SchedulerResourceId,
+  TemporalSupportedObject,
+} from '../../models';
+import type { Adapter } from '../../use-adapter/useAdapter.types';
+import { useAdapterContext } from '../../use-adapter-context';
+import { clampResizedEventEdge } from './resize-utils';
+import {
+  dateToTimelineAxisOffsetMs,
+  getTimelineAxisDurationMs,
+  timelineAxisOffsetToDate,
+} from './timeline-axis';
+import type { TimelineAxis } from './timeline-axis';
+import { useDropTarget } from './useDropTarget';
+
+type LinearAxis = 'horizontal' | 'vertical';
+
+interface PointerInput {
+  clientX?: number;
+  clientY?: number;
+}
+
+interface ElementMeasurement {
+  getBoundingClientRect: () => Pick<DOMRect, 'x' | 'y'>;
+}
+
+interface CollectionMeasurement {
+  offsetHeight: number;
+  offsetWidth: number;
+}
+
+interface LinearTimeInteractionEngineParameters {
+  adapter: Adapter;
+  axis: LinearAxis;
+  timeScale: LinearTimeScale;
+  constrainEventToTimeAxis: boolean;
+}
+
+type LinearTimeScale =
+  | {
+      type: 'continuous';
+      start: TemporalSupportedObject;
+      end: TemporalSupportedObject;
+    }
+  | {
+      type: 'timeline-axis';
+      axis: TimelineAxis & { durationMs?: number };
+    };
+
+interface EventRangeParameters {
+  start: TemporalSupportedObject;
+  end: TemporalSupportedObject;
+  cursorPositionInCollectionMs: number;
+  initialCursorPositionInEventMs: number;
+}
+
+interface LinearEventData {
+  start: TemporalSupportedObject;
+  end: TemporalSupportedObject;
+  initialCursorPositionInEventMs: number;
+}
+
+interface InternalEventData {
+  start: TemporalSupportedObject;
+  end: TemporalSupportedObject;
+  originalOccurrence: unknown;
+}
+
+type DropSourceFor<Shape> = Extract<
+  {
+    [Source in keyof EventDropDataLookup]: EventDropDataLookup[Source] extends Shape
+      ? Source
+      : never;
+  }[keyof EventDropDataLookup],
+  string
+>;
+
+type InternalDropData = Parameters<useDropTarget.GetDataFromInside>[0];
+type ExternalDropData = Parameters<useDropTarget.GetDataFromOutside>[0];
+type LinearEventDropData = InternalDropData & LinearEventData;
+type LinearResizeDropData = LinearEventDropData & { side: 'start' | 'end' };
+
+/**
+ * Creates the date calculations shared by every drag-and-drop surface laid out on a linear time
+ * axis. DOM measurement stays at the hook boundary so the calculations can remain deterministic.
+ */
+export function createLinearTimeInteractionEngine(
+  parameters: LinearTimeInteractionEngineParameters,
+) {
+  const { adapter, axis, timeScale, constrainEventToTimeAxis } = parameters;
+  const timeAxis = timeScale.type === 'continuous' ? null : timeScale.axis;
+  const timeAxisStart = timeScale.type === 'continuous' ? timeScale.start : timeScale.axis.start;
+  const timeAxisEnd = timeScale.type === 'continuous' ? timeScale.end : timeScale.axis.end;
+  const timeAxisDurationMs =
+    timeScale.type === 'continuous'
+      ? adapter.getTime(timeScale.end) - adapter.getTime(timeScale.start)
+      : (timeScale.axis.durationMs ?? getTimelineAxisDurationMs(adapter, timeScale.axis));
+
+  const offsetToDate = (offsetMs: number) =>
+    timeAxis
+      ? timelineAxisOffsetToDate(adapter, timeAxis, offsetMs)
+      : adapter.addMilliseconds(timeAxisStart, offsetMs);
+  const dateToOffset = (date: TemporalSupportedObject) =>
+    timeAxis
+      ? dateToTimelineAxisOffsetMs(adapter, timeAxis, date)
+      : adapter.getTime(date) - adapter.getTime(timeAxisStart);
+
+  const getDateAtOffset = (offsetMs: number) => {
+    const roundedOffsetMs =
+      Math.round(offsetMs / EVENT_DRAG_PRECISION_MS) * EVENT_DRAG_PRECISION_MS;
+    return offsetToDate(roundedOffsetMs);
+  };
+
+  const getCursorPositionInElementMs = (input: {
+    pointer: PointerInput;
+    element: ElementMeasurement;
+    collection: CollectionMeasurement;
+  }) => {
+    const { pointer, element, collection } = input;
+    const elementPosition = element.getBoundingClientRect();
+    const pointerPosition = axis === 'horizontal' ? pointer.clientX : pointer.clientY;
+    const elementStart = axis === 'horizontal' ? elementPosition.x : elementPosition.y;
+    const collectionSize = axis === 'horizontal' ? collection.offsetWidth : collection.offsetHeight;
+
+    if (pointerPosition == null) {
+      return 0;
+    }
+
+    const relativePosition = Math.max(
+      0,
+      Math.min(1, (pointerPosition - elementStart) / collectionSize),
+    );
+    return Math.round(timeAxisDurationMs * relativePosition);
+  };
+
+  const getMovedEventRange = (input: EventRangeParameters) => {
+    const { start, end, cursorPositionInCollectionMs, initialCursorPositionInEventMs } = input;
+    const eventDurationMs = adapter.getTime(end) - adapter.getTime(start);
+    const startAnchor = offsetToDate(dateToOffset(start));
+    const hiddenRemainderMs = adapter.getTime(start) - adapter.getTime(startAnchor);
+    const newStartAnchor = getDateAtOffset(
+      cursorPositionInCollectionMs - initialCursorPositionInEventMs,
+    );
+    let newStart = adapter.addMilliseconds(newStartAnchor, hiddenRemainderMs);
+
+    if (constrainEventToTimeAxis) {
+      if (adapter.isBefore(newStart, timeAxisStart)) {
+        newStart = timeAxisStart;
+      }
+
+      const maxStart = adapter.addMilliseconds(timeAxisEnd, -eventDurationMs);
+      if (adapter.isAfter(newStart, maxStart)) {
+        newStart = maxStart;
+      }
+    }
+
+    return {
+      start: newStart,
+      end: adapter.addMilliseconds(newStart, eventDurationMs),
+    };
+  };
+
+  const getResizedEventRange = (input: EventRangeParameters & { side: 'start' | 'end' }) => {
+    const { start, end, side, cursorPositionInCollectionMs, initialCursorPositionInEventMs } =
+      input;
+    const eventAxisDurationMs = dateToOffset(end) - dateToOffset(start);
+    const cursorOffsetMs =
+      cursorPositionInCollectionMs -
+      initialCursorPositionInEventMs +
+      (side === 'end' ? eventAxisDurationMs : 0);
+    let cursorDate = getDateAtOffset(cursorOffsetMs);
+
+    if (constrainEventToTimeAxis) {
+      if (side === 'start' && adapter.isBefore(cursorDate, timeAxisStart)) {
+        cursorDate = timeAxisStart;
+      } else if (side === 'end' && adapter.isAfter(cursorDate, timeAxisEnd)) {
+        cursorDate = timeAxisEnd;
+      }
+    }
+
+    return clampResizedEventEdge({
+      adapter,
+      side,
+      start,
+      end,
+      cursorDate,
+      precisionMinute: EVENT_DRAG_PRECISION_MINUTE,
+    });
+  };
+
+  return {
+    getCursorPositionInElementMs,
+    getDateAtOffset,
+    getMovedEventRange,
+    getResizedEventRange,
+    timeAxisDurationMs,
+  };
+}
+
+/**
+ * Registers a drop target whose primary axis represents a linear time scale.
+ */
+export function useLinearTimeDropTarget(parameters: useLinearTimeDropTarget.Parameters) {
+  const {
+    axis,
+    timeScale,
+    constrainEventToTimeAxis,
+    sources,
+    surfaceType,
+    resourceId,
+    getFixedDurationInMinutes,
+    addPropertiesToDroppedEvent,
+  } = parameters;
+  const adapter = useAdapterContext();
+  const ref = React.useRef<HTMLDivElement>(null);
+  const engine = createLinearTimeInteractionEngine({
+    adapter,
+    axis,
+    timeScale,
+    constrainEventToTimeAxis,
+  });
+
+  const validSources = React.useMemo(
+    () => new Set(Object.values(sources).filter((source) => source != null)),
+    [sources.external, sources.fixedDuration, sources.move, sources.resize],
+  );
+  const isValidDropTarget = React.useCallback(
+    (data: any): data is EventDropData => validSources.has(data.source),
+    [validSources],
+  );
+
+  const getCursorPositionInElementMs = useStableCallback(
+    ({ input, elementRef }: useLinearTimeDropTarget.CursorPositionParameters) => {
+      if (!ref.current || !elementRef.current) {
+        return 0;
+      }
+
+      return engine.getCursorPositionInElementMs({
+        pointer: input,
+        element: elementRef.current,
+        collection: ref.current,
+      });
+    },
+  );
+
+  const getDateAtPointer = useStableCallback((input: { clientX: number; clientY: number }) => {
+    const collectionSize =
+      axis === 'horizontal' ? ref.current?.offsetWidth : ref.current?.offsetHeight;
+    if (!ref.current || collectionSize === 0) {
+      return null;
+    }
+
+    const offsetMs = getCursorPositionInElementMs({ input, elementRef: ref });
+    return engine.getDateAtOffset(offsetMs);
+  });
+
+  const getEventDropData: useDropTarget.GetEventDropData = useStableCallback(
+    ({ data, getDataFromInside, getDataFromOutside, input }) => {
+      if (!isValidDropTarget(data)) {
+        return undefined;
+      }
+
+      const cursorPositionInCollectionMs = getCursorPositionInElementMs({
+        input,
+        elementRef: ref,
+      });
+
+      if (data.source === sources.move) {
+        const eventData = data as LinearEventDropData;
+        const range = engine.getMovedEventRange({
+          start: eventData.start,
+          end: eventData.end,
+          cursorPositionInCollectionMs,
+          initialCursorPositionInEventMs: eventData.initialCursorPositionInEventMs,
+        });
+        return getDataFromInside(eventData, range.start, range.end, 'drag');
+      }
+
+      if (data.source === sources.resize) {
+        const resizeData = data as LinearResizeDropData;
+        const range = engine.getResizedEventRange({
+          start: resizeData.start,
+          end: resizeData.end,
+          side: resizeData.side,
+          cursorPositionInCollectionMs,
+          initialCursorPositionInEventMs: resizeData.initialCursorPositionInEventMs,
+        });
+        return getDataFromInside(resizeData, range.start, range.end, 'resize');
+      }
+
+      if (sources.fixedDuration != null && data.source === sources.fixedDuration) {
+        const start = engine.getDateAtOffset(cursorPositionInCollectionMs);
+        const end = adapter.addMinutes(start, getFixedDurationInMinutes!());
+        return getDataFromInside(data as InternalDropData, start, end, 'drag');
+      }
+
+      if (data.source === sources.external) {
+        const offsetMs =
+          parameters.externalDropStart === 'last-slot'
+            ? Math.min(
+                cursorPositionInCollectionMs,
+                engine.timeAxisDurationMs - EVENT_DRAG_PRECISION_MS,
+              )
+            : cursorPositionInCollectionMs;
+        return getDataFromOutside(data as ExternalDropData, engine.getDateAtOffset(offsetMs));
+      }
+
+      return undefined;
+    },
+  );
+
+  useDropTarget({
+    ref,
+    resourceId,
+    surfaceType,
+    getEventDropData,
+    isValidDropTarget,
+    addPropertiesToDroppedEvent,
+  });
+
+  return { getCursorPositionInElementMs, getDateAtPointer, ref };
+}
+
+export namespace useLinearTimeDropTarget {
+  export interface Sources {
+    move: DropSourceFor<LinearEventData>;
+    resize: DropSourceFor<LinearEventData & { side: 'start' | 'end' }>;
+    fixedDuration?: DropSourceFor<InternalEventData>;
+    external: DropSourceFor<{ eventData: unknown }>;
+  }
+
+  interface SharedParameters {
+    axis: LinearAxis;
+    timeScale: LinearTimeScale;
+    constrainEventToTimeAxis: boolean;
+    externalDropStart?: 'pointer' | 'last-slot';
+    sources: Sources;
+    surfaceType: EventSurfaceType;
+    resourceId?: SchedulerResourceId | null;
+    addPropertiesToDroppedEvent?: () => Partial<SchedulerEvent>;
+  }
+
+  export type Parameters = SharedParameters &
+    (
+      | {
+          sources: Sources & { fixedDuration: DropSourceFor<InternalEventData> };
+          getFixedDurationInMinutes: () => number;
+        }
+      | {
+          sources: Sources & { fixedDuration?: undefined };
+          getFixedDurationInMinutes?: undefined;
+        }
+    );
+
+  export interface CursorPositionParameters {
+    input: PointerInput;
+    elementRef: React.RefObject<HTMLElement | null>;
+  }
+}


### PR DESCRIPTION
## Changelog

- Extract the time grid and timeline drag-and-drop calculations into a shared, axis-independent interaction engine.
- Support both continuous time ranges and the timeline’s piecewise trimmed-hours scale while keeping each surface’s bounds and external-drop behavior.
- Make drag versus resize explicit when building occurrence placeholders, including timeline resize interactions.

## Validation

- `pnpm test:unit --project "x-scheduler-internals" --run`
- `pnpm test:unit --project "x-scheduler-internals-premium" --run`
- `pnpm test:unit --project "x-scheduler" --run packages/x-scheduler/src/week-view/tests/dragAndDrop.WeekView.test.tsx`
- `pnpm test:unit --project "x-scheduler-premium" --run packages/x-scheduler-premium/src/event-timeline-premium/tests/dragAndDrop.EventTimelinePremium.test.tsx`
- TypeScript checks for both internals packages
- `pnpm eslint`
- `pnpm prettier`
- `pnpm proptypes`
- `pnpm docs:api`

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).