### PR TITLE
[docs][charts] Document line mark size customization

### DIFF
--- a/docs/data/charts/lines/MarkSize.js
+++ b/docs/data/charts/lines/MarkSize.js
@@ -1,0 +1,82 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import MenuItem from '@mui/material/MenuItem';
+import Slider from '@mui/material/Slider';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import { HighlightedCode } from '@mui/internal-core-docs/HighlightedCode';
+import { LineChart, lineClasses } from '@mui/x-charts/LineChart';
+
+const shapes = ['circle', 'cross', 'diamond', 'square', 'star', 'triangle', 'wye'];
+
+export default function MarkSize() {
+  const [shape, setShape] = React.useState('circle');
+  const [radius, setRadius] = React.useState(5);
+  const [scale, setScale] = React.useState(1);
+
+  const isCircle = shape === 'circle';
+  const markStyle = isCircle ? { r: radius } : { scale: `${scale}` };
+
+  const code = `<LineChart
+  series={[{ data: [...], showMark: true, shape: '${shape}' }]}
+  sx={{
+    [\`& .\${lineClasses.mark}\`]: {
+      ${isCircle ? `r: ${radius}` : `scale: '${scale}'`},
+    },
+  }}
+/>`;
+
+  return (
+    <Box sx={{ p: 2, width: '100%', maxWidth: 600 }}>
+      <Stack direction="row" spacing={3} sx={{ alignItems: 'center', mb: 1 }}>
+        <TextField
+          select
+          label="shape"
+          value={shape}
+          sx={{ minWidth: 140 }}
+          onChange={(event) => setShape(event.target.value)}
+        >
+          {shapes.map((option) => (
+            <MenuItem key={option} value={option}>
+              {option}
+            </MenuItem>
+          ))}
+        </TextField>
+        <Stack sx={{ flex: 1 }}>
+          <Typography id="mark-size" gutterBottom>
+            {isCircle ? 'radius' : 'scale'}
+          </Typography>
+          {isCircle ? (
+            <Slider
+              aria-labelledby="mark-size"
+              value={radius}
+              onChange={(event, value) => setRadius(value)}
+              valueLabelDisplay="auto"
+              min={1}
+              max={12}
+              step={1}
+            />
+          ) : (
+            <Slider
+              aria-labelledby="mark-size"
+              value={scale}
+              onChange={(event, value) => setScale(value)}
+              valueLabelDisplay="auto"
+              min={0.5}
+              max={3}
+              step={0.1}
+            />
+          )}
+        </Stack>
+      </Stack>
+      <LineChart
+        xAxis={[{ data: [1, 2, 3, 5, 8, 10] }]}
+        series={[{ data: [2, 5.5, 2, 8.5, 1.5, 5], showMark: true, shape }]}
+        height={250}
+        sx={{ [`& .${lineClasses.mark}`]: markStyle }}
+      />
+      <HighlightedCode code={code} language="tsx" />
+    </Box>
+  );
+}

