### PR TITLE
[scheduler] Reduce selector bundle size

### DIFF
--- a/packages/x-scheduler-internals-premium/src/event-timeline-premium-selectors/eventTimelinePremiumDependencySelectors.ts
+++ b/packages/x-scheduler-internals-premium/src/event-timeline-premium-selectors/eventTimelinePremiumDependencySelectors.ts
@@ -1,4 +1,4 @@
-import { createSelector, createSelectorMemoized } from '@base-ui/utils/store';
+import { createSelectorMemoized } from '@base-ui/utils/store';
 import { EMPTY_ARRAY } from '@base-ui/utils/empty';
 import type { SchedulerEventId, SchedulerResourceId } from '@mui/x-scheduler-internals/models';
 import type { SchedulerDependency, SchedulerDependencyId } from '../models';
@@ -54,25 +54,20 @@ const activeSourceTitlesByTargetSelector = createSelectorMemoized(
   },
 );
 
-const selectedIdSelector = createSelector(
-  (state: State) => state.selection,
-  (state: State) => state.dependencyModelLookup,
-  (selection, dependencyModelLookup) =>
-    selection?.type === 'dependency' && dependencyModelLookup.has(selection.id)
-      ? selection.id
-      : null,
-);
+const selectedIdSelector = (state: State) => {
+  const selection = state.selection;
+  return selection?.type === 'dependency' && state.dependencyModelLookup.has(selection.id)
+    ? selection.id
+    : null;
+};
 
