### PR TITLE
[charts] Announce the visible zoom range to screen readers

### DIFF
--- a/docs/data/charts/accessibility/accessibility.md
+++ b/docs/data/charts/accessibility/accessibility.md
@@ -114,6 +114,7 @@ Charts with zoom enabled accept keyboard zoom and pan, so a keyboard-only user c
 
 While the chart is focused, <kbd class="key">+</kbd> and <kbd class="key">-</kbd> zoom, <kbd class="key">0</kbd> resets the zoom, and <kbd class="key">Shift</kbd>+ arrow keys pan.
 The arrow keys keep moving the focus between items when pressed without <kbd class="key">Shift</kbd>.
+The visible range is announced in a live region each time it changes from the keyboard.
 
 See [Keyboard zoom and pan](/x/react-charts/zoom-and-pan/#keyboard-zoom-and-pan) for the complete list of keys and the interaction configuration.
 

--- a/docs/data/charts/localization/data.json
+++ b/docs/data/charts/localization/data.json
@@ -3,48 +3,48 @@
     "languageTag": "fr-FR",
     "importName": "frFR",
     "localeName": "French",
-    "missingKeysCount": 18,
-    "totalKeysCount": 120,
+    "missingKeysCount": 19,
+    "totalKeysCount": 121,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-charts/src/locales/frFR.ts"
   },
   {
     "languageTag": "el-GR",
     "importName": "elGR",
     "localeName": "Greek",
-    "missingKeysCount": 17,
-    "totalKeysCount": 120,
+    "missingKeysCount": 18,
+    "totalKeysCount": 121,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-charts/src/locales/elGR.ts"
   },
   {
     "languageTag": "nb-NO",
     "importName": "nbNO",
     "localeName": "Norwegian (Bokmål)",
-    "missingKeysCount": 17,
-    "totalKeysCount": 120,
+    "missingKeysCount": 18,
+    "totalKeysCount": 121,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-charts/src/locales/nbNO.ts"
   },
   {
     "languageTag": "pt-PT",
     "importName": "ptPT",
     "localeName": "Portuguese",
-    "missingKeysCount": 13,
-    "totalKeysCount": 120,
+    "missingKeysCount": 14,
+    "totalKeysCount": 121,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-charts/src/locales/ptPT.ts"
   },
   {
     "languageTag": "pt-BR",
     "importName": "ptBR",
     "localeName": "Portuguese (Brazil)",
-    "missingKeysCount": 17,
-    "totalKeysCount": 120,
+    "missingKeysCount": 18,
+    "totalKeysCount": 121,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-charts/src/locales/ptBR.ts"
   },
   {
     "languageTag": "sv-SE",
     "importName": "svSE",
     "localeName": "Swedish",
-    "missingKeysCount": 113,
-    "totalKeysCount": 120,
+    "missingKeysCount": 114,
+    "totalKeysCount": 121,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-charts/src/locales/svSE.ts"
   }
 ]

