### PR TITLE
[charts] Rename the local test helper in the keyboard focus tests

### DIFF
--- a/packages/x-charts-pro/src/Heatmap/seriesConfig/keyboardFocusHandler.test.ts
+++ b/packages/x-charts-pro/src/Heatmap/seriesConfig/keyboardFocusHandler.test.ts
@@ -70,7 +70,7 @@ const cell_11 = {
   yIndex: 1,
 } as const;
 
-function test(
+function moveFocus(
   direction: 'ArrowRight' | 'ArrowLeft' | 'ArrowUp' | 'ArrowDown',
   initialFocus: FocusedItemIdentifier<'heatmap'> | null,
 ) {
@@ -81,23 +81,23 @@ function test(
 
 describe('<Heatmap /> - keyboard navigation', () => {
   it('should move to the first node if no current focus', async () => {
-    expect(test('ArrowRight', null)).to.deep.equal(cell_00);
-    expect(test('ArrowLeft', null)).to.deep.equal(cell_00);
-    expect(test('ArrowUp', null)).to.deep.equal(cell_00);
-    expect(test('ArrowDown', null)).to.deep.equal(cell_00);
+    expect(moveFocus('ArrowRight', null)).to.deep.equal(cell_00);
+    expect(moveFocus('ArrowLeft', null)).to.deep.equal(cell_00);
+    expect(moveFocus('ArrowUp', null)).to.deep.equal(cell_00);
+    expect(moveFocus('ArrowDown', null)).to.deep.equal(cell_00);
   });
 
   it('should move to different cell', () => {
-    expect(test('ArrowRight', cell_00)).to.deep.equal(cell_01);
-    expect(test('ArrowLeft', cell_11)).to.deep.equal(cell_10);
-    expect(test('ArrowUp', cell_10)).to.deep.equal(cell_00);
-    expect(test('ArrowDown', cell_01)).to.deep.equal(cell_11);
+    expect(moveFocus('ArrowRight', cell_00)).to.deep.equal(cell_01);
+    expect(moveFocus('ArrowLeft', cell_11)).to.deep.equal(cell_10);
+    expect(moveFocus('ArrowUp', cell_10)).to.deep.equal(cell_00);
+    expect(moveFocus('ArrowDown', cell_01)).to.deep.equal(cell_11);
   });
 
   it('should try to go outside of the range', () => {
-    expect(test('ArrowRight', cell_01)).to.deep.equal(cell_01);
-    expect(test('ArrowLeft', cell_10)).to.deep.equal(cell_10);
-    expect(test('ArrowUp', cell_00)).to.deep.equal(cell_00);
-    expect(test('ArrowDown', cell_11)).to.deep.equal(cell_11);
+    expect(moveFocus('ArrowRight', cell_01)).to.deep.equal(cell_01);
+    expect(moveFocus('ArrowLeft', cell_10)).to.deep.equal(cell_10);
+    expect(moveFocus('ArrowUp', cell_00)).to.deep.equal(cell_00);
+    expect(moveFocus('ArrowDown', cell_11)).to.deep.equal(cell_11);
   });
 });

--- a/packages/x-charts-pro/src/SankeyChart/seriesConfig/keyboardFocusHandler.test.ts
+++ b/packages/x-charts-pro/src/SankeyChart/seriesConfig/keyboardFocusHandler.test.ts
@@ -76,7 +76,7 @@ const linkBE = {
   targetId: 'E',
 } as const;
 
-function test(
+function moveFocus(
   direction: 'ArrowRight' | 'ArrowLeft' | 'ArrowUp' | 'ArrowDown' | 'A',
   initialFocus: FocusedItemIdentifier<'sankey'> | null,
   align: 'left' | 'justify' = 'left',
@@ -87,99 +87,99 @@ function test(
 describe('<Sankey /> - keyboard navigation', () => {
   describe('ArrowRight', () => {
     it('should move to the first node if no current focus', async () => {
-      expect(test('ArrowRight', null)).to.deep.equal(nodeA);
+      expect(moveFocus('ArrowRight', null)).to.deep.equal(nodeA);
     });
 
     it('should move to the first the first link if focus is on node', async () => {
-      expect(test('ArrowRight', nodeA)).to.deep.equal(linkAC);
+      expect(moveFocus('ArrowRight', nodeA)).to.deep.equal(linkAC);
     });
 
     it('should not move if no node on the right', async () => {
-      expect(test('ArrowRight', nodeE)).to.deep.equal(nodeE);
+      expect(moveFocus('ArrowRight', nodeE)).to.deep.equal(nodeE);
     });
 
     it('should move to the target node', async () => {
-      expect(test('ArrowRight', linkAC)).to.deep.equal(nodeC);
+      expect(moveFocus('ArrowRight', linkAC)).to.deep.equal(nodeC);
     });
   });
 
   describe('ArrowLeft', () => {
     it('should move to the first node if no current focus', async () => {
-      expect(test('ArrowLeft', null)).to.deep.equal(nodeA);
+      expect(moveFocus('ArrowLeft', null)).to.deep.equal(nodeA);
     });
 
     it('should move to the first the first link if focus is on node', async () => {
-      expect(test('ArrowLeft', nodeC)).to.deep.equal(linkAC);
+      expect(moveFocus('ArrowLeft', nodeC)).to.deep.equal(linkAC);
     });
 
     it('should not move if no node on the left', async () => {
-      expect(test('ArrowLeft', nodeA)).to.deep.equal(nodeA);
+      expect(moveFocus('ArrowLeft', nodeA)).to.deep.equal(nodeA);
     });
 
     it('should move to the source node', async () => {
-      expect(test('ArrowLeft', linkAC)).to.deep.equal(nodeA);
+      expect(moveFocus('ArrowLeft', linkAC)).to.deep.equal(nodeA);
     });
   });
 
   describe('ArrowDown', () => {
     it('should move to the first node if no current focus', async () => {
-      expect(test('ArrowDown', null)).to.deep.equal(nodeA);
+      expect(moveFocus('ArrowDown', null)).to.deep.equal(nodeA);
     });
 
     it('should move to next node of same layer - align=left', async () => {
-      expect(test('ArrowDown', nodeC, 'left')).to.deep.equal(nodeD);
+      expect(moveFocus('ArrowDown', nodeC, 'left')).to.deep.equal(nodeD);
     });
 
     it('should move to next node of same layer - align=justify', async () => {
-      expect(test('ArrowDown', nodeC, 'justify')).to.deep.equal(nodeE);
+      expect(moveFocus('ArrowDown', nodeC, 'justify')).to.deep.equal(nodeE);
     });
 
     it('should loop on node of same layer', async () => {
-      expect(test('ArrowDown', nodeA)).to.deep.equal(nodeB);
-      expect(test('ArrowDown', nodeB)).to.deep.equal(nodeA);
+      expect(moveFocus('ArrowDown', nodeA)).to.deep.equal(nodeB);
+      expect(moveFocus('ArrowDown', nodeB)).to.deep.equal(nodeA);
     });
 
     it('should move to next link with same source', async () => {
-      expect(test('ArrowDown', linkAC)).to.deep.equal(linkAD);
-      expect(test('ArrowDown', linkAD)).to.deep.equal(linkAC);
+      expect(moveFocus('ArrowDown', linkAC)).to.deep.equal(linkAD);
+      expect(moveFocus('ArrowDown', linkAD)).to.deep.equal(linkAC);
     });
 
     it('should stay if source has no other link', async () => {
-      expect(test('ArrowDown', linkBE)).to.deep.equal(linkBE);
+      expect(moveFocus('ArrowDown', linkBE)).to.deep.equal(linkBE);
     });
   });
 
   describe('ArrowUp', () => {
     it('should move to the first node if no current focus', async () => {
-      expect(test('ArrowUp', null)).to.deep.equal(nodeA);
+      expect(moveFocus('ArrowUp', null)).to.deep.equal(nodeA);
     });
 
     it('should move to next node of same layer - align=left', async () => {
-      expect(test('ArrowUp', nodeC, 'left')).to.deep.equal(nodeD);
+      expect(moveFocus('ArrowUp', nodeC, 'left')).to.deep.equal(nodeD);
     });
 
     it('should move to next node of same layer - align=justify', async () => {
-      expect(test('ArrowUp', nodeC, 'justify')).to.deep.equal(nodeE);
+      expect(moveFocus('ArrowUp', nodeC, 'justify')).to.deep.equal(nodeE);
     });
 
     it('should loop on node of same layer', async () => {
-      expect(test('ArrowUp', nodeA)).to.deep.equal(nodeB);
-      expect(test('ArrowUp', nodeB)).to.deep.equal(nodeA);
+      expect(moveFocus('ArrowUp', nodeA)).to.deep.equal(nodeB);
+      expect(moveFocus('ArrowUp', nodeB)).to.deep.equal(nodeA);
     });
 
     it('should move to next link with same source', async () => {
-      expect(test('ArrowUp', linkAC)).to.deep.equal(linkAD);
-      expect(test('ArrowUp', linkAD)).to.deep.equal(linkAC);
+      expect(moveFocus('ArrowUp', linkAC)).to.deep.equal(linkAD);
+      expect(moveFocus('ArrowUp', linkAD)).to.deep.equal(linkAC);
     });
 
     it('should stay if source has no other link', async () => {
-      expect(test('ArrowUp', linkBE)).to.deep.equal(linkBE);
+      expect(moveFocus('ArrowUp', linkBE)).to.deep.equal(linkBE);
     });
   });
 
   it('should no move is the key is not an arrow key', async () => {
-    expect(test('A', null)).to.deep.equal(null);
-    expect(test('A', nodeC)).to.deep.equal(nodeC);
-    expect(test('A', linkAD)).to.deep.equal(linkAD);
+    expect(moveFocus('A', null)).to.deep.equal(null);
+    expect(moveFocus('A', nodeC)).to.deep.equal(nodeC);
+    expect(moveFocus('A', linkAD)).to.deep.equal(linkAD);
   });
 });

--- a/packages/x-charts/src/ScatterChart/seriesConfig/keyboardFocusHandler.test.ts
+++ b/packages/x-charts/src/ScatterChart/seriesConfig/keyboardFocusHandler.test.ts
@@ -33,7 +33,7 @@ const state = {
   },
 } as any;
 
-function test(
+function moveFocus(
   direction: 'ArrowRight' | 'ArrowLeft',
   initialFocus: FocusedItemIdentifier<'scatter'> | null,
 ) {
@@ -42,7 +42,9 @@ function test(
 
 describe('<Scatter /> - keyboard navigation', () => {
   it('should move to the next item', () => {
-    expect(test('ArrowRight', { type: 'scatter', seriesId: 'short', dataIndex: 0 })).to.deep.equal({
+    expect(
+      moveFocus('ArrowRight', { type: 'scatter', seriesId: 'short', dataIndex: 0 }),
+    ).to.deep.equal({
       type: 'scatter',
       seriesId: 'short',
       dataIndex: 1,
@@ -50,7 +52,9 @@ describe('<Scatter /> - keyboard navigation', () => {
   });
 
   it('should keep focus on the last item of a shorter series', () => {
-    expect(test('ArrowRight', { type: 'scatter', seriesId: 'short', dataIndex: 1 })).to.deep.equal({
+    expect(
+      moveFocus('ArrowRight', { type: 'scatter', seriesId: 'short', dataIndex: 1 }),
+    ).to.deep.equal({
       type: 'scatter',
       seriesId: 'short',
       dataIndex: 1,
@@ -58,7 +62,9 @@ describe('<Scatter /> - keyboard navigation', () => {
   });
 
   it('should not move left from the first item', () => {
-    expect(test('ArrowLeft', { type: 'scatter', seriesId: 'short', dataIndex: 0 })).to.deep.equal({
+    expect(
+      moveFocus('ArrowLeft', { type: 'scatter', seriesId: 'short', dataIndex: 0 }),
+    ).to.deep.equal({
       type: 'scatter',
       seriesId: 'short',
       dataIndex: 0,


### PR DESCRIPTION
Three keyboard focus test files declare a local `function test()` that shadows Vitest's `test`:

```ts
function test(direction: 'ArrowRight' | 'ArrowLeft', initialFocus: ... ) {
  return keyboardFocusHandler({ key: direction } as KeyboardEvent)?.(initialFocus, state);
}
```

That trips `vitest/prefer-importing-vitest-globals`, which matches on the identifier name rather than the binding. It reads those calls as the global and asks for an `import { test } from 'vitest'`, which would then collide with the local declaration. Autofixing it produces `SyntaxError: Identifier 'test' has already been declared`.

mui/mui-public#1798 turns that rule on in `createTestConfig`, so this renames the helper to `moveFocus`, which is what it actually does. No behaviour change.

## Why this is the whole job for mui-x

I ran the merged `createTestConfig` over all 933 `*.test.*` files. These three are the only ones it flags. mui-x is otherwise already done:

- Test files import their globals from `vitest` rather than relying on the injection.
- No file imports `expect` from `chai`, so nothing collides with the Vitest `expect`.
- No shared helper defines tests off the globals, so `globals: true` is not load bearing and can come out of `vitest.shared.mts` whenever you want.

`test/e2e-website/data-grid.spec.ts` uses Playwright's `test` and `expect` and would be flagged too, but the eslint test block matches `**/*.test.*` only, so `.spec.ts` never reaches the rule. Worth remembering if that glob ever widens.

## Verification

- `pnpm test:unit --run keyboardFocusHandler`: 3 files, 27 tests pass.
- `pnpm eslint`, `pnpm prettier`: clean.
- Re-ran the rule afterwards: 0 files flagged.
