### PR TITLE
[code-infra] Point the support validator link at frontend-public

### DIFF
--- a/.github/workflows/priority-support-validation-prompt.yml
+++ b/.github/workflows/priority-support-validation-prompt.yml
@@ -31,7 +31,7 @@ jobs:
           body: |
             You have created a support request under the ["Priority Support"](https://mui.com/legal/technical-support-sla/#priority-support) terms, which is a paid add-on to MUI X Premium ⏰. Please validate your support key using the link below:
 
-            https://tools-public.mui.com/prod/pages/validateSupport?repo=mui-x&issueId=${{ github.event.issue.number }}
+            https://frontend-public.mui.com/validate-support?repo=mui-x&issueId=${{ github.event.issue.number }}
 
             Do not share your support key in this issue!
 


### PR DESCRIPTION
The support key validator moved from the deprecated Toolpad app to code-infra-dashboard in mui/mui-public#1743, which is merged and live. This points the link in the priority support comment at the new page.
