### PR TITLE
[charts] Fix React 18 propTypes warnings and stray-pointer test flakiness

### DIFF
--- a/packages/x-charts/src/ChartsTooltip/ChartsAxisTooltipContent.tsx
+++ b/packages/x-charts/src/ChartsTooltip/ChartsAxisTooltipContent.tsx
@@ -143,7 +143,7 @@ DefaultContent.propTypes /* remove-proptypes */ = {
    * Override or extend the styles applied to the component.
    */
   classes: PropTypes.object,
-  item: PropTypes.shape({
+  item: PropTypes /* @typescript-to-proptypes-ignore */.shape({
     color: PropTypes.string.isRequired,
     formattedLabel: PropTypes.string,
     formattedValue: PropTypes.string.isRequired,
@@ -153,17 +153,7 @@ DefaultContent.propTypes /* remove-proptypes */ = {
       PropTypes.func,
     ]),
     seriesId: PropTypes.string.isRequired,
-    value: PropTypes.oneOfType([
-      PropTypes.number,
-      PropTypes.shape({
-        colorValue: PropTypes.any,
-        id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-        sizeValue: PropTypes.any,
-        x: PropTypes.number.isRequired,
-        y: PropTypes.number.isRequired,
-        z: PropTypes.any,
-      }),
-    ]),
+    value: PropTypes.any,
   }).isRequired,
 } as any;
 

--- a/packages/x-charts/src/ChartsTooltip/ChartsItemTooltipContent.tsx
+++ b/packages/x-charts/src/ChartsTooltip/ChartsItemTooltipContent.tsx
@@ -222,13 +222,13 @@ DefaultSingleValueContent.propTypes /* remove-proptypes */ = {
    * Override or extend the styles applied to the component.
    */
   classes: PropTypes.object,
-  item: PropTypes.shape({
+  item: PropTypes /* @typescript-to-proptypes-ignore */.shape({
     color: PropTypes.string.isRequired,
     formattedValue: PropTypes.any.isRequired,
     identifier: PropTypes.shape({
       dataIndex: PropTypes.number,
       seriesId: PropTypes.string.isRequired,
-      type: PropTypes.oneOf(['bar', 'line', 'pie', 'radar', 'scatter']).isRequired,
+      type: PropTypes.string.isRequired,
     }).isRequired,
     label: PropTypes.string,
     markShape: PropTypes.oneOf(['circle', 'cross', 'diamond', 'square', 'star', 'triangle', 'wye']),

--- a/packages/x-charts/src/ChartsTooltip/ChartsTooltipContainer.tsx
+++ b/packages/x-charts/src/ChartsTooltip/ChartsTooltipContainer.tsx
@@ -287,6 +287,10 @@ function ChartsTooltipContainer(inProps: ChartsTooltipContainerProps) {
     [positionRef],
   );
 
+  // `anchorEl` is only set once the portal below is mounted. Rendering the popper
+  // without an anchor makes Popper warn about an invalid `anchorEl`.
+  const tooltipAnchorEl = itemPosition ? anchorEl : pointerAnchorEl;
+
   const isMouse = pointerType === 'mouse' || isFineMainPointer;
   const isTouch = pointerType === 'touch' || !isFineMainPointer;
 
@@ -345,7 +349,7 @@ function ChartsTooltipContainer(inProps: ChartsTooltipContainerProps) {
           chartsLayerContainerRef.current,
         )}
       <NoSsr>
-        {isOpen && (
+        {isOpen && tooltipAnchorEl && (
           <ChartsTooltipRoot
             {...other}
             // The key is here to make sure the tooltip uses the new anchor immediately.
@@ -358,7 +362,7 @@ function ChartsTooltipContainer(inProps: ChartsTooltipContainerProps) {
               (!isTooltipNodeAnchored && isMouse ? 'right-start' : 'top')
             }
             popperRef={popperRef}
-            anchorEl={itemPosition ? anchorEl : pointerAnchorEl}
+            anchorEl={tooltipAnchorEl}
             modifiers={modifiers}
             container={other.container ?? chartsLayerContainerRef.current}
             popperOptions={{ ...other.popperOptions, strategy: 'fixed' }}

--- a/packages/x-charts/src/LineChart/CircleMarkElement.tsx
+++ b/packages/x-charts/src/LineChart/CircleMarkElement.tsx
@@ -124,11 +124,6 @@ CircleMarkElement.propTypes = {
   dataIndex: PropTypes.number.isRequired,
   seriesId: PropTypes.string.isRequired,
   /**
-   * The shape of the marker.
-   */
-  shape: PropTypes.oneOf(['circle', 'cross', 'diamond', 'square', 'star', 'triangle', 'wye'])
-    .isRequired,
-  /**
    * If `true`, animations are skipped.
    * @default false
    */

--- a/test/setupVitest.ts
+++ b/test/setupVitest.ts
@@ -24,6 +24,7 @@ beforeAll(async () => {
   if (!isJsdom()) {
     const { server } = await import('vitest/browser');
     await server.commands.setupCrashHandler();
+    await server.commands.resetMousePosition();
   }
 });
 

--- a/vitest.shared.mts
+++ b/vitest.shared.mts
@@ -97,6 +97,11 @@ export default defineConfig({
       headless: true,
       screenshotFailures: false,
       commands: {
+        async resetMousePosition(ctx) {
+          // Move the pointer out of the page. A pointer left over the content
+          // makes components react to hover during unrelated tests.
+          await ctx.page.mouse.move(10_000, 10_000);
+        },
         async setupCrashHandler(ctx) {
           ctx.page.on('crash', (page) => {
             console.error(`Browser page crashed! URL: ${page.url()}`);


### PR DESCRIPTION
Fixes the flaky charts tests on the React 18 pipeline. Two independent causes.

## 1. propTypes reject Pro and Premium series types

React 18 validates `propTypes`, React 19 ignores them. The charts tests use `vitest-fail-on-console`, so any warning fails a test on the React 18 pipeline only.

Keyboard navigation opens the item tooltip. The tooltip renders `DefaultSingleValueContent`, whose generated propTypes accept only the community series types (`bar`, `line`, `pie`, `radar`, `scatter`). `funnel` comes from Pro, which augments `ChartsSeriesConfig` by declaration merging, so the generator running on the community package never sees it.

React prints each propTypes message only once per browser page. `isolate: false` shares one page across test files, so the failure lands on whichever funnel tooltip test runs first, and the file order changes between runs.

Example failure: https://app.circleci.com/pipelines/github/mui/mui-x/138415/workflows/ff457a0c-051a-4a5c-a49e-43fc4f91b3d7/jobs/897461

Changes:

- `DefaultSingleValueContent`: `item.identifier.type` becomes `PropTypes.string`. This also covers `heatmap` and `sankey`.
- `DefaultContent`: `item.value` becomes `PropTypes.any`. Same cause -- the Premium `rangeBar` value is a `[number, number]` tuple.
- `CircleMarkElement`: removed the required `shape` propType. `shape` is not part of `CircleMarkElementProps` any more; the component only destructures it behind a `@ts-expect-error` to keep it off the SVG element. `pnpm proptypes` confirms the entry is stale and does not regenerate it.
- `ChartsTooltipContainer`: do not mount the Popper before the anchor exists. `anchorEl` stays null until the portal div mounts, so a controlled `tooltipItem` opened the tooltip one render too early and Popper reported an invalid `anchorEl`.

The three propTypes fixes use the existing `@typescript-to-proptypes-ignore` marker, so `pnpm proptypes` keeps them.

These are user-facing too: on a React 18 development build, every Pro or Premium chart logs these warnings to the console.

## 2. A stray browser pointer over the chart

Browser tests share one page, so a real pointer left over the content keeps hovering whatever mounts under it. Charts then react to hover during tests that never asked for it.

Two React 18 failures show this. `FunnelChart` runs `handlePointerEnter` during a keyboard-only test. `useChartCartesianAxis.axisHighlight` gets an extra `onHighlightedAxisChange` call, so the exact-count assertion reports `expected 2 to equal 1`. Both fail the same way on every retry, which is what a page-level pointer position does, and the axis one also fails on master.

Example failure on master: https://circleci.com/gh/mui/mui-x/897473

The fix parks the pointer outside the page in the existing `beforeAll` hook of the shared browser setup. Playwright does not clamp the coordinates, so the document reports `pointerout` and nothing stays hovered.

## Testing

Pinned the catalog to React 18.3.1 locally to reproduce, then reverted the pin.

- React 18 before: 8 failures across the charts suites.
- React 18 after: 164 files / 1103 tests pass in browser mode, 148 files / 867 tests pass in jsdom.
- Reproduced the axis highlight failure by parking a real pointer over the chart, which adds the extra `onHighlightedAxisChange` call.
- React 19: the same suites pass. `pnpm proptypes` and `pnpm docs:api` produce no drift.
- Ran the whole browser suite with the pointer reset. The only remaining failures are pre-existing local ones in `x-data-grid-pro` that also fail without this branch.
- The `zoom on pinch` charts tests are independently flaky on this machine at the same rate with and without the pointer reset (1 failure in 8 runs each way).

No new tests. Each propTypes fix is covered by an existing test that failed on React 18: `FunnelChart.test.tsx`, both `keyboardActivation.test.tsx` files, `MarkElement.test.tsx`, and `ChartsTooltipContainer.test.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