--- a/docs/data/charts/zoom-and-pan/zoom-and-pan.md
+++ b/docs/data/charts/zoom-and-pan/zoom-and-pan.md
@@ -276,6 +276,9 @@ The keys require [keyboard navigation](/x/react-charts/accessibility/#keyboard-s
 Charts rendered with `disableKeyboardNavigation` have no keyboard zoom.
 :::
 
+The visible range is announced to screen readers each time it changes from the keyboard.
+A zoom coming from the pointer or from the application is not announced, because it is not the user driving the chart from the keyboard.
+
 {{"demo": "ZoomKeyboard.js"}}
 
 ### Key modifiers

--- a/docs/data/charts/zoom-and-pan/zoom-and-pan.md
+++ b/docs/data/charts/zoom-and-pan/zoom-and-pan.md
@@ -277,6 +277,7 @@ Charts rendered with `disableKeyboardNavigation` have no keyboard zoom.
 :::
 
 The visible range is announced to screen readers each time it changes from the keyboard.
+The default message reads `Showing 5% to 95% of the horizontal axis`, and can be customized with the `zoomRangeDescription` [localization key](/x/react-charts/localization/#localize-text).
 A zoom coming from the pointer or from the application is not announced, because it is not the user driving the chart from the keyboard.
 
 {{"demo": "ZoomKeyboard.js"}}

--- a/packages/x-charts-pro/src/internals/plugins/useChartProZoom/gestureHooks/usePanOnKeyboard.ts
+++ b/packages/x-charts-pro/src/internals/plugins/useChartProZoom/gestureHooks/usePanOnKeyboard.ts
@@ -54,6 +54,8 @@ export const usePanOnKeyboard = (
       setZoomDataCallback((prev) =>
         translateZoom(prev, movement, drawingArea, optionsLookup, direction.x === 0 ? 'y' : 'x'),
       );
+
+      instance.announceZoomChange?.();
     },
   });
 };

--- a/packages/x-charts-pro/src/internals/plugins/useChartProZoom/gestureHooks/useZoomOnKeyboard.ts
+++ b/packages/x-charts-pro/src/internals/plugins/useChartProZoom/gestureHooks/useZoomOnKeyboard.ts
@@ -55,6 +55,8 @@ export const useZoomOnKeyboard = (
           );
         }),
       );
+
+      instance.announceZoomChange?.();
     },
   });
 };

