### PR TITLE
[chat] Add feedback form to the docs

### DIFF
--- a/docs/data/chat/overview/overview.md
+++ b/docs/data/chat/overview/overview.md
@@ -6,6 +6,8 @@ githubLabel: 'scope: chat'
 components: ChatBox
 ---
 
+{{"component": "modules/components/overview/chat/ChatFeedbackBanner.tsx"}}
+
 {{"component": "modules/components/overview/XLogo.tsx"}}
 
 # MUI X Chat

--- a/docs/data/pages.ts
+++ b/docs/data/pages.ts
@@ -950,6 +950,23 @@ const pages: MuiPage[] = [
       { pathname: '/x/react-chat/all-components', title: 'Components' },
       { pathname: '/x/react-chat/accessibility', title: 'Accessibility' },
       {
+        // Keep in sync with `FEEDBACK_FORM_URL` in
+        // `docs/src/modules/components/overview/chat/ChatFeedbackBanner.tsx`.
+        pathname: 'https://forms.gle/XSKycguxQYxQma829',
+        title: 'Share your feedback',
+        icon: CampaignIcon,
+        linkProps: {
+          target: '_blank',
+          rel: 'noopener noreferrer',
+          sx: {
+            paddingLeft: 'calc(10px + (var(--_depth) + 1) * 13px - (var(--_expandable) * 21px))',
+            '& > span:first-of-type': {
+              order: 1,
+            },
+          },
+        },
+      },
+      {
         pathname: '/x/react-chat/main-features',
         subheader: 'Main features',
         children: [

--- a/docs/src/modules/components/overview/chat/ChatFeedbackBanner.tsx
+++ b/docs/src/modules/components/overview/chat/ChatFeedbackBanner.tsx
@@ -1,0 +1,108 @@
+import * as React from 'react';
+import { alpha } from '@mui/material/styles';
+import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import Link from '@mui/material/Link';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
+
+// Keep in sync with the "Share your feedback" entry of the Chat pages in `docs/data/pages.ts`.
+const FEEDBACK_FORM_URL = 'https://forms.gle/XSKycguxQYxQma829';
+const DISMISSED_STORAGE_KEY = 'mui-x-chat-feedback-dismissed';
+
+export default function ChatFeedbackBanner() {
+  const [open, setOpen] = React.useState(true);
+
+  React.useEffect(() => {
+    if (window.localStorage.getItem(DISMISSED_STORAGE_KEY) === 'true') {
+      setOpen(false);
+    }
+  }, []);
+
+  const handleDismiss = () => {
+    setOpen(false);
+    window.localStorage.setItem(DISMISSED_STORAGE_KEY, 'true');
+  };
+
+  if (!open) {
+    return null;
+  }
+
+  const content = (
+    <Stack
+      direction="row"
+      spacing={1.5}
+      sx={{ alignItems: 'center', justifyContent: 'space-between' }}
+    >
+      <Typography
+        variant="body2"
+        sx={(theme) => ({
+          color: 'primary.900',
+          ...theme.applyDarkStyles({ color: 'primary.100' }),
+        })}
+      >
+        💬 MUI X Chat is in early development — we&apos;d love your input.{' '}
+        <Link
+          href={FEEDBACK_FORM_URL}
+          target="_blank"
+          sx={(theme) => ({
+            fontWeight: 'semiBold',
+            color: 'primary.700',
+            textDecorationColor: alpha(theme.palette.primary[700], 0.4),
+            '&:hover': { textDecorationColor: 'currentColor' },
+            ...theme.applyDarkStyles({
+              color: 'primary.200',
+              textDecorationColor: alpha(theme.palette.primary[200], 0.4),
+            }),
+          })}
+        >
+          Share your feedback →
+        </Link>
+      </Typography>
+      <IconButton
+        size="small"
+        aria-label="Dismiss feedback banner"
+        onClick={handleDismiss}
+        sx={(theme) => ({
+          color: 'primary.700',
+          '&:hover': { bgcolor: alpha(theme.palette.primary[200], 0.4) },
+          ...theme.applyDarkStyles({
+            color: 'primary.200',
+            '&:hover': { bgcolor: alpha(theme.palette.primary[800], 0.4) },
+          }),
+        })}
+      >
+        <CloseRoundedIcon fontSize="small" />
+      </IconButton>
+    </Stack>
+  );
+
+  const innerSx = { px: 3, py: 0.5 };
+
+  return (
+    <React.Fragment>
+      <Box inert aria-hidden sx={{ ...innerSx, visibility: 'hidden', mb: 3 }}>
+        {content}
+      </Box>
+      <Box
+        sx={(theme) => ({
+          ...innerSx,
+          position: 'fixed',
+          top: 'var(--MuiDocs-header-height, 0px)',
+          left: { xs: 0, lg: 'var(--MuiDocs-navDrawer-width, 0px)' },
+          right: 0,
+          zIndex: theme.zIndex.appBar - 1,
+          bgcolor: 'primary.50',
+          borderBottom: '1px solid',
+          borderColor: 'divider',
+          ...theme.applyDarkStyles({
+            bgcolor: 'primaryDark.800',
+          }),
+        })}
+      >
+        {content}
+      </Box>
+    </React.Fragment>
+  );
+}


### PR DESCRIPTION
Mirrors the Scheduler's feedback loop for MUI X Chat: a dismissible banner at the top of the Chat overview page and a "Share your feedback" entry in the sidebar, both linking to a new Google Form.

Chat is `unstable: true` in the docs nav but had no channel to collect early-adopter use cases while the API is still moving. The Scheduler pattern was added in #22237; this reuses it as-is.

### Changes

- **`docs/src/modules/components/overview/chat/ChatFeedbackBanner.tsx`** (new) — copy of `SchedulerFeedbackBanner.tsx` with a Chat-specific form URL, its own `localStorage` dismiss key (`mui-x-chat-feedback-dismissed`, so dismissing one product's banner doesn't hide the other's), and Chat copy.
- **`docs/data/chat/overview/overview.md`** — renders the banner above the `XLogo` directive, same position as the Scheduler's.
- **`docs/data/pages.ts`** — external nav entry with `CampaignIcon` inside the Chat group, after *Accessibility* and before the *Main features* subheader. Same `linkProps` indent/icon-order handling as the Scheduler entry.

The form URL is duplicated between the component const and the nav entry (as it is for the Scheduler); both sites carry a sync comment.

### Testing

Local `pnpm eslint`, `prettier --check` and the `docs` typecheck are clean. Banner behaviour to check on the deploy preview: pinned under the header and offset by the nav drawer on `lg+`, page content not sliding under it, dismiss persisting across reloads, and the Scheduler banner unaffected.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
