### PR TITLE
[scheduler] Fix the un-awaited act warning in the event dialog slot test

### DIFF
--- a/packages/x-scheduler/src/internals/components/event-dialog/EventDialog.test.tsx
+++ b/packages/x-scheduler/src/internals/components/event-dialog/EventDialog.test.tsx
@@ -1274,6 +1274,14 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
       const priority = screen.getByRole('textbox', { name: 'Priority' });
       await user.clear(priority);
       await user.type(priority, 'high');
+      expect(priority).to.have.value('high');
+
+      // Typing leaves the input focused, and unmounting a typed-in focused node dispatches
+      // events inside the remount's own `act`, which React then reports as an un-awaited
+      // `act` warning. Blurring first keeps the remount free of them.
+      act(() => {
+        priority.blur();
+      });
 
       // The new identity remounts the slot content, but the draft lives in the form store above it.
       setProps({ slot: SlotB });


### PR DESCRIPTION
`<EventDialogContent /> > eventDialogGeneralTab slot > should keep the draft when the slot component identity changes` fails in the browser run, on `vitest-fail-on-console`:

> A component suspended inside an `act` scope, but the `act` call was not awaited.

## Cause

Typing leaves the Priority input focused, and the slot identity swap unmounts that focused node. Instrumenting React's internal act queue shows the typing itself is clean: the nested acts that `user.clear` / `user.type` open through testing-library's `eventWrapper` all drain, and the queue is back to 0 when they finish. The act React complains about is the **remount** one: `setProps` opens a fresh act, and a nested `eventWrapper` act opens inside it, meaning events are dispatched synchronously during the commit that unmounts the focused input.

That is why wrapping the typing changes nothing. It happens before the act at fault. `await act(...)` around the typing, `await act(...)` around `setProps`, `setPropsAsync`, `findBy` between the steps, a macrotask gap, and driving the remount from React state instead of `setProps` all still fail.

Blurring the input before the swap keeps the remount free of those events, and the test passes with `user.type` intact. The sibling test above hits the same thing when Escape closes the dialog over the focused, edited title, and works around it with an awaited `act` around the trigger.

## Changes

- Blur the Priority input before the slot identity swap.
- Assert the drafted value before the swap too, so a write that never landed cannot pass the test by accident.

No product code is touched.

## Verification

- `x-scheduler` chromium: 70 passed in this file, 496 passed across the package.
- `x-scheduler` jsdom: 70 passed.
- eslint clean on the file.