### PR TITLE
[code-infra] Fix changelog categorization of docs and DateRangeCalendar tags

### DIFF
--- a/scripts/changelogUtils.mjs
+++ b/scripts/changelogUtils.mjs
@@ -250,6 +250,7 @@ async function generateChangelog({
   const docsCommits = [];
   const otherCommits = [];
   const codemodCommits = [];
+  const virtualizerCommits = [];
 
   commitsItems
     .filter((item) => !item.labels?.some((label) => excludeLabels.includes(label)))
@@ -312,11 +313,13 @@ async function generateChangelog({
         case 'scheduler-premium':
           schedulerPremiumCommits.push(commitItem);
           break;
+        case 'virtualizer':
+          virtualizerCommits.push(commitItem);
+          break;
         case 'internal':
         case 'support-infra':
         case 'code-infra':
         case 'docs-infra':
-        case 'virtualizer':
           internalCommits.push(commitItem);
           break;
         case 'codemod':
@@ -592,6 +595,13 @@ ${logProductSection({
   packageName: 'x-codemod',
   baseCommits: codemodCommits,
   changelogKey: 'codemod',
+})}
+
+${logProductSection({
+  productName: 'Virtualizer',
+  packageName: 'x-virtualizer',
+  baseCommits: virtualizerCommits,
+  changelogKey: 'virtualizer',
 })}
 
 ${logOtherSection({

--- a/scripts/changelogUtils.mjs
+++ b/scripts/changelogUtils.mjs
@@ -255,9 +255,14 @@ async function generateChangelog({
     .filter((item) => !item.labels?.some((label) => excludeLabels.includes(label)))
     .filter((item) => !excludeTitleTags.some((tag) => item.commit.message.includes(tag)))
     .forEach((commitItem) => {
-      const tag = parseTags(commitItem.commit.message);
+      const tags = parseTags(commitItem.commit.message).split(',');
+      // a `docs` tag wins over the product one: `[docs][charts]` is a docs change
+      if (tags.includes('docs')) {
+        docsCommits.push(commitItem);
+        return;
+      }
       // for now we use only one parsed tag
-      const firstTag = tag.split(',')[0];
+      const firstTag = tags[0];
       switch (firstTag) {
         case 'DataGrid':
         case 'data grid':
@@ -276,6 +281,7 @@ async function generateChangelog({
         case 'fields':
           pickersCommits.push(commitItem);
           break;
+        case 'DateRangeCalendar':
         case 'DateRangePicker':
         case 'DateTimeRangePicker':
         case 'TimeRangePicker':
@@ -306,13 +312,11 @@ async function generateChangelog({
         case 'scheduler-premium':
           schedulerPremiumCommits.push(commitItem);
           break;
-        case 'docs':
-          docsCommits.push(commitItem);
-          break;
         case 'internal':
         case 'support-infra':
         case 'code-infra':
         case 'docs-infra':
+        case 'virtualizer':
           internalCommits.push(commitItem);
           break;
         case 'codemod':

--- a/scripts/changelogUtils.mjs
+++ b/scripts/changelogUtils.mjs
@@ -250,7 +250,6 @@ async function generateChangelog({
   const docsCommits = [];
   const otherCommits = [];
   const codemodCommits = [];
-  const virtualizerCommits = [];
 
   commitsItems
     .filter((item) => !item.labels?.some((label) => excludeLabels.includes(label)))
@@ -312,9 +311,6 @@ async function generateChangelog({
           break;
         case 'scheduler-premium':
           schedulerPremiumCommits.push(commitItem);
-          break;
-        case 'virtualizer':
-          virtualizerCommits.push(commitItem);
           break;
         case 'internal':
         case 'support-infra':
@@ -595,13 +591,6 @@ ${logProductSection({
   packageName: 'x-codemod',
   baseCommits: codemodCommits,
   changelogKey: 'codemod',
-})}
-
-${logProductSection({
-  productName: 'Virtualizer',
-  packageName: 'x-virtualizer',
-  baseCommits: virtualizerCommits,
-  changelogKey: 'virtualizer',
 })}
 
 ${logOtherSection({


### PR DESCRIPTION
Two fixes to `scripts/changelogUtils.mjs`, found while preparing the v9.12.0 release:

- `[docs][charts]` and friends landed in the product section, because `parseTags` sorts the tags alphabetically and only the first one is used. A `docs` tag now wins over the product one.
- `[DateRangeCalendar]` had no case and fell through to **Miscellaneous**. It is now listed under `@mui/x-date-pickers-pro`.

Verified by regenerating the v9.11.1..master changelog: both entries move to the expected sections and nothing else changes.