--- a/packages/x-charts-pro/src/internals/plugins/useChartProZoom/zoomAnnouncement.test.tsx
+++ b/packages/x-charts-pro/src/internals/plugins/useChartProZoom/zoomAnnouncement.test.tsx
@@ -1,0 +1,123 @@
+import { act, createRenderer, fireEvent } from '@mui/internal-test-utils';
+import * as React from 'react';
+import { vi, describe, it, expect } from 'vitest';
+import { BarChartPro } from '@mui/x-charts-pro/BarChartPro';
+import { chartsSvgLayerClasses } from '../../../ChartsSvgLayer';
+
+describe('zoom range announcement', () => {
+  const { render } = createRenderer();
+
+  const barChartProps = {
+    series: [{ id: 'A', data: [10, 20, 30, 40] }],
+    xAxis: [{ id: 'x', data: ['A', 'B', 'C', 'D'], zoom: true, height: 30 }],
+    yAxis: [{ position: 'none' as const }],
+    width: 100,
+    height: 130,
+    margin: 0,
+    hideLegend: true,
+    skipAnimation: true,
+    slotProps: { tooltip: { trigger: 'none' as const } },
+  };
+
+  const options = {
+    wrapper: ({ children }: { children?: React.ReactNode }) => (
+      <div style={{ width: 100, height: 130 }}>{children}</div>
+    ),
+  };
+
+  const getLiveRegion = (container: HTMLElement) =>
+    container.querySelector<HTMLElement>('[role="status"]')!;
+
+  const wheelZoom = async (
+    container: HTMLElement,
+    user: ReturnType<typeof render>['user'],
+    onZoomChange: ReturnType<typeof vi.fn>,
+  ) => {
+    const layerContainer = container.querySelector<HTMLElement>(
+      `.${chartsSvgLayerClasses.root}`,
+    )!.parentElement!;
+
+    await user.pointer([{ target: layerContainer, coords: { x: 50, y: 50 } }]);
+
+    const callsBefore = onZoomChange.mock.calls.length;
+    fireEvent.wheel(layerContainer, { deltaY: -30, clientX: 50, clientY: 50 });
+    await act(
+      async () =>
+        new Promise((resolve) => {
+          requestAnimationFrame(resolve);
+        }),
+    );
+
+    // The rest of the test only means something if the wheel did zoom.
+    expect(onZoomChange.mock.calls.length).to.be.greaterThan(callsBefore);
+  };
+
+  it('should announce the visible range after a keyboard zoom', async () => {
+    const { user, container } = render(
+      <BarChartPro {...barChartProps} initialZoom={[{ axisId: 'x', start: 20, end: 70 }]} />,
+      options,
+    );
+
+    const liveRegion = getLiveRegion(container);
+    expect(liveRegion).not.to.equal(null);
+    expect(liveRegion.getAttribute('aria-live')).to.equal('polite');
+    // Nothing is announced before the user interacts with the zoom.
+    expect(liveRegion.textContent).to.equal('');
+
+    await user.keyboard('{Tab}');
+    await user.keyboard('{Shift>}{ArrowRight}{/Shift}');
+
+    expect(liveRegion.textContent).to.equal('Showing 25% to 75% of the horizontal axis');
+  });
+
+  it('should stop announcing once the chart loses focus', async () => {
+    const { user, container } = render(
+      <div>
+        <BarChartPro {...barChartProps} />
+        <button type="button">outside</button>
+      </div>,
+      options,
+    );
+
+    const liveRegion = getLiveRegion(container);
+
+    await user.keyboard('{Tab}');
+    await user.keyboard('+');
+    expect(liveRegion.textContent).to.equal('Showing 5% to 95% of the horizontal axis');
+
+    await user.click(container.querySelector('button')!);
+    expect(liveRegion.textContent).to.equal('');
+  });
+
+  it('should not announce a zoom coming from the pointer', async () => {
+    const onZoomChange = vi.fn();
+    const { container, user } = render(
+      <BarChartPro {...barChartProps} onZoomChange={onZoomChange} />,
+      options,
+    );
+
+    await wheelZoom(container, user, onZoomChange);
+
+    expect(getLiveRegion(container).textContent).to.equal('');
+  });
+
+  it('should not keep announcing the pointer zoom that follows a keyboard zoom', async () => {
+    const onZoomChange = vi.fn();
+    const { user, container } = render(
+      <BarChartPro {...barChartProps} onZoomChange={onZoomChange} />,
+      options,
+    );
+
+    const liveRegion = getLiveRegion(container);
+
+    await user.keyboard('{Tab}');
+    await user.keyboard('+');
+    const announced = liveRegion.textContent;
+    expect(announced).to.equal('Showing 5% to 95% of the horizontal axis');
+
+    // The keyboard asks for the announcement, so the wheel must not rewrite it.
+    await wheelZoom(container, user, onZoomChange);
+
+    expect(liveRegion.textContent).to.equal(announced);
+  });
+});

--- a/packages/x-charts/src/internals/components/ChartsAccessibilityProxy/ChartsAccessibilityProxy.tsx
+++ b/packages/x-charts/src/internals/components/ChartsAccessibilityProxy/ChartsAccessibilityProxy.tsx
@@ -4,6 +4,7 @@ import useForkRef from '@mui/utils/useForkRef';
 import { useChartId } from '../../../hooks/useChartId';
 import { useChartsContext } from '../../../context/ChartsProvider';
 import { useDescription } from './useDescription';
+import { useZoomAnnouncement } from './useZoomAnnouncement';
 
 /**
  * Make the proxy looks like a layer.
@@ -21,6 +22,19 @@ const fullSizeLayerStyle: React.CSSProperties = {
   pointerEvents: 'none',
 };
 
+/**
+ * Keeps the live region out of sight without removing it from the accessibility tree.
+ */
+const liveRegionStyle: React.CSSProperties = {
+  position: 'absolute',
+  width: 1,
+  height: 1,
+  overflow: 'hidden',
+  clipPath: 'inset(50%)',
+  whiteSpace: 'nowrap',
+  pointerEvents: 'none',
+};
+
 // The proxy is implemented by having two divs with the same content, and toggling the visibility of each one when the content changes.
 // The idea is to imitate the behavior of the focus moving from a list element to another, but with the minimal number of DOM elements.
 
