### PR TITLE
[code-infra] Fix the publish workflow failing on an outdated Node version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,9 @@ jobs:
           ref: ${{ inputs.sha }}
           fetch-depth: 0 # Fetch full history for proper git operations
       - name: Prepare for publishing
-        uses: mui/mui-public/.github/actions/publish-prepare@bcba759d16e06c283bcf4dba32ed562f2f9e77cc # @mui/internal-code-infra@0.0.4-canary.28
+        uses: mui/mui-public/.github/actions/publish-prepare@2266e66cb9b09ec1f0439b053aee05549f1f5f25 # master
+        with:
+          node-version: '22.23.2'
       - name: Publish packages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The v8.29.3 publish run failed before publishing anything: https://github.com/mui/mui-x/actions/runs/32474122797

```
npm error code EBADENGINE
npm error engine Not compatible with your version of node/npm: npm@12.0.2
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.9.3","node":"v22.19.0"}
```

The `publish-prepare` action pinned on `v8.x` predates the `node-version` input, so it defaults to Node 22.19.0, and the action's `npm install -g npm@latest` now resolves to npm 12, which requires Node >= 22.22.2.

This aligns the action pin and the Node version with `master`, where the publish workflow still works. The `actions/checkout` pin is intentionally left as is to keep the diff to the failure.