### PR TITLE
[charts] Fix y axis tick labels shortened near the top of the chart

### DIFF
--- a/packages/x-charts/src/ChartsYAxis/ChartsYAxis.test.tsx
+++ b/packages/x-charts/src/ChartsYAxis/ChartsYAxis.test.tsx
@@ -1,5 +1,6 @@
 import { createRenderer } from '@mui/internal-test-utils/createRenderer';
 import { screen } from '@mui/internal-test-utils';
+import { isJSDOM } from 'test/utils/skipIf';
 import { ChartsYAxis } from '@mui/x-charts/ChartsYAxis';
 import { axisClasses } from '@mui/x-charts/ChartsAxis';
 import { ChartsContainer } from '@mui/x-charts/ChartsContainer';
@@ -36,6 +37,42 @@ describe('<ChartsYAxis />', () => {
     );
 
     expect(screen.getByText('Downloads')).toBeTruthy();
+  });
+
+  /* Text measurement always returns 0 in JSDOM, so labels are never shortened there. */
+  describe.skipIf(isJSDOM)('tick label shortening', () => {
+    const shorteningProps = {
+      width: 400,
+      height: 160,
+      margin: { top: 10, bottom: 10 },
+      series: [{ type: 'line', data: [0, 40] }],
+      yAxis: [
+        {
+          id: 'test-y-axis',
+          width: 52,
+          min: 0,
+          max: 40,
+          valueFormatter: (value: number) => `${value} °C`,
+        },
+      ],
+    } as const;
+
+    it('does not shorten the top tick label when it fits the axis width', () => {
+      const { container } = render(
+        <ChartsContainer {...shorteningProps}>
+          <ChartsYAxis axisId="test-y-axis" />
+        </ChartsContainer>,
+      );
+
+      const labels = Array.from(
+        container.querySelectorAll(`.${axisClasses.tickLabel}`),
+        (label) => label.textContent,
+      );
+
+      expect(labels.length).to.be.greaterThan(0);
+      expect(labels.every((label) => !label?.includes('…'))).to.equal(true);
+      expect(labels).to.include('40 °C');
+    });
   });
 
   it('should apply className to root element', () => {

--- a/packages/x-charts/src/ChartsYAxis/shortenLabels.tsx
+++ b/packages/x-charts/src/ChartsYAxis/shortenLabels.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { clampAngle } from '../internals/clampAngle';
-import { doesTextFitInRect, ellipsize } from '../internals/ellipsize';
+import { ellipsize, getRotatedTextBounds } from '../internals/ellipsize';
 import { getStringSize } from '../internals/domUtils';
 import type { ChartDrawingArea } from '../hooks';
 import type { TickItem } from '../hooks/useTicks';
@@ -15,49 +15,27 @@ export function shortenLabels(
 ) {
   const shortenedLabels = new Map<TickItem, string>();
   const angle = clampAngle(tickLabelStyle?.angle ?? 0);
-
-  let topBoundFactor = 1;
-  let bottomBoundFactor = 1;
-
-  if (tickLabelStyle?.textAnchor === 'start') {
-    topBoundFactor = Infinity;
-    bottomBoundFactor = 1;
-  } else if (tickLabelStyle?.textAnchor === 'end') {
-    topBoundFactor = 1;
-    bottomBoundFactor = Infinity;
-  } else {
-    topBoundFactor = 2;
-    bottomBoundFactor = 2;
-  }
-
-  if (angle > 180) {
-    [topBoundFactor, bottomBoundFactor] = [bottomBoundFactor, topBoundFactor];
-  }
-
-  if (isRtl) {
-    [topBoundFactor, bottomBoundFactor] = [bottomBoundFactor, topBoundFactor];
-  }
+  const boundsConfig = {
+    angle,
+    textAnchor: tickLabelStyle?.textAnchor,
+    dominantBaseline: tickLabelStyle?.dominantBaseline,
+    isRtl,
+  };
+  const svgHeight = drawingArea.top + drawingArea.height + drawingArea.bottom;
 
   for (const item of visibleLabels) {
     if (item.formattedValue) {
-      // That maximum height of the tick depends on its proximity to the axis bounds.
-      const height = Math.min(
-        (item.offset + item.labelOffset) * topBoundFactor,
-        (drawingArea.top +
-          drawingArea.height +
-          drawingArea.bottom -
-          item.offset -
-          item.labelOffset) *
-          bottomBoundFactor,
-      );
+      // The label is anchored on the tick, so how far it can extend vertically depends on the
+      // proximity of the tick to the SVG bounds.
+      const anchor = item.offset + item.labelOffset;
+      const spaceAbove = anchor;
+      const spaceBelow = svgHeight - anchor;
 
-      const doesTextFit = (text: string) =>
-        doesTextFitInRect(text, {
-          width: maxWidth,
-          height,
-          angle,
-          measureText: (string: string) => getStringSize(string, tickLabelStyle),
-        });
+      const doesTextFit = (text: string) => {
+        const bounds = getRotatedTextBounds(getStringSize(text, tickLabelStyle), boundsConfig);
+
+        return bounds.width <= maxWidth && bounds.above <= spaceAbove && bounds.below <= spaceBelow;
+      };
 
       shortenedLabels.set(item, ellipsize(item.formattedValue.toString(), doesTextFit));
     }

--- a/packages/x-charts/src/internals/ellipsize.test.ts
+++ b/packages/x-charts/src/internals/ellipsize.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { ellipsize } from './ellipsize';
+import { ellipsize, getRotatedTextBounds } from './ellipsize';
 
 describe('ellipsizeText', () => {
   it('returns the original text if it fits', () => {
@@ -71,6 +71,106 @@ describe('ellipsizeText', () => {
 
       /* Starting with 5 graphemes, we should reduce to 2, then 1, totaling 3 calls. */
       expect(doesTextFitCalled).to.equal(3);
+    });
+  });
+});
+
+describe('getRotatedTextBounds', () => {
+  const textSize = { width: 40, height: 10 };
+
+  /* `Math.cos(Math.PI / 2)` is not exactly 0, so the results are rounded before being compared. */
+  const round = (bounds: ReturnType<typeof getRotatedTextBounds>) => ({
+    width: Number(bounds.width.toFixed(6)),
+    above: Number(bounds.above.toFixed(6)),
+    below: Number(bounds.below.toFixed(6)),
+  });
+
+  describe('without rotation', () => {
+    it('splits the height evenly around the anchor for a central baseline', () => {
+      const bounds = getRotatedTextBounds(textSize, {
+        angle: 0,
+        textAnchor: 'end',
+        dominantBaseline: 'central',
+      });
+
+      expect(round(bounds)).to.deep.equal({ width: 40, above: 5, below: 5 });
+    });
+
+    it('puts the whole text below the anchor for a hanging baseline', () => {
+      const bounds = getRotatedTextBounds(textSize, {
+        angle: 0,
+        textAnchor: 'end',
+        dominantBaseline: 'hanging',
+      });
+
+      expect(round(bounds)).to.deep.equal({ width: 40, above: 0, below: 10 });
+    });
+
+    it('puts the whole text above the anchor for an auto baseline', () => {
+      const bounds = getRotatedTextBounds(textSize, {
+        angle: 0,
+        textAnchor: 'end',
+        dominantBaseline: 'auto',
+      });
+
+      expect(round(bounds)).to.deep.equal({ width: 40, above: 10, below: 0 });
+    });
+
+    it('does not let the text anchor influence the vertical extents', () => {
+      const anchors = ['start', 'middle', 'end'] as const;
+
+      anchors.forEach((textAnchor) => {
+        const bounds = getRotatedTextBounds(textSize, {
+          angle: 0,
+          textAnchor,
+          dominantBaseline: 'central',
+        });
+
+        expect(round(bounds)).to.deep.equal({ width: 40, above: 5, below: 5 });
+      });
+    });
+  });
+
+  describe('with a quarter turn', () => {
+    it('splits the width evenly around the anchor for a middle text anchor', () => {
+      const bounds = getRotatedTextBounds(textSize, {
+        angle: 90,
+        textAnchor: 'middle',
+        dominantBaseline: 'hanging',
+      });
+
+      expect(round(bounds)).to.deep.equal({ width: 10, above: 20, below: 20 });
+    });
+
+    it('puts the whole text below the anchor for a start text anchor', () => {
+      const bounds = getRotatedTextBounds(textSize, {
+        angle: 90,
+        textAnchor: 'start',
+        dominantBaseline: 'hanging',
+      });
+
+      expect(round(bounds)).to.deep.equal({ width: 10, above: 0, below: 40 });
+    });
+
+    it('mirrors the extents when the text is rotated the other way', () => {
+      const bounds = getRotatedTextBounds(textSize, {
+        angle: 270,
+        textAnchor: 'start',
+        dominantBaseline: 'hanging',
+      });
+
+      expect(round(bounds)).to.deep.equal({ width: 10, above: 40, below: 0 });
+    });
+
+    it('mirrors the extents in right-to-left', () => {
+      const bounds = getRotatedTextBounds(textSize, {
+        angle: 90,
+        textAnchor: 'start',
+        dominantBaseline: 'hanging',
+        isRtl: true,
+      });
+
+      expect(round(bounds)).to.deep.equal({ width: 10, above: 40, below: 0 });
     });
   });
 });

--- a/packages/x-charts/src/internals/ellipsize.ts
+++ b/packages/x-charts/src/internals/ellipsize.ts
@@ -1,6 +1,7 @@
 import { getGraphemeCount } from './getGraphemeCount';
 import { degToRad } from './degToRad';
 import { sliceUntil } from './sliceUntil';
+import type { ChartsTextAnchor, ChartsTextBaseline } from './getWordsByLines';
 
 const ELLIPSIS = '…';
 
@@ -23,6 +24,91 @@ export function doesTextFitInRect(text: string, config: EllipsizeConfig) {
     Math.abs(textSize.width * Math.sin(angle)) + Math.abs(textSize.height * Math.cos(angle));
 
   return angledWidth <= width && angledHeight <= height;
+}
+
+/**
+ * Position of the text bounding box relative to its anchor point, as a fraction of the text width.
+ * `0` means the box starts at the anchor, `-1` that it ends there.
+ */
+function getHorizontalAnchorOffset(textAnchor: ChartsTextAnchor | undefined, isRtl: boolean) {
+  const anchor = textAnchor ?? 'middle';
+
+  if (anchor === 'middle') {
+    return -1 / 2;
+  }
+
+  const startsAtAnchor = isRtl ? anchor === 'end' : anchor === 'start';
+
+  return startsAtAnchor ? 0 : -1;
+}
+
+/**
+ * Position of the text bounding box relative to its anchor point, as a fraction of the text height.
+ * `0` means the box starts at the anchor, `-1` that it ends there.
+ */
+function getVerticalAnchorOffset(dominantBaseline: ChartsTextBaseline | undefined) {
+  switch (dominantBaseline ?? 'central') {
+    case 'hanging':
+    case 'text-before-edge':
+      return 0;
+    case 'central':
+      return -1 / 2;
+    default:
+      return -1;
+  }
+}
+
+export interface RotatedTextBoundsConfig {
+  /** Angle, in degrees, in which the text is displayed. */
+  angle: number;
+  textAnchor?: ChartsTextAnchor;
+  dominantBaseline?: ChartsTextBaseline;
+  isRtl?: boolean;
+}
+
+export interface RotatedTextBounds {
+  /** Width of the text bounding box once rotated. */
+  width: number;
+  /** How far the text extends above its anchor point. */
+  above: number;
+  /** How far the text extends below its anchor point. */
+  below: number;
+}
+
+/**
+ * Returns the size of a rotated text, and how far it extends on each side of its anchor point.
+ *
+ * Which side of the anchor the text is drawn on depends on both the text anchoring and the rotation,
+ * so `above` and `below` are not necessarily equal. Either of them is negative when the whole text
+ * sits on the other side of the anchor point.
+ *
+ * @param textSize The size of the text before rotation.
+ * @param config How the text is anchored and rotated.
+ */
+export function getRotatedTextBounds(
+  textSize: { width: number; height: number },
+  config: RotatedTextBoundsConfig,
+): RotatedTextBounds {
+  const angle = degToRad(config.angle);
+  const sin = Math.sin(angle);
+  const cos = Math.cos(angle);
+
+  const left = getHorizontalAnchorOffset(config.textAnchor, config.isRtl ?? false) * textSize.width;
+  const right = left + textSize.width;
+  const top = getVerticalAnchorOffset(config.dominantBaseline) * textSize.height;
+  const bottom = top + textSize.height;
+
+  /* A rotation by `angle` maps a point to `(x * cos - y * sin, x * sin + y * cos)`. Both terms of
+   * the vertical coordinate are independent, so the extrema of their sum are the sums of their
+   * extrema. */
+  const fromWidth = [left * sin, right * sin];
+  const fromHeight = [top * cos, bottom * cos];
+
+  return {
+    width: Math.abs(textSize.width * cos) + Math.abs(textSize.height * sin),
+    above: -(Math.min(...fromWidth) + Math.min(...fromHeight)),
+    below: Math.max(...fromWidth) + Math.max(...fromHeight),
+  };
 }
 
 /** This function finds the best place to clip the text to add an ellipsis.


### PR DESCRIPTION
Fixes #23433.

## The bug

A y axis tick label sitting close to the top of the chart was shortened, or dropped entirely, even when it comfortably fit the axis width. Increasing `margin.top` made the ellipsis go away, which is what pointed at the vertical bound rather than the horizontal one.

<img width="64" height="366" alt="Y axis with the top tick label truncated" src="https://github.com/user-attachments/assets/3f49216e-24f2-4ee9-8288-3bf3fea61c60" />

## Cause

`ChartsYAxis/shortenLabels` derived the vertical space available to a label from `tickLabelStyle.textAnchor`, which is the *horizontal* anchor. An unrotated left axis defaults to `textAnchor: 'end'` and `dominantBaseline: 'central'`, so the branch picked `topBoundFactor = 1` and gave the label the whole distance between the tick and the top of the SVG as its height budget. A vertically centered label only overflows upward by half its height, so the budget was off by a factor of two. `bottomBoundFactor` was `Infinity` in that same branch, so `Math.min` always selected the top term and the bottom edge was never clamped at all.

That bound is then compared against the *measured* bbox of each candidate string. `getStringSize` measures a real SVG `<text>`, so the height varies with the glyphs present: `40 °C` is taller than `4…` because of the degree sign. `ellipsize` therefore kept chopping characters until the bbox got short enough, producing a truncation driven by which glyphs the label happened to contain rather than by the space actually available.

The `textAnchor` heuristic is correct for labels rotated a quarter turn, where the horizontal anchor really does decide the vertical extent. It is wrong for unrotated ones.

## Fix

Added `getRotatedTextBounds` next to `doesTextFitInRect`. It returns the rotated width of a text plus how far it extends above and below its anchor point, derived from the rotation and both anchors, so it is correct at any angle instead of only at multiples of a quarter turn. `shortenLabels` now compares those extents to the space above and below the tick.

## Tests

- Unit tests for `getRotatedTextBounds` covering each baseline unrotated, each anchor at a quarter turn, the opposite rotation, and RTL.
- A regression test on `ChartsYAxis`, browser only since text measurement always returns 0 in JSDOM. It fails on `master` with `expected [ '0 °C', '20 °C', '' ] to include '40 °C'`.

## Follow up

The x axis has the mirrored weakness: `ChartsXAxis/shortenLabels` derives the *horizontal* bounds from `textAnchor`, which is right unrotated but not at a quarter turn, where `dominantBaseline` decides the horizontal extent. The defaults make it hard to hit today, so it is left out of this PR to keep the change focused. `getRotatedTextBounds` is general enough to serve it when it becomes a problem.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
