### PR TITLE
[core] Declare the missing `react-dom` peer dependencies

### DIFF
--- a/packages/x-codemod/package.json
+++ b/packages/x-codemod/package.json
@@ -30,11 +30,11 @@
   },
   "dependencies": {
     "@babel/runtime": "catalog:",
-    "@mui/x-internals": "workspace:^",
     "jscodeshift": "catalog:",
     "yargs": "catalog:"
   },
   "devDependencies": {
+    "@mui/x-internals": "workspace:^",
     "@types/jscodeshift": "17.3.0",
     "dayjs": "catalog:",
     "moment-timezone": "catalog:",

--- a/packages/x-data-grid-generator/package.json
+++ b/packages/x-data-grid-generator/package.json
@@ -49,7 +49,9 @@
     "@emotion/styled": "^11.8.1",
     "@mui/icons-material": "^7.3.0 || ^9.0.0",
     "@mui/material": "^7.3.0 || ^9.0.0",
-    "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+    "@mui/system": "^7.3.0 || ^9.0.0",
+    "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "peerDependenciesMeta": {
     "@emotion/react": {

--- a/packages/x-internal-gestures/package.json
+++ b/packages/x-internal-gestures/package.json
@@ -42,6 +42,10 @@
     "@babel/runtime": "catalog:",
     "@base-ui/utils": "catalog:"
   },
+  "peerDependencies": {
+    "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+  },
   "sideEffects": false,
   "exports": {
     "./*": "./src/*/index.ts"

--- a/packages/x-internals/package.json
+++ b/packages/x-internals/package.json
@@ -43,7 +43,8 @@
     "use-sync-external-store": "catalog:"
   },
   "peerDependencies": {
-    "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+    "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "@mui/internal-test-utils": "catalog:",

--- a/packages/x-license/package.json
+++ b/packages/x-license/package.json
@@ -33,7 +33,8 @@
     "@mui/x-telemetry": "workspace:^"
   },
   "peerDependencies": {
-    "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+    "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "@mui/internal-test-utils": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1202,9 +1202,6 @@ importers:
       '@babel/runtime':
         specifier: 'catalog:'
         version: 7.29.7
-      '@mui/x-internals':
-        specifier: workspace:^
-        version: link:../x-internals/build
       jscodeshift:
         specifier: 'catalog:'
         version: 17.4.0(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(supports-color@10.2.2)
@@ -1212,6 +1209,9 @@ importers:
         specifier: 'catalog:'
         version: 18.0.0
     devDependencies:
+      '@mui/x-internals':
+        specifier: workspace:^
+        version: link:../x-internals/build
       '@types/jscodeshift':
         specifier: 17.3.0
         version: 17.3.0
@@ -1302,6 +1302,9 @@ importers:
       '@emotion/styled':
         specifier: ^11.8.1
         version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
+      '@mui/system':
+        specifier: ^7.3.0 || ^9.0.0
+        version: 9.3.0(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)
       '@mui/x-data-grid':
         specifier: workspace:^
         version: link:../x-data-grid/build
@@ -1648,6 +1651,12 @@ importers:
       '@base-ui/utils':
         specifier: 'catalog:'
         version: 0.3.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react:
+        specifier: ^17.0.0 || ^18.0.0 || ^19.0.0
+        version: 19.2.8
+      react-dom:
+        specifier: ^17.0.0 || ^18.0.0 || ^19.0.0
+        version: 19.2.8(react@19.2.8)
     publishDirectory: build
 
   packages/x-internals:


### PR DESCRIPTION
Fixes #23380

## Problem

`@base-ui/utils` declares `react-dom` as a required peer dependency. `@mui/x-internals` depends on `@base-ui/utils` but declares only `react`, so Yarn reports `YN0086` on install:

    Package @mui/x-internals@9.11.0 is requested to provide react-dom by its descendants
    @mui/x-internals@9.11.0
    └─ @base-ui/utils@0.3.2 (via ^17 || ^18 || ^19)
    ✘ Package @mui/x-internals@9.11.0 does not provide react-dom.

## Solution

I walked the peer graph of every published workspace package and forwarded each required peer that was missing. `@mui/x-internals` alone is not enough -- adding `react-dom` there moves the same warning up to `@mui/x-license`, which every Pro and Premium user installs.

| Package | Change | Why |
| --- | --- | --- |
| `@mui/x-internals` | add `react-dom` peer | the reported case: `@base-ui/utils` requires it |
| `@mui/x-license` | add `react-dom` peer | depends on `@mui/x-internals` |
| `@mui/x-internal-gestures` | add `react` + `react-dom` peers | depends on `@base-ui/utils`, declared no peers at all |
| `@mui/x-data-grid-generator` | add `react-dom` + `@mui/system` peers | the Data Grid packages require both |
| `@mui/x-codemod` | move `@mui/x-internals` to `devDependencies` | only `src/types.ts` imports it, for a type, and the build excludes that file (`--ignore 'src/types.ts' --buildTypes false`) |

All ranges match the ranges the sibling packages already use.

The last four are pre-existing gaps of the same class. The `@mui/x-license` one is a direct consequence of the first change, so it cannot be left out.

## Verification

- A script that resolves every dependency's `peerDependencies` and checks that each workspace package provides them reports no missing React peer after the change. Before, it reported the 5 rows above.
- `pnpm install` + `pnpm dedupe --check` pass.
- `pnpm peers check` shows no new issue.
- `pnpm --filter ... run typescript` passes for the 5 packages.
- `pnpm test:unit --project x-internals --project x-license --run`: 151 tests pass.
- `@mui/x-codemod` builds, and the output contains 0 references to `@mui/x-internals`, which confirms the dependency move is safe.

## Not included

`@mui/x-date-pickers`, `@mui/x-tree-view`, and `@mui/x-tree-view-pro` do not forward `@types/react`, which `@types/react-transition-group` requires. That is a types-only concern and a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