--- a/docs/data/charts/lines/MarkSize.js
+++ b/docs/data/charts/lines/MarkSize.js
@@ -12,8 +12,8 @@ const shapes = ['circle', 'cross', 'diamond', 'square', 'star', 'triangle', 'wye
 
 export default function MarkSize() {
   const [shape, setShape] = React.useState('circle');
-  const [radius, setRadius] = React.useState(5);
-  const [scale, setScale] = React.useState(1);
+  const [radius, setRadius] = React.useState(6);
+  const [scale, setScale] = React.useState(1.2);
 
   const isCircle = shape === 'circle';
   const markStyle = isCircle ? { r: radius } : { scale: `${scale}` };

--- a/docs/data/charts/lines/MarkSize.tsx
+++ b/docs/data/charts/lines/MarkSize.tsx
@@ -22,8 +22,8 @@ const shapes: Shape[] = [
 
 export default function MarkSize() {
   const [shape, setShape] = React.useState<Shape>('circle');
-  const [radius, setRadius] = React.useState(5);
-  const [scale, setScale] = React.useState(1);
+  const [radius, setRadius] = React.useState(6);
+  const [scale, setScale] = React.useState(1.2);
 
   const isCircle = shape === 'circle';
   const markStyle = isCircle ? { r: radius } : { scale: `${scale}` };

--- a/docs/data/charts/lines/MarkSize.tsx
+++ b/docs/data/charts/lines/MarkSize.tsx
@@ -1,0 +1,92 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import MenuItem from '@mui/material/MenuItem';
+import Slider from '@mui/material/Slider';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import { HighlightedCode } from '@mui/internal-core-docs/HighlightedCode';
+import { LineChart, lineClasses } from '@mui/x-charts/LineChart';
+
+type Shape = 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye';
+
+const shapes: Shape[] = [
+  'circle',
+  'cross',
+  'diamond',
+  'square',
+  'star',
+  'triangle',
+  'wye',
+];
+
+export default function MarkSize() {
+  const [shape, setShape] = React.useState<Shape>('circle');
+  const [radius, setRadius] = React.useState(5);
+  const [scale, setScale] = React.useState(1);
+
+  const isCircle = shape === 'circle';
+  const markStyle = isCircle ? { r: radius } : { scale: `${scale}` };
+
+  const code = `<LineChart
+  series={[{ data: [...], showMark: true, shape: '${shape}' }]}
+  sx={{
+    [\`& .\${lineClasses.mark}\`]: {
+      ${isCircle ? `r: ${radius}` : `scale: '${scale}'`},
+    },
+  }}
+/>`;
+
+  return (
+    <Box sx={{ p: 2, width: '100%', maxWidth: 600 }}>
+      <Stack direction="row" spacing={3} sx={{ alignItems: 'center', mb: 1 }}>
+        <TextField
+          select
+          label="shape"
+          value={shape}
+          sx={{ minWidth: 140 }}
+          onChange={(event) => setShape(event.target.value as Shape)}
+        >
+          {shapes.map((option) => (
+            <MenuItem key={option} value={option}>
+              {option}
+            </MenuItem>
+          ))}
+        </TextField>
+        <Stack sx={{ flex: 1 }}>
+          <Typography id="mark-size" gutterBottom>
+            {isCircle ? 'radius' : 'scale'}
+          </Typography>
+          {isCircle ? (
+            <Slider
+              aria-labelledby="mark-size"
+              value={radius}
+              onChange={(event, value) => setRadius(value as number)}
+              valueLabelDisplay="auto"
+              min={1}
+              max={12}
+              step={1}
+            />
+          ) : (
+            <Slider
+              aria-labelledby="mark-size"
+              value={scale}
+              onChange={(event, value) => setScale(value as number)}
+              valueLabelDisplay="auto"
+              min={0.5}
+              max={3}
+              step={0.1}
+            />
+          )}
+        </Stack>
+      </Stack>
+      <LineChart
+        xAxis={[{ data: [1, 2, 3, 5, 8, 10] }]}
+        series={[{ data: [2, 5.5, 2, 8.5, 1.5, 5], showMark: true, shape }]}
+        height={250}
+        sx={{ [`& .${lineClasses.mark}`]: markStyle }}
+      />
+      <HighlightedCode code={code} language="tsx" />
+    </Box>
+  );
+}

--- a/docs/data/charts/lines/lines.md
+++ b/docs/data/charts/lines/lines.md
@@ -308,6 +308,16 @@ The next example shows how to apply a dashed stroke to the chart line, legend ma
 
 {{"demo": "StyledLineChart.js"}}
 
+#### Mark size
+
+Neither the line series nor the `mark` slot accepts a size property, so you set the mark size with CSS on the `lineClasses.mark` class.
+
+The default `'circle'` shape renders an SVG `circle` element, so use the `r` (radius) property, which defaults to `5`.
+The other shapes render an SVG `path` element that `r` does not affect.
+For those, use the `scale` property, which resizes the mark around its own center.
+
+{{"demo": "MarkSize.js"}}
+
 ## Animation
 
 Chart containers respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@media/prefers-reduced-motion), but you can also disable animations manually by setting the `skipAnimation` prop to `true`.


### PR DESCRIPTION
Closes #20742.

The Lines page never explained how to resize the marks. Follow-up to the discussion in #20721, where the suggested `markElementClasses.root` selector does not work for the default `'circle'` shape.

Verified against the source and in a browser test:

- There is no size property on the line series (`markerSize` only exists on scatter series) and no usable one on the `mark` slot: `CircleMarkElement` hardcodes `r={5}` after the prop spread, and `MarkElement` builds its `d` attribute from a fixed-size d3 symbol, so `slotProps.mark` cannot change either.
- CSS on `lineClasses.mark` does work: `r` for the default `'circle'` shape, and `scale` for the `path`-based shapes, which keeps the mark centered on its data point. `r` has no effect on paths, and `scale` shifts circles off their data point, so the two are not interchangeable.

Adds a `Mark size` subsection to the CSS section, plus a playground demo that switches between shapes and prints the matching `sx` snippet.
