### PR TITLE
[code-infra] Pin npm 11 to fix the v8 publish workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,3 +16,24 @@ jobs:
     uses: mui/mui-public/.github/workflows/ci-base.yml@bcba759d16e06c283bcf4dba32ed562f2f9e77cc # @mui/internal-code-infra@0.0.4-canary.28
     with:
       node-version: '22.18.0'
+
+  # Mirrors the real publish workflow environment (`publish.yml`) so an env mismatch, such as the
+  # npm version installed by `publish-prepare` breaking the pinned code-infra, is caught here
+  # instead of during a release.
+  publish-dry-run:
+    name: Publish Dry Run
+    if: ${{ github.repository_owner == 'mui' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+      - name: Prepare for publishing
+        uses: mui/mui-public/.github/actions/publish-prepare@2266e66cb9b09ec1f0439b053aee05549f1f5f25 # master
+        with:
+          node-version: '22.23.2'
+      # Keep in sync with `publish.yml`.
+      - name: Pin npm to 11
+        run: npm install -g npm@11
+      - name: Dry run npm publishing
+        env:
+          IS_PUBLISH_TEST: 'true'
+        run: pnpm code-infra publish --ci --dry-run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,5 +35,19 @@ jobs:
         run: npm install -g npm@11
       - name: Dry run npm publishing
         env:
+          # Honored by newer code-infra versions. The one pinned on this branch ignores it and
+          # always pushes the tag, so the failure is filtered out below instead.
           IS_PUBLISH_TEST: 'true'
-        run: pnpm code-infra publish --ci --dry-run
+        run: |
+          set +e
+          output=$(pnpm code-infra publish --ci --dry-run 2>&1)
+          status=$?
+          echo "$output"
+          # `git push --dry-run` still authenticates, and this check runs with a read-only token.
+          # Everything before the tag push is what we want to smoke-test, so only that specific
+          # failure is tolerated.
+          if [ $status -ne 0 ] && echo "$output" | grep -q 'Failed to create git tag'; then
+            echo 'Tag push requires write access, which this check does not have. Ignoring.'
+            exit 0
+          fi
+          exit $status

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,12 @@ jobs:
         uses: mui/mui-public/.github/actions/publish-prepare@2266e66cb9b09ec1f0439b053aee05549f1f5f25 # master
         with:
           node-version: '22.23.2'
+      # The `@mui/internal-code-infra` version pinned on this branch reads the release version
+      # with `pnpm pkg get version` and parses it as JSON. npm 12 prints the raw value instead of
+      # a quoted string, so the parse fails. Keep npm 11 until this branch moves to a code-infra
+      # version that reads `package.json` directly.
+      - name: Pin npm to 11
+        run: npm install -g npm@11
       - name: Publish packages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Follow-up to #23392. The v8.29.3 publish failed with:

```
🔍 Discovering all workspace packages...
Unexpected non-whitespace character after JSON at position 4 (line 1 column 5)
```

The failing parse is not the discovery itself, it is `getReleaseVersion()` in the `@mui/internal-code-infra` version pinned on this branch:

```js
const result = await $`pnpm pkg get version`;
const version = JSON.parse(result.stdout.trim());
```

`publish-prepare` runs `npm install -g npm@latest`, which is now npm 12, and npm 12 prints the raw value rather than a quoted string:

| npm | `pnpm pkg get version` |
| --- | --- |
| 11.19.0 | `"8.29.3"` |
| 12.0.2 | `8.29.3` |

`JSON.parse('8.29.3')` reads `8.29` as a number and then trips on the second `.`, which is exactly the reported position 4. `master` is unaffected because its newer code-infra reads `package.json` directly through `readPackageJson` instead of shelling out.

Verified on a branch in my fork: with this pin, `pnpm pkg get version` returns `"8.29.3"`, discovery passes, and `code-infra publish --ci --dry-run` gets all the way to `📦 Publishing packages to npm...`, stopping only at the fork's git push, as expected there.

The pin is a stopgap. The real fix is moving this branch to a code-infra version that reads `package.json` directly, at which point this step should be dropped.

---

**Second commit:** backports master's `publish-dry-run` CI job to this branch. Master gained it to catch exactly this class of problem, an environment mismatch in the publish workflow, on PRs rather than mid-release. v8.x never had it, which is why npm 12 broke the release instead of a PR. The job mirrors `publish.yml` on this branch, npm pin included, and the `Publish Dry Run` check on this PR is now the proof that the fix works.