### PR TITLE
[docs] Star-prefix bare :where() dark-mode selectors

### DIFF
--- a/docs/src/modules/components/DemoPropsForm.tsx
+++ b/docs/src/modules/components/DemoPropsForm.tsx
@@ -196,7 +196,7 @@ export default function ChartDemoPropsForm<
         borderColor: theme.palette.grey[200],
         background: alpha(theme.palette.grey[50], 0.5),
         minWidth: '250px',
-        [`:where(${theme.vars ? '[data-mui-color-scheme="dark"]' : '.mode-dark'}) &`]: {
+        [`*:where(${theme.vars ? '[data-mui-color-scheme="dark"]' : '.mode-dark'}) &`]: {
           borderColor: alpha(theme.palette.grey[900], 0.8),
           backgroundColor: alpha(theme.palette.grey[900], 0.3),
         },

--- a/docs/src/modules/components/chat-playground/PlaygroundCard.tsx
+++ b/docs/src/modules/components/chat-playground/PlaygroundCard.tsx
@@ -121,7 +121,7 @@ export interface PlaygroundCardProps {
 }
 
 const DEFAULT_PACKAGE_NAME = '@mui/x-chat';
-const docsDarkModeSelector = ':where([data-mui-color-scheme="dark"], .mode-dark) &';
+const docsDarkModeSelector = '*:where([data-mui-color-scheme="dark"], .mode-dark) &';
 
 const defaultRegistryMetadata: Record<string, PlaygroundCardRegistryMetadata> = {
   ChatBox: {


### PR DESCRIPTION
Converts the two bare `':where(…) &'` style keys (`DemoPropsForm`, `PlaygroundCard`) to the `*:where(…) &` form. The bare form relies on the `globalSelector` stylis middleware in `@mui/internal-core-docs` to strip the class emotion glues in front of it (emotion-js/emotion#2836); that middleware is being removed in mui/material-ui#49029 because it also destroys intentional `&:where(…)` scoping, so these would lose their dark-mode styles on the next core-docs bump. The `*` prefix is the same workaround `theme.applyStyles` uses and works with or without the middleware.