@@ -30,6 +44,7 @@ const fullSizeLayerStyle: React.CSSProperties = {
  */
 export function ChartsAccessibilityProxy() {
   const message = useDescription();
+  const zoomMessage = useZoomAnnouncement();
   const chartId = useChartId();
 
   const { instance } = useChartsContext();
@@ -113,13 +128,19 @@ export function ChartsAccessibilityProxy() {
   }, [message, chartId]);
 
   return (
-    <div
-      role="none"
-      // Stays focusable once an announcer child owns the tab stop, otherwise the browser would
-      // blur the root mid hand-off and the chart would look like it lost the focus.
-      tabIndex={message ? -1 : 0}
-      ref={handleRef}
-      style={fullSizeLayerStyle}
-    />
+    <React.Fragment>
+      <div
+        role="none"
+        // Stays focusable once an announcer child owns the tab stop, otherwise the browser would
+        // blur the root mid hand-off and the chart would look like it lost the focus.
+        tabIndex={message ? -1 : 0}
+        ref={handleRef}
+        style={fullSizeLayerStyle}
+      />
+      {/* The zoom range does not move the focus, so it is announced with a live region instead of the proxy. */}
+      <div role="status" aria-live="polite" aria-atomic="true" style={liveRegionStyle}>
+        {zoomMessage}
+      </div>
+    </React.Fragment>
   );
 }

--- a/packages/x-charts/src/internals/components/ChartsAccessibilityProxy/useZoomAnnouncement.ts
+++ b/packages/x-charts/src/internals/components/ChartsAccessibilityProxy/useZoomAnnouncement.ts
@@ -1,0 +1,67 @@
+'use client';
+import * as React from 'react';
+import { useChartsLocalization } from '../../../hooks';
+import { useStore } from '../../store/useStore';
+import { selectorChartsZoomAnnouncement } from '../../plugins/featurePlugins/useChartKeyboardNavigation';
+import {
+  selectorChartZoomMap,
+  selectorChartZoomOptionsLookup,
+} from '../../plugins/featurePlugins/useChartCartesianAxis';
+
+/**
+ * Get the message announcing the visible range of the zoomable axes.
+ *
+ * The message is taken when the keyboard zoom and pan asks for it, not derived from the zoom
+ * itself: the zoom also moves on wheel, drag, and from the application, and the live region must
+ * stay silent then.
+ * @returns {string | null} the message to announce, or `null` when there is nothing to announce
+ */
+export function useZoomAnnouncement(): string | null {
+  const store = useStore();
+  const announcement = store.use(selectorChartsZoomAnnouncement);
+  const zoomMap = store.use(selectorChartZoomMap);
+  const optionsLookup = store.use(selectorChartZoomOptionsLookup);
+  const { localeText } = useChartsLocalization();
+
+  const [message, setMessage] = React.useState<string | null>(null);
+
+  // The announcement is written from the values of the render the request lands on, so a later
+  // zoom coming from elsewhere does not rewrite the live region.
+  const currentValuesRef = React.useRef({ zoomMap, optionsLookup, localeText });
+  currentValuesRef.current = { zoomMap, optionsLookup, localeText };
+
+  React.useEffect(() => {
+    if (announcement === 0) {
+      setMessage(null);
+      return;
+    }
+
+    const current = currentValuesRef.current;
+
+    if (!current.zoomMap) {
+      return;
+    }
+
+    const descriptions = Object.values(current.optionsLookup)
+      .map((options) => {
+        const zoomData = current.zoomMap!.get(options.axisId);
+
+        if (!zoomData) {
+          return null;
+        }
+
+        return current.localeText.zoomRangeDescription({
+          axisDirection: options.axisDirection,
+          start: zoomData.start,
+          end: zoomData.end,
+        });
+      })
+      .filter(Boolean);
+
+    setMessage(
+      descriptions.length === 0 ? null : descriptions.join(current.localeText.a11yConnector),
+    );
+  }, [announcement]);
+
+  return message;
+}

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.selectors.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.selectors.ts
@@ -62,6 +62,11 @@ export const selectorChartsFocusedOrToFocusedItem = createSelector(
   (keyboardNavigationState) => keyboardNavigationState?.item ?? null,
 );
 
