### PR TITLE
[code-infra] Load Sinon only in the browser suites that use it

### DIFF
--- a/packages/x-charts-pro/vitest.config.browser.mts
+++ b/packages/x-charts-pro/vitest.config.browser.mts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { mergeConfig, defineConfig } from 'vitest/config';
 import sharedConfig from '../../vitest.shared.mts';
 import { getTestName } from '../../scripts/getTestName.mts';
@@ -7,6 +8,7 @@ export default mergeConfig(
   defineConfig({
     test: {
       name: getTestName(import.meta.url),
+      setupFiles: [fileURLToPath(new URL('../../test/utils/setupSinon.ts', import.meta.url))],
       exclude: ['**/materialVersion.test.tsx'],
       browser: {
         enabled: true,

--- a/packages/x-charts/vitest.config.browser.mts
+++ b/packages/x-charts/vitest.config.browser.mts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { mergeConfig, defineConfig } from 'vitest/config';
 import sharedConfig from '../../vitest.shared.mts';
 import { getTestName } from '../../scripts/getTestName.mts';
@@ -7,6 +8,7 @@ export default mergeConfig(
   defineConfig({
     test: {
       name: getTestName(import.meta.url),
+      setupFiles: [fileURLToPath(new URL('../../test/utils/setupSinon.ts', import.meta.url))],
       exclude: ['**/materialVersion.test.tsx'],
       browser: {
         enabled: true,

--- a/packages/x-chat-headless/vitest.config.browser.mts
+++ b/packages/x-chat-headless/vitest.config.browser.mts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { mergeConfig, defineConfig } from 'vitest/config';
 import sharedConfig from '../../vitest.shared.mts';
 import { getTestName } from '../../scripts/getTestName.mts';
@@ -7,6 +8,7 @@ export default mergeConfig(
   defineConfig({
     test: {
       name: getTestName(import.meta.url),
+      setupFiles: [fileURLToPath(new URL('../../test/utils/setupSinon.ts', import.meta.url))],
       browser: {
         enabled: true,
         instances: [{ browser: 'chromium' }],

--- a/packages/x-data-grid-premium/vitest.config.browser.mts
+++ b/packages/x-data-grid-premium/vitest.config.browser.mts
@@ -8,7 +8,10 @@ export default mergeConfig(
   defineConfig({
     test: {
       name: getTestName(import.meta.url),
-      setupFiles: [fileURLToPath(new URL('../../test/utils/setupDataGrid.ts', import.meta.url))],
+      setupFiles: [
+        fileURLToPath(new URL('../../test/utils/setupDataGrid.ts', import.meta.url)),
+        fileURLToPath(new URL('../../test/utils/setupSinon.ts', import.meta.url)),
+      ],
       exclude: [
         '**/materialVersion.test.tsx',
         // The formula engine is DOM-free by design (no React/grid imports) —

--- a/packages/x-data-grid-pro/vitest.config.browser.mts
+++ b/packages/x-data-grid-pro/vitest.config.browser.mts
@@ -8,7 +8,10 @@ export default mergeConfig(
   defineConfig({
     test: {
       name: getTestName(import.meta.url),
-      setupFiles: [fileURLToPath(new URL('../../test/utils/setupDataGrid.ts', import.meta.url))],
+      setupFiles: [
+        fileURLToPath(new URL('../../test/utils/setupDataGrid.ts', import.meta.url)),
+        fileURLToPath(new URL('../../test/utils/setupSinon.ts', import.meta.url)),
+      ],
       exclude: ['**/materialVersion.test.tsx'],
       browser: {
         enabled: true,

--- a/packages/x-data-grid/vitest.config.browser.mts
+++ b/packages/x-data-grid/vitest.config.browser.mts
@@ -8,7 +8,10 @@ export default mergeConfig(
   defineConfig({
     test: {
       name: getTestName(import.meta.url),
-      setupFiles: [fileURLToPath(new URL('../../test/utils/setupDataGrid.ts', import.meta.url))],
+      setupFiles: [
+        fileURLToPath(new URL('../../test/utils/setupDataGrid.ts', import.meta.url)),
+        fileURLToPath(new URL('../../test/utils/setupSinon.ts', import.meta.url)),
+      ],
       exclude: ['**/materialVersion.test.tsx'],
       browser: {
         enabled: true,

--- a/packages/x-date-pickers-pro/vitest.config.browser.mts
+++ b/packages/x-date-pickers-pro/vitest.config.browser.mts
@@ -8,7 +8,10 @@ export default mergeConfig(
   defineConfig({
     test: {
       name: getTestName(import.meta.url),
-      setupFiles: [fileURLToPath(new URL('../../test/utils/setupPickers.js', import.meta.url))],
+      setupFiles: [
+        fileURLToPath(new URL('../../test/utils/setupPickers.js', import.meta.url)),
+        fileURLToPath(new URL('../../test/utils/setupSinon.ts', import.meta.url)),
+      ],
       exclude: ['**/materialVersion.test.tsx'],
       browser: {
         enabled: true,

--- a/packages/x-date-pickers/vitest.config.browser.mts
+++ b/packages/x-date-pickers/vitest.config.browser.mts
@@ -19,7 +19,10 @@ export default mergeConfig(
     },
     test: {
       name: getTestName(import.meta.url),
-      setupFiles: [fileURLToPath(new URL('../../test/utils/setupPickers.js', import.meta.url))],
+      setupFiles: [
+        fileURLToPath(new URL('../../test/utils/setupPickers.js', import.meta.url)),
+        fileURLToPath(new URL('../../test/utils/setupSinon.ts', import.meta.url)),
+      ],
       exclude: ['**/materialVersion.test.tsx'],
       browser: {
         enabled: true,

--- a/packages/x-scheduler-internals-premium/vitest.config.browser.mts
+++ b/packages/x-scheduler-internals-premium/vitest.config.browser.mts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { mergeConfig, defineConfig } from 'vitest/config';
 import sharedConfig from '../../vitest.shared.mts';
 import { getTestName } from '../../scripts/getTestName.mts';
@@ -7,6 +8,7 @@ export default mergeConfig(
   defineConfig({
     test: {
       name: getTestName(import.meta.url),
+      setupFiles: [fileURLToPath(new URL('../../test/utils/setupSinon.ts', import.meta.url))],
       browser: {
         enabled: true,
         instances: [{ browser: 'chromium' }],

--- a/packages/x-scheduler-internals/vitest.config.browser.mts
+++ b/packages/x-scheduler-internals/vitest.config.browser.mts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { mergeConfig, defineConfig } from 'vitest/config';
 import sharedConfig from '../../vitest.shared.mts';
 import { getTestName } from '../../scripts/getTestName.mts';
@@ -7,6 +8,7 @@ export default mergeConfig(
   defineConfig({
     test: {
       name: getTestName(import.meta.url),
+      setupFiles: [fileURLToPath(new URL('../../test/utils/setupSinon.ts', import.meta.url))],
       browser: {
         enabled: true,
         instances: [{ browser: 'chromium' }],

--- a/packages/x-scheduler-premium/vitest.config.browser.mts
+++ b/packages/x-scheduler-premium/vitest.config.browser.mts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { mergeConfig, defineConfig } from 'vitest/config';
 import sharedConfig from '../../vitest.shared.mts';
 import { getTestName } from '../../scripts/getTestName.mts';
@@ -7,6 +8,7 @@ export default mergeConfig(
   defineConfig({
     test: {
       name: getTestName(import.meta.url),
+      setupFiles: [fileURLToPath(new URL('../../test/utils/setupSinon.ts', import.meta.url))],
       browser: {
         enabled: true,
         instances: [{ browser: 'chromium' }],

--- a/packages/x-scheduler/vitest.config.browser.mts
+++ b/packages/x-scheduler/vitest.config.browser.mts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { mergeConfig, defineConfig } from 'vitest/config';
 import sharedConfig from '../../vitest.shared.mts';
 import { getTestName } from '../../scripts/getTestName.mts';
@@ -7,6 +8,7 @@ export default mergeConfig(
   defineConfig({
     test: {
       name: getTestName(import.meta.url),
+      setupFiles: [fileURLToPath(new URL('../../test/utils/setupSinon.ts', import.meta.url))],
       browser: {
         enabled: true,
         instances: [{ browser: 'chromium' }],

--- a/packages/x-tree-view-pro/vitest.config.browser.mts
+++ b/packages/x-tree-view-pro/vitest.config.browser.mts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { mergeConfig, defineConfig } from 'vitest/config';
 import sharedConfig from '../../vitest.shared.mts';
 import { getTestName } from '../../scripts/getTestName.mts';
@@ -7,6 +8,7 @@ export default mergeConfig(
   defineConfig({
     test: {
       name: getTestName(import.meta.url),
+      setupFiles: [fileURLToPath(new URL('../../test/utils/setupSinon.ts', import.meta.url))],
       exclude: ['**/materialVersion.test.tsx'],
       browser: {
         enabled: true,

--- a/packages/x-tree-view/vitest.config.browser.mts
+++ b/packages/x-tree-view/vitest.config.browser.mts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { defineConfig, mergeConfig } from 'vitest/config';
 import sharedConfig from '../../vitest.shared.mts';
 import { getTestName } from '../../scripts/getTestName.mts';
@@ -7,6 +8,7 @@ export default mergeConfig(
   defineConfig({
     test: {
       name: getTestName(import.meta.url),
+      setupFiles: [fileURLToPath(new URL('../../test/utils/setupSinon.ts', import.meta.url))],
       exclude: ['**/materialVersion.test.tsx'],
       browser: {
         enabled: true,

--- a/test/setupVitest.ts
+++ b/test/setupVitest.ts
@@ -2,7 +2,6 @@ import { beforeAll, beforeEach, afterEach } from 'vitest';
 import 'test/utils/addChaiAssertions';
 import 'test/utils/licenseRelease';
 import { config } from 'react-transition-group';
-import sinon from 'sinon';
 import { clearWarningsCache } from '@mui/x-internals/warning';
 import setupVitest from '@mui/internal-test-utils/setupVitest';
 import { isJsdom } from '@mui/internal-test-utils/env';
@@ -38,9 +37,14 @@ beforeEach(() => {
   config.disabled = true;
 });
 
-afterEach(() => {
-  // Restore Sinon default sandbox to avoid memory leak
-  // See https://github.com/sinonjs/sinon/issues/1866
-  sinon.restore();
+afterEach(async () => {
+  if (isJsdom()) {
+    // The browser suites register this through `test/utils/setupSinon.ts` instead, so that
+    // the pages of the packages that never use Sinon do not load it.
+    const { default: sinon } = await import('sinon');
+    // Restore the Sinon default sandbox to avoid a memory leak.
+    // See https://github.com/sinonjs/sinon/issues/1866
+    sinon.restore();
+  }
   config.disabled = false;
 });

--- a/test/utils/setupSinon.ts
+++ b/test/utils/setupSinon.ts
@@ -1,0 +1,11 @@
+import { afterEach } from 'vitest';
+import sinon from 'sinon';
+
+// Registered only by the browser suites that import Sinon. The module costs about 341kB
+// per page and, because `isolate` is off, the page keeps it for the whole run. Add this
+// setup file to a package's browser config as soon as one of its tests imports Sinon.
+afterEach(() => {
+  // Restore the Sinon default sandbox to avoid a memory leak.
+  // See https://github.com/sinonjs/sinon/issues/1866
+  sinon.restore();
+});


### PR DESCRIPTION
`test/setupVitest.ts` imports `sinon` statically for a single `sinon.restore()` in `afterEach`. The module is about 341kB per page and, because `isolate` is off, every browser page holds it for the whole run ([vitest#10990](https://github.com/vitest-dev/vitest/issues/10990)) - including the 6 of 20 browser projects whose tests never import Sinon.

The 14 projects that do use it now register `test/utils/setupSinon.ts` from their browser config.

The jsdom projects share the same `test/setupVitest.ts`, so simply moving the restore out of it would have relocated the cost to jsdom rather than removing it. They keep the current behaviour through a dynamic import guarded by `isJsdom()`, so no jsdom config changes are needed.

## Which projects are Sinon free

`x-charts-premium`, `x-charts-vendor`, `x-chat`, `x-internal-gestures`, `x-license`, `x-virtualizer`.

I checked these for indirect use as well: several shared helpers under `test/utils` do import Sinon (`helperFn.ts`, `setupFakeClock.ts`, `scheduler/StoreSpy.tsx`, the Pickers `describeValue` and `describeValidation` suites), but none of the six import any of them, and the helpers they do import (`skipIf`, `slotDataAttributes`, `charts/getCenter`, `licenseKeys`) pull nothing.

## Measured

`x-chat` page, post-GC JS heap (CDP `HeapProfiler.collectGarbage` then `Performance.getMetrics`):

| | heap |
| --- | --- |
| master | ~28.9 MB |
| this PR | ~27.7 MB |

About 1.3MB per page across 12 of the roughly 40 pages a run holds open. Small, in line with the other per-page trims; it does not fix the OOM on its own.

## Testing

Both with a cold `node_modules/.vite`, which is what CI always has:

- Full browser suite: 759 passed, 4 skipped (763 files), 12893 tests, 0 page crashes, 0 dependency re-optimizations. Identical to master's cold baseline.
- jsdom for `x-scheduler`, `x-data-grid`, `x-tree-view`: 94 passed, 5 skipped.

## Trade-off worth naming

This is opt-in per project, so a package that adds its first Sinon usage without also registering the setup file loses the sandbox restore. The comment in `setupSinon.ts` says so. If that feels too sharp an edge, the alternative is leaving the static import in place and accepting the 341kB on all pages.