-const creationSelector = createSelector((state: State) => state.dependencyCreation);
+const creationSelector = (state: State) => state.dependencyCreation;
 
 export const eventTimelinePremiumDependencySelectors = {
-  modelList: createSelector((state: State) => state.dependencyModelList),
-  modelLookup: createSelector((state: State) => state.dependencyModelLookup),
-  model: createSelector(
-    (state: State) => state.dependencyModelLookup,
-    (dependencyModelLookup, dependencyId: SchedulerDependencyId) =>
-      dependencyModelLookup.get(dependencyId) ?? null,
-  ),
+  modelList: (state: State) => state.dependencyModelList,
+  modelLookup: (state: State) => state.dependencyModelLookup,
+  model: (state: State, dependencyId: SchedulerDependencyId) =>
+    state.dependencyModelLookup.get(dependencyId) ?? null,
   /**
    * Dependencies whose two events exist and are not recurring.
    * Rendering and the scheduling engine must only consume these.
@@ -89,15 +84,12 @@ export const eventTimelinePremiumDependencySelectors = {
    * Used to describe an event with the events it depends on.
    */
   activeSourceTitlesByTarget: activeSourceTitlesByTargetSelector,
-  activeSourceTitlesForTarget: createSelector(
-    activeSourceTitlesByTargetSelector,
-    (titlesByTarget, eventId: SchedulerEventId): readonly string[] =>
-      titlesByTarget.get(eventId) ?? EMPTY_ARRAY,
-  ),
+  activeSourceTitlesForTarget: (state: State, eventId: SchedulerEventId): readonly string[] =>
+    activeSourceTitlesByTargetSelector(state).get(eventId) ?? EMPTY_ARRAY,
   /**
    * Whether the dependencies feature is enabled (internal parameters provided).
    */
-  enabled: createSelector((state: State) => state.areDependenciesEnabled),
+  enabled: (state: State) => state.areDependenciesEnabled,
   /**
    * The pending create-dependency drag gesture, or `null`.
    */
@@ -105,20 +97,22 @@ export const eventTimelinePremiumDependencySelectors = {
   // Keyed by occurrence *and* resource: an event appearing on several resources
   // repeats the same occurrence key on each row, and only the row appearance the
   // gesture actually involves must highlight.
-  isCreationSource: createSelector(
-    creationSelector,
-    (creation, occurrenceKey: string, resourceId: SchedulerResourceId) =>
+  isCreationSource: (state: State, occurrenceKey: string, resourceId: SchedulerResourceId) => {
+    const creation = creationSelector(state);
+    return (
       creation !== null &&
       creation.sourceOccurrenceKey === occurrenceKey &&
-      creation.sourceResourceId === resourceId,
-  ),
-  isCreationTarget: createSelector(
-    creationSelector,
-    (creation, occurrenceKey: string, resourceId: SchedulerResourceId) =>
+      creation.sourceResourceId === resourceId
+    );
+  },
+  isCreationTarget: (state: State, occurrenceKey: string, resourceId: SchedulerResourceId) => {
+    const creation = creationSelector(state);
+    return (
       creation !== null &&
       creation.targetOccurrenceKey === occurrenceKey &&
-      creation.targetResourceId === resourceId,
-  ),
+      creation.targetResourceId === resourceId
+    );
+  },
   /**
    * The id of the selected dependency, or `null`.
    * The masking is membership-only: an id absent from the dependency lookup resolves
@@ -131,12 +125,12 @@ export const eventTimelinePremiumDependencySelectors = {
    * Whether the dependency cannot be deleted because one of its events is read-only.
    * Unknown ids resolve to `false`.
    */
-  isModelReadOnly: createSelector((state: State, dependencyId: SchedulerDependencyId | null) => {
+  isModelReadOnly: (state: State, dependencyId: SchedulerDependencyId | null) => {
     const dependency =
       dependencyId === null ? undefined : state.dependencyModelLookup.get(dependencyId);
     if (!dependency) {
       return false;
     }
     return isDependencyReadOnly(state, dependency);
-  }),
+  },
 };

--- a/packages/x-scheduler-internals-premium/src/event-timeline-premium-selectors/eventTimelinePremiumOccurrencePlaceholderSelectors.ts
+++ b/packages/x-scheduler-internals-premium/src/event-timeline-premium-selectors/eventTimelinePremiumOccurrencePlaceholderSelectors.ts
@@ -1,4 +1,3 @@
-import { createSelector } from '@base-ui/utils/store';
 import type {
   SchedulerOccurrencePlaceholder,
   SchedulerResourceId,
@@ -43,7 +42,7 @@ function isResourceInPlaceholderTargetSet(
 }
 
 export const timelineOccurrencePlaceholderSelectors = {
-  placeholderInResource: createSelector((state: State, resourceId: SchedulerResourceId | null) => {
+  placeholderInResource: (state: State, resourceId: SchedulerResourceId | null) => {
     const placeholder = state.occurrencePlaceholder;
     if (
       placeholder === null ||
@@ -64,8 +63,8 @@ export const timelineOccurrencePlaceholderSelectors = {
     }
 
     return placeholder;
-  }),
-  isCreatingInResource: createSelector((state: State, resourceId: SchedulerResourceId | null) => {
+  },
+  isCreatingInResource: (state: State, resourceId: SchedulerResourceId | null) => {
     const placeholder = state.occurrencePlaceholder;
     if (
       placeholder === null ||
@@ -76,5 +75,5 @@ export const timelineOccurrencePlaceholderSelectors = {
       return false;
     }
     return true;
-  }),
+  },
 };

--- a/packages/x-scheduler-internals-premium/src/event-timeline-premium-selectors/eventTimelinePremiumOccurrenceSelectors.ts
+++ b/packages/x-scheduler-internals-premium/src/event-timeline-premium-selectors/eventTimelinePremiumOccurrenceSelectors.ts
@@ -1,4 +1,4 @@
-import { createSelector, createSelectorMemoized } from '@base-ui/utils/store';
+import { createSelectorMemoized } from '@base-ui/utils/store';
 import { EMPTY_ARRAY } from '@base-ui/utils/empty';
 import { schedulerOccurrenceSelectors } from '@mui/x-scheduler-internals/scheduler-selectors';
 import {
@@ -66,10 +66,8 @@ const visibleAxisDataSelector = createSelectorMemoized(
  * The filtered source for all timeline layout consumers. Using this list keeps hidden
  * occurrences out of rendered lanes, lane counts, dependency arrows, and tab navigation.
  */
-const visibleGroupedByResourceListSelector = createSelector(
-  visibleAxisDataSelector,
-  (data) => data.resources,
-);
+const visibleGroupedByResourceListSelector = (state: State) =>
+  visibleAxisDataSelector(state).resources;
 
 const visibleOccurrencesByResourceMapSelector = createSelectorMemoized(
   visibleGroupedByResourceListSelector,
@@ -112,13 +110,11 @@ export const eventTimelinePremiumOccurrenceSelectors = {
    * The axis position of every visible occurrence, or `null` on the full-day window
    * (where filtering is an identity and mounted rows derive positions on demand).
    */
-  visiblePositionByOccurrenceKey: createSelector(
-    visibleAxisDataSelector,
-    (data): ReadonlyMap<string, OccurrencePosition> | null => data.positionByOccurrenceKey,
-  ),
-  visibleResourceOccurrences: createSelector(
-    visibleOccurrencesByResourceMapSelector,
-    (map, resourceId: SchedulerResourceId): readonly SchedulerEventOccurrence[] =>
-      map.get(resourceId) ?? EMPTY_ARRAY,
-  ),
+  visiblePositionByOccurrenceKey: (state: State): ReadonlyMap<string, OccurrencePosition> | null =>
+    visibleAxisDataSelector(state).positionByOccurrenceKey,
+  visibleResourceOccurrences: (
+    state: State,
+    resourceId: SchedulerResourceId,
+  ): readonly SchedulerEventOccurrence[] =>
+    visibleOccurrencesByResourceMapSelector(state).get(resourceId) ?? EMPTY_ARRAY,
 };

--- a/packages/x-scheduler-internals-premium/src/event-timeline-premium-selectors/eventTimelinePremiumPresetSelectors.ts
+++ b/packages/x-scheduler-internals-premium/src/event-timeline-premium-selectors/eventTimelinePremiumPresetSelectors.ts
@@ -1,4 +1,4 @@
-import { createSelector, createSelectorMemoized } from '@base-ui/utils/store';
+import { createSelectorMemoized } from '@base-ui/utils/store';
 import { schedulerPreferenceSelectors } from '@mui/x-scheduler-internals/scheduler-selectors';
 import {
   getDisplayedHourRange,
@@ -10,8 +10,8 @@ import type { EventTimelinePremiumState as State } from '../use-event-timeline-p
 import { EVENT_TIMELINE_PREMIUM_PRESET_DEFINITIONS } from '../internals/utils/preset-utils';
 
 export const eventTimelinePremiumPresetSelectors = {
-  preset: createSelector((state: State) => state.preset),
-  presets: createSelector((state: State) => state.presets),
+  preset: (state: State) => state.preset,
+  presets: (state: State) => state.presets,
   config: createSelectorMemoized(
     (state: State) => state.adapter,
     (state: State) => state.visibleDate,

--- a/packages/x-scheduler-internals/src/calendar-grid/header-cell/CalendarGridHeaderCell.tsx
+++ b/packages/x-scheduler-internals/src/calendar-grid/header-cell/CalendarGridHeaderCell.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import { createSelector, useStore } from '@base-ui/utils/store';
+import { useStore } from '@base-ui/utils/store';
 import { useRenderElement } from '@base-ui/react/internals/useRenderElement';
 import type { BaseUIComponentProps } from '@base-ui/react/internals/types';
 import { useCompositeListItem } from '@base-ui/react/internals/composite';
@@ -14,13 +14,11 @@ import { useCalendarGridRootContext } from '../root/CalendarGridRootContext';
 import { schedulerNowSelectors } from '../../scheduler-selectors';
 import type { EventCalendarState } from '../../use-event-calendar';
 
-const selectorIsCurrentDate = createSelector(
-  (
-    state: EventCalendarState,
-    date: TemporalSupportedObject,
-    skipDataCurrent: boolean | undefined,
-  ) => !skipDataCurrent && schedulerNowSelectors.isCurrentDay(state, date),
-);
+const selectorIsCurrentDate = (
+  state: EventCalendarState,
+  date: TemporalSupportedObject,
+  skipDataCurrent: boolean | undefined,
+) => !skipDataCurrent && schedulerNowSelectors.isCurrentDay(state, date);
 
 export const CalendarGridHeaderCell = React.forwardRef(function CalendarGridHeaderCell(
   componentProps: CalendarGridHeaderCell.Props,

--- a/packages/x-scheduler-internals/src/event-calendar-selectors/eventCalendarOccurrencePlaceholderSelectors.ts
+++ b/packages/x-scheduler-internals/src/event-calendar-selectors/eventCalendarOccurrencePlaceholderSelectors.ts
@@ -1,77 +1,82 @@
-import { createSelector } from '@base-ui/utils/store';
 import type { EventCalendarState as State } from '../use-event-calendar';
 import type { TemporalSupportedObject } from '../models';
 
 export const eventCalendarOccurrencePlaceholderSelectors = {
-  placeholderInDayCell: createSelector(
-    (state: State, day: TemporalSupportedObject, rowStart: TemporalSupportedObject) => {
-      if (
-        state.occurrencePlaceholder === null ||
-        state.occurrencePlaceholder.surfaceType !== 'day-grid' ||
-        state.occurrencePlaceholder.isHidden
-      ) {
-        return null;
-      }
-
-      if (state.adapter.isSameDay(day, state.occurrencePlaceholder.start)) {
-        return state.occurrencePlaceholder;
-      }
-
-      if (
-        state.adapter.isSameDay(day, rowStart) &&
-        state.adapter.isWithinRange(rowStart, [
-          state.occurrencePlaceholder.start,
-          state.occurrencePlaceholder.end,
-        ])
-      ) {
-        return state.occurrencePlaceholder;
-      }
-
+  placeholderInDayCell: (
+    state: State,
+    day: TemporalSupportedObject,
+    rowStart: TemporalSupportedObject,
+  ) => {
+    if (
+      state.occurrencePlaceholder === null ||
+      state.occurrencePlaceholder.surfaceType !== 'day-grid' ||
+      state.occurrencePlaceholder.isHidden
+    ) {
       return null;
-    },
-  ),
-  placeholderInTimeRange: createSelector(
-    (state: State, start: TemporalSupportedObject, end: TemporalSupportedObject) => {
-      if (
-        state.occurrencePlaceholder === null ||
-        state.occurrencePlaceholder.surfaceType !== 'time-grid' ||
-        state.occurrencePlaceholder.isHidden
-      ) {
-        return null;
-      }
+    }
 
-      if (
-        state.adapter.isBefore(state.occurrencePlaceholder.end, start) ||
-        state.adapter.isAfter(state.occurrencePlaceholder.start, end)
-      ) {
-        return null;
-      }
-
+    if (state.adapter.isSameDay(day, state.occurrencePlaceholder.start)) {
       return state.occurrencePlaceholder;
-    },
-  ),
-  isCreatingInDayCell: createSelector((state: State, day: TemporalSupportedObject) => {
+    }
+
+    if (
+      state.adapter.isSameDay(day, rowStart) &&
+      state.adapter.isWithinRange(rowStart, [
+        state.occurrencePlaceholder.start,
+        state.occurrencePlaceholder.end,
+      ])
+    ) {
+      return state.occurrencePlaceholder;
+    }
+
+    return null;
+  },
+  placeholderInTimeRange: (
+    state: State,
+    start: TemporalSupportedObject,
+    end: TemporalSupportedObject,
+  ) => {
+    if (
+      state.occurrencePlaceholder === null ||
+      state.occurrencePlaceholder.surfaceType !== 'time-grid' ||
+      state.occurrencePlaceholder.isHidden
+    ) {
+      return null;
+    }
+
+    if (
+      state.adapter.isBefore(state.occurrencePlaceholder.end, start) ||
+      state.adapter.isAfter(state.occurrencePlaceholder.start, end)
+    ) {
+      return null;
+    }
+
+    return state.occurrencePlaceholder;
+  },
+  isCreatingInDayCell: (state: State, day: TemporalSupportedObject) => {
     const placeholder = state.occurrencePlaceholder;
     if (placeholder?.surfaceType !== 'day-grid' || placeholder.type !== 'creation') {
       return false;
     }
     return state.adapter.isSameDay(day, placeholder.start);
-  }),
-  isCreatingInTimeRange: createSelector(
-    (state: State, dayStart: TemporalSupportedObject, dayEnd: TemporalSupportedObject) => {
-      const placeholder = state.occurrencePlaceholder;
-      if (placeholder?.surfaceType !== 'time-grid' || placeholder.type !== 'creation') {
-        return false;
-      }
+  },
+  isCreatingInTimeRange: (
+    state: State,
+    dayStart: TemporalSupportedObject,
+    dayEnd: TemporalSupportedObject,
+  ) => {
+    const placeholder = state.occurrencePlaceholder;
+    if (placeholder?.surfaceType !== 'time-grid' || placeholder.type !== 'creation') {
+      return false;
+    }
 
-      if (!state.adapter.isSameDay(placeholder.start, dayStart)) {
-        return false;
-      }
+    if (!state.adapter.isSameDay(placeholder.start, dayStart)) {
+      return false;
+    }
 
-      const startsBeforeEnd = state.adapter.isBefore(placeholder.start, dayEnd);
-      const endsAfterStart = state.adapter.isAfter(placeholder.end, dayStart);
+    const startsBeforeEnd = state.adapter.isBefore(placeholder.start, dayEnd);
+    const endsAfterStart = state.adapter.isAfter(placeholder.end, dayStart);
 
-      return startsBeforeEnd && endsAfterStart;
-    },
-  ),
+    return startsBeforeEnd && endsAfterStart;
+  },
 };

--- a/packages/x-scheduler-internals/src/event-calendar-selectors/eventCalendarPreferenceSelectors.ts
+++ b/packages/x-scheduler-internals/src/event-calendar-selectors/eventCalendarPreferenceSelectors.ts
@@ -1,4 +1,4 @@
-import { createSelector, createSelectorMemoized } from '@base-ui/utils/store';
+import { createSelectorMemoized } from '@base-ui/utils/store';
 import type { EventCalendarState as State } from '../use-event-calendar';
 import { DEFAULT_EVENT_CALENDAR_PREFERENCES } from '../use-event-calendar/EventCalendarStore';
 
@@ -12,20 +12,11 @@ const allPreferencesSelector = createSelectorMemoized(
 
 export const eventCalendarPreferenceSelectors = {
   all: allPreferencesSelector,
-  menuConfig: createSelector((state: State) => state.preferencesMenuConfig),
-  ampm: createSelector(allPreferencesSelector, (preferences) => preferences.ampm),
-  showWeekends: createSelector(allPreferencesSelector, (preferences) => preferences.showWeekends),
-  showWeekNumber: createSelector(
-    allPreferencesSelector,
-    (preferences) => preferences.showWeekNumber,
-  ),
-  showEmptyDaysInAgenda: createSelector(
-    allPreferencesSelector,
-    (preferences) => preferences.showEmptyDaysInAgenda,
-  ),
-  isSidePanelOpen: createSelector(
-    allPreferencesSelector,
-    (preferences) => preferences.isSidePanelOpen,
-  ),
-  weekStartsOn: createSelector(allPreferencesSelector, (preferences) => preferences.weekStartsOn),
+  menuConfig: (state: State) => state.preferencesMenuConfig,
+  ampm: (state: State) => allPreferencesSelector(state).ampm,
+  showWeekends: (state: State) => allPreferencesSelector(state).showWeekends,
+  showWeekNumber: (state: State) => allPreferencesSelector(state).showWeekNumber,
+  showEmptyDaysInAgenda: (state: State) => allPreferencesSelector(state).showEmptyDaysInAgenda,
+  isSidePanelOpen: (state: State) => allPreferencesSelector(state).isSidePanelOpen,
+  weekStartsOn: (state: State) => allPreferencesSelector(state).weekStartsOn,
 };

--- a/packages/x-scheduler-internals/src/event-calendar-selectors/eventCalendarViewSelectors.ts
+++ b/packages/x-scheduler-internals/src/event-calendar-selectors/eventCalendarViewSelectors.ts
@@ -1,14 +1,11 @@
-import { createSelector } from '@base-ui/utils/store';
 import type { EventCalendarState as State } from '../use-event-calendar';
 
 export const eventCalendarViewSelectors = {
-  view: createSelector((state: State) => state.view),
-  views: createSelector((state: State) => state.views),
-  hasDayView: createSelector((state: State) => state.views.includes('day')),
+  view: (state: State) => state.view,
+  views: (state: State) => state.views,
+  hasDayView: (state: State) => state.views.includes('day'),
   /**
    * The user configuration for a time-grid based view (`day` or `week`), or `null` when none is set.
    */
-  timeGridConfig: createSelector(
-    (state: State, view: 'day' | 'week') => state.viewConfig?.[view] ?? null,
-  ),
+  timeGridConfig: (state: State, view: 'day' | 'week') => state.viewConfig?.[view] ?? null,
 };

--- a/packages/x-scheduler-internals/src/scheduler-selectors/schedulerEventSelectors.ts
+++ b/packages/x-scheduler-internals/src/scheduler-selectors/schedulerEventSelectors.ts
@@ -1,4 +1,4 @@
-import { createSelector, createSelectorMemoized } from '@base-ui/utils/store';
+import { createSelectorMemoized } from '@base-ui/utils/store';
 import type {
   SchedulerEvent,
   SchedulerEventId,
@@ -32,13 +32,10 @@ function inferCanHaveMultipleResourcesFromEvents(
   return undefined;
 }
 
-const processedEventSelector = createSelector(
-  (state: State) => state.processedEventLookup,
-  (processedEventLookup, eventId: SchedulerEventId | null | undefined) =>
-    eventId == null ? null : processedEventLookup.get(eventId),
-);
+const processedEventSelector = (state: State, eventId: SchedulerEventId | null | undefined) =>
+  eventId == null ? null : state.processedEventLookup.get(eventId);
 
-const isEventReadOnlySelector = createSelector((state: State, eventId: SchedulerEventId) => {
+const isEventReadOnlySelector = (state: State, eventId: SchedulerEventId) => {
   const processedEvent = processedEventSelector(state, eventId);
   if (!processedEvent) {
     return false;
@@ -51,7 +48,7 @@ const isEventReadOnlySelector = createSelector((state: State, eventId: Scheduler
     getValueInResource: (r) => r.areEventsReadOnly,
     valueInState: state.readOnly ?? false,
   });
-});
+};
 
 export const schedulerEventSelectors = {
   creationConfig: createSelectorMemoized(
@@ -77,16 +74,14 @@ export const schedulerEventSelectors = {
    * Gets the default duration (in minutes) for newly created events.
    * This can be used when you need the value event on read-only calendar.
    */
-  defaultEventDuration: createSelector(
-    (state: State) => state.eventCreation,
-    (eventCreation) => {
-      if (typeof eventCreation === 'boolean') {
-        return DEFAULT_EVENT_CREATION_CONFIG.duration;
-      }
+  defaultEventDuration: (state: State) => {
+    const eventCreation = state.eventCreation;
+    if (typeof eventCreation === 'boolean') {
+      return DEFAULT_EVENT_CREATION_CONFIG.duration;
+    }
 
-      return eventCreation?.duration ?? DEFAULT_EVENT_CREATION_CONFIG.duration;
-    },
-  ),
+    return eventCreation?.duration ?? DEFAULT_EVENT_CREATION_CONFIG.duration;
+  },
   /**
    * Whether an occurrence whose own `resource` carries no shape (`null`/`undefined`) should
    * be edited/created as multi-resource. Reads `eventCreation.canHaveMultipleResources`
@@ -109,20 +104,18 @@ export const schedulerEventSelectors = {
     },
   ),
   processedEvent: processedEventSelector,
-  processedEventRequired: createSelector(
-    processedEventSelector,
-    (event, eventId: SchedulerEventId) => {
-      if (!event) {
-        throw new Error(
-          `MUI X Scheduler: Event with id="${eventId}" was not found. ` +
-            'The requested event does not exist in the scheduler state. ' +
-            'Verify the event id is correct and the event has been added.',
-        );
-      }
+  processedEventRequired: (state: State, eventId: SchedulerEventId) => {
+    const event = processedEventSelector(state, eventId);
+    if (!event) {
+      throw new Error(
+        `MUI X Scheduler: Event with id="${eventId}" was not found. ` +
+          'The requested event does not exist in the scheduler state. ' +
+          'Verify the event id is correct and the event has been added.',
+      );
+    }
 
-      return event;
-    },
-  ),
+    return event;
+  },
   isReadOnly: isEventReadOnlySelector,
   /**
    * Resolves an event's color. `resourceId` picks which resource's `eventColor` counts when the
@@ -133,26 +126,24 @@ export const schedulerEventSelectors = {
    * Event Calendar). The argument can't be optional: the selector's memoization keys off
    * `Function.length`, which requires every parameter to be explicitly passed.
    */
-  color: createSelector(
-    (
-      state: State,
-      eventId: SchedulerEventId,
-      resourceId: SchedulerResourceId | null | undefined,
-    ) => {
-      const event = processedEventSelector(state, eventId);
-      if (!event) {
-        return state.eventColor;
-      }
+  color: (
+    state: State,
+    eventId: SchedulerEventId,
+    resourceId: SchedulerResourceId | null | undefined,
+  ) => {
+    const event = processedEventSelector(state, eventId);
+    if (!event) {
+      return state.eventColor;
+    }
 
-      return resolveEventProperty({
-        state,
-        resourceId: resourceId === undefined ? getPrimaryResourceId(event.resource) : resourceId,
-        valueInEvent: event.color,
-        getValueInResource: (r) => r.eventColor,
-        valueInState: state.eventColor,
-      });
-    },
-  ),
+    return resolveEventProperty({
+      state,
+      resourceId: resourceId === undefined ? getPrimaryResourceId(event.resource) : resourceId,
+      valueInEvent: event.color,
+      getValueInResource: (r) => r.eventColor,
+      valueInState: state.eventColor,
+    });
+  },
   isPropertyReadOnly: createSelectorMemoized(
     isEventReadOnlySelector,
     (state: State) => state.eventModelStructure,
@@ -175,16 +166,13 @@ export const schedulerEventSelectors = {
     (state: State) => state.processedEventLookup,
     (eventIds, processedEventLookup) => eventIds.map((id) => processedEventLookup.get(id)!),
   ),
-  idList: createSelector((state: State) => state.eventIdList),
-  modelList: createSelector((state: State) => state.eventModelList),
-  modelLookup: createSelector((state: State) => state.eventModelLookup),
-  canDragEventsFromTheOutside: createSelector(
-    (state: State) => state.canDragEventsFromTheOutside && !state.readOnly,
-  ),
-  canDropEventsToTheOutside: createSelector(
-    (state: State) => state.canDropEventsToTheOutside && !state.readOnly,
-  ),
-  isDraggable: createSelector((state: State, eventId: SchedulerEventId) => {
+  idList: (state: State) => state.eventIdList,
+  modelList: (state: State) => state.eventModelList,
+  modelLookup: (state: State) => state.eventModelLookup,
+  canDragEventsFromTheOutside: (state: State) =>
+    state.canDragEventsFromTheOutside && !state.readOnly,
+  canDropEventsToTheOutside: (state: State) => state.canDropEventsToTheOutside && !state.readOnly,
+  isDraggable: (state: State, eventId: SchedulerEventId) => {
     if (isEventReadOnlySelector(state, eventId)) {
       return false;
     }
@@ -210,43 +198,38 @@ export const schedulerEventSelectors = {
       getValueInResource: (r) => r.areEventsDraggable,
       valueInState: state.areEventsDraggable,
     });
-  }),
-  isResizable: createSelector(
-    (state: State, eventId: SchedulerEventId, side: SchedulerEventSide) => {
-      if (isEventReadOnlySelector(state, eventId)) {
-        return false;
-      }
+  },
+  isResizable: (state: State, eventId: SchedulerEventId, side: SchedulerEventSide) => {
+    if (isEventReadOnlySelector(state, eventId)) {
+      return false;
+    }
 
-      const eventModelStructure = state.eventModelStructure;
-      if (side === 'start' && eventModelStructure?.start && !eventModelStructure?.start.setter) {
-        return false;
-      }
+    const eventModelStructure = state.eventModelStructure;
+    if (side === 'start' && eventModelStructure?.start && !eventModelStructure?.start.setter) {
+      return false;
+    }
 
-      if (side === 'end' && eventModelStructure?.end && !eventModelStructure?.end.setter) {
-        return false;
-      }
+    if (side === 'end' && eventModelStructure?.end && !eventModelStructure?.end.setter) {
+      return false;
+    }
 
-      const processedEvent = processedEventSelector(state, eventId);
-      if (!processedEvent) {
-        return false;
-      }
+    const processedEvent = processedEventSelector(state, eventId);
+    if (!processedEvent) {
+      return false;
+    }
 
-      return resolveEventProperty({
-        state,
-        resourceId: getPrimaryResourceId(processedEvent.resource),
-        valueInEvent: getIsResizableFromProperty(processedEvent.resizable, side) ?? undefined,
-        getValueInResource: (r) =>
-          getIsResizableFromProperty(r.areEventsResizable, side) ?? undefined,
-        valueInState: getIsResizableFromProperty(state.areEventsResizable, side) ?? false,
-      });
-    },
-  ),
-  isRecurring: createSelector(
-    processedEventSelector,
-    (state: State) => state.recurringEventsPlugin,
-    (event, recurringEventsPlugin, _eventId: SchedulerEventId) =>
-      recurringEventsPlugin != null && Boolean(event?.dataTimezone.rrule),
-  ),
+    return resolveEventProperty({
+      state,
+      resourceId: getPrimaryResourceId(processedEvent.resource),
+      valueInEvent: getIsResizableFromProperty(processedEvent.resizable, side) ?? undefined,
+      getValueInResource: (r) =>
+        getIsResizableFromProperty(r.areEventsResizable, side) ?? undefined,
+      valueInState: getIsResizableFromProperty(state.areEventsResizable, side) ?? false,
+    });
+  },
+  isRecurring: (state: State, eventId: SchedulerEventId) =>
+    state.recurringEventsPlugin != null &&
+    Boolean(processedEventSelector(state, eventId)?.dataTimezone.rrule),
 };
 
 function getIsResizableFromProperty(

--- a/packages/x-scheduler-internals/src/scheduler-selectors/schedulerNowSelectors.ts
+++ b/packages/x-scheduler-internals/src/scheduler-selectors/schedulerNowSelectors.ts
@@ -1,13 +1,9 @@
-import { createSelector } from '@base-ui/utils/store';
 import type { TemporalSupportedObject } from '../models';
 import type { SchedulerState as State } from '../internals/utils/SchedulerStore/SchedulerStore.types';
 
 export const schedulerNowSelectors = {
-  showCurrentTimeIndicator: createSelector((state: State) => state.showCurrentTimeIndicator),
-  nowUpdatedEveryMinute: createSelector((state: State) => state.nowUpdatedEveryMinute),
-  isCurrentDay: createSelector(
-    (state: State) => state.adapter,
-    (state: State) => state.nowUpdatedEveryMinute,
-    (adapter, now, date: TemporalSupportedObject) => adapter.isSameDay(date, now),
-  ),
+  showCurrentTimeIndicator: (state: State) => state.showCurrentTimeIndicator,
+  nowUpdatedEveryMinute: (state: State) => state.nowUpdatedEveryMinute,
+  isCurrentDay: (state: State, date: TemporalSupportedObject) =>
+    state.adapter.isSameDay(date, state.nowUpdatedEveryMinute),
 };

--- a/packages/x-scheduler-internals/src/scheduler-selectors/schedulerOccurrencePlaceholderSelectors.ts
+++ b/packages/x-scheduler-internals/src/scheduler-selectors/schedulerOccurrencePlaceholderSelectors.ts
@@ -1,21 +1,20 @@
-import { createSelector } from '@base-ui/utils/store';
 import type { SchedulerState as State } from '../internals/utils/SchedulerStore/SchedulerStore.types';
 import { isInternalDragOrResizePlaceholder } from '../internals/utils/drag-utils';
 
 export const schedulerOccurrencePlaceholderSelectors = {
-  value: createSelector((state: State) => state.occurrencePlaceholder),
-  isDefined: createSelector((state: State) => state.occurrencePlaceholder !== null),
+  value: (state: State) => state.occurrencePlaceholder,
+  isDefined: (state: State) => state.occurrencePlaceholder !== null,
   /**
    * Returns `true` while a `creation` placeholder is active.
    * Selecting a boolean instead of the placeholder object avoids re-rendering on every mutation.
    */
-  isCreating: createSelector((state: State) => state.occurrencePlaceholder?.type === 'creation'),
+  isCreating: (state: State) => state.occurrencePlaceholder?.type === 'creation',
   /**
    * The type of the active placeholder, or `undefined` if none.
    * Selecting the primitive avoids re-rendering on every mutation (e.g. each drag/resize move).
    */
-  type: createSelector((state: State) => state.occurrencePlaceholder?.type),
-  actionForOccurrence: createSelector((state: State, occurrenceKey: string) => {
+  type: (state: State) => state.occurrencePlaceholder?.type,
+  actionForOccurrence: (state: State, occurrenceKey: string) => {
     const placeholder = state.occurrencePlaceholder;
     if (
       isInternalDragOrResizePlaceholder(placeholder) &&
@@ -25,5 +24,5 @@ export const schedulerOccurrencePlaceholderSelectors = {
     }
 
     return null;
-  }),
+  },
 };

--- a/packages/x-scheduler-internals/src/scheduler-selectors/schedulerOccurrenceSelectors.ts
+++ b/packages/x-scheduler-internals/src/scheduler-selectors/schedulerOccurrenceSelectors.ts
@@ -1,4 +1,4 @@
-import { createSelector, createSelectorMemoized } from '@base-ui/utils/store';
+import { createSelectorMemoized } from '@base-ui/utils/store';
 import type {
   SchedulerEventOccurrence,
   SchedulerProcessedDate,
@@ -89,19 +89,12 @@ const occurrencesGroupedByResourceListSelector = createSelectorMemoized(
 );
 
 export const schedulerOccurrenceSelectors = {
-  isStarted: createSelector(
-    (state: State) => state.adapter,
-    (state: State) => state.nowUpdatedEveryMinute,
-    (adapter, now, start: SchedulerProcessedDate) => {
-      return adapter.isBefore(start.value, now) || adapter.isEqual(start.value, now);
-    },
-  ),
-  isEnded: createSelector(
-    (state: State) => state.adapter,
-    (state: State) => state.nowUpdatedEveryMinute,
-    (adapter, now, end: SchedulerProcessedDate) => {
-      return adapter.isBefore(end.value, now);
-    },
-  ),
+  isStarted: (state: State, start: SchedulerProcessedDate) => {
+    const now = state.nowUpdatedEveryMinute;
+    return state.adapter.isBefore(start.value, now) || state.adapter.isEqual(start.value, now);
+  },
+  isEnded: (state: State, end: SchedulerProcessedDate) => {
+    return state.adapter.isBefore(end.value, state.nowUpdatedEveryMinute);
+  },
   groupedByResourceList: occurrencesGroupedByResourceListSelector,
 };

--- a/packages/x-scheduler-internals/src/scheduler-selectors/schedulerOtherSelectors.ts
+++ b/packages/x-scheduler-internals/src/scheduler-selectors/schedulerOtherSelectors.ts
@@ -1,4 +1,4 @@
-import { createSelector, createSelectorMemoized } from '@base-ui/utils/store';
+import { createSelectorMemoized } from '@base-ui/utils/store';
 import type { SchedulerState as State } from '../internals/utils/SchedulerStore/SchedulerStore.types';
 
 // Warning: Only add selectors here that do not belong to any specific feature.
@@ -7,16 +7,15 @@ export const schedulerOtherSelectors = {
    * Returns `true` if the occurrence with the given key is the one being edited.
    * Occurrence-precise: editing one occurrence of a recurring series doesn't match its siblings.
    */
-  isEditedOccurrence: createSelector(
-    (state: State) => state.editingOccurrence?.occurrence.key ?? null,
-    (editedOccurrenceKey, occurrenceKey: string | undefined) =>
-      editedOccurrenceKey != null && editedOccurrenceKey === occurrenceKey,
-  ),
+  isEditedOccurrence: (state: State, occurrenceKey: string | undefined) => {
+    const editedOccurrenceKey = state.editingOccurrence?.occurrence.key ?? null;
+    return editedOccurrenceKey != null && editedOccurrenceKey === occurrenceKey;
+  },
   /**
    * The occurrence currently being edited (existing or a creation draft), or `null`.
    * The editing surfaces (dialog / drawer) read from here.
    */
-  editingOccurrence: createSelector((state: State) => state.editingOccurrence?.occurrence ?? null),
+  editingOccurrence: (state: State) => state.editingOccurrence?.occurrence ?? null,
   visibleDate: createSelectorMemoized(
     (state: State) => state.adapter,
     (state: State) => state.visibleDate,
@@ -27,51 +26,47 @@ export const schedulerOtherSelectors = {
    * Which face the edited occurrence is in (`'armed'` toolbar or `'edit'` surface), or `null` when idle.
    * Drives the toolbar-vs-surface swap and whether the edited event stays resizable.
    */
-  editingMode: createSelector((state: State) => state.editingOccurrence?.mode ?? null),
+  editingMode: (state: State) => state.editingOccurrence?.mode ?? null,
   /**
    * Returns `true` when the occurrence with the given key is armed (`'armed'`): it shows its resize
    * handles + action toolbar and no surface is open.
    */
-  isEditedOccurrenceArmed: createSelector(
-    (state: State) => state.editingOccurrence?.occurrence.key ?? null,
-    (state: State) => state.editingOccurrence?.mode ?? null,
-    (editedOccurrenceKey, mode, occurrenceKey: string | undefined) =>
-      mode === 'armed' && editedOccurrenceKey != null && editedOccurrenceKey === occurrenceKey,
-  ),
+  isEditedOccurrenceArmed: (state: State, occurrenceKey: string | undefined) => {
+    const editedOccurrenceKey = state.editingOccurrence?.occurrence.key ?? null;
+    return (
+      state.editingOccurrence?.mode === 'armed' &&
+      editedOccurrenceKey != null &&
+      editedOccurrenceKey === occurrenceKey
+    );
+  },
   /**
    * Returns `true` when the occurrence with the given key is being edited in the form (`'edit'`).
    * Resizing is disabled then — the form is the only way to change times.
    */
-  isEditedOccurrenceInEditMode: createSelector(
-    (state: State) => state.editingOccurrence?.occurrence.key ?? null,
-    (state: State) => state.editingOccurrence?.mode ?? null,
-    (editedOccurrenceKey, mode, occurrenceKey: string | undefined) =>
-      mode === 'edit' && editedOccurrenceKey != null && editedOccurrenceKey === occurrenceKey,
-  ),
-  isRecurringScopeDialogOpen: createSelector(
-    (state: State) => state.pendingRecurringEventOperation != null,
-  ),
+  isEditedOccurrenceInEditMode: (state: State, occurrenceKey: string | undefined) => {
+    const editedOccurrenceKey = state.editingOccurrence?.occurrence.key ?? null;
+    return (
+      state.editingOccurrence?.mode === 'edit' &&
+      editedOccurrenceKey != null &&
+      editedOccurrenceKey === occurrenceKey
+    );
+  },
+  isRecurringScopeDialogOpen: (state: State) => state.pendingRecurringEventOperation != null,
   /**
    * The default event color used when no color is specified on the event or its resource.
    */
-  defaultEventColor: createSelector((state: State) => state.eventColor),
-  displayTimezone: createSelector((state: State) => state.displayTimezone),
+  defaultEventColor: (state: State) => state.eventColor,
+  displayTimezone: (state: State) => state.displayTimezone,
   /**
    * Whether each event must be assigned to a resource. When true, the resource cannot be cleared in the editing surface and the form cannot be submitted without one.
    * Resolves to `false` when no resources are configured, even if `shouldEventRequireResource` was set to `true`,
    * since that combination is contradictory (the store already warns about it) and would otherwise block
    * submission with no resource picker to fix it from.
    */
-  shouldEventRequireResource: createSelector(
-    (state: State) => state.shouldEventRequireResource,
-    (state: State) => state.resourceIdList,
-    (shouldEventRequireResource, resourceIdList) =>
-      shouldEventRequireResource && resourceIdList.length > 0,
-  ),
-  recurringEventsPlugin: createSelector((state: State) => state.recurringEventsPlugin),
-  areRecurringEventsAvailable: createSelector(
-    (state: State) => state.recurringEventsPlugin != null,
-  ),
-  isLoading: createSelector((state: State) => state.isLoading),
-  errors: createSelector((state: State) => state.errors),
+  shouldEventRequireResource: (state: State) =>
+    state.shouldEventRequireResource && state.resourceIdList.length > 0,
+  recurringEventsPlugin: (state: State) => state.recurringEventsPlugin,
+  areRecurringEventsAvailable: (state: State) => state.recurringEventsPlugin != null,
+  isLoading: (state: State) => state.isLoading,
+  errors: (state: State) => state.errors,
 };

--- a/packages/x-scheduler-internals/src/scheduler-selectors/schedulerPreferenceSelectors.ts
+++ b/packages/x-scheduler-internals/src/scheduler-selectors/schedulerPreferenceSelectors.ts
@@ -1,4 +1,4 @@
-import { createSelector, createSelectorMemoized } from '@base-ui/utils/store';
+import { createSelectorMemoized } from '@base-ui/utils/store';
 import type { SchedulerState as State } from '../internals/utils/SchedulerStore/SchedulerStore.types';
 import { DEFAULT_SCHEDULER_PREFERENCES } from '../internals/utils/SchedulerStore';
 
@@ -12,9 +12,6 @@ const allSchedulerPreferencesSelector = createSelectorMemoized(
 
 export const schedulerPreferenceSelectors = {
   all: allSchedulerPreferencesSelector,
-  ampm: createSelector(allSchedulerPreferencesSelector, (preferences) => preferences.ampm),
-  weekStartsOn: createSelector(
-    allSchedulerPreferencesSelector,
-    (preferences) => preferences.weekStartsOn,
-  ),
+  ampm: (state: State) => allSchedulerPreferencesSelector(state).ampm,
+  weekStartsOn: (state: State) => allSchedulerPreferencesSelector(state).weekStartsOn,
 };

--- a/packages/x-scheduler-internals/src/scheduler-selectors/schedulerRecurringEventSelectors.ts
+++ b/packages/x-scheduler-internals/src/scheduler-selectors/schedulerRecurringEventSelectors.ts
@@ -1,4 +1,4 @@
-import { createSelector, createSelectorMemoized } from '@base-ui/utils/store';
+import { createSelectorMemoized } from '@base-ui/utils/store';
 import type {
   RecurringEventPresetKey,
   SchedulerProcessedEventRecurrenceRule,
@@ -31,22 +31,17 @@ export const schedulerRecurringEventSelectors = {
     ): RecurringEventPresetKey | 'custom' | null =>
       recurringEventsPlugin?.getDefaultPresetKey(adapter, rule, occurrenceStart) ?? null,
   ),
-  isSameRRule: createSelector(
-    (state: State) => state.adapter,
-    selectRecurringEventsPlugin,
-    (
-      adapter,
-      recurringEventsPlugin,
-      rruleA: SchedulerProcessedEventRecurrenceRule | undefined,
-      rruleB: SchedulerProcessedEventRecurrenceRule | undefined,
-    ): boolean => {
-      if (!rruleA && !rruleB) {
-        return true;
-      }
-      if (!rruleA || !rruleB) {
-        return false;
-      }
-      return recurringEventsPlugin?.isSameRRule(adapter, rruleA, rruleB) ?? false;
-    },
-  ),
+  isSameRRule: (
+    state: State,
+    rruleA: SchedulerProcessedEventRecurrenceRule | undefined,
+    rruleB: SchedulerProcessedEventRecurrenceRule | undefined,
+  ): boolean => {
+    if (!rruleA && !rruleB) {
+      return true;
+    }
+    if (!rruleA || !rruleB) {
+      return false;
+    }
+    return selectRecurringEventsPlugin(state)?.isSameRRule(state.adapter, rruleA, rruleB) ?? false;
+  },
 };

--- a/packages/x-scheduler-internals/src/scheduler-selectors/schedulerResourceSelectors.ts
+++ b/packages/x-scheduler-internals/src/scheduler-selectors/schedulerResourceSelectors.ts
@@ -1,4 +1,4 @@
-import { createSelector, createSelectorMemoized } from '@base-ui/utils/store';
+import { createSelectorMemoized } from '@base-ui/utils/store';
 import { EMPTY_ARRAY } from '@base-ui/utils/empty';
 import type { SchedulerState as State } from '../internals/utils/SchedulerStore/SchedulerStore.types';
 import type { SchedulerResource, SchedulerResourceId } from '../models';
@@ -88,11 +88,8 @@ const resourceHasVisibleChildrenLookupSelector = createSelectorMemoized(
 );
 
 export const schedulerResourceSelectors = {
-  processedResource: createSelector(
-    (state: State) => state.processedResourceLookup,
-    (processedResourceLookup, resourceId: string | null | undefined) =>
-      resourceId == null ? null : (processedResourceLookup.get(resourceId) ?? null),
-  ),
+  processedResource: (state: State, resourceId: string | null | undefined) =>
+    resourceId == null ? null : (state.processedResourceLookup.get(resourceId) ?? null),
   processedResourceList: createSelectorMemoized(
     (state: State) => state.resourceIdList,
     (state: State) => state.processedResourceLookup,
@@ -143,36 +140,24 @@ export const schedulerResourceSelectors = {
     },
   ),
   childrenIdLookup: (state: State) => state.resourceChildrenIdLookup,
-  // Single-function createSelector is unmemoized; keep the body returning a
-  // stable ref (a Map value or EMPTY_ARRAY), never a freshly-built array.
-  resourceChildrenIds: createSelector(
-    (state: State, resourceId: SchedulerResourceId) =>
-      state.resourceChildrenIdLookup.get(resourceId) ?? EMPTY_ARRAY,
-  ),
+  // Unmemoized; keep the body returning a stable ref (a Map value or
+  // EMPTY_ARRAY), never a freshly-built array.
+  resourceChildrenIds: (state: State, resourceId: SchedulerResourceId) =>
+    state.resourceChildrenIdLookup.get(resourceId) ?? EMPTY_ARRAY,
   // O(1) read from the memoized lookup; a resource with no entry (a leaf) has no
   // visible children.
-  resourceHasVisibleChildren: createSelector(
-    resourceHasVisibleChildrenLookupSelector,
-    (lookup, resourceId: SchedulerResourceId) => lookup.get(resourceId) ?? false,
-  ),
-  hasNestedResources: createSelector(
-    resourceParentIdLookupSelector,
-    (parentLookup) => parentLookup.size > 0,
-  ),
+  resourceHasVisibleChildren: (state: State, resourceId: SchedulerResourceId) =>
+    resourceHasVisibleChildrenLookupSelector(state).get(resourceId) ?? false,
+  hasNestedResources: (state: State) => resourceParentIdLookupSelector(state).size > 0,
   // Unmemoized (returns a primitive); don't change the body to build an object.
-  isResourceCollapsed: createSelector(
-    (state: State, resourceId: SchedulerResourceId) =>
-      state.collapsedResources[resourceId] === true,
-  ),
+  isResourceCollapsed: (state: State, resourceId: SchedulerResourceId) =>
+    state.collapsedResources[resourceId] === true,
   collapsedResources: (state: State) => state.collapsedResources,
   resourceParentIdLookup: resourceParentIdLookupSelector,
   resourceDepthLookup: resourceDepthLookupSelector,
-  resourceDepth: createSelector(
-    resourceDepthLookupSelector,
-    (resourceDepthLookup, resourceId: SchedulerResourceId) =>
-      resourceDepthLookup.get(resourceId) ?? 0,
-  ),
-  idList: createSelector((state: State) => state.resourceIdList),
+  resourceDepth: (state: State, resourceId: SchedulerResourceId) =>
+    resourceDepthLookupSelector(state).get(resourceId) ?? 0,
+  idList: (state: State) => state.resourceIdList,
   visibleMap: createSelectorMemoized(
     (state: State) => state.visibleResources,
     resourceParentIdLookupSelector,
@@ -220,13 +205,11 @@ export const schedulerResourceSelectors = {
    * Walks the resource hierarchy (child → parent → …) until a color is found,
    * falling back to the component-level default.
    */
-  defaultEventColor: createSelector(
-    (state: State, resourceId: SchedulerResourceId | null | undefined) => {
-      if (resourceId == null) {
-        return state.eventColor;
-      }
+  defaultEventColor: (state: State, resourceId: SchedulerResourceId | null | undefined) => {
+    if (resourceId == null) {
+      return state.eventColor;
+    }
 
-      return resolveResourceProperty(state, resourceId, (r) => r.eventColor, state.eventColor);
-    },
-  ),
+    return resolveResourceProperty(state, resourceId, (r) => r.eventColor, state.eventColor);
+  },
 };

--- a/packages/x-scheduler/src/internals/components/event-dialog/form/EventDialogFormStore.ts
+++ b/packages/x-scheduler/src/internals/components/event-dialog/form/EventDialogFormStore.ts
@@ -1,5 +1,5 @@
 import type * as React from 'react';
-import { createSelector, Store } from '@base-ui/utils/store';
+import { Store } from '@base-ui/utils/store';
 import type { SchedulerRenderableEventOccurrence } from '@mui/x-scheduler-internals/models';
 import type { ResourceSelectionMode } from '@mui/x-scheduler-internals/internals';
 import type { EventDialogFormValues } from '../utils';
@@ -63,9 +63,9 @@ export interface EventDialogFormParameters<
 }
 
 export const eventDialogFormSelectors = {
-  value: createSelector((state: EventDialogFormState, key: string) => state.values[key]),
-  hasValue: createSelector((state: EventDialogFormState, key: string) => key in state.values),
-  error: createSelector((state: EventDialogFormState, key: string) => state.errors[key]),
+  value: (state: EventDialogFormState, key: string) => state.values[key],
+  hasValue: (state: EventDialogFormState, key: string) => key in state.values,
+  error: (state: EventDialogFormState, key: string) => state.errors[key],
 };
 
 /**

--- a/packages/x-scheduler/src/internals/components/event/day-grid-event/DayGridEvent.tsx
+++ b/packages/x-scheduler/src/internals/components/event/day-grid-event/DayGridEvent.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import clsx from 'clsx';
 import { styled } from '@mui/material/styles';
-import { createSelector, useStore } from '@base-ui/utils/store';
+import { useStore } from '@base-ui/utils/store';
 import RepeatRounded from '@mui/icons-material/RepeatRounded';
 import { CalendarGrid } from '@mui/x-scheduler-internals/calendar-grid';
 import type {
@@ -271,31 +271,29 @@ const DayGridEventLinesClamp = styled('span', {
   flexGrow: 1,
 });
 
-const isResizableSelector = createSelector(
-  (
-    state: EventCalendarState,
-    side: SchedulerEventSide,
-    occurrence: SchedulerRenderableEventOccurrence,
-  ) => {
-    if (!schedulerEventSelectors.isResizable(state, occurrence.id, side)) {
-      return false;
-    }
+const isResizableSelector = (
+  state: EventCalendarState,
+  side: SchedulerEventSide,
+  occurrence: SchedulerRenderableEventOccurrence,
+) => {
+  if (!schedulerEventSelectors.isResizable(state, occurrence.id, side)) {
+    return false;
+  }
 
-    const view = eventCalendarViewSelectors.view(state);
+  const view = eventCalendarViewSelectors.view(state);
 
-    // There is only one day cell in the day view
-    if (view === 'day') {
-      return false;
-    }
+  // There is only one day cell in the day view
+  if (view === 'day') {
+    return false;
+  }
 
-    // In month view, only multi-day and all-day events can be resized
-    if (view === 'month') {
-      return isOccurrenceAllDayOrMultipleDay(occurrence, state.adapter);
-    }
+  // In month view, only multi-day and all-day events can be resized
+  if (view === 'month') {
+    return isOccurrenceAllDayOrMultipleDay(occurrence, state.adapter);
+  }
 
-    return true;
-  },
-);
+  return true;
+};
 
 export const DayGridEvent = React.forwardRef(function DayGridEvent(
   props: DayGridEventProps,


### PR DESCRIPTION
Removes internal selector factories that don't memoize across the four scheduler packages, without changing the public API. Same technique as the Base UI bundle-size effort (mui/base-ui#5250): `createSelector` with a single function argument returns it unchanged, so the wrapper is an identity call that only adds bytes, and composed non-memoized selectors re-run their inputs on every call anyway, so they are collapsed into single plain `(state, ...args)` functions.

## Changes

- Replace single-argument `createSelector(fn)` wrappers with the bare function in `scheduler-selectors`, `event-calendar-selectors`, `event-timeline-premium-selectors`, and the component-local selectors (`CalendarGridHeaderCell`, `DayGridEvent`, `EventDialogFormStore`).
- Collapse composed non-memoized selectors (e.g. `ampm`/`weekStartsOn` reading through the memoized `all` preferences selector, `isCurrentDay`, `isSameRRule`, `visibleResourceOccurrences`, …) into single plain functions that call their memoized inputs directly.
- Keep every `createSelectorMemoized` selector untouched; they still receive the same input functions.

Behavior is identical: the non-memoized `createSelector` composition executed all inputs on each call, so the plain functions compute the same values. The bundle-size CI check is authoritative for the size impact.

Sibling PR applying the same technique to the Tree View: #23412.

## Validation

- `pnpm --filter "@mui/x-scheduler*" run typescript` — all 4 packages pass
- `pnpm test:unit --project "x-scheduler*" --run` — 2535 passing
- `pnpm eslint` — no findings in the scheduler packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)