+export const selectorChartsZoomAnnouncement = createSelector(
+  selectKeyboardNavigation,
+  (keyboardNavigationState) => keyboardNavigationState?.zoomAnnouncement ?? 0,
+);
+
 export const selectorChartsIsKeyboardNavigationEnabled = createSelector(
   selectKeyboardNavigation,
   (keyboardNavigationState) => !!keyboardNavigationState?.enabled,

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.ts
@@ -234,6 +234,13 @@ export const useChartKeyboardNavigation: ChartPlugin<UseChartKeyboardNavigationS
   const activationRegistrationsRef = React.useRef(new Map<number, ItemActivationRegistration>());
   const nextRegistrationIdRef = React.useRef(0);
 
+  const announceZoomChange = React.useCallback(() => {
+    store.set('keyboardNavigation', {
+      ...store.state.keyboardNavigation,
+      zoomAnnouncement: store.state.keyboardNavigation.zoomAnnouncement + 1,
+    });
+  }, [store]);
+
   const registerItemActivationHandler = React.useCallback(
     (scope: ItemActivationScope, handler: ItemActivationHandler) => {
       const registrationId = nextRegistrationIdRef.current;
@@ -267,11 +274,14 @@ export const useChartKeyboardNavigation: ChartPlugin<UseChartKeyboardNavigationS
         return;
       }
 
-      if (store.state.keyboardNavigation.isFocused) {
+      const keyboardNavigation = store.state.keyboardNavigation;
+      if (keyboardNavigation.isFocused || keyboardNavigation.zoomAnnouncement > 0) {
         store.set('keyboardNavigation', {
-          ...store.state.keyboardNavigation,
+          ...keyboardNavigation,
           isFocused: false,
           isFocusVisible: false,
+          // The visible range is only announced while the user operates the chart.
+          zoomAnnouncement: 0,
         });
       }
     }
@@ -438,7 +448,7 @@ export const useChartKeyboardNavigation: ChartPlugin<UseChartKeyboardNavigationS
     });
   }, [store, params.disableKeyboardNavigation]);
 
-  return { instance: { focusItem, registerItemActivationHandler } };
+  return { instance: { focusItem, registerItemActivationHandler, announceZoomChange } };
 };
 
 useChartKeyboardNavigation.getInitialState = (params) => ({
@@ -447,6 +457,7 @@ useChartKeyboardNavigation.getInitialState = (params) => ({
     isFocused: false,
     isFocusVisible: false,
     enabled: !params.disableKeyboardNavigation,
+    zoomAnnouncement: 0,
   },
 });
 

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.types.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.types.ts
@@ -68,6 +68,12 @@ export interface UseChartKeyboardNavigationInstance {
     scope: ItemActivationScope,
     handler: ItemActivationHandler,
   ) => () => void;
+  /**
+   * Asks for the visible zoom range to be announced to screen readers.
+   * Called by the plugin owning keyboard zoom and pan, on each change the user makes with the keys.
+   * @returns {void}
+   */
+  announceZoomChange: () => void;
 }
 
 export interface UseChartKeyboardNavigationState {
@@ -89,6 +95,12 @@ export interface UseChartKeyboardNavigationState {
      * Indicates whether keyboard navigation is enabled or not.
      */
     enabled: boolean;
+    /**
+     * Incremented on each zoom change the user makes with the keyboard, and reset when the chart
+     * loses focus. The live region reads the visible range when it changes, so a zoom coming from
+     * the pointer or from the application is not announced.
+     */
+    zoomAnnouncement: number;
   };
 }
 

