### PR TITLE
[test] Isolate date pickers pro browser tests

### DIFF
--- a/packages/x-date-pickers-pro/vitest.config.browser.mts
+++ b/packages/x-date-pickers-pro/vitest.config.browser.mts
@@ -14,6 +14,8 @@ export default mergeConfig(
         enabled: true,
         instances: [{ browser: 'chromium' }],
       },
+      // Avoid Chromium renderer crashes caused by running this memory-heavy project in parallel.
+      sequence: { groupOrder: 1 },
     },
   }),
 );


### PR DESCRIPTION
The browser test job has started crashing Chromium renderers late in the `x-date-pickers-pro` suite on `master` and unrelated PR branches. The specific test file varies between runs, while the failure is consistently a closed Vitest browser connection.

This restores a dedicated Vitest sequence group for `x-date-pickers-pro`, so the memory-heavy project runs after the other browser projects instead of concurrently with them. This configuration was previously used for the same purpose before the browser runner resource class was increased.

Validation:
- `CI=true pnpm test:browser --project x-date-pickers-pro --run` (1,027 passed, 296 skipped, 2 todo)
- Sequencing verified with a combined `x-charts-vendor` and `x-date-pickers-pro` browser run
- `pnpm prettier`
- `pnpm exec eslint packages/x-date-pickers-pro/vitest.config.browser.mts --report-unused-disable-directives --max-warnings 0`