### PR TITLE
[fields] Keep the field editable on blank space clicks

### DIFF
--- a/packages/x-date-pickers/src/DateField/tests/selection.DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/selection.DateField.test.tsx
@@ -336,27 +336,6 @@ describe('<DateField /> - Selection', () => {
       expect(event.defaultPrevented).to.equal(false);
     });
 
-    it('should ignore a `data-sectionindex` ancestor above the field', () => {
-      // `closest` is not bound to the sections container, so an unrelated
-      // ancestor carrying the attribute used to be read as a section. An index
-      // out of range left the field focused with no section to type into.
-      const view = renderWithProps(
-        { enableAccessibleFieldDOMStructure: true },
-        {
-          hook: () => ({}),
-        },
-      );
-      const sectionsContainer = view.getSectionsContainer();
-      const ancestor = sectionsContainer.closest('.MuiFormControl-root')!.parentElement!;
-      ancestor.setAttribute('data-sectionindex', '7');
-
-      fireEvent.mouseDown(sectionsContainer);
-      fireEvent.click(sectionsContainer);
-
-      ancestor.removeAttribute('data-sectionindex');
-      expect(getCleanedSelectedContent()).to.equal('MM');
-    });
-
     it('should forward mousedown to a userland `onMouseDown` consumer', () => {
       const consumer = spy();
       const view = renderWithProps({

--- a/packages/x-date-pickers/src/DateField/tests/selection.DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/selection.DateField.test.tsx
@@ -409,7 +409,7 @@ describe('<DateField /> - Selection', () => {
           </div>,
         );
 
-        const { userEvent } = await import('@vitest/browser/context');
+        const { userEvent } = await import('vitest/browser');
         await userEvent.click(screen.getByTestId('flex-wrapper'));
 
         expect(getCleanedSelectedContent()).to.equal('');

--- a/packages/x-date-pickers/src/DateField/tests/selection.DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/selection.DateField.test.tsx
@@ -336,6 +336,27 @@ describe('<DateField /> - Selection', () => {
       expect(event.defaultPrevented).to.equal(false);
     });
 
+    it('should ignore a `data-sectionindex` ancestor above the field', () => {
+      // `closest` is not bound to the sections container, so an unrelated
+      // ancestor carrying the attribute used to be read as a section. An index
+      // out of range left the field focused with no section to type into.
+      const view = renderWithProps(
+        { enableAccessibleFieldDOMStructure: true },
+        {
+          hook: () => ({}),
+        },
+      );
+      const sectionsContainer = view.getSectionsContainer();
+      const ancestor = sectionsContainer.closest('.MuiFormControl-root')!.parentElement!;
+      ancestor.setAttribute('data-sectionindex', '7');
+
+      fireEvent.mouseDown(sectionsContainer);
+      fireEvent.click(sectionsContainer);
+
+      ancestor.removeAttribute('data-sectionindex');
+      expect(getCleanedSelectedContent()).to.equal('MM');
+    });
+
     it('should forward mousedown to a userland `onMouseDown` consumer', () => {
       const consumer = spy();
       const view = renderWithProps({

--- a/packages/x-date-pickers/src/DateField/tests/selection.DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/selection.DateField.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
+import { spy } from 'sinon';
 import { DateField } from '@mui/x-date-pickers/DateField';
-import { act, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
+import { act, createEvent, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import {
   createPickerRenderer,
   expectFieldValueV7,
@@ -10,6 +11,7 @@ import {
   buildFieldInteractions,
   adapterToUse,
 } from 'test/utils/pickers';
+import { isJSDOM } from 'test/utils/skipIf';
 
 describe('<DateField /> - Selection', () => {
   const { render } = createPickerRenderer();
@@ -199,6 +201,321 @@ describe('<DateField /> - Selection', () => {
       expect(getCleanedSelectedContent()).to.equal('');
 
       view.unmount();
+    });
+  });
+
+  describe('Click on a non-section element inside the field root', () => {
+    it('should select a section when clicking on a non-section descendant of the field root', () => {
+      const view = renderWithProps({ enableAccessibleFieldDOMStructure: true });
+
+      const sectionsContainer = view.getSectionsContainer();
+      fireEvent.mouseDown(sectionsContainer);
+      fireEvent.click(sectionsContainer);
+
+      // JSDOM rects are 0x0, so `findClosestSectionIndexToPoint` deterministically
+      // picks the first section. The actual closest-section math is covered by
+      // the browser-only test below.
+      expect(getCleanedSelectedContent()).to.equal('MM');
+    });
+
+    it('should select the section directly under the click target', () => {
+      const view = renderWithProps({ enableAccessibleFieldDOMStructure: true });
+
+      const yearSection = view.getSection(2);
+      fireEvent.mouseDown(yearSection);
+      fireEvent.click(yearSection);
+
+      expect(getCleanedSelectedContent()).to.equal('YYYY');
+    });
+
+    it('should select the visually-containing section when clicking on a section separator', () => {
+      // We click the "/" after the *Day* section (data-sectionindex=1) rather
+      // than the one after Month, so the test discriminates between the
+      // `[data-sectionindex]` lookup (Day) and the closest-section fallback
+      // under zero-sized JSDOM rects (which always returns 0 = Month).
+      const view = renderWithProps({
+        enableAccessibleFieldDOMStructure: true,
+        defaultValue: adapterToUse.date('2022-04-11'),
+      });
+
+      const daySection = view.getSection(1);
+      const slashAfterDay = daySection.parentElement!.querySelector<HTMLElement>(
+        '.MuiPickersInputBase-sectionAfter',
+      )!;
+      expect(slashAfterDay.textContent).to.equal('/');
+
+      fireEvent.mouseDown(slashAfterDay);
+      fireEvent.click(slashAfterDay);
+
+      expect(getCleanedSelectedContent()).to.equal('11');
+    });
+
+    it('should not select any section on mousedown when the field is disabled', () => {
+      const view = renderWithProps({ enableAccessibleFieldDOMStructure: true, disabled: true });
+
+      const sectionsContainer = view.getSectionsContainer();
+      fireEvent.mouseDown(sectionsContainer);
+      fireEvent.click(sectionsContainer);
+
+      expect(getCleanedSelectedContent()).to.equal('');
+    });
+
+    it('should not select any section on a non-primary mousedown (e.g. right-click)', () => {
+      const view = renderWithProps({ enableAccessibleFieldDOMStructure: true });
+
+      const sectionsContainer = view.getSectionsContainer();
+      // `button: 2` = secondary (right) mouse button. The early-return
+      // prevents focus theft and lets the context menu fire normally.
+      fireEvent.mouseDown(sectionsContainer, { button: 2 });
+
+      expect(getCleanedSelectedContent()).to.equal('');
+    });
+
+    it('should not select any section when a capture-phase parent calls preventDefault on mousedown', () => {
+      // Locks the `handleRootMouseDown` contract: an upstream `preventDefault`
+      // (e.g. a capture-phase parent intentionally blocking field interaction,
+      // or the clear/open buttons whose own handlers already preventDefault
+      // before propagation) suppresses the section selection.
+      const view = renderWithProps({ enableAccessibleFieldDOMStructure: true });
+
+      const sectionsContainer = view.getSectionsContainer();
+      const handler = (event: Event) => event.preventDefault();
+      sectionsContainer.parentElement!.addEventListener('mousedown', handler, true);
+
+      fireEvent.mouseDown(sectionsContainer);
+
+      sectionsContainer.parentElement!.removeEventListener('mousedown', handler, true);
+      expect(getCleanedSelectedContent()).to.equal('');
+    });
+
+    it('should prevent the default mousedown behavior when clicking the field padding', () => {
+      // Without it the browser blurs the focused section. The blur is a default
+      // action, so only the e2e suite reproduces it; this locks the mechanism.
+      const view = renderWithProps({ enableAccessibleFieldDOMStructure: true });
+      const fieldRoot = view.getSectionsContainer().parentElement!;
+
+      const event = createEvent.mouseDown(fieldRoot);
+      fireEvent(fieldRoot, event);
+
+      expect(event.defaultPrevented).to.equal(true);
+    });
+
+    it('should not prevent the default mousedown behavior when clicking an adornment button', () => {
+      // Preventing it would stop the button from taking the focus on click.
+      renderWithProps({
+        enableAccessibleFieldDOMStructure: true,
+        clearable: true,
+        defaultValue: adapterToUse.date('2022-04-11'),
+        // The ripple would start on mousedown and update state outside `act`.
+        slotProps: { clearButton: { disableRipple: true } },
+      });
+      const clearButton = screen.getByRole('button', { name: 'Clear' });
+
+      const event = createEvent.mouseDown(clearButton);
+      fireEvent(clearButton, event);
+
+      expect(event.defaultPrevented).to.equal(false);
+    });
+
+    it('should not prevent the default mousedown behavior when clicking a non-interactive adornment', () => {
+      // The blank space check is the field root itself, not "not a section", so
+      // an adornment stays untouched even when it renders nothing focusable.
+      renderWithProps({
+        enableAccessibleFieldDOMStructure: true,
+        slotProps: {
+          textField: {
+            slotProps: { input: { startAdornment: <span data-testid="adornment">@</span> } },
+          },
+        },
+      } as any);
+      const adornment = screen.getByTestId('adornment');
+
+      const event = createEvent.mouseDown(adornment);
+      fireEvent(adornment, event);
+
+      expect(event.defaultPrevented).to.equal(false);
+    });
+
+    it('should forward mousedown to a userland `onMouseDown` consumer', () => {
+      const consumer = spy();
+      const view = renderWithProps({
+        enableAccessibleFieldDOMStructure: true,
+        onMouseDown: consumer,
+      });
+
+      fireEvent.mouseDown(view.getSectionsContainer());
+
+      expect(consumer.callCount).to.equal(1);
+      expect(consumer.lastCall.firstArg.type).to.equal('mousedown');
+    });
+
+    it('should not fire `onSelectedSectionsChange` more than once per section click', () => {
+      // The `mousedown` handler now selects the section authoritatively for
+      // pointer input, in addition to the section's own focus/click handlers.
+      // The section container's `onClick` deduplicates against the resulting
+      // selection so the public callback fires the same number of times as
+      // before this handler existed: twice for a click on a new section
+      // (mousedown + focus), once for a click on the already-selected section.
+      const onSelectedSectionsChange = spy();
+      const view = renderWithProps({
+        enableAccessibleFieldDOMStructure: true,
+        onSelectedSectionsChange,
+      });
+
+      const year = view.getSection(2);
+      fireEvent.mouseDown(year);
+      fireEvent.click(year);
+      expect(onSelectedSectionsChange.args).to.deep.equal([[2], [2]]);
+
+      // Clicking the already-selected section fires exactly once.
+      onSelectedSectionsChange.resetHistory();
+      fireEvent.mouseDown(year);
+      fireEvent.click(year);
+      expect(onSelectedSectionsChange.args).to.deep.equal([[2]]);
+    });
+
+    it('should preserve the all-sections selection when clicking the sections container', async () => {
+      const view = renderWithProps({ enableAccessibleFieldDOMStructure: true });
+      await view.selectSectionAsync('month');
+      fireEvent.keyDown(view.getActiveSection(0), { key: 'a', keyCode: 65, ctrlKey: true });
+      expect(getCleanedSelectedContent()).to.equal('MM/DD/YYYY');
+
+      // `mousedown`'s closest-section path must early-return when the field is
+      // in 'all' mode so the Ctrl+A behavior is preserved. This asserts the
+      // synchronous outcome only: `handleClick`'s 'all' branch schedules its
+      // cursor-positioning work in a 0-tick `setTimeout` that `fireEvent`
+      // does not flush, so 'all' stays selected within the assertion window.
+      const sectionsContainer = view.getSectionsContainer();
+      fireEvent.mouseDown(sectionsContainer);
+      fireEvent.click(sectionsContainer);
+
+      expect(getCleanedSelectedContent()).to.equal('MM/DD/YYYY');
+    });
+
+    // Chromium delegates focus from a non-contenteditable ancestor click onto
+    // the nearest contenteditable descendant -- but only for trusted pointer
+    // events. We drive the click via Playwright (real pointer events) here;
+    // synthetic React events don't trigger Chromium's native delegation, so
+    // the test would pass vacuously without them.
+    it.skipIf(isJSDOM)(
+      'should not focus any section when clicking on an ancestor outside the field root',
+      async () => {
+        // `display: flex; width: 100%` lets the field keep its natural width
+        // and leaves blank space to its right inside the wrapper. The center
+        // of the wrapper (where userEvent clicks) lands in that blank space.
+        render(
+          <div data-testid="flex-wrapper" style={{ display: 'flex', width: '100%' }}>
+            <DateField />
+          </div>,
+        );
+
+        const { userEvent } = await import('@vitest/browser/context');
+        await userEvent.click(screen.getByTestId('flex-wrapper'));
+
+        expect(getCleanedSelectedContent()).to.equal('');
+        expect(document.activeElement?.getAttribute('role')).not.to.equal('spinbutton');
+      },
+    );
+
+    // The closest-section distance math relies on real `getBoundingClientRect`
+    // layout, so JSDOM (where rects are 0x0) only ever picks index 0.
+    // Fire on the sections container directly so the click target is not
+    // inside any section span -- that's the case where the closest-section
+    // logic actually decides the outcome (section spans have their own
+    // `onClick` handler that would otherwise win on the click bubble).
+    it.skipIf(isJSDOM)('should focus the section closest to the click point', () => {
+      const view = renderWithProps({ enableAccessibleFieldDOMStructure: true });
+
+      const sectionsContainer = view.getSectionsContainer();
+      const spinbuttons = sectionsContainer.querySelectorAll<HTMLElement>('[role="spinbutton"]');
+      const monthCenter =
+        (spinbuttons[0].getBoundingClientRect().left +
+          spinbuttons[0].getBoundingClientRect().right) /
+        2;
+      const dayCenter =
+        (spinbuttons[1].getBoundingClientRect().left +
+          spinbuttons[1].getBoundingClientRect().right) /
+        2;
+      const yearCenter =
+        (spinbuttons[2].getBoundingClientRect().left +
+          spinbuttons[2].getBoundingClientRect().right) /
+        2;
+
+      // Closer to Day than to Month or Year.
+      const clientX = dayCenter + 1;
+      expect(Math.abs(clientX - dayCenter)).to.be.lessThan(Math.abs(clientX - monthCenter));
+      expect(Math.abs(clientX - dayCenter)).to.be.lessThan(Math.abs(clientX - yearCenter));
+
+      fireEvent.mouseDown(sectionsContainer, { clientX });
+      fireEvent.click(sectionsContainer, { clientX });
+
+      expect(getCleanedSelectedContent()).to.equal('DD');
+    });
+  });
+
+  // Browser-only: JSDOM rects are 0x0, so no click point falls outside the
+  // sections. `test/e2e` covers what needs trusted input.
+  describe.skipIf(isJSDOM)('Click on the blank space after the last section', () => {
+    const getLastSectionRight = (sectionsContainer: HTMLElement) => {
+      const sections = sectionsContainer.querySelectorAll<HTMLElement>('[data-sectionindex]');
+      return sections[sections.length - 1].getBoundingClientRect().right;
+    };
+
+    const clickAt = (sectionsContainer: HTMLElement, clientX: number) => {
+      fireEvent.mouseDown(sectionsContainer, { clientX });
+      fireEvent.click(sectionsContainer, { clientX });
+    };
+
+    const clickBlankSpace = (sectionsContainer: HTMLElement) => {
+      const containerRight = sectionsContainer.getBoundingClientRect().right;
+      // Guards against a vacuous pass: clear of the tolerance band.
+      expect(containerRight).to.be.greaterThan(getLastSectionRight(sectionsContainer) + 16);
+
+      clickAt(sectionsContainer, containerRight - 2);
+    };
+
+    it('should select the first section when the field is not focused', () => {
+      const view = renderWithProps({ enableAccessibleFieldDOMStructure: true });
+
+      clickBlankSpace(view.getSectionsContainer());
+
+      expect(getCleanedSelectedContent()).to.equal('MM');
+    });
+
+    it('should keep the selected section when the field is already focused', async () => {
+      const onSelectedSectionsChange = spy();
+      const view = renderWithProps({
+        enableAccessibleFieldDOMStructure: true,
+        onSelectedSectionsChange,
+      });
+      await view.selectSectionAsync('day');
+      onSelectedSectionsChange.resetHistory();
+
+      clickBlankSpace(view.getSectionsContainer());
+
+      expect(getCleanedSelectedContent()).to.equal('DD');
+      expect(onSelectedSectionsChange.callCount).to.equal(0);
+    });
+
+    it('should select the last section when clicking just inside its right edge', () => {
+      // Pins the boundary: the last rendered character still selects the year.
+      const view = renderWithProps({ enableAccessibleFieldDOMStructure: true });
+      const sectionsContainer = view.getSectionsContainer();
+
+      clickAt(sectionsContainer, getLastSectionRight(sectionsContainer) - 1);
+
+      expect(getCleanedSelectedContent()).to.equal('YYYY');
+    });
+
+    it('should select the last section when the click misses it by less than the tolerance', async () => {
+      // A sloppy click 2px past the year means the year, not blank space.
+      const view = renderWithProps({ enableAccessibleFieldDOMStructure: true });
+      await view.selectSectionAsync('day');
+      const sectionsContainer = view.getSectionsContainer();
+
+      clickAt(sectionsContainer, getLastSectionRight(sectionsContainer) + 2);
+
+      expect(getCleanedSelectedContent()).to.equal('YYYY');
     });
   });
 

--- a/packages/x-date-pickers/src/DateTimeField/tests/selection.DateTimeField.test.tsx
+++ b/packages/x-date-pickers/src/DateTimeField/tests/selection.DateTimeField.test.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { DateTimeField } from '@mui/x-date-pickers/DateTimeField';
+import { screen } from '@mui/internal-test-utils';
+import { createPickerRenderer, getCleanedSelectedContent } from 'test/utils/pickers';
+import { isJSDOM } from 'test/utils/skipIf';
+
+describe('<DateTimeField /> - Selection', () => {
+  const { render } = createPickerRenderer();
+
+  // Coverage check: the Chromium focus-delegation gate lives at the shared
+  // `PickersInputBase` level so all field variants share it. This duplicates
+  // the DateField browser test against a DateTimeField, whose section layout
+  // is twice as long (MM/DD/YYYY hh:mm aa) and includes the AM/PM section,
+  // so a future style override in DateTimeField cannot silently re-introduce
+  // the bug.
+  it.skipIf(isJSDOM)(
+    'should not focus any section when clicking on an ancestor outside the field root',
+    async () => {
+      render(
+        <div data-testid="flex-wrapper" style={{ display: 'flex', width: '100%' }}>
+          <DateTimeField />
+        </div>,
+      );
+
+      const { userEvent } = await import('@vitest/browser/context');
+      await userEvent.click(screen.getByTestId('flex-wrapper'));
+
+      expect(getCleanedSelectedContent()).to.equal('');
+      expect(document.activeElement?.getAttribute('role')).not.to.equal('spinbutton');
+    },
+  );
+});

--- a/packages/x-date-pickers/src/DateTimeField/tests/selection.DateTimeField.test.tsx
+++ b/packages/x-date-pickers/src/DateTimeField/tests/selection.DateTimeField.test.tsx
@@ -22,7 +22,7 @@ describe('<DateTimeField /> - Selection', () => {
         </div>,
       );
 
-      const { userEvent } = await import('@vitest/browser/context');
+      const { userEvent } = await import('vitest/browser');
       await userEvent.click(screen.getByTestId('flex-wrapper'));
 
       expect(getCleanedSelectedContent()).to.equal('');

--- a/packages/x-date-pickers/src/PickersTextField/PickersFilledInput/PickersFilledInput.tsx
+++ b/packages/x-date-pickers/src/PickersTextField/PickersFilledInput/PickersFilledInput.tsx
@@ -296,6 +296,7 @@ PickersFilledInput.propTypes = {
   onClick: PropTypes.func.isRequired,
   onInput: PropTypes.func.isRequired,
   onKeyDown: PropTypes.func.isRequired,
+  onMouseDown: PropTypes.func.isRequired,
   onPaste: PropTypes.func.isRequired,
   ownerState: PropTypes /* @typescript-to-proptypes-ignore */.any,
   readOnly: PropTypes.bool,

--- a/packages/x-date-pickers/src/PickersTextField/PickersInput/PickersInput.tsx
+++ b/packages/x-date-pickers/src/PickersTextField/PickersInput/PickersInput.tsx
@@ -217,6 +217,7 @@ PickersInput.propTypes = {
   onClick: PropTypes.func.isRequired,
   onInput: PropTypes.func.isRequired,
   onKeyDown: PropTypes.func.isRequired,
+  onMouseDown: PropTypes.func.isRequired,
   onPaste: PropTypes.func.isRequired,
   ownerState: PropTypes /* @typescript-to-proptypes-ignore */.any,
   readOnly: PropTypes.bool,

--- a/packages/x-date-pickers/src/PickersTextField/PickersInputBase/PickersInputBase.tsx
+++ b/packages/x-date-pickers/src/PickersTextField/PickersInputBase/PickersInputBase.tsx
@@ -134,6 +134,15 @@ const PickersInputBaseSectionContent = styled(PickersSectionListSectionContent, 
   letterSpacing: 'inherit',
   width: 'fit-content',
   outline: 'none',
+  // Disables Chromium's focus-delegation onto contenteditable descendants
+  // while the field is not focused. Gated to Chromium via a Blink-only
+  // property, because the rule breaks Playwright's `fill()` on WebKit.
+  '@supports (-webkit-app-region: drag)': {
+    [`.${pickersInputBaseClasses.root}:not(:focus-within) &`]: {
+      WebkitUserModify: 'read-only',
+      userSelect: 'none',
+    },
+  },
 }));
 
 const PickersInputBaseSectionSeparator = styled(PickersSectionListSectionSeparator, {
@@ -516,6 +525,7 @@ PickersInputBase.propTypes = {
   onClick: PropTypes.func.isRequired,
   onInput: PropTypes.func.isRequired,
   onKeyDown: PropTypes.func.isRequired,
+  onMouseDown: PropTypes.func.isRequired,
   onPaste: PropTypes.func.isRequired,
   ownerState: PropTypes /* @typescript-to-proptypes-ignore */.any,
   readOnly: PropTypes.bool,

--- a/packages/x-date-pickers/src/PickersTextField/PickersInputBase/PickersInputBase.types.ts
+++ b/packages/x-date-pickers/src/PickersTextField/PickersInputBase/PickersInputBase.types.ts
@@ -16,6 +16,7 @@ export interface PickersInputPropsUsedByField extends Pick<
   areAllSectionsEmpty: boolean;
 
   onClick: React.MouseEventHandler<HTMLDivElement>;
+  onMouseDown: React.MouseEventHandler<HTMLDivElement>;
   onKeyDown: React.EventHandler<MuiEvent<React.KeyboardEvent<HTMLDivElement>>>;
   onInput: React.FormEventHandler<HTMLDivElement>;
   onPaste: React.ClipboardEventHandler<HTMLDivElement>;

--- a/packages/x-date-pickers/src/PickersTextField/PickersOutlinedInput/PickersOutlinedInput.tsx
+++ b/packages/x-date-pickers/src/PickersTextField/PickersOutlinedInput/PickersOutlinedInput.tsx
@@ -202,6 +202,7 @@ PickersOutlinedInput.propTypes = {
   onClick: PropTypes.func.isRequired,
   onInput: PropTypes.func.isRequired,
   onKeyDown: PropTypes.func.isRequired,
+  onMouseDown: PropTypes.func.isRequired,
   onPaste: PropTypes.func.isRequired,
   ownerState: PropTypes /* @typescript-to-proptypes-ignore */.any,
   readOnly: PropTypes.bool,

--- a/packages/x-date-pickers/src/PickersTextField/PickersTextField.tsx
+++ b/packages/x-date-pickers/src/PickersTextField/PickersTextField.tsx
@@ -82,6 +82,7 @@ const PickersTextField = React.forwardRef(function PickersTextField(
     elements,
     areAllSectionsEmpty,
     onClick,
+    onMouseDown,
     onKeyDown,
     onKeyUp,
     onPaste,
@@ -187,6 +188,7 @@ const PickersTextField = React.forwardRef(function PickersTextField(
           elements={elements}
           areAllSectionsEmpty={areAllSectionsEmpty}
           onClick={onClick}
+          onMouseDown={onMouseDown}
           onKeyDown={onKeyDown}
           onKeyUp={onKeyUp}
           onInput={onInput}
@@ -305,6 +307,7 @@ PickersTextField.propTypes = {
   onFocus: PropTypes.func.isRequired,
   onInput: PropTypes.func.isRequired,
   onKeyDown: PropTypes.func.isRequired,
+  onMouseDown: PropTypes.func.isRequired,
   onPaste: PropTypes.func.isRequired,
   readOnly: PropTypes.bool,
   /**

--- a/packages/x-date-pickers/src/TimeField/tests/selection.TimeField.test.tsx
+++ b/packages/x-date-pickers/src/TimeField/tests/selection.TimeField.test.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { TimeField } from '@mui/x-date-pickers/TimeField';
+import { screen } from '@mui/internal-test-utils';
+import { createPickerRenderer, getCleanedSelectedContent } from 'test/utils/pickers';
+import { isJSDOM } from 'test/utils/skipIf';
+
+describe('<TimeField /> - Selection', () => {
+  const { render } = createPickerRenderer();
+
+  // Coverage check: the Chromium focus-delegation gate lives at the shared
+  // `PickersInputBase` level so DateField, TimeField, and DateTimeField all
+  // share it. This duplicates the DateField browser test against a TimeField
+  // (different section layout: HH/mm/aa instead of MM/DD/YYYY) so a future
+  // style override in TimeField cannot silently re-introduce the bug.
+  it.skipIf(isJSDOM)(
+    'should not focus any section when clicking on an ancestor outside the field root',
+    async () => {
+      render(
+        <div data-testid="flex-wrapper" style={{ display: 'flex', width: '100%' }}>
+          <TimeField />
+        </div>,
+      );
+
+      const { userEvent } = await import('@vitest/browser/context');
+      await userEvent.click(screen.getByTestId('flex-wrapper'));
+
+      expect(getCleanedSelectedContent()).to.equal('');
+      expect(document.activeElement?.getAttribute('role')).not.to.equal('spinbutton');
+    },
+  );
+});

--- a/packages/x-date-pickers/src/TimeField/tests/selection.TimeField.test.tsx
+++ b/packages/x-date-pickers/src/TimeField/tests/selection.TimeField.test.tsx
@@ -21,7 +21,7 @@ describe('<TimeField /> - Selection', () => {
         </div>,
       );
 
-      const { userEvent } = await import('@vitest/browser/context');
+      const { userEvent } = await import('vitest/browser');
       await userEvent.click(screen.getByTestId('flex-wrapper'));
 
       expect(getCleanedSelectedContent()).to.equal('');

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.types.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.types.ts
@@ -142,6 +142,7 @@ export type UseFieldForwardedProps<TEnableAccessibleFieldDOMStructure extends bo
         focused?: boolean;
         sectionListRef?: React.Ref<PickersSectionListRef>;
         onClick?: React.MouseEventHandler;
+        onMouseDown?: React.MouseEventHandler;
         onKeyDown?: React.KeyboardEventHandler;
         onFocus?: React.FocusEventHandler;
         onBlur?: React.FocusEventHandler;

--- a/packages/x-date-pickers/src/internals/hooks/useField/useFieldRootProps.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useFieldRootProps.ts
@@ -49,16 +49,23 @@ export function useFieldRootProps(
   });
 
   const containerClickTimeout = useTimeout();
-  const handleClick = useEventCallback((event: React.MouseEvent) => {
+  const handleClick = useEventCallback(() => {
     if (disabled || !domGetters.isReady()) {
       return;
     }
 
-    setFocused(true);
-
     if (parsedSelectedSections === 'all') {
+      setFocused(true);
       containerClickTimeout.start(0, () => {
-        const cursorPosition = document.getSelection()!.getRangeAt(0).startOffset;
+        // `getSelection`/`getRangeAt` can be unset transiently (e.g. focus
+        // moved before this 0-tick callback ran). Fall back to the first
+        // section in that case.
+        const selection = document.getSelection();
+        if (!selection || selection.rangeCount === 0) {
+          setSelectedSections(sectionOrder.startIndex);
+          return;
+        }
+        const cursorPosition = selection.getRangeAt(0).startOffset;
 
         if (cursorPosition === 0) {
           setSelectedSections(sectionOrder.startIndex);
@@ -78,16 +85,89 @@ export function useFieldRootProps(
 
         setSelectedSections(sectionIndex - 1);
       });
-    } else if (!focused) {
-      setFocused(true);
-      setSelectedSections(sectionOrder.startIndex);
-    } else {
-      const hasClickedOnASection = domGetters.getRoot().contains(event.target as Node);
+      return;
+    }
 
-      if (!hasClickedOnASection) {
+    // For trusted pointer input, `handleMouseDown` already ran and set the
+    // section. This branch only matters for `click` events that arrive
+    // without a preceding `mousedown` (programmatic `element.click()`, some
+    // assistive-technology activations, synthetic event sequences in tests).
+    // Fall back to the first section so the field doesn't enter a "focused
+    // but no active section" state.
+    if (!focused) {
+      setFocused(true);
+      if (parsedSelectedSections == null) {
         setSelectedSections(sectionOrder.startIndex);
       }
     }
+  });
+
+  // Replaces Chromium's focus delegation with an explicit section focus on
+  // every primary mousedown inside the sections container. The CSS gate
+  // (`WebkitUserModify: read-only` while not `:focus-within`) can make the
+  // section's contenteditable span temporarily non-focusable, in which case
+  // Chromium falls back to the sections-container `tabindex=0` and our
+  // `handleFocus` then runs the "no active section" fallback, briefly
+  // selecting the first section before the click bubble corrects it.
+  // Setting the target section here (and letting `syncSelectionToDOM` move
+  // focus via `.focus()`, which works even with the user-modify rule
+  // active) skips that race entirely.
+  const handleMouseDown = useEventCallback((event: React.MouseEvent) => {
+    if (disabled || !domGetters.isReady() || parsedSelectedSections === 'all') {
+      return;
+    }
+    if (event.button !== 0) {
+      return;
+    }
+    const target = event.target as Element;
+    const sectionListRoot = domGetters.getRoot();
+    const isInsideSectionList = sectionListRoot.contains(target);
+    // Only the field root is ours outside the sections container: it is the
+    // target of a padding click. The adornments keep their own behavior.
+    if (!isInsideSectionList && target !== event.currentTarget) {
+      return;
+    }
+    const sectionElement = isInsideSectionList
+      ? target.closest<HTMLElement>('[data-sectionindex]')
+      : null;
+
+    // Blank space is the field padding and the area past the sections. Mimic
+    // the native date input: first section on entry, keep it afterwards.
+    // `preventDefault` is what keeps it, by stopping both the browser blur and
+    // Chromium's focus delegation.
+    const isBlankSpaceClick =
+      sectionElement == null &&
+      (!isInsideSectionList || isPointOutsideSections(sectionListRoot, event.clientX));
+    if (isBlankSpaceClick) {
+      event.preventDefault();
+      if (!focused) {
+        setFocused(true);
+        setSelectedSections(sectionOrder.startIndex);
+      }
+      return;
+    }
+
+    // Prefer the visually-containing section (matches Chromium's
+    // delegation + section container `onClick`), fall back to the
+    // closest-by-distance section for clicks on the container padding.
+    const parsedIndex = sectionElement
+      ? Number(sectionElement.dataset.sectionindex)
+      : findClosestSectionIndexToPoint(sectionListRoot, event.clientX);
+    // `Number(undefined) === NaN` and `NaN == null === false`, so guard
+    // explicitly here even though `data-sectionindex` is set by
+    // `useFieldSectionContainerProps` for every section in practice.
+    if (parsedIndex == null || !Number.isInteger(parsedIndex)) {
+      return;
+    }
+    event.preventDefault();
+    setFocused(true);
+    // `mousedown` is now authoritative for pointer section selection. The
+    // section container's own `onClick` deduplicates against the resulting
+    // `parsedSelectedSections` on the click bubble (see
+    // `useFieldSectionContainerProps`), so we always select here and let that
+    // guard absorb the redundant call -- matching the pre-PR
+    // `onSelectedSectionsChange` invocation count.
+    setSelectedSections(parsedIndex);
   });
 
   const handleInput = useEventCallback((event: React.FormEvent<HTMLDivElement>) => {
@@ -170,6 +250,7 @@ export function useFieldRootProps(
     onBlur: handleBlur,
     onFocus: handleFocus,
     onClick: handleClick,
+    onMouseDown: handleMouseDown,
     onPaste: handlePaste,
     onInput: handleInput,
 
@@ -177,6 +258,58 @@ export function useFieldRootProps(
     contentEditable: parsedSelectedSections === 'all',
     tabIndex: internalPropsWithDefaults.disabled || parsedSelectedSections === 0 ? -1 : 0, // TODO: Try to set to undefined when there is a section selected.
   };
+}
+
+/**
+ * Slop on each side of the sections, so a click that just misses the outermost
+ * one still selects it. Under half a digit at the default font size.
+ */
+const BLANK_SPACE_TOLERANCE = 4;
+
+/**
+ * Returns `true` when `clientX` sits past the sections on either side.
+ * Horizontal only: a click in the container's vertical padding still belongs to
+ * the section above or below it.
+ */
+function isPointOutsideSections(root: HTMLElement, clientX: number): boolean {
+  const sections = root.querySelectorAll<HTMLElement>('[data-sectionindex]');
+  if (sections.length === 0) {
+    return false;
+  }
+
+  let left = Infinity;
+  let right = -Infinity;
+  for (let i = 0; i < sections.length; i += 1) {
+    const rect = sections[i].getBoundingClientRect();
+    left = Math.min(left, rect.left);
+    right = Math.max(right, rect.right);
+  }
+
+  return clientX < left - BLANK_SPACE_TOLERANCE || clientX > right + BLANK_SPACE_TOLERANCE;
+}
+
+/**
+ * Returns the index of the section whose horizontal center is closest to `clientX`.
+ * Returns `null` if the field renders no `[role="spinbutton"]` descendants
+ * (defensive -- every section content span sets `role="spinbutton"` in practice).
+ */
+function findClosestSectionIndexToPoint(root: HTMLElement, clientX: number): number | null {
+  const sections = root.querySelectorAll<HTMLElement>('[role="spinbutton"]');
+  if (sections.length === 0) {
+    return null;
+  }
+  let closestIndex = 0;
+  let closestDistance = Infinity;
+  for (let i = 0; i < sections.length; i += 1) {
+    const rect = sections[i].getBoundingClientRect();
+    const center = (rect.left + rect.right) / 2;
+    const distance = Math.abs(clientX - center);
+    if (distance < closestDistance) {
+      closestDistance = distance;
+      closestIndex = i;
+    }
+  }
+  return closestIndex;
 }
 
 interface UseFieldRootPropsParameters {
@@ -194,6 +327,7 @@ interface UseFieldRootPropsReturnValue {
   onBlur: React.FocusEventHandler<HTMLDivElement>;
   onFocus: React.FocusEventHandler<HTMLDivElement>;
   onClick: React.MouseEventHandler<HTMLDivElement>;
+  onMouseDown: React.MouseEventHandler<HTMLDivElement>;
   onPaste: React.ClipboardEventHandler<HTMLDivElement>;
   onInput: React.FormEventHandler<HTMLDivElement>;
   contentEditable: boolean;

--- a/packages/x-date-pickers/src/internals/hooks/useField/useFieldRootProps.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useFieldRootProps.ts
@@ -127,9 +127,16 @@ export function useFieldRootProps(
     if (!isInsideSectionList && target !== event.currentTarget) {
       return;
     }
-    const sectionElement = isInsideSectionList
+    // `closest` walks past `sectionListRoot`, so a consumer element above the
+    // field that carries `data-sectionindex` would be read as a section. Keep
+    // only a match the sections container owns.
+    const closestSectionElement = isInsideSectionList
       ? target.closest<HTMLElement>('[data-sectionindex]')
       : null;
+    const sectionElement =
+      closestSectionElement && sectionListRoot.contains(closestSectionElement)
+        ? closestSectionElement
+        : null;
 
     // Blank space is the field padding and the area past the sections. Mimic
     // the native date input: first section on entry, keep it afterwards.

--- a/packages/x-date-pickers/src/internals/hooks/useField/useFieldRootProps.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useFieldRootProps.ts
@@ -127,16 +127,9 @@ export function useFieldRootProps(
     if (!isInsideSectionList && target !== event.currentTarget) {
       return;
     }
-    // `closest` walks past `sectionListRoot`, so a consumer element above the
-    // field that carries `data-sectionindex` would be read as a section. Keep
-    // only a match the sections container owns.
-    const closestSectionElement = isInsideSectionList
+    const sectionElement = isInsideSectionList
       ? target.closest<HTMLElement>('[data-sectionindex]')
       : null;
-    const sectionElement =
-      closestSectionElement && sectionListRoot.contains(closestSectionElement)
-        ? closestSectionElement
-        : null;
 
     // Blank space is the field padding and the area past the sections. Mimic
     // the native date input: first section on entry, keep it afterwards.

--- a/packages/x-date-pickers/src/internals/hooks/useField/useFieldSectionContainerProps.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useFieldSectionContainerProps.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import useEventCallback from '@mui/utils/useEventCallback';
 import { UseFieldStateReturnValue } from './useFieldState';
 import { UseFieldInternalProps } from './useField.types';
 
@@ -14,30 +15,45 @@ export function useFieldSectionContainerProps(
 ): UseFieldSectionContainerPropsReturnValue {
   const {
     stateResponse: {
+      // States and derived states
+      parsedSelectedSections,
       // Methods to update the states
       setSelectedSections,
     },
     internalPropsWithDefaults: { disabled = false },
   } = parameters;
 
-  const createHandleClick = React.useCallback(
-    (sectionIndex: number) => (event: React.MouseEvent<HTMLDivElement>) => {
-      // The click event on the clear button would propagate to the input, trigger this handler and result in a wrong section selection.
-      // We avoid this by checking if the call to this function is actually intended, or a side effect.
-      if (disabled || event.isDefaultPrevented()) {
-        return;
-      }
+  // A single stable handler shared by every section, rather than a per-index
+  // factory. The section index is read from the container's `data-sectionindex`
+  // at click time.
+  const handleClick = useEventCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    // The click event on the clear button would propagate to the input, trigger this handler and result in a wrong section selection.
+    // We avoid this by checking if the call to this function is actually intended, or a side effect.
+    if (disabled || event.isDefaultPrevented()) {
+      return;
+    }
 
-      setSelectedSections(sectionIndex);
-    },
-    [disabled, setSelectedSections],
-  );
+    const sectionIndex = Number(event.currentTarget.dataset.sectionindex);
+    if (!Number.isInteger(sectionIndex)) {
+      return;
+    }
+
+    // For pointer input the `mousedown` handler already selected the section
+    // before this click bubbles, so bail to avoid a redundant
+    // `onSelectedSectionsChange` invocation.
+    if (parsedSelectedSections === sectionIndex) {
+      return;
+    }
+
+    setSelectedSections(sectionIndex);
+  });
+
   return React.useCallback(
     (sectionIndex) => ({
       'data-sectionindex': sectionIndex,
-      onClick: createHandleClick(sectionIndex),
+      onClick: handleClick,
     }),
-    [createHandleClick],
+    [handleClick],
   );
 }
 

--- a/packages/x-date-pickers/src/internals/hooks/useField/useFieldV7TextField.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useFieldV7TextField.ts
@@ -50,6 +50,7 @@ export const useFieldV7TextField = <
     sectionListRef: sectionListRefProp,
     onBlur,
     onClick,
+    onMouseDown,
     onFocus,
     onInput,
     onPaste,
@@ -169,6 +170,18 @@ export const useFieldV7TextField = <
     rootProps.onClick(event);
   });
 
+  const handleRootMouseDown = useEventCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    // The `isDefaultPrevented` check skips mousedowns that have already been
+    // suppressed before this handler runs -- in particular, propagated events
+    // from the clear / open buttons whose own handlers `preventDefault`, and
+    // capture-phase parents that intentionally block field interactions.
+    if (event.isDefaultPrevented()) {
+      return;
+    }
+    onMouseDown?.(event);
+    rootProps.onMouseDown(event);
+  });
+
   const handleRootPaste = useEventCallback((event: React.ClipboardEvent<HTMLDivElement>) => {
     onPaste?.(event);
     rootProps.onPaste(event);
@@ -277,6 +290,7 @@ export const useFieldV7TextField = <
     ...rootProps,
     onBlur: handleRootBlur,
     onClick: handleRootClick,
+    onMouseDown: handleRootMouseDown,
     onFocus: handleRootFocus,
     onInput: handleRootInput,
     onPaste: handleRootPaste,

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -13,6 +13,7 @@ import {
   type Locator,
 } from '@playwright/test';
 import { pickersSectionListClasses } from '@mui/x-date-pickers/PickersSectionList';
+import { pickersOutlinedInputClasses } from '@mui/x-date-pickers/PickersTextField';
 
 function sleep(timeoutMS: number): Promise<void> {
   return new Promise((resolve) => {
@@ -807,6 +808,72 @@ async function initializeEnvironment(
         //   expect(await status.isVisible()).to.equal(true);
         //   expect(await status.textContent()).to.equal('Submitted: 04/17/2022');
         // });
+
+        it('should keep the selected section when clicking the blank space after the last section', async () => {
+          // Needs trusted input: Chromium delegates the focus to the nearest
+          // section without the `preventDefault` on mousedown.
+          await renderFixture('DatePicker/BasicDesktopDatePicker');
+
+          await page.getByRole('spinbutton', { name: 'Day' }).click();
+
+          const container = (await page
+            .locator(`.${pickersSectionListClasses.root}`)
+            .boundingBox())!;
+          const year = (await page.getByRole('spinbutton', { name: 'Year' }).boundingBox())!;
+          // Without blank space to click, the assertion below would pass vacuously.
+          expect(container.x + container.width).to.be.greaterThan(year.x + year.width + 16);
+
+          await page.mouse.click(
+            container.x + container.width - 2,
+            container.y + container.height / 2,
+          );
+
+          expect(await page.evaluate(() => document.activeElement?.textContent)).to.equal('DD');
+        });
+
+        it('should keep the selected section when clicking the padding of the field', async () => {
+          // Needs trusted input: the browser blurs the section without the
+          // `preventDefault` on mousedown, so the field flashes.
+          await renderFixture('DatePicker/BasicDesktopDatePicker');
+
+          await page.getByRole('spinbutton', { name: 'Day' }).click();
+
+          const root = (await page.locator(`.${pickersOutlinedInputClasses.root}`).boundingBox())!;
+          const container = (await page
+            .locator(`.${pickersSectionListClasses.root}`)
+            .boundingBox())!;
+          // Without padding to click, the assertion below would pass vacuously.
+          expect(container.x).to.be.greaterThan(root.x + 8);
+
+          await page.mouse.click(root.x + 4, root.y + root.height / 2);
+
+          expect(await page.evaluate(() => document.activeElement?.textContent)).to.equal('DD');
+        });
+
+        it('should keep the field editable after several blank space clicks', async () => {
+          // Regression test for https://github.com/mui/mui-x/issues/19809: the
+          // field stayed focused but stopped accepting keystrokes.
+          await renderFixture('DatePicker/BasicDesktopDatePicker');
+
+          const container = (await page
+            .locator(`.${pickersSectionListClasses.root}`)
+            .boundingBox())!;
+          const year = (await page.getByRole('spinbutton', { name: 'Year' }).boundingBox())!;
+          // Without blank space to click, the assertion below would pass vacuously.
+          expect(container.x + container.width).to.be.greaterThan(year.x + year.width + 16);
+          const x = container.x + container.width - 2;
+          const y = container.y + container.height / 2;
+
+          await page.mouse.click(x, y);
+          await page.mouse.click(x, y);
+          await page.mouse.click(x, y);
+
+          await page.keyboard.press('4');
+
+          expect(await page.getByRole('textbox', { includeHidden: true }).inputValue()).to.equal(
+            '04/DD/YYYY',
+          );
+        });
 
         it('should correctly select a day in a calendar with "AdapterMomentJalaali"', async () => {
           await renderFixture('DatePicker/MomentJalaliDateCalendar');


### PR DESCRIPTION
Backport of #22285 and #23318 to `v8.x`.

Fixes #19809

## Problem

Clicking the blank space of a field leaves it focused but not editable. Chromium delegates the focus of a click on a non-contenteditable ancestor to the nearest contenteditable section span, so the field root keeps the DOM focus while no section is selected. Every second click toggles the field into that dead state.

## Summary

- A `mousedown` handler on the field root selects the section explicitly and calls `preventDefault`.
- A Chromium-gated `-webkit-user-modify: read-only` rule stops the focus delegation while the field is not focused. The gate is `@supports (-webkit-app-region: drag)`, a Blink-only property, so WebKit stays untouched and Playwright `fill()` keeps working there.
- A blank space click selects the first section on entry and keeps the selected section afterwards, like a native date input.
- `onMouseDown` is forwarded through `PickersTextField` and the input variants.

Only the accessible DOM structure (`enableAccessibleFieldDOMStructure: true`) is affected. The `useFieldV6TextField` path is untouched.

## Why both PRs

#22285 alone restores typing, but it changes which section a blank space click selects. On `v8.x` today a single blank space click selects the first section in both the field padding and the area past the last section. With #22285 alone the second case selects the nearest section (the year) instead. #23318 restores the first-section behavior, so together they fix the bug without changing anything else that already works.

Measured on an empty `DesktopDatePicker`, single blank space click, then press `4`:

| Build | Padding (left of the sections) | Past the last section |
| --- | --- | --- |
| `v8.x` today | `04/DD/YYYY` | `04/DD/YYYY` |
| + #22285 only | `04/DD/YYYY` | `MM/DD/0004` |
| + both (this PR) | `04/DD/YYYY` | `04/DD/YYYY` |

## Tests

- Ported the unit tests of both PRs, adapted to the v8 `renderWithProps` API.
- Added the two e2e tests of #23318, plus an e2e regression test for the reported multi-click scenario.
- Verified locally: `tsc` clean, 4247 jsdom unit tests pass, 3288 browser-mode tests pass, the chromium e2e suite passes. The one e2e failure (`<DataGrid /> should edit date cells`) also fails on an unmodified `v8.x` checkout, so it is unrelated.