--- a/packages/x-charts/src/locales/elGR.ts
+++ b/packages/x-charts/src/locales/elGR.ts
@@ -125,6 +125,14 @@ export const elGRLocaleText: Partial<ChartsLocaleText> = {
   // Accessibility descriptions
   // a11yNoValue: 'no value',
   // a11yConnector: '; ',
+  // zoomRangeDescription: function zoomRangeDescription({
+  //   axisDirection,
+  //   start,
+  //   end
+  // }) {
+  //   const axisName = axisDirection === 'x' ? 'horizontal axis' : 'vertical axis';
+  //   return `Showing ${Math.round(start)}% to ${Math.round(end)}% of the ${axisName}`;
+  // },
   // barDescription: function barDescription({
   //   value,
   //   formattedValue,

--- a/packages/x-charts/src/locales/enUS.ts
+++ b/packages/x-charts/src/locales/enUS.ts
@@ -126,6 +126,10 @@ export const enUSLocaleText: ChartsLocaleText = {
   // Accessibility descriptions
   a11yNoValue: 'no value',
   a11yConnector: '; ',
+  zoomRangeDescription: function zoomRangeDescription({ axisDirection, start, end }) {
+    const axisName = axisDirection === 'x' ? 'horizontal axis' : 'vertical axis';
+    return `Showing ${Math.round(start)}% to ${Math.round(end)}% of the ${axisName}`;
+  },
   barDescription: function barDescription({
     value,
     formattedValue,

--- a/packages/x-charts/src/locales/frFR.ts
+++ b/packages/x-charts/src/locales/frFR.ts
@@ -124,6 +124,14 @@ export const frFRLocalText: Partial<ChartsLocaleText> = {
   // Accessibility descriptions
   // a11yNoValue: 'no value',
   // a11yConnector: '; ',
+  // zoomRangeDescription: function zoomRangeDescription({
+  //   axisDirection,
+  //   start,
+  //   end
+  // }) {
+  //   const axisName = axisDirection === 'x' ? 'horizontal axis' : 'vertical axis';
+  //   return `Showing ${Math.round(start)}% to ${Math.round(end)}% of the ${axisName}`;
+  // },
   // barDescription: function barDescription({
   //   value,
   //   formattedValue,

--- a/packages/x-charts/src/locales/nbNO.ts
+++ b/packages/x-charts/src/locales/nbNO.ts
@@ -125,6 +125,14 @@ export const nbNOLocaleText: Partial<ChartsLocaleText> = {
   // Accessibility descriptions
   // a11yNoValue: 'no value',
   // a11yConnector: '; ',
+  // zoomRangeDescription: function zoomRangeDescription({
+  //   axisDirection,
+  //   start,
+  //   end
+  // }) {
+  //   const axisName = axisDirection === 'x' ? 'horizontal axis' : 'vertical axis';
+  //   return `Showing ${Math.round(start)}% to ${Math.round(end)}% of the ${axisName}`;
+  // },
   // barDescription: function barDescription({
   //   value,
   //   formattedValue,

--- a/packages/x-charts/src/locales/ptBR.ts
+++ b/packages/x-charts/src/locales/ptBR.ts
@@ -125,6 +125,14 @@ export const ptBRLocaleText: Partial<ChartsLocaleText> = {
   // Accessibility descriptions
   // a11yNoValue: 'no value',
   // a11yConnector: '; ',
+  // zoomRangeDescription: function zoomRangeDescription({
+  //   axisDirection,
+  //   start,
+  //   end
+  // }) {
+  //   const axisName = axisDirection === 'x' ? 'horizontal axis' : 'vertical axis';
+  //   return `Showing ${Math.round(start)}% to ${Math.round(end)}% of the ${axisName}`;
+  // },
   // barDescription: function barDescription({
   //   value,
   //   formattedValue,

--- a/packages/x-charts/src/locales/ptPT.ts
+++ b/packages/x-charts/src/locales/ptPT.ts
@@ -125,6 +125,14 @@ export const ptPTLocaleText: Partial<ChartsLocaleText> = {
   // Accessibility descriptions
   // a11yNoValue: 'no value',
   // a11yConnector: '; ',
+  // zoomRangeDescription: function zoomRangeDescription({
+  //   axisDirection,
+  //   start,
+  //   end
+  // }) {
+  //   const axisName = axisDirection === 'x' ? 'horizontal axis' : 'vertical axis';
+  //   return `Showing ${Math.round(start)}% to ${Math.round(end)}% of the ${axisName}`;
+  // },
   // barDescription: function barDescription({
   //   value,
   //   formattedValue,

--- a/packages/x-charts/src/locales/svSE.ts
+++ b/packages/x-charts/src/locales/svSE.ts
@@ -125,6 +125,14 @@ export const svSELocaleText: Partial<ChartsLocaleText> = {
   // Accessibility descriptions
   // a11yNoValue: 'no value',
   // a11yConnector: '; ',
+  // zoomRangeDescription: function zoomRangeDescription({
+  //   axisDirection,
+  //   start,
+  //   end
+  // }) {
+  //   const axisName = axisDirection === 'x' ? 'horizontal axis' : 'vertical axis';
+  //   return `Showing ${Math.round(start)}% to ${Math.round(end)}% of the ${axisName}`;
+  // },
   // barDescription: function barDescription({
   //   value,
   //   formattedValue,

--- a/packages/x-charts/src/locales/utils/chartsLocaleTextApi.ts
+++ b/packages/x-charts/src/locales/utils/chartsLocaleTextApi.ts
@@ -447,6 +447,20 @@ export interface ChartsLocaleText {
    */
   a11yConnector: string;
   /**
+   * The description of the visible range of a zoomable axis for accessibility purpose.
+   * It is announced when the user zooms or pans the chart with the keyboard.
+   * @param {object} params - The parameters for the description getter.
+   * @param {'x'|'y'} params.axisDirection - The direction of the zoomed axis.
+   * @param {number} params.start - The start of the visible range, as a percentage of the axis extent.
+   * @param {number} params.end - The end of the visible range, as a percentage of the axis extent.
+   * @returns {string} The localized description of the visible range.
+   */
+  zoomRangeDescription: (params: {
+    axisDirection: 'x' | 'y';
+    start: number;
+    end: number;
+  }) => string;
+  /**
    * The description of a bar series item for accessibility purpose.
    * @param {object} params - The parameters for the description getter.
    * @param {number|null} params.value - The value of the bar item.


### PR DESCRIPTION
Follow-up of #23369, which added the keyboard zoom and pan keys themselves. This PR only adds the screen reader announcement, so the interaction and the announcement can be reviewed separately. #23369 is merged, so this branch is now rebased on `master` and the whole diff is the announcement.

## The problem

Keyboard zoom and pan move the visible window without moving the focus, so nothing tells a screen reader user where the chart now is.

## The change

The accessibility proxy renders a polite live region with the visible range of the zoomable axes, localized with the new `zoomRangeDescription` key:

> Showing 25% to 75% of the horizontal axis

The message is taken when the keyboard gesture asks for it, through a counter carried by the keyboard navigation state, rather than derived from the zoom state. The zoom also moves on wheel, drag, and from the application, and the live region must stay silent then. The counter resets when the chart loses focus, so a pointer zoom after a keyboard zoom does not rewrite the region either, covered by a test.

## Known follow-ups

Not addressed here, deliberately:

- The message enumerates every zoomable axis, so panning x re-announces the unchanged y range, and two zoomable x axes both read as "horizontal axis".
- A key that changes nothing (panning at a boundary, or the vertical arrows on an x-only chart) still asks for an announcement.
