### PR TITLE
[code-infra] Align the pnpm version with master to fix publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,9 +147,9 @@
     "yargs": "catalog:",
     "zod": "^4.3.6"
   },
-  "packageManager": "pnpm@10.27.0",
+  "packageManager": "pnpm@11.20.0",
   "engines": {
-    "pnpm": "10.27.0",
+    "pnpm": "11.20.0",
     "node": ">=22.18"
   }
 }

--- a/packages/x-charts-vendor/.babelrc.js
+++ b/packages/x-charts-vendor/.babelrc.js
@@ -7,7 +7,6 @@
  */
 const path = require('path');
 const fs = require('fs');
-const { execSync } = require('child_process');
 
 const packageJsonPath = path.resolve('./package.json');
 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, { encoding: 'utf8' }));
@@ -18,9 +17,10 @@ if (!babelRuntimeVersion) {
     'package.json needs to have a dependency on `@babel/runtime` when building with `@babel/plugin-transform-runtime`.',
   );
 } else if (babelRuntimeVersion === 'catalog:') {
-  const listedBabelRuntime = execSync('pnpm list "@babel/runtime" --json');
-  const jsonListedDependencies = JSON.parse(listedBabelRuntime);
-  babelRuntimeVersion = jsonListedDependencies[0].dependencies['@babel/runtime'].version;
+  const runtimePackageJsonPath = require.resolve('@babel/runtime/package.json');
+  babelRuntimeVersion = JSON.parse(
+    fs.readFileSync(runtimePackageJsonPath, { encoding: 'utf8' }),
+  ).version;
 }
 
 module.exports = function getBabelConfig(api) {


### PR DESCRIPTION
Follow-up to #23392. The v8.29.3 publish still fails, now inside the publish step: https://github.com/mui/mui-x/actions/runs/32476311934

```
🔍 Discovering all workspace packages...
Unexpected non-whitespace character after JSON at position 4 (line 1 column 5)
```

The only environmental difference between this branch and `master`, whose publish works, is the pnpm switch that the setup step logs:

```
Switching pnpm from v11.7.0 to v10.27.0...
[WARN] Detected a pnpm v10 installation layout at PNPM_HOME. The pnpm shims at PNPM_HOME
have been refreshed so the new version is active, but pnpm v11 expects bins in PNPM_HOME/bin.
```

The runner image now ships pnpm 11, and `pnpm/action-setup` downgrades it to the version in `packageManager`. `master` is on pnpm 11.20.0, so nothing is switched; `v8.x` is on 10.27.0, so it is. This aligns `packageManager` and `engines.pnpm` with master to remove the switch. `pnpm-lock.yaml` needs no change: both branches are on `lockfileVersion: '9.0'`, and `pnpm@11.20.0 install --frozen-lockfile` passes on this branch untouched.

The second commit is needed for the bump: `x-charts-vendor`'s `.babelrc.js` resolved the `catalog:` version of `@babel/runtime` by parsing `pnpm list --json` and indexing `[0].dependencies`, which broke the postinstall build. It now reads the version through `require.resolve('@babel/runtime/package.json')`, making the file identical to master's.

To be explicit about what is and is not proven: the vendor build failure is reproduced and fixed locally, while the link between the pnpm switch and the publish parse error is inference, since the offending stdout is not in the run log. Re-dispatching the publish after this lands is the test.