### PR TITLE
[scheduler] Index timeline occurrences by position

### DIFF
--- a/packages/x-scheduler-premium/package.json
+++ b/packages/x-scheduler-premium/package.json
@@ -48,8 +48,9 @@
   ],
   "scripts": {
     "typescript": "tsgo -p tsconfig.json",
-    "build": "code-infra build --tsgo --copy \"src/**/*.css\" --copy \"src/**/*.css:esm\"",
-    "prebuild": "rimraf build tsconfig.build.tsbuildinfo"
+    "build": "code-infra build --tsgo --copy \"src/**/*.css\" --copy \"src/**/*.css:esm\" --ignore 'src/**/*.bench.ts'",
+    "prebuild": "rimraf build tsconfig.build.tsbuildinfo",
+    "bench:jsdom": "pnpm vitest bench -c ./vitest.config.jsdom.mts"
   },
   "repository": {
     "type": "git",

--- a/packages/x-scheduler-premium/src/event-timeline-premium/content/EventTimelinePremiumContent.tsx
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/content/EventTimelinePremiumContent.tsx
@@ -39,6 +39,7 @@ import { EventTimelinePremiumHeader } from './timeline-header';
 import type { EventTimelinePremiumContentProps } from './EventTimelinePremiumContent.types';
 import EventTimelinePremiumTitleCell from './timeline-title-cell/EventTimelinePremiumTitleCell';
 import { EventTimelinePremiumEvent } from './timeline-event';
+import { createEventTimelinePremiumOccurrenceIndex } from '../utils/eventTimelinePremiumOccurrenceIndex';
 import { useEventTimelinePremiumStyledContext } from '../EventTimelinePremiumStyledContext';
 import {
   EventTimelinePremiumVirtualizerContext,
@@ -539,12 +540,16 @@ function EventList({
 
         return {
           occurrence,
-          fractionStart: position,
-          fractionEnd: position + duration,
+          start: position,
+          end: position + duration,
         };
       }),
     // The config selector is memoized, so the object identity only changes with its content.
     [adapter, occurrences, config, visiblePositions],
+  );
+  const occurrenceIndex = React.useMemo(
+    () => createEventTimelinePremiumOccurrenceIndex(occurrencesWithFraction),
+    [occurrencesWithFraction],
   );
 
   // Convert virtualizer column range to fraction range
@@ -552,23 +557,20 @@ function EventList({
     renderContext,
     config.tickCount,
   );
+  const visibleOccurrences = occurrenceIndex(visibleStart, visibleEnd);
 
   return (
     <React.Fragment>
-      {occurrencesWithFraction.map(
-        ({ occurrence, fractionStart, fractionEnd }) =>
-          fractionEnd > visibleStart &&
-          fractionStart < visibleEnd && (
-            <EventEditingTrigger key={occurrence.key} occurrence={occurrence}>
-              <EventTimelinePremiumEvent
-                occurrence={occurrence}
-                ariaLabelledBy={`${schedulerId}-EventTimelinePremiumTitleCell-${resourceId}`}
-                variant="regular"
-                resourceId={resourceId}
-              />
-            </EventEditingTrigger>
-          ),
-      )}
+      {visibleOccurrences.map(({ occurrence }) => (
+        <EventEditingTrigger key={occurrence.key} occurrence={occurrence}>
+          <EventTimelinePremiumEvent
+            occurrence={occurrence}
+            ariaLabelledBy={`${schedulerId}-EventTimelinePremiumTitleCell-${resourceId}`}
+            variant="regular"
+            resourceId={resourceId}
+          />
+        </EventEditingTrigger>
+      ))}
     </React.Fragment>
   );
 }

--- a/packages/x-scheduler-premium/src/event-timeline-premium/utils/eventTimelinePremiumOccurrenceIndex.bench.ts
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/utils/eventTimelinePremiumOccurrenceIndex.bench.ts
@@ -1,0 +1,32 @@
+import { bench, describe } from 'vitest';
+import { createEventTimelinePremiumOccurrenceIndex } from './eventTimelinePremiumOccurrenceIndex';
+
+const occurrenceCount = 50_000;
+const occurrences = Array.from({ length: occurrenceCount }, (_, index) => ({
+  id: index,
+  start: index / occurrenceCount,
+  end: (index + 1) / occurrenceCount,
+}));
+const start = 0.5;
+const end = 0.51;
+const occurrenceIndex = createEventTimelinePremiumOccurrenceIndex(occurrences);
+export const benchmarkResult = { value: undefined as unknown };
+
+describe('event timeline horizontal window lookup', () => {
+  bench('build an index of 50k occurrences', () => {
+    const index = createEventTimelinePremiumOccurrenceIndex(occurrences);
+    benchmarkResult.value = index(start, end).length;
+  });
+
+  bench('linear scan of 50k occurrences', () => {
+    const result = occurrences.filter(
+      (occurrence) => occurrence.end > start && occurrence.start < end,
+    );
+    benchmarkResult.value = result.length;
+  });
+
+  bench('indexed lookup of 50k occurrences', () => {
+    const result = occurrenceIndex(start, end);
+    benchmarkResult.value = result.length;
+  });
+});

--- a/packages/x-scheduler-premium/src/event-timeline-premium/utils/eventTimelinePremiumOccurrenceIndex.test.ts
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/utils/eventTimelinePremiumOccurrenceIndex.test.ts
@@ -1,0 +1,56 @@
+import { createEventTimelinePremiumOccurrenceIndex } from './eventTimelinePremiumOccurrenceIndex';
+
+interface TestOccurrence {
+  id: number;
+  start: number;
+  end: number;
+}
+
+function createOccurrence(id: number, position: number, duration: number): TestOccurrence {
+  return { id, start: position, end: position + duration };
+}
+
+describe('createEventTimelinePremiumOccurrenceIndex', () => {
+  it('should find intersecting occurrences and preserve their order', () => {
+    const occurrences = [
+      createOccurrence(1, 0, 0.25),
+      createOccurrence(2, 0.1, 0.7),
+      createOccurrence(3, 0.3, 0.1),
+      createOccurrence(4, 0.5, 0.1),
+    ];
+    const index = createEventTimelinePremiumOccurrenceIndex(occurrences);
+
+    expect(index(0.25, 0.5).map((occurrence) => occurrence.id)).to.deep.equal([2, 3]);
+  });
+
+  it('should handle empty and invalid ranges', () => {
+    const index = createEventTimelinePremiumOccurrenceIndex([createOccurrence(1, 0.2, 0.1)]);
+
+    expect(index(0.5, 0.5)).to.deep.equal([]);
+    expect(index(0.6, 0.5)).to.deep.equal([]);
+    expect(createEventTimelinePremiumOccurrenceIndex<TestOccurrence>([])(0, 1)).to.deep.equal([]);
+  });
+
+  it('should match a linear scan', () => {
+    let seed = 1;
+    const random = () => {
+      seed = (seed * 1_664_525 + 1_013_904_223) % 2 ** 32;
+      return seed / 2 ** 32;
+    };
+    const occurrences = Array.from({ length: 1_000 }, (_, id) => {
+      const position = random();
+      return createOccurrence(id, position, random() * 0.2);
+    }).sort((a, b) => a.start - b.start);
+    const index = createEventTimelinePremiumOccurrenceIndex(occurrences);
+
+    for (let query = 0; query < 200; query += 1) {
+      const start = random();
+      const end = start + random() * 0.1;
+      const expected = occurrences.filter(
+        (occurrence) => occurrence.end > start && occurrence.start < end,
+      );
+
+      expect(index(start, end)).to.deep.equal(expected);
+    }
+  });
+});

--- a/packages/x-scheduler-premium/src/event-timeline-premium/utils/eventTimelinePremiumOccurrenceIndex.test.ts
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/utils/eventTimelinePremiumOccurrenceIndex.test.ts
@@ -31,6 +31,14 @@ describe('createEventTimelinePremiumOccurrenceIndex', () => {
     expect(createEventTimelinePremiumOccurrenceIndex<TestOccurrence>([])(0, 1)).to.deep.equal([]);
   });
 
+  it('should throw in development when occurrences are not sorted by start position', () => {
+    const occurrences = [createOccurrence(1, 0.2, 0.1), createOccurrence(2, 0.1, 0.1)];
+
+    expect(() => createEventTimelinePremiumOccurrenceIndex(occurrences)).to.throw(
+      /items that are not sorted by start position/,
+    );
+  });
+
   it('should match a linear scan', () => {
     let seed = 1;
     const random = () => {

--- a/packages/x-scheduler-premium/src/event-timeline-premium/utils/eventTimelinePremiumOccurrenceIndex.ts
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/utils/eventTimelinePremiumOccurrenceIndex.ts
@@ -1,0 +1,54 @@
+/**
+ * Builds an interval index for items sorted by their start position.
+ */
+export function createEventTimelinePremiumOccurrenceIndex<T extends { start: number; end: number }>(
+  items: readonly T[],
+) {
+  let leafCount = 1;
+  while (leafCount < items.length) {
+    leafCount *= 2;
+  }
+
+  const maxEndByNode = new Float64Array(leafCount * 2);
+  for (let index = 0; index < items.length; index += 1) {
+    maxEndByNode[leafCount + index] = items[index].end;
+  }
+  for (let node = leafCount - 1; node > 0; node -= 1) {
+    maxEndByNode[node] = Math.max(maxEndByNode[node * 2], maxEndByNode[node * 2 + 1]);
+  }
+
+  return function getOccurrencesInRange(start: number, end: number) {
+    if (start >= end || items.length === 0) {
+      return [];
+    }
+
+    let firstExcludedIndex = 0;
+    let upperBound = items.length;
+    while (firstExcludedIndex < upperBound) {
+      const middle = Math.floor((firstExcludedIndex + upperBound) / 2);
+      if (items[middle].start < end) {
+        firstExcludedIndex = middle + 1;
+      } else {
+        upperBound = middle;
+      }
+    }
+
+    const result: T[] = [];
+    const visitNode = (node: number, firstIndex: number, lastIndex: number) => {
+      if (firstIndex >= firstExcludedIndex || maxEndByNode[node] <= start) {
+        return;
+      }
+      if (lastIndex - firstIndex === 1) {
+        result.push(items[firstIndex]);
+        return;
+      }
+
+      const middle = (firstIndex + lastIndex) / 2;
+      visitNode(node * 2, firstIndex, middle);
+      visitNode(node * 2 + 1, middle, lastIndex);
+    };
+
+    visitNode(1, 0, leafCount);
+    return result;
+  };
+}

--- a/packages/x-scheduler-premium/src/event-timeline-premium/utils/eventTimelinePremiumOccurrenceIndex.ts
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/utils/eventTimelinePremiumOccurrenceIndex.ts
@@ -4,6 +4,20 @@
 export function createEventTimelinePremiumOccurrenceIndex<T extends { start: number; end: number }>(
   items: readonly T[],
 ) {
+  if (process.env.NODE_ENV !== 'production') {
+    for (let index = 1; index < items.length; index += 1) {
+      if (items[index - 1].start > items[index].start) {
+        // TODO: fix mui/no-guarded-throw
+        // eslint-disable-next-line mui/no-guarded-throw
+        throw new Error(
+          `MUI X Scheduler: The timeline occurrence index received items that are not sorted by start position.
+The index uses this order to find visible occurrences, so unsorted items can disappear while scrolling.
+Sort the items by start position before building the index.`,
+        );
+      }
+    }
+  }
+
   let leafCount = 1;
   while (leafCount < items.length) {
     leafCount *= 2;

--- a/packages/x-scheduler-premium/tsconfig.build.json
+++ b/packages/x-scheduler-premium/tsconfig.build.json
@@ -20,5 +20,5 @@
     { "path": "../x-virtualizer/tsconfig.build.json" }
   ],
   "include": ["src/**/*.ts*"],
-  "exclude": ["src/**/*.spec.ts*", "src/**/*.test.ts*", "src/**/tests/**/*"]
+  "exclude": ["src/**/*.spec.ts*", "src/**/*.test.ts*", "src/**/*.bench.ts*", "src/**/tests/**/*"]
 }


### PR DESCRIPTION
## Summary

- build a max-end interval index when a timeline row's positioned occurrences change
- replace the full occurrence scan on every horizontal scroll update with an indexed query
- preserve the existing strict edge intersection behavior and occurrence order
- add boundary, randomized equivalence, integration, and benchmark coverage

This PR is based directly on the latest `master`. It is complementary to #23366; after that PR lands, the index can move from `EventList` into its shared per-resource layout during a small localized rebase.

## Benchmark

Synthetic workload: query a 1% horizontal window among 50,000 positioned occurrences.

| Scenario | Mean | Throughput |
| --- | ---: | ---: |
| Build index | 0.5208 ms | 1,920 ops/s |
| Linear scan | 0.3682 ms | 2,716 ops/s |
| Indexed lookup | 0.0092 ms | 108,515 ops/s |

The indexed lookup is **39.96x faster** than the linear scan. Index construction occurs when positioned occurrences change, not during scrolling.

Run the benchmark with:

```bash
pnpm --filter @mui/x-scheduler-premium bench:jsdom --run src/event-timeline-premium/utils/eventTimelinePremiumOccurrenceIndex.bench.ts
```

## Tests

- `pnpm test:unit --project x-scheduler-premium --run packages/x-scheduler-premium/src/event-timeline-premium/utils/eventTimelinePremiumOccurrenceIndex.test.ts packages/x-scheduler-premium/src/event-timeline-premium/EventTimelinePremium.test.tsx`
- `pnpm --filter @mui/x-scheduler-premium typescript`
- focused ESLint and Prettier checks
- `pnpm proptypes`
- `pnpm docs:api`
