### PR TITLE
[tree view] Reduce selector bundle size

### DIFF
--- a/packages/x-tree-view-pro/src/internals/plugins/itemsReordering/selectors.ts
+++ b/packages/x-tree-view-pro/src/internals/plugins/itemsReordering/selectors.ts
@@ -1,4 +1,4 @@
-import { createSelector, createSelectorMemoized } from '@mui/x-internals/store';
+import { createSelectorMemoized } from '@mui/x-internals/store';
 import { itemsSelectors, labelSelectors } from '@mui/x-tree-view/internals';
 import type { TreeViewItemId } from '@mui/x-tree-view/models';
 import type { RichTreeViewProState } from '../../RichTreeViewProStore';
@@ -7,7 +7,7 @@ export const itemsReorderingSelectors = {
   /**
    * Gets the properties of the current reordering.
    */
-  currentReorder: createSelector((state: RichTreeViewProState<any, any>) => state.currentReorder),
+  currentReorder: (state: RichTreeViewProState<any, any>) => state.currentReorder,
   /**
    * Gets the properties of the dragged item.
    */
@@ -39,16 +39,10 @@ export const itemsReorderingSelectors = {
   /**
    * Checks whether an item is being dragged.
    */
-  isDragging: createSelector(
-    (state: RichTreeViewProState<any, any>) => !!state.currentReorder?.draggedItemId,
-  ),
+  isDragging: (state: RichTreeViewProState<any, any>) => !!state.currentReorder?.draggedItemId,
   /**
    * Checks whether an item can be reordered.
    */
-  canItemBeReordered: createSelector(
-    (state: RichTreeViewProState<any, any>) => state.isItemReorderable,
-    labelSelectors.isAnyItemBeingEdited,
-    (isItemReorderable, isEditing, itemId: TreeViewItemId) =>
-      !isEditing && isItemReorderable(itemId),
-  ),
+  canItemBeReordered: (state: RichTreeViewProState<any, any>, itemId: TreeViewItemId) =>
+    !labelSelectors.isAnyItemBeingEdited(state) && state.isItemReorderable(itemId),
 };

--- a/packages/x-tree-view-pro/src/internals/plugins/virtualization/selectors.ts
+++ b/packages/x-tree-view-pro/src/internals/plugins/virtualization/selectors.ts
@@ -1,6 +1,5 @@
-import { createSelector } from '@mui/x-internals/store';
 import type { RichTreeViewProState } from '../../RichTreeViewProStore';
 
 export const virtualizationSelectors = {
-  enabled: createSelector((state: RichTreeViewProState<any, any>) => state.virtualization),
+  enabled: (state: RichTreeViewProState<any, any>) => state.virtualization,
 };

--- a/packages/x-tree-view/src/internals/plugins/expansion/selectors.ts
+++ b/packages/x-tree-view/src/internals/plugins/expansion/selectors.ts
@@ -1,4 +1,4 @@
-import { createSelector, createSelectorMemoized } from '@mui/x-internals/store';
+import { createSelectorMemoized } from '@mui/x-internals/store';
 import type { TreeViewItemId } from '../../../models';
 import type { MinimalTreeViewState } from '../../MinimalTreeViewStore';
 import { itemsSelectors } from '../items/selectors';
@@ -20,7 +20,7 @@ export const expansionSelectors = {
   /**
    * Gets the expanded items as provided to the component.
    */
-  expandedItemsRaw: createSelector((state: MinimalTreeViewState<any, any>) => state.expandedItems),
+  expandedItemsRaw: (state: MinimalTreeViewState<any, any>) => state.expandedItems,
   /**
    * Gets the expanded items as a Map.
    */
@@ -52,19 +52,15 @@ export const expansionSelectors = {
   /**
    * Gets the slot that triggers the item's expansion when clicked.
    */
-  triggerSlot: createSelector((state: MinimalTreeViewState<any, any>) => state.expansionTrigger),
+  triggerSlot: (state: MinimalTreeViewState<any, any>) => state.expansionTrigger,
   /**
    * Checks whether an item is expanded.
    */
-  isItemExpanded: createSelector(
-    expandedItemMapSelector,
-    (expandedItemsMap, itemId: TreeViewItemId) => expandedItemsMap.has(itemId),
-  ),
+  isItemExpanded: (state: MinimalTreeViewState<any, any>, itemId: TreeViewItemId) =>
+    expandedItemMapSelector(state).has(itemId),
   /**
    * Checks whether an item is expandable.
    */
-  isItemExpandable: createSelector(
-    itemsSelectors.itemMeta,
-    (itemMeta, _itemId: TreeViewItemId) => itemMeta?.expandable ?? false,
-  ),
+  isItemExpandable: (state: MinimalTreeViewState<any, any>, itemId: TreeViewItemId) =>
+    itemsSelectors.itemMeta(state, itemId)?.expandable ?? false,
 };

--- a/packages/x-tree-view/src/internals/plugins/focus/selectors.ts
+++ b/packages/x-tree-view/src/internals/plugins/focus/selectors.ts
@@ -1,4 +1,4 @@
-import { createSelector, createSelectorMemoized } from '@mui/x-internals/store';
+import { createSelectorMemoized } from '@mui/x-internals/store';
 import { selectionSelectors } from '../selection/selectors';
 import { itemsSelectors } from '../items/selectors';
 import { isItemDisabled } from '../items/utils';
@@ -48,19 +48,15 @@ export const focusSelectors = {
   /**
    * Checks whether an item is the default focusable item.
    */
-  isItemTheDefaultFocusableItem: createSelector(
-    defaultFocusableItemIdSelector,
-    (defaultFocusableItemId, itemId) => defaultFocusableItemId === itemId,
-  ),
+  isItemTheDefaultFocusableItem: (state: MinimalTreeViewState<any, any>, itemId: TreeViewItemId) =>
+    defaultFocusableItemIdSelector(state) === itemId,
   /**
    * Gets the id of the item that is currently focused.
    */
-  focusedItemId: createSelector((state: MinimalTreeViewState<any, any>) => state.focusedItemId),
+  focusedItemId: (state: MinimalTreeViewState<any, any>) => state.focusedItemId,
   /**
    * Checks whether an item is focused.
    */
-  isItemFocused: createSelector(
-    (state: MinimalTreeViewState<any, any>, itemId: TreeViewItemId) =>
-      state.focusedItemId === itemId,
-  ),
+  isItemFocused: (state: MinimalTreeViewState<any, any>, itemId: TreeViewItemId) =>
+    state.focusedItemId === itemId,
 };

--- a/packages/x-tree-view/src/internals/plugins/id/selectors.ts
+++ b/packages/x-tree-view/src/internals/plugins/id/selectors.ts
@@ -1,10 +1,8 @@
-import { createSelector } from '@mui/x-internals/store';
 import type { MinimalTreeViewState } from '../../MinimalTreeViewStore';
 import type { TreeViewItemId } from '../../../models';
 
-const treeIdSelector = createSelector(
-  (state: MinimalTreeViewState<any, any>) => state.providedTreeId ?? state.treeId,
-);
+const treeIdSelector = (state: MinimalTreeViewState<any, any>) =>
+  state.providedTreeId ?? state.treeId;
 
 export const idSelectors = {
   /**
@@ -16,14 +14,15 @@ export const idSelectors = {
    * If the user explicitly defined an id attribute, it will be returned.
    * Otherwise, the method creates a unique id for the item based on the Tree View id attribute and the item `itemId`
    */
-  treeItemIdAttribute: createSelector(
-    treeIdSelector,
-    (treeId, itemId: TreeViewItemId, providedIdAttribute: string | undefined) => {
-      if (providedIdAttribute != null) {
-        return providedIdAttribute;
-      }
+  treeItemIdAttribute: (
+    state: MinimalTreeViewState<any, any>,
+    itemId: TreeViewItemId,
+    providedIdAttribute: string | undefined,
+  ) => {
+    if (providedIdAttribute != null) {
+      return providedIdAttribute;
+    }
 
-      return `${treeId ?? ''}-${itemId}`;
-    },
-  ),
+    return `${treeIdSelector(state) ?? ''}-${itemId}`;
+  },
 };

--- a/packages/x-tree-view/src/internals/plugins/items/selectors.ts
+++ b/packages/x-tree-view/src/internals/plugins/items/selectors.ts
@@ -1,4 +1,3 @@
-import { createSelector } from '@mui/x-internals/store';
 import type { TreeViewItemId } from '../../../models';
 import type { TreeViewItemMeta } from '../../models';
 import { isItemDisabled, TREE_VIEW_ROOT_PARENT_ID } from './utils';
@@ -11,54 +10,44 @@ export const itemsSelectors = {
   /**
    * Gets the DOM structure of the Tree View.
    */
-  domStructure: createSelector((state: RichTreeViewState<any, any>) => state.domStructure),
+  domStructure: (state: RichTreeViewState<any, any>) => state.domStructure,
   /**
    * Checks whether the disabled items are focusable.
    */
-  disabledItemFocusable: createSelector(
-    (state: MinimalTreeViewState<any, any>) => state.disabledItemsFocusable,
-  ),
+  disabledItemFocusable: (state: MinimalTreeViewState<any, any>) => state.disabledItemsFocusable,
   /**
    * Gets the meta-information of all items.
    */
-  itemMetaLookup: createSelector((state: MinimalTreeViewState<any, any>) => state.itemMetaLookup),
+  itemMetaLookup: (state: MinimalTreeViewState<any, any>) => state.itemMetaLookup,
   /**
    * Gets the ordered children ids of all items.
    */
-  itemOrderedChildrenIdsLookup: createSelector(
-    (state: MinimalTreeViewState<any, any>) => state.itemOrderedChildrenIdsLookup,
-  ),
+  itemOrderedChildrenIdsLookup: (state: MinimalTreeViewState<any, any>) =>
+    state.itemOrderedChildrenIdsLookup,
   /**
    * Gets the meta-information of an item.
    */
-  itemMeta: createSelector(
-    (state: MinimalTreeViewState<any, any>, itemId: TreeViewItemId | null) =>
-      (state.itemMetaLookup[itemId ?? TREE_VIEW_ROOT_PARENT_ID] ?? null) as TreeViewItemMeta | null,
-  ),
+  itemMeta: (state: MinimalTreeViewState<any, any>, itemId: TreeViewItemId | null) =>
+    (state.itemMetaLookup[itemId ?? TREE_VIEW_ROOT_PARENT_ID] ?? null) as TreeViewItemMeta | null,
   /**
    * Gets the ordered children ids of an item.
    */
-  itemOrderedChildrenIds: createSelector(
-    (state: MinimalTreeViewState<any, any>, itemId: TreeViewItemId | null) =>
-      state.itemOrderedChildrenIdsLookup[itemId ?? TREE_VIEW_ROOT_PARENT_ID] ?? EMPTY_CHILDREN,
-  ),
+  itemOrderedChildrenIds: (state: MinimalTreeViewState<any, any>, itemId: TreeViewItemId | null) =>
+    state.itemOrderedChildrenIdsLookup[itemId ?? TREE_VIEW_ROOT_PARENT_ID] ?? EMPTY_CHILDREN,
   /**
    * Gets the model of an item.
    */
-  itemModel: createSelector(
-    (state: MinimalTreeViewState<any, any>, itemId: TreeViewItemId) =>
-      state.itemModelLookup[itemId],
-  ),
+  itemModel: (state: MinimalTreeViewState<any, any>, itemId: TreeViewItemId) =>
+    state.itemModelLookup[itemId],
   /**
    * Checks whether an item is disabled.
    */
-  isItemDisabled: createSelector((state: MinimalTreeViewState<any, any>, itemId: TreeViewItemId) =>
+  isItemDisabled: (state: MinimalTreeViewState<any, any>, itemId: TreeViewItemId) =>
     isItemDisabled(state.itemMetaLookup, itemId),
-  ),
   /**
    * Gets the index of an item in its parent's children.
    */
-  itemIndex: createSelector((state: MinimalTreeViewState<any, any>, itemId: TreeViewItemId) => {
+  itemIndex: (state: MinimalTreeViewState<any, any>, itemId: TreeViewItemId) => {
     const itemMeta = state.itemMetaLookup[itemId];
     if (itemMeta == null) {
       return -1;
@@ -67,37 +56,29 @@ export const itemsSelectors = {
     const parentIndexes =
       state.itemChildrenIndexesLookup[itemMeta.parentId ?? TREE_VIEW_ROOT_PARENT_ID];
     return parentIndexes[itemMeta.id];
-  }),
+  },
   /**
    * Gets the id of an item's parent.
    */
-  itemParentId: createSelector(
-    (state: MinimalTreeViewState<any, any>, itemId: TreeViewItemId) =>
-      state.itemMetaLookup[itemId]?.parentId ?? null,
-  ),
+  itemParentId: (state: MinimalTreeViewState<any, any>, itemId: TreeViewItemId) =>
+    state.itemMetaLookup[itemId]?.parentId ?? null,
   /**
    * Gets the depth of an item (items at the root level have a depth of 0).
    */
-  itemDepth: createSelector(
-    (state: MinimalTreeViewState<any, any>, itemId: TreeViewItemId) =>
-      state.itemMetaLookup[itemId]?.depth ?? 0,
-  ),
+  itemDepth: (state: MinimalTreeViewState<any, any>, itemId: TreeViewItemId) =>
+    state.itemMetaLookup[itemId]?.depth ?? 0,
   /**
    * Checks whether an item can be focused.
    */
-  canItemBeFocused: createSelector(
-    (state: MinimalTreeViewState<any, any>, itemId: TreeViewItemId) =>
-      state.disabledItemsFocusable ||
-      (state.itemModelLookup[itemId] != null && !isItemDisabled(state.itemMetaLookup, itemId)),
-  ),
+  canItemBeFocused: (state: MinimalTreeViewState<any, any>, itemId: TreeViewItemId) =>
+    state.disabledItemsFocusable ||
+    (state.itemModelLookup[itemId] != null && !isItemDisabled(state.itemMetaLookup, itemId)),
   /**
    * Gets the identation between an item and its children.
    */
-  itemChildrenIndentation: createSelector(
-    (state: MinimalTreeViewState<any, any>) => state.itemChildrenIndentation,
-  ),
+  itemChildrenIndentation: (state: MinimalTreeViewState<any, any>) => state.itemChildrenIndentation,
   /**
    * Gets the height of an individual item.
    */
-  itemHeight: createSelector((state: MinimalTreeViewState<any, any>) => state.itemHeight),
+  itemHeight: (state: MinimalTreeViewState<any, any>) => state.itemHeight,
 };

--- a/packages/x-tree-view/src/internals/plugins/labelEditing/selectors.ts
+++ b/packages/x-tree-view/src/internals/plugins/labelEditing/selectors.ts
@@ -1,4 +1,3 @@
-import { createSelector } from '@mui/x-internals/store';
 import { itemsSelectors } from '../items/selectors';
 import type { RichTreeViewState } from '../../RichTreeViewStore';
 import type { TreeViewItemId } from '../../../models';
@@ -7,32 +6,26 @@ export const labelSelectors = {
   /**
    * Checks whether an item is editable.
    */
-  isItemEditable: createSelector(
-    (state: RichTreeViewState<any, any>) => state.isItemEditable,
-    itemsSelectors.itemModel,
-    (isItemEditable, itemModel, _itemId: TreeViewItemId) => {
-      if (!itemModel || isItemEditable == null) {
-        return false;
-      }
+  isItemEditable: (state: RichTreeViewState<any, any>, itemId: TreeViewItemId) => {
+    const isItemEditable = state.isItemEditable;
+    const itemModel = itemsSelectors.itemModel(state, itemId);
+    if (!itemModel || isItemEditable == null) {
+      return false;
+    }
 
-      if (typeof isItemEditable === 'boolean') {
-        return isItemEditable;
-      }
+    if (typeof isItemEditable === 'boolean') {
+      return isItemEditable;
+    }
 
-      return isItemEditable(itemModel);
-    },
-  ),
+    return isItemEditable(itemModel);
+  },
   /**
    * Checks whether an item is being edited.
    */
-  isItemBeingEdited: createSelector(
-    (state: RichTreeViewState<any, any>, itemId: TreeViewItemId | null) =>
-      itemId == null ? false : state.editedItemId === itemId,
-  ),
+  isItemBeingEdited: (state: RichTreeViewState<any, any>, itemId: TreeViewItemId | null) =>
+    itemId == null ? false : state.editedItemId === itemId,
   /**
    * Checks whether any item is being edited.
    */
-  isAnyItemBeingEdited: createSelector(
-    (state: RichTreeViewState<any, any>) => !!state.editedItemId,
-  ),
+  isAnyItemBeingEdited: (state: RichTreeViewState<any, any>) => !!state.editedItemId,
 };

--- a/packages/x-tree-view/src/internals/plugins/lazyLoading/selectors.ts
+++ b/packages/x-tree-view/src/internals/plugins/lazyLoading/selectors.ts
@@ -1,4 +1,3 @@
-import { createSelector } from '@mui/x-internals/store';
 import type { TreeViewItemId } from '../../../models';
 import { TREE_VIEW_ROOT_PARENT_ID } from '../items';
 import type { RichTreeViewState } from '../../RichTreeViewStore';
@@ -7,7 +6,7 @@ export const lazyLoadingSelectors = {
   /**
    * Checks if the lazy loaded state is empty.
    */
-  isEmpty: createSelector((state: RichTreeViewState<any, any>) => {
+  isEmpty: (state: RichTreeViewState<any, any>) => {
     if (state.lazyLoadedItems == null) {
       return true;
     }
@@ -16,26 +15,20 @@ export const lazyLoadingSelectors = {
       Object.keys(state.lazyLoadedItems.loading).length === 0 &&
       Object.keys(state.lazyLoadedItems.errors).length === 0
     );
-  }),
+  },
   /**
    * Checks whether an item is loading.
    */
-  isItemLoading: createSelector(
-    (state: RichTreeViewState<any, any>, itemId: TreeViewItemId | null) =>
-      state.lazyLoadedItems?.loading[itemId ?? TREE_VIEW_ROOT_PARENT_ID] ?? false,
-  ),
+  isItemLoading: (state: RichTreeViewState<any, any>, itemId: TreeViewItemId | null) =>
+    state.lazyLoadedItems?.loading[itemId ?? TREE_VIEW_ROOT_PARENT_ID] ?? false,
   /**
    * Checks whether an item has errors.
    */
-  itemHasError: createSelector(
-    (state: RichTreeViewState<any, any>, itemId: TreeViewItemId | null) =>
-      !!state.lazyLoadedItems?.errors[itemId ?? TREE_VIEW_ROOT_PARENT_ID],
-  ),
+  itemHasError: (state: RichTreeViewState<any, any>, itemId: TreeViewItemId | null) =>
+    !!state.lazyLoadedItems?.errors[itemId ?? TREE_VIEW_ROOT_PARENT_ID],
   /**
    * Get an item error.
    */
-  itemError: createSelector(
-    (state: RichTreeViewState<any, any>, itemId: TreeViewItemId | null) =>
-      state.lazyLoadedItems?.errors[itemId ?? TREE_VIEW_ROOT_PARENT_ID],
-  ),
+  itemError: (state: RichTreeViewState<any, any>, itemId: TreeViewItemId | null) =>
+    state.lazyLoadedItems?.errors[itemId ?? TREE_VIEW_ROOT_PARENT_ID],
 };

--- a/packages/x-tree-view/src/internals/plugins/selection/selectors.ts
+++ b/packages/x-tree-view/src/internals/plugins/selection/selectors.ts
@@ -1,4 +1,4 @@
-import { createSelector, createSelectorMemoized } from '@mui/x-internals/store';
+import { createSelectorMemoized } from '@mui/x-internals/store';
 import type { TreeViewItemId, TreeViewItemSelectionStatus } from '../../../models';
 import type { MinimalTreeViewState } from '../../MinimalTreeViewStore';
 import { itemsSelectors } from '../items/selectors';
@@ -26,83 +26,76 @@ const selectedItemsMapSelector = createSelectorMemoized(selectedItemsSelector, (
   return selectedItemsMap;
 });
 
-const isItemSelectableSelector = createSelector(
-  (state: MinimalTreeViewState<any, any>, itemId: TreeViewItemId) =>
-    state.itemMetaLookup[itemId]?.selectable ?? true,
-);
+const isItemSelectableSelector = (state: MinimalTreeViewState<any, any>, itemId: TreeViewItemId) =>
+  state.itemMetaLookup[itemId]?.selectable ?? true;
 
-const isItemSelectedSelector = createSelector(
-  selectedItemsMapSelector,
-  (selectedItemsMap, itemId: TreeViewItemId) => selectedItemsMap.has(itemId),
-);
+const isItemSelectedSelector = (state: MinimalTreeViewState<any, any>, itemId: TreeViewItemId) =>
+  selectedItemsMapSelector(state).has(itemId);
 
-const canItemBeSelectedSelector = createSelector(
-  itemsSelectors.isItemDisabled,
-  isItemSelectableSelector,
-  (state: MinimalTreeViewState<any, any>) => !state.disableSelection,
-  (isItemDisabled, isItemSelectable, isSelectionEnabled, _itemId: TreeViewItemId) =>
-    isSelectionEnabled && !isItemDisabled && isItemSelectable,
-);
+const canItemBeSelectedSelector = (state: MinimalTreeViewState<any, any>, itemId: TreeViewItemId) =>
+  !state.disableSelection &&
+  !itemsSelectors.isItemDisabled(state, itemId) &&
+  isItemSelectableSelector(state, itemId);
 
-const propagationRulesSelector = createSelector(
-  (state: MinimalTreeViewState<any, any>) => state.selectionPropagation,
-);
+const propagationRulesSelector = (state: MinimalTreeViewState<any, any>) =>
+  state.selectionPropagation;
 
-const itemSelectionStatusSelector = createSelector(
-  (state: MinimalTreeViewState<any, any>, itemId: TreeViewItemId): TreeViewItemSelectionStatus => {
-    if (isItemSelectedSelector(state, itemId)) {
-      return 'selected';
-    }
+const itemSelectionStatusSelector = (
+  state: MinimalTreeViewState<any, any>,
+  itemId: TreeViewItemId,
+): TreeViewItemSelectionStatus => {
+  if (isItemSelectedSelector(state, itemId)) {
+    return 'selected';
+  }
 
-    // Only the descendants can make an unselected item `indeterminate`, so leaves can be resolved
-    // without traversing the tree.
-    if (itemsSelectors.itemOrderedChildrenIds(state, itemId).length === 0) {
-      return 'unselected';
-    }
+  // Only the descendants can make an unselected item `indeterminate`, so leaves can be resolved
+  // without traversing the tree.
+  if (itemsSelectors.itemOrderedChildrenIds(state, itemId).length === 0) {
+    return 'unselected';
+  }
 
-    let hasSelectedDescendant = false;
-    let hasUnSelectedDescendant = false;
+  let hasSelectedDescendant = false;
+  let hasUnSelectedDescendant = false;
 
-    const traverseDescendants = (itemToTraverseId: TreeViewItemId) => {
-      if (itemToTraverseId !== itemId) {
-        if (canItemBeSelectedSelector(state, itemToTraverseId)) {
-          if (isItemSelectedSelector(state, itemToTraverseId)) {
-            hasSelectedDescendant = true;
-          } else {
-            hasUnSelectedDescendant = true;
-          }
+  const traverseDescendants = (itemToTraverseId: TreeViewItemId) => {
+    if (itemToTraverseId !== itemId) {
+      if (canItemBeSelectedSelector(state, itemToTraverseId)) {
+        if (isItemSelectedSelector(state, itemToTraverseId)) {
+          hasSelectedDescendant = true;
+        } else {
+          hasUnSelectedDescendant = true;
         }
       }
-
-      itemsSelectors.itemOrderedChildrenIds(state, itemToTraverseId).forEach(traverseDescendants);
-    };
-
-    traverseDescendants(itemId);
-
-    const shouldSelectBasedOnDescendants = propagationRulesSelector(state).parents;
-    if (shouldSelectBasedOnDescendants) {
-      if (hasSelectedDescendant && hasUnSelectedDescendant) {
-        return 'indeterminate';
-      }
-      if (hasSelectedDescendant && !hasUnSelectedDescendant) {
-        return 'selected';
-      }
-      return 'unselected';
     }
 
-    if (hasSelectedDescendant) {
+    itemsSelectors.itemOrderedChildrenIds(state, itemToTraverseId).forEach(traverseDescendants);
+  };
+
+  traverseDescendants(itemId);
+
+  const shouldSelectBasedOnDescendants = propagationRulesSelector(state).parents;
+  if (shouldSelectBasedOnDescendants) {
+    if (hasSelectedDescendant && hasUnSelectedDescendant) {
       return 'indeterminate';
     }
-
+    if (hasSelectedDescendant && !hasUnSelectedDescendant) {
+      return 'selected';
+    }
     return 'unselected';
-  },
-);
+  }
+
+  if (hasSelectedDescendant) {
+    return 'indeterminate';
+  }
+
+  return 'unselected';
+};
 
 export const selectionSelectors = {
   /**
    * Gets the selected items as provided to the component.
    */
-  selectedItemsRaw: createSelector((state: MinimalTreeViewState<any, any>) => state.selectedItems),
+  selectedItemsRaw: (state: MinimalTreeViewState<any, any>) => state.selectedItems,
   /**
    * Gets the selected items as an array.
    */
@@ -114,19 +107,15 @@ export const selectionSelectors = {
   /**
    * Checks whether selection is enabled.
    */
-  enabled: createSelector((state: MinimalTreeViewState<any, any>) => !state.disableSelection),
+  enabled: (state: MinimalTreeViewState<any, any>) => !state.disableSelection,
   /**
    * Checks whether multi selection is enabled.
    */
-  isMultiSelectEnabled: createSelector(
-    (state: MinimalTreeViewState<any, any>) => state.multiSelect,
-  ),
+  isMultiSelectEnabled: (state: MinimalTreeViewState<any, any>) => state.multiSelect,
   /**
    * Checks whether checkbox selection is enabled.
    */
-  isCheckboxSelectionEnabled: createSelector(
-    (state: MinimalTreeViewState<any, any>) => state.checkboxSelection,
-  ),
+  isCheckboxSelectionEnabled: (state: MinimalTreeViewState<any, any>) => state.checkboxSelection,
   /**
    * Gets the selection propagation rules.
    */
@@ -144,20 +133,14 @@ export const selectionSelectors = {
   /**
    * Checks whether an item is indeterminate (it is not selected but some of its selectable descendants are).
    */
-  isItemIndeterminate: createSelector(
-    itemSelectionStatusSelector,
-    (selectionStatus, _itemId: TreeViewItemId) => selectionStatus === 'indeterminate',
-  ),
+  isItemIndeterminate: (state: MinimalTreeViewState<any, any>, itemId: TreeViewItemId) =>
+    itemSelectionStatusSelector(state, itemId) === 'indeterminate',
   /**
    * Checks whether the selection feature is enabled for an item.
    * Returns `true` when selection is enabled on the Tree View and the item is selectable (even if the item is disabled).
    */
-  isFeatureEnabledForItem: createSelector(
-    isItemSelectableSelector,
-    (state: MinimalTreeViewState<any, any>) => !state.disableSelection,
-    (isItemSelectable, isSelectionEnabled, _itemId: TreeViewItemId) =>
-      isSelectionEnabled && isItemSelectable,
-  ),
+  isFeatureEnabledForItem: (state: MinimalTreeViewState<any, any>, itemId: TreeViewItemId) =>
+    !state.disableSelection && isItemSelectableSelector(state, itemId),
   /**
    * Checks whether an item can be selected (if selection is enabled, if the item is not disabled, and if the item is selectable).
    */


### PR DESCRIPTION
Removes internal selector factories that don't memoize, without changing the public API. Same technique as the Base UI bundle-size effort (mui/base-ui#5250): `createSelector` with a single function argument returns it unchanged, so the wrapper is an identity call that only adds bytes, and composed non-memoized selectors re-run their inputs on every call anyway, so they are collapsed into single plain `(state, ...args)` functions.

## Changes

- Replace single-argument `createSelector(fn)` wrappers with the bare function across the Tree View and Tree View Pro plugin selectors.
- Collapse composed non-memoized selectors (`isItemSelected`, `canItemBeSelected`, `isItemExpanded`, `isItemEditable`, `treeItemIdAttribute`, `canItemBeReordered`, …) into single plain functions that call their memoized inputs directly.
- Keep every `createSelectorMemoized` selector untouched; they still receive the same input functions.

Behavior is identical: the non-memoized `createSelector` composition executed all inputs on each call, so the plain functions compute the same values (short-circuiting saves a few calls). The bundle-size CI check is authoritative for the size impact.

Sibling PR applying the same technique to the Scheduler: #23413.

## Validation

- `pnpm --filter "@mui/x-tree-view*" run typescript`
- `pnpm test:unit --project "x-tree-view*" --run` — 1059 passing
- `pnpm eslint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
