### PR TITLE
[code-infra] Reduce per-page memory in the browser test suite

### DIFF
--- a/packages/x-data-grid-premium/vitest.config.browser.mts
+++ b/packages/x-data-grid-premium/vitest.config.browser.mts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { mergeConfig, defineConfig } from 'vitest/config';
 import sharedConfig from '../../vitest.shared.mts';
 import { getTestName } from '../../scripts/getTestName.mts';
@@ -7,6 +8,7 @@ export default mergeConfig(
   defineConfig({
     test: {
       name: getTestName(import.meta.url),
+      setupFiles: [fileURLToPath(new URL('../../test/utils/setupDataGrid.ts', import.meta.url))],
       exclude: [
         '**/materialVersion.test.tsx',
         // The formula engine is DOM-free by design (no React/grid imports) —

--- a/packages/x-data-grid-premium/vitest.config.jsdom.mts
+++ b/packages/x-data-grid-premium/vitest.config.jsdom.mts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { mergeConfig } from 'vitest/config';
 import sharedConfig from '../../vitest.shared.mts';
 import { getTestName } from '../../scripts/getTestName.mts';
@@ -5,6 +6,7 @@ import { getTestName } from '../../scripts/getTestName.mts';
 export default mergeConfig(sharedConfig, {
   test: {
     name: getTestName(import.meta.url),
+    setupFiles: [fileURLToPath(new URL('../../test/utils/setupDataGrid.ts', import.meta.url))],
     environment: 'jsdom',
   },
 });

--- a/packages/x-data-grid-pro/vitest.config.browser.mts
+++ b/packages/x-data-grid-pro/vitest.config.browser.mts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { defineConfig, mergeConfig } from 'vitest/config';
 import sharedConfig from '../../vitest.shared.mts';
 import { getTestName } from '../../scripts/getTestName.mts';
@@ -7,6 +8,7 @@ export default mergeConfig(
   defineConfig({
     test: {
       name: getTestName(import.meta.url),
+      setupFiles: [fileURLToPath(new URL('../../test/utils/setupDataGrid.ts', import.meta.url))],
       exclude: ['**/materialVersion.test.tsx'],
       browser: {
         enabled: true,

--- a/packages/x-data-grid-pro/vitest.config.jsdom.mts
+++ b/packages/x-data-grid-pro/vitest.config.jsdom.mts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { mergeConfig } from 'vitest/config';
 import sharedConfig from '../../vitest.shared.mts';
 import { getTestName } from '../../scripts/getTestName.mts';
@@ -5,6 +6,7 @@ import { getTestName } from '../../scripts/getTestName.mts';
 export default mergeConfig(sharedConfig, {
   test: {
     name: getTestName(import.meta.url),
+    setupFiles: [fileURLToPath(new URL('../../test/utils/setupDataGrid.ts', import.meta.url))],
     environment: 'jsdom',
   },
 });

--- a/packages/x-data-grid/vitest.config.browser.mts
+++ b/packages/x-data-grid/vitest.config.browser.mts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { mergeConfig, defineConfig } from 'vitest/config';
 import sharedConfig from '../../vitest.shared.mts';
 import { getTestName } from '../../scripts/getTestName.mts';
@@ -7,6 +8,7 @@ export default mergeConfig(
   defineConfig({
     test: {
       name: getTestName(import.meta.url),
+      setupFiles: [fileURLToPath(new URL('../../test/utils/setupDataGrid.ts', import.meta.url))],
       exclude: ['**/materialVersion.test.tsx'],
       browser: {
         enabled: true,

--- a/packages/x-data-grid/vitest.config.jsdom.mts
+++ b/packages/x-data-grid/vitest.config.jsdom.mts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { mergeConfig } from 'vitest/config';
 import sharedConfig from '../../vitest.shared.mts';
 import { getTestName } from '../../scripts/getTestName.mts';
@@ -5,6 +6,7 @@ import { getTestName } from '../../scripts/getTestName.mts';
 export default mergeConfig(sharedConfig, {
   test: {
     name: getTestName(import.meta.url),
+    setupFiles: [fileURLToPath(new URL('../../test/utils/setupDataGrid.ts', import.meta.url))],
     environment: 'jsdom',
   },
 });

--- a/test/setupVitest.ts
+++ b/test/setupVitest.ts
@@ -3,13 +3,12 @@ import 'test/utils/addChaiAssertions';
 import 'test/utils/licenseRelease';
 import { config } from 'react-transition-group';
 import sinon from 'sinon';
-import { unstable_resetCleanupTracking as unstable_resetCleanupTrackingDataGrid } from '@mui/x-data-grid';
-import { unstable_resetCleanupTracking as unstable_resetCleanupTrackingDataGridPro } from '@mui/x-data-grid-pro';
 import { clearWarningsCache } from '@mui/x-internals/warning';
 import setupVitest from '@mui/internal-test-utils/setupVitest';
 import { configure, isJsdom } from '@mui/internal-test-utils';
 import { LicenseInfo } from '@mui/x-license';
 import { TEST_LICENSE_KEY_PREMIUM } from './utils/licenseKeys';
+import { setupCrashHandlerOnce } from './utils/setupCrashHandler';
 
 (globalThis as any).MUI_TEST_ENV = true;
 
@@ -22,8 +21,10 @@ configure({
 
 beforeAll(async () => {
   if (!isJsdom()) {
+    // Attaches a `page.on('crash')` listener, so it must only happen once per page.
+    await setupCrashHandlerOnce();
+    // Not a listener: this must run for every file to reset the pointer position.
     const { server } = await import('vitest/browser');
-    await server.commands.setupCrashHandler();
     await server.commands.resetMousePosition();
   }
 });
@@ -35,9 +36,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  unstable_resetCleanupTrackingDataGrid();
-  unstable_resetCleanupTrackingDataGridPro();
-
   // Restore Sinon default sandbox to avoid memory leak
   // See https://github.com/sinonjs/sinon/issues/1866
   sinon.restore();

--- a/test/utils/setupCrashHandler.ts
+++ b/test/utils/setupCrashHandler.ts
@@ -1,0 +1,18 @@
+/**
+ * Registers the Playwright `page.on('crash')` handler for the current browser page.
+ *
+ * With `isolate: false` every test file in a project shares one page, but setup files are
+ * re-evaluated per file, so this guard lives in a regular module: its instance is cached
+ * for the lifetime of the page, while the setup file around it is not. Without it the
+ * handler is attached once per test file and a single crash is reported dozens of times.
+ */
+let isRegistered = false;
+
+export async function setupCrashHandlerOnce() {
+  if (isRegistered) {
+    return;
+  }
+  isRegistered = true;
+  const { server } = await import('vitest/browser');
+  await server.commands.setupCrashHandler();
+}

--- a/test/utils/setupDataGrid.ts
+++ b/test/utils/setupDataGrid.ts
@@ -1,0 +1,11 @@
+import { afterEach } from 'vitest';
+import { unstable_resetCleanupTracking } from '@mui/x-data-grid';
+
+// Only registered by the Data Grid projects. Loading `@mui/x-data-grid` evaluates the whole
+// grid source graph (~650 modules plus `@mui/material`), so keeping it out of the shared
+// `setupVitest.ts` avoids pulling it into every other project's browser page.
+// `@mui/x-data-grid-pro` re-exports `@mui/x-data-grid/hooks`, so it shares this exact
+// registry and does not need a second reset.
+afterEach(() => {
+  unstable_resetCleanupTracking();
+});

--- a/test/utils/vitestBrowserCommands.d.ts
+++ b/test/utils/vitestBrowserCommands.d.ts
@@ -1,0 +1,9 @@
+import 'vitest/browser';
+
+// Custom commands registered in `vitest.shared.mts` under `test.browser.commands`.
+declare module 'vitest/browser' {
+  interface BrowserCommands {
+    resetMousePosition: () => Promise<void>;
+    setupCrashHandler: () => Promise<void>;
+  }
+}


### PR DESCRIPTION
With `isolate: false` a page is never reloaded, and pages stay open until the whole run ends ([vitest#10990](https://github.com/vitest-dev/vitest/issues/10990)) — so whatever the shared setup imports is held by all 21 projects for the entire run.

`test/setupVitest.ts` imported `unstable_resetCleanupTracking` from the `@mui/x-data-grid` and `@mui/x-data-grid-pro` barrels, which through the source aliases evaluates ~650 modules plus `@mui/material` in **every** page — charts, chat, scheduler, pickers, none of which touch the grid. (Both imports were also the same function.) Moved to `test/utils/setupDataGrid.ts`, registered only by the three Data Grid projects.

Also registers the crash handler once per page instead of once per test file, which is why one crash prints dozens of times in CI logs.

| | before | after |
| --- | --- | --- |
| heap, `x-date-pickers` page | 47.5 MB | 39.3 MB (−17%) |
| peak RSS, full local run | 18.15 GB | 17.35 GB |

Buys headroom; doesn't fix the OOM on its own ([vitest#9696](https://github.com/vitest-dev/vitest/issues/9696), [#10990](https://github.com/vitest-dev/vitest/issues/10990)). FWIW the jump to a ~50% failure rate bisects to a single commit, #22807.

Testing: full browser suite passes (758 files); `x-data-grid*` and `x-date-pickers*` jsdom match master, including its existing flakes.
