### PR TITLE
[code-infra] Replace the sinon `spy(fn)` usages with `vi.fn(fn)`

### DIFF
--- a/packages/x-data-grid-premium/src/tests/dataSourceRowGrouping.DataGridPremium.test.tsx
+++ b/packages/x-data-grid-premium/src/tests/dataSourceRowGrouping.DataGridPremium.test.tsx
@@ -11,10 +11,9 @@ import type {
   GridGetRowsResponse,
   GridGroupNode,
 } from '@mui/x-data-grid-premium';
-import { spy } from 'sinon';
 import { getCell } from 'test/utils/helperFn';
 import { isJSDOM } from 'test/utils/skipIf';
-import { describe, it, expect } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 
 describe('<DataGridPremium /> - Data source row grouping (loading state)', () => {
   const { render } = createRenderer();
@@ -23,7 +22,7 @@ describe('<DataGridPremium /> - Data source row grouping (loading state)', () =>
     let resolveSecond: (response: GridGetRowsResponse) => void = () => {};
     const responses: GridGetRowsResponse[] = [{ rows: [{ id: 'A', group: 'A' }], rowCount: 1 }];
     let callIndex = 0;
-    const getRows = spy(() => {
+    const getRows = vi.fn(() => {
       const index = callIndex;
       callIndex += 1;
       if (index === 0) {
@@ -59,7 +58,7 @@ describe('<DataGridPremium /> - Data source row grouping (loading state)', () =>
     const { setProps } = render(<Test />);
 
     await waitFor(() => {
-      expect(getRows.callCount).to.equal(1);
+      expect(getRows.mock.calls.length).to.equal(1);
     });
     await waitFor(() => {
       expect(apiRef.current?.state.rows.loading).to.equal(false);
@@ -68,7 +67,7 @@ describe('<DataGridPremium /> - Data source row grouping (loading state)', () =>
     setProps({ rowGroupingModel: ['group', 'category'] });
 
     await waitFor(() => {
-      expect(getRows.callCount).to.equal(2);
+      expect(getRows.mock.calls.length).to.equal(2);
     });
     expect(apiRef.current?.state.rows.loading).to.equal(true);
 
@@ -82,7 +81,7 @@ describe('<DataGridPremium /> - Data source row grouping (loading state)', () =>
   });
 
   it('should warn when `dataSourceKeepPreviousData` is used with row grouping', async () => {
-    const getRows = spy(() => Promise.resolve({ rows: [{ id: 'A', group: 'A' }], rowCount: 1 }));
+    const getRows = vi.fn(() => Promise.resolve({ rows: [{ id: 'A', group: 'A' }], rowCount: 1 }));
     const dataSource: GridDataSource = {
       getRows: getRows as unknown as GridDataSource['getRows'],
       getGroupKey: (row) => row.group,
@@ -106,7 +105,7 @@ describe('<DataGridPremium /> - Data source row grouping (loading state)', () =>
     await expect(async () => {
       render(<Test />);
       await waitFor(() => {
-        expect(getRows.callCount).to.be.greaterThan(0);
+        expect(getRows.mock.calls.length).to.be.greaterThan(0);
       });
     }).toWarnDev(
       [
@@ -127,7 +126,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Data source row grouping', () =>
   const gridHeight = 4 * rowHeight + columnHeaderHeight + 2;
 
   it('should reset the rows after row grouping model change when children are expanded', async () => {
-    const getRowsSpy = spy();
+    const getRowsSpy = vi.fn();
 
     function TestComponent(props: { rowGroupingModel: DataGridPremiumProps['rowGroupingModel'] }) {
       apiRef = useGridApiRef();
@@ -187,7 +186,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Data source row grouping', () =>
     setProps({ rowGroupingModel: ['company', 'trader'] });
 
     await waitFor(() => {
-      expect(getRowsSpy.lastCall.args[0].groupFields).to.deep.equal(['company', 'trader']);
+      expect(getRowsSpy.mock.lastCall?.[0].groupFields).to.deep.equal(['company', 'trader']);
     });
 
     await waitFor(() => {
@@ -317,7 +316,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Data source row grouping', () =>
     }
 
     it('should create row grouping nodes with the grouping field for each lazy-loaded level', async () => {
-      const getRowsSpy = spy();
+      const getRowsSpy = vi.fn();
       const { user } = render(<TestNestedLazyRowGrouping onFetchRows={getRowsSpy} />);
 
       await waitFor(() => {
@@ -347,16 +346,16 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Data source row grouping', () =>
       const updatedTechNode = apiRef.current!.getRowNode<GridGroupNode>('sector-tech')!;
       expect(updatedTechNode.childrenFromPath.industry.Software).to.equal('industry-software');
 
-      const technologyRequest = getRowsSpy.getCalls().find((call) => {
-        const params = call.firstArg as GridGetRowsParams;
+      const technologyRequest = getRowsSpy.mock.calls.find((call) => {
+        const params = call[0] as GridGetRowsParams;
         return JSON.stringify(params.groupKeys) === JSON.stringify(['Technology']);
-      })?.firstArg as GridGetRowsParams | undefined;
+      })?.[0] as GridGetRowsParams | undefined;
 
       expect(technologyRequest?.groupFields).to.deep.equal(['sector', 'industry']);
     });
 
     it('should lazy load children for default-expanded row grouping groups', async () => {
-      const getRowsSpy = spy();
+      const getRowsSpy = vi.fn();
       render(
         <TestNestedLazyRowGrouping defaultGroupingExpansionDepth={1} onFetchRows={getRowsSpy} />,
       );
@@ -368,16 +367,16 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Data source row grouping', () =>
       const sectorNode = apiRef.current!.getRowNode<GridGroupNode>('sector-tech')!;
       expect(sectorNode.childrenExpanded).to.equal(true);
 
-      const technologyRequest = getRowsSpy.getCalls().find((call) => {
-        const params = call.firstArg as GridGetRowsParams;
+      const technologyRequest = getRowsSpy.mock.calls.find((call) => {
+        const params = call[0] as GridGetRowsParams;
         return JSON.stringify(params.groupKeys) === JSON.stringify(['Technology']);
-      })?.firstArg as GridGetRowsParams | undefined;
+      })?.[0] as GridGetRowsParams | undefined;
       expect(technologyRequest?.groupFields).to.deep.equal(['sector', 'industry']);
     });
 
     it('should use isGroupExpandedByDefault for lazy-loaded row grouping groups', async () => {
-      const getRowsSpy = spy();
-      const isGroupExpandedByDefault = spy(
+      const getRowsSpy = vi.fn();
+      const isGroupExpandedByDefault = vi.fn(
         (node: GridGroupNode) => node.groupingField === 'sector' && node.groupingKey === 'Finance',
       );
       render(
@@ -396,7 +395,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Data source row grouping', () =>
       expect(technologyNode.childrenExpanded).to.equal(false);
       expect(financeNode.childrenExpanded).to.equal(true);
       expect(apiRef.current!.getRow('industry-software')).to.equal(null);
-      expect(isGroupExpandedByDefault.called).to.equal(true);
+      expect(isGroupExpandedByDefault.mock.calls.length).to.be.greaterThan(0);
     });
 
     [
@@ -418,7 +417,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Data source row grouping', () =>
       },
     ].forEach(({ label, updateModel, isMatchingRequest }) => {
       it(`should preserve expanded row grouping groups and fetch children after ${label}`, async () => {
-        const getRowsSpy = spy();
+        const getRowsSpy = vi.fn();
         const { user } = render(<TestNestedLazyRowGrouping onFetchRows={getRowsSpy} />);
 
         await waitFor(() => expect(apiRef.current!.getRow('sector-tech')).not.to.equal(null));
@@ -427,31 +426,31 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Data source row grouping', () =>
         await user.click(within(getCell(1, 0)).getByRole('button'));
         await waitFor(() => expect(apiRef.current!.getRow('stock-msft')).not.to.equal(null));
 
-        getRowsSpy.resetHistory();
+        getRowsSpy.mockClear();
 
         act(() => updateModel());
 
         await waitFor(() => {
-          const nestedRequest = getRowsSpy.getCalls().find((call) => {
-            const params = call.firstArg as GridGetRowsParams;
+          const nestedRequest = getRowsSpy.mock.calls.find((call) => {
+            const params = call[0] as GridGetRowsParams;
             return (
               JSON.stringify(params.groupKeys) === JSON.stringify(['Technology']) &&
               isMatchingRequest(params)
             );
-          })?.firstArg as GridGetRowsParams | undefined;
+          })?.[0] as GridGetRowsParams | undefined;
 
           expect(nestedRequest?.groupFields).to.deep.equal(['sector', 'industry']);
         });
 
         // Deeper expanded levels must also be re-fetched, not only the first.
         await waitFor(() => {
-          const deepRequest = getRowsSpy.getCalls().find((call) => {
-            const params = call.firstArg as GridGetRowsParams;
+          const deepRequest = getRowsSpy.mock.calls.find((call) => {
+            const params = call[0] as GridGetRowsParams;
             return (
               JSON.stringify(params.groupKeys) === JSON.stringify(['Technology', 'Software']) &&
               isMatchingRequest(params)
             );
-          })?.firstArg as GridGetRowsParams | undefined;
+          })?.[0] as GridGetRowsParams | undefined;
 
           expect(deepRequest?.groupFields).to.deep.equal(['sector', 'industry']);
         });
@@ -465,7 +464,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Data source row grouping', () =>
     });
 
     it('should lazy load leaves under the final row grouping level', async () => {
-      const getRowsSpy = spy();
+      const getRowsSpy = vi.fn();
       const { user } = render(<TestNestedLazyRowGrouping onFetchRows={getRowsSpy} />);
 
       await waitFor(() => expect(apiRef.current!.getRow('sector-tech')).not.to.equal(null));
@@ -486,16 +485,16 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Data source row grouping', () =>
       const noGroupingField = '__no_field__';
       expect(softwareNode.childrenFromPath[noGroupingField].Microsoft).to.equal('stock-msft');
 
-      const softwareRequest = getRowsSpy.getCalls().find((call) => {
-        const params = call.firstArg as GridGetRowsParams;
+      const softwareRequest = getRowsSpy.mock.calls.find((call) => {
+        const params = call[0] as GridGetRowsParams;
         return JSON.stringify(params.groupKeys) === JSON.stringify(['Technology', 'Software']);
-      })?.firstArg as GridGetRowsParams | undefined;
+      })?.[0] as GridGetRowsParams | undefined;
 
       expect(softwareRequest?.groupFields).to.deep.equal(['sector', 'industry']);
     });
 
     it('should collapse expanded row grouping parents without removing skeleton rows through row updates', async () => {
-      const getRowsSpy = spy();
+      const getRowsSpy = vi.fn();
       const { user } = render(<TestNestedLazyRowGrouping onFetchRows={getRowsSpy} />);
 
       await waitFor(() => expect(apiRef.current!.getRow('sector-tech')).not.to.equal(null));

--- a/packages/x-data-grid-premium/src/tests/formula.DataGridPremium.test.tsx
+++ b/packages/x-data-grid-premium/src/tests/formula.DataGridPremium.test.tsx
@@ -2,8 +2,7 @@ import * as React from 'react';
 import type { RefObject } from '@mui/x-internals/types';
 import { createRenderer, act, waitFor } from '@mui/internal-test-utils';
 import { getColumnValues, microtasks } from 'test/utils/helperFn';
-import { spy } from 'sinon';
-import { onTestFinished, describe, it, expect } from 'vitest';
+import { vi, onTestFinished, describe, it, expect } from 'vitest';
 import { DataGridPremium, useGridApiRef } from '@mui/x-data-grid-premium';
 import { GRID_FORMULA_FUNCTIONS, formulaFeature } from '@mui/x-data-grid-premium/formula';
 import type {
@@ -248,23 +247,23 @@ describe('<DataGridPremium /> - Formulas', () => {
 
     it('should publish formulaEvaluated with the changed cells', async () => {
       await render(<Test />);
-      const listener = spy();
+      const listener = vi.fn();
       apiRef.current!.subscribeEvent('formulaEvaluated', listener);
 
       await act(async () => apiRef.current!.updateRows([{ id: 0, price: 10 }]));
 
-      expect(listener.callCount).to.equal(1);
-      expect(listener.lastCall.args[0].changedCells).to.deep.equal([{ id: 0, field: 'total' }]);
+      expect(listener.mock.calls.length).to.equal(1);
+      expect(listener.mock.lastCall?.[0].changedCells).to.deep.equal([{ id: 0, field: 'total' }]);
     });
 
     it('should not re-evaluate when an unrelated cell changes', async () => {
       await render(<Test />);
-      const listener = spy();
+      const listener = vi.fn();
       apiRef.current!.subscribeEvent('formulaEvaluated', listener);
 
       await act(async () => apiRef.current!.updateRows([{ id: 0, item: 'Apricot' }]));
 
-      expect(listener.callCount).to.equal(0);
+      expect(listener.mock.calls.length).to.equal(0);
       expect(getColumnValues(3)).to.deep.equal(['6', '5', '8']);
     });
   });
@@ -321,14 +320,14 @@ describe('<DataGridPremium /> - Formulas', () => {
           columns={summaryColumns}
         />,
       );
-      const listener = spy();
+      const listener = vi.fn();
       apiRef.current!.subscribeEvent('formulaEvaluated', listener);
 
       await act(async () => apiRef.current!.updateRows([{ id: 1, price: 10 }]));
 
       expect(getColumnValues(1)).to.deep.equal(['17', '', '']);
-      expect(listener.callCount).to.equal(1);
-      expect(listener.lastCall.args[0].changedCells).to.deep.equal([{ id: 0, field: 'summary' }]);
+      expect(listener.mock.calls.length).to.equal(1);
+      expect(listener.mock.lastCall?.[0].changedCells).to.deep.equal([{ id: 0, field: 'summary' }]);
     });
 
     it('should evaluate formula cells inside a range before the range consumer', async () => {
@@ -417,17 +416,17 @@ describe('<DataGridPremium /> - Formulas', () => {
       );
       expect(getColumnValues(2)).to.deep.equal(['10', '', '']);
 
-      const listener = spy();
+      const listener = vi.fn();
       apiRef.current!.subscribeEvent('formulaEvaluated', listener);
 
       // A change inside the rectangle recomputes the consumer.
       await act(async () => apiRef.current!.updateRows([{ id: 1, p2: 14 }]));
       expect(getColumnValues(2)).to.deep.equal(['20', '', '']);
-      expect(listener.callCount).to.equal(1);
+      expect(listener.mock.calls.length).to.equal(1);
 
       // A change outside the rectangle does not.
       await act(async () => apiRef.current!.updateRows([{ id: 2, p1: 7 }]));
-      expect(listener.callCount).to.equal(1);
+      expect(listener.mock.calls.length).to.equal(1);
       expect(getColumnValues(2)).to.deep.equal(['20', '', '']);
     });
 
@@ -532,7 +531,7 @@ describe('<DataGridPremium /> - Formulas', () => {
       // Initial view order [a, b, c]: posVal = [price@3, price@2, price@1].
       expect(getColumnValues(2)).to.deep.equal(['20', '10', '30']);
 
-      const sortListener = spy();
+      const sortListener = vi.fn();
       apiRef.current!.subscribeEvent('sortedRowsSet', sortListener);
 
       await act(async () => apiRef.current!.setSortModel([{ field: 'posVal', sort: 'asc' }]));
@@ -543,7 +542,7 @@ describe('<DataGridPremium /> - Formulas', () => {
       // exactly once — and even though they now disagree with the ascending
       // sort, the grid did not re-sort.
       expect(getColumnValues(2)).to.deep.equal(['30', '20', '10']);
-      expect(sortListener.callCount).to.equal(1);
+      expect(sortListener.mock.calls.length).to.equal(1);
     });
 
     it('should rebind COLUMN_POSITION references on visibility changes and column reorder', async () => {
@@ -824,7 +823,7 @@ describe('<DataGridPremium /> - Formulas', () => {
       );
       expect(getColumnValues(1)).to.deep.equal(['10', '5', '7']);
 
-      const filterListener = spy();
+      const filterListener = vi.fn();
       apiRef.current!.subscribeEvent('filteredRowsSet', filterListener);
 
       await act(async () =>
@@ -838,7 +837,7 @@ describe('<DataGridPremium /> - Formulas', () => {
       // exist — but the grid never re-filters (one-shot, D4): the row stays
       // visible showing #REF!.
       expect(getColumnValues(1)).to.deep.equal(['10', '#REF!']);
-      expect(filterListener.callCount).to.equal(1);
+      expect(filterListener.mock.calls.length).to.equal(1);
     });
 
     it('should materialize COLUMN_VALUES over all pages', async () => {
@@ -963,14 +962,14 @@ describe('<DataGridPremium /> - Formulas', () => {
       );
       expect(getColumnValues(1)).to.deep.equal(['', '2', '8']);
 
-      const listener = spy();
+      const listener = vi.fn();
       apiRef.current!.subscribeEvent('formulaEvaluated', listener);
 
       await act(async () => apiRef.current!.updateRows([{ id: 0, _action: 'delete' }]));
 
       expect(getColumnValues(1)).to.deep.equal(['#REF!', '8']);
-      expect(listener.callCount).to.equal(1);
-      expect(listener.lastCall.args[0].changedCells).to.deep.equal([{ id: 1, field: 'calc' }]);
+      expect(listener.mock.calls.length).to.equal(1);
+      expect(listener.mock.lastCall?.[0].changedCells).to.deep.equal([{ id: 1, field: 'calc' }]);
     });
   });
 
@@ -993,7 +992,7 @@ describe('<DataGridPremium /> - Formulas', () => {
     });
 
     it('should ignore the valueGetter of the formula column for formula cells only', async () => {
-      const warnSpy = spy();
+      const warnSpy = vi.fn();
       const originalWarn = console.warn;
       console.warn = warnSpy;
       onTestFinished(() => {
@@ -1018,13 +1017,11 @@ describe('<DataGridPremium /> - Formulas', () => {
       );
       expect(getColumnValues(1)).to.deep.equal(['3', '700']);
       expect(
-        warnSpy
-          .getCalls()
-          .some((call) =>
-            call.args.some(
-              (arg) => typeof arg === 'string' && arg.includes('`allowFormulas` and `valueGetter`'),
-            ),
+        warnSpy.mock.calls.some((call) =>
+          call.some(
+            (arg) => typeof arg === 'string' && arg.includes('`allowFormulas` and `valueGetter`'),
           ),
+        ),
       ).to.equal(true);
     });
   });
@@ -1138,13 +1135,13 @@ describe('<DataGridPremium /> - Formulas', () => {
     });
 
     it('should not evaluate formulas when dataSource is set', async () => {
-      const warnSpy = spy();
+      const warnSpy = vi.fn();
       const originalWarn = console.warn;
       console.warn = warnSpy;
       onTestFinished(() => {
         console.warn = originalWarn;
       });
-      const getRows = spy(async () => ({
+      const getRows = vi.fn(async () => ({
         rows: baselineProps.rows as Record<string, unknown>[],
         rowCount: 3,
       }));

--- a/packages/x-data-grid-premium/src/tests/formula.editing.DataGridPremium.test.tsx
+++ b/packages/x-data-grid-premium/src/tests/formula.editing.DataGridPremium.test.tsx
@@ -2,8 +2,7 @@ import * as React from 'react';
 import type { RefObject } from '@mui/x-internals/types';
 import { createRenderer, fireEvent, act, waitFor } from '@mui/internal-test-utils';
 import { getCell, getColumnValues, microtasks } from 'test/utils/helperFn';
-import { spy } from 'sinon';
-import { onTestFinished, describe, it, expect } from 'vitest';
+import { vi, onTestFinished, describe, it, expect } from 'vitest';
 import { DataGridPremium, useGridApiContext, useGridApiRef } from '@mui/x-data-grid-premium';
 import { formulaFeature } from '@mui/x-data-grid-premium/formula';
 import type {
@@ -184,7 +183,7 @@ describe('<DataGridPremium /> - Formulas editing', () => {
     });
 
     it('should commit a new formula and re-evaluate', async () => {
-      const processRowUpdate = spy((newRow) => newRow);
+      const processRowUpdate = vi.fn((newRow) => newRow);
       const { user } = await render(<Test processRowUpdate={processRowUpdate} />);
       await user.dblClick(getCell(0, 3));
       await waitFor(() => {
@@ -198,7 +197,7 @@ describe('<DataGridPremium /> - Formulas editing', () => {
       expect(apiRef.current!.getRow(0).total).to.equal('=price + quantity');
       expect(getColumnValues(3)).to.deep.equal(['5', '5', '8']);
       // The commit hands the formula source (not the evaluated value) to userland.
-      expect(processRowUpdate.lastCall.args[0].total).to.equal('=price + quantity');
+      expect(processRowUpdate.mock.lastCall?.[0].total).to.equal('=price + quantity');
     });
 
     it('should commit a plain value over a formula', async () => {
@@ -488,7 +487,7 @@ describe('<DataGridPremium /> - Formulas editing', () => {
 
     it('focuses the editor without scrolling the grid into view', async () => {
       // Shadow `focus` on HTMLDivElement (the editable is a div) with a
-      // recording wrapper. A plain sinon spy cannot wrap it here: the test
+      // recording wrapper. A plain mock cannot wrap it here: the test
       // environment turns `HTMLElement.prototype.focus` into an accessor.
       const focusCalls: { element: Element; options?: FocusOptions }[] = [];
       const divProto = HTMLDivElement.prototype;

--- a/packages/x-data-grid-premium/src/tests/formulaBar.DataGridPremium.test.tsx
+++ b/packages/x-data-grid-premium/src/tests/formulaBar.DataGridPremium.test.tsx
@@ -3,7 +3,6 @@ import * as ReactDOM from 'react-dom';
 import type { RefObject } from '@mui/x-internals/types';
 import { createRenderer, fireEvent, act, waitFor } from '@mui/internal-test-utils';
 import { getCell, microtasks } from 'test/utils/helperFn';
-import { spy } from 'sinon';
 import {
   DataGridPremium,
   Toolbar,
@@ -14,7 +13,7 @@ import { FormulaBar, formulaFeature } from '@mui/x-data-grid-premium/formula';
 import type { DataGridPremiumProps, GridApi } from '@mui/x-data-grid-premium';
 import { unwrapPrivateAPI } from '@mui/x-data-grid/internals';
 import { isJSDOM } from 'test/utils/skipIf';
-import { describe, it, expect } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 import type { GridPrivateApiPremium } from '../models/gridApiPremium';
 import { setCaretOffset } from '../components/formulaEditorCaret';
 
@@ -216,7 +215,7 @@ describe('<DataGridPremium /> - Formula bar', () => {
     });
 
     it('commits on Enter through processRowUpdate and moves the focus below', async () => {
-      const processRowUpdate = spy((newRow) => newRow);
+      const processRowUpdate = vi.fn((newRow) => newRow);
       render(<Test processRowUpdate={processRowUpdate} />);
       await microtasks();
       focusCell(0, 'total');
@@ -226,8 +225,8 @@ describe('<DataGridPremium /> - Formula bar', () => {
       await waitFor(() => {
         expect(apiRef.current!.getRow(0).total).to.equal('=price * quantity * 2');
       });
-      expect(processRowUpdate.callCount).to.equal(1);
-      expect(processRowUpdate.lastCall.args[0].total).to.equal('=price * quantity * 2');
+      expect(processRowUpdate.mock.calls.length).to.equal(1);
+      expect(processRowUpdate.mock.lastCall?.[0].total).to.equal('=price * quantity * 2');
       expect(getCell(0, 3).textContent).to.equal('12');
       expect(gridFocusCellSelector(privateApi())).to.deep.equal({ id: 1, field: 'total' });
       // The draft is gone — the bar shows the next focused cell.

--- a/packages/x-data-grid-premium/src/tests/history.DataGridPremium.test.tsx
+++ b/packages/x-data-grid-premium/src/tests/history.DataGridPremium.test.tsx
@@ -12,10 +12,9 @@ import type {
 import { createRenderer, waitFor, act, fireEvent, screen } from '@mui/internal-test-utils';
 import type { MuiRenderResult } from '@mui/internal-test-utils';
 import { getCell, getColumnValues } from 'test/utils/helperFn';
-import { spy } from 'sinon';
 import { getBasicGridData } from '@mui/x-data-grid-generator';
 import { isJSDOM } from 'test/utils/skipIf';
-import { describe, it, expect } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 
 describe('<DataGridPremium /> - History', () => {
   const { render } = createRenderer();
@@ -580,7 +579,7 @@ describe('<DataGridPremium /> - History', () => {
 
   describe('Events', () => {
     it('should fire `onUndo` callback', async () => {
-      const onUndo = spy();
+      const onUndo = vi.fn();
 
       const customHandler: GridHistoryEventHandler = {
         store: () => ({ data: 'test' }),
@@ -606,12 +605,12 @@ describe('<DataGridPremium /> - History', () => {
         await apiRef.current!.history.undo();
       });
 
-      expect(onUndo.callCount).to.equal(1);
-      expect(onUndo.firstCall.args[0]).to.have.property('eventName', 'cellClick');
+      expect(onUndo.mock.calls.length).to.equal(1);
+      expect(onUndo.mock.calls[0][0]).to.have.property('eventName', 'cellClick');
     });
 
     it('should fire `onRedo` callback', async () => {
-      const onRedo = spy();
+      const onRedo = vi.fn();
 
       const customHandler: GridHistoryEventHandler = {
         store: () => ({ data: 'test' }),
@@ -642,8 +641,8 @@ describe('<DataGridPremium /> - History', () => {
         await apiRef.current!.history.redo();
       });
 
-      expect(onRedo.callCount).to.equal(1);
-      expect(onRedo.firstCall.args[0]).to.have.property('eventName', 'cellClick');
+      expect(onRedo.mock.calls.length).to.equal(1);
+      expect(onRedo.mock.calls[0][0]).to.have.property('eventName', 'cellClick');
     });
   });
 
@@ -706,7 +705,7 @@ describe('<DataGridPremium /> - History', () => {
     });
 
     it('should call `dataSource.updateRow` when undoing with data source', async () => {
-      const updateRowSpy = spy();
+      const updateRowSpy = vi.fn();
 
       function TestWithDataSource() {
         const dataSource = React.useMemo(
@@ -750,7 +749,7 @@ describe('<DataGridPremium /> - History', () => {
       });
 
       // Reset the call count
-      updateRowSpy.resetHistory();
+      updateRowSpy.mockClear();
 
       // Perform undo
       await act(async () => {
@@ -758,10 +757,10 @@ describe('<DataGridPremium /> - History', () => {
       });
 
       // one additional call to `updateRow` should have been made
-      expect(updateRowSpy.callCount).to.equal(1);
-      const undoCall = updateRowSpy.lastCall;
-      expect(undoCall.args[0]).to.have.property('rowId', 0);
-      expect(undoCall.args[0].updatedRow).to.have.property('currencyPair', originalValue);
+      expect(updateRowSpy.mock.calls.length).to.equal(1);
+      const undoCall = updateRowSpy.mock.lastCall;
+      expect(undoCall?.[0]).to.have.property('rowId', 0);
+      expect(undoCall?.[0].updatedRow).to.have.property('currencyPair', originalValue);
     });
   });
 
@@ -1021,7 +1020,7 @@ describe('<DataGridPremium /> - History', () => {
 
     it('should hand the stored row to `dataSource.updateRow()` when undoing', async () => {
       const rows = [new Commodity(0, 'Nickel'), new Commodity(1, 'Cobalt')];
-      const updateRow = spy(async (params: GridUpdateRowParams) => ({
+      const updateRow = vi.fn(async (params: GridUpdateRowParams) => ({
         _action: 'replace' as const,
         row: (params.previousRow as Commodity).withCommodity(params.updatedRow.commodity),
       }));
@@ -1044,13 +1043,13 @@ describe('<DataGridPremium /> - History', () => {
         await apiRef.current!.history.undo();
       });
 
-      const undoParams = updateRow.lastCall.args[0];
+      const undoParams = updateRow.mock.lastCall?.[0];
       // Rebuilding the request as `{ ...row, commodity: oldValue }` would send a plain
       // object, so the server would never see the row it stored.
-      expect(undoParams.updatedRow).to.be.instanceOf(Commodity);
-      expect((undoParams.updatedRow as Commodity).revision).to.equal(0);
-      expect(undoParams.previousRow).to.be.instanceOf(Commodity);
-      expect((undoParams.previousRow as Commodity).revision).to.equal(1);
+      expect(undoParams?.updatedRow).to.be.instanceOf(Commodity);
+      expect((undoParams?.updatedRow as Commodity).revision).to.equal(0);
+      expect(undoParams?.previousRow).to.be.instanceOf(Commodity);
+      expect((undoParams?.previousRow as Commodity).revision).to.equal(1);
     });
 
     it('should still restore a single field when the row is a plain object', async () => {

--- a/packages/x-data-grid-premium/src/tests/rowGroupingProp.DataGridPremium.test.tsx
+++ b/packages/x-data-grid-premium/src/tests/rowGroupingProp.DataGridPremium.test.tsx
@@ -20,9 +20,8 @@ import type {
   GridGroupingColDefOverrideParams,
   GridGroupNode,
 } from '@mui/x-data-grid-premium';
-import { spy } from 'sinon';
 import { isJSDOM } from 'test/utils/skipIf';
-import { describe, it, expect } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 
 interface BaselineProps extends DataGridPremiumProps {
   rows: GridRowsProp;
@@ -512,7 +511,7 @@ describe('<DataGridPremium /> - Row grouping', () => {
 
   describe('prop: isGroupExpandedByDefault', () => {
     it('should expand groups according to isGroupExpandedByDefault when defined', () => {
-      const isGroupExpandedByDefault = spy(
+      const isGroupExpandedByDefault = vi.fn(
         (node: GridGroupNode) => node.groupingKey === 'Cat A' && node.groupingField === 'category1',
       );
 
@@ -522,17 +521,14 @@ describe('<DataGridPremium /> - Row grouping', () => {
           isGroupExpandedByDefault={isGroupExpandedByDefault}
         />,
       );
-      expect(isGroupExpandedByDefault.callCount).to.equal(reactMajor >= 19 ? 6 : 12); // Should not be called on leaves
+      expect(isGroupExpandedByDefault.mock.calls.length).to.equal(reactMajor >= 19 ? 6 : 12); // Should not be called on leaves
       const { childrenExpanded, ...node } = apiRef.current?.state.rows.tree[
         'auto-generated-row-category1/Cat A'
       ] as GridGroupNode;
-      const callForNodeA = isGroupExpandedByDefault
-        .getCalls()
-        .find(
-          (call) =>
-            call.firstArg.groupingKey === 'Cat A' && call.firstArg.groupingField === 'category1',
-        )!;
-      expect(callForNodeA.firstArg).to.deep.includes(node);
+      const callForNodeA = isGroupExpandedByDefault.mock.calls.find(
+        (call) => call[0].groupingKey === 'Cat A' && call[0].groupingField === 'category1',
+      )!;
+      expect(callForNodeA[0]).to.deep.includes(node);
       expect(getColumnValues(0)).to.deep.equal([
         'Cat A (3)',
         'Cat 1 (1)',
@@ -685,7 +681,7 @@ describe('<DataGridPremium /> - Row grouping', () => {
       });
 
       it('should render the leafField `renderCell` on leaves  if `renderCell` is defined on the leafColDef', () => {
-        const renderIdCell = spy(() => 'Custom leaf');
+        const renderIdCell = vi.fn(() => 'Custom leaf');
 
         render(
           <Test
@@ -718,7 +714,7 @@ describe('<DataGridPremium /> - Row grouping', () => {
 
       // See https://github.com/mui/mui-x/issues/7949
       it('should correctly pass `hasFocus` to `renderCell` defined on the leafColDef', () => {
-        const renderIdCell = spy((params) => `Focused: ${params.hasFocus}`);
+        const renderIdCell = vi.fn((params) => `Focused: ${params.hasFocus}`);
 
         render(
           <Test
@@ -739,7 +735,7 @@ describe('<DataGridPremium /> - Row grouping', () => {
         );
 
         fireUserEvent.mousePress(getCell(1, 0));
-        expect(renderIdCell.lastCall.firstArg.field).to.equal('id');
+        expect(renderIdCell.mock.lastCall?.[0].field).to.equal('id');
         expect(getCell(1, 0)).to.have.text('Focused: true');
       });
     });
@@ -1103,7 +1099,7 @@ describe('<DataGridPremium /> - Row grouping', () => {
       });
 
       it('should render the leafField `renderCell` on leaves  if `renderCell` is defined on the leafColDef', () => {
-        const renderIdCell = spy(() => 'Custom leaf');
+        const renderIdCell = vi.fn(() => 'Custom leaf');
 
         render(
           <Test

--- a/packages/x-data-grid-premium/src/tests/rowReorder.DataGridPremium.test.tsx
+++ b/packages/x-data-grid-premium/src/tests/rowReorder.DataGridPremium.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { spy } from 'sinon';
 import {
   createRenderer,
   fireEvent,
@@ -24,7 +23,7 @@ import type {
   GridValidRowModel,
 } from '@mui/x-data-grid-premium';
 import { isJSDOM } from 'test/utils/skipIf';
-import { describe, it, expect } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 
 // Helper function to create drag over event with coordinates
 function createDragOverEvent(target: ChildNode, dropPosition: 'above' | 'below' = 'above') {
@@ -196,7 +195,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
 
     describe('Valid reorder cases', () => {
       it('should reorder leaves within same parent group', async () => {
-        const onRowOrderChange = spy();
+        const onRowOrderChange = vi.fn();
         render(
           <div style={{ width: 500, height: 500 }}>
             <DataGridPremium {...baselineProps} onRowOrderChange={onRowOrderChange} />
@@ -218,7 +217,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
 
         await waitFor(() => {
           // Verify callback was called
-          expect(onRowOrderChange.callCount).to.equal(1);
+          expect(onRowOrderChange.mock.calls.length).to.equal(1);
         });
 
         // Verify new order: A2, A3, A1
@@ -232,7 +231,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
       });
 
       it('should move leaf between different parent groups', async () => {
-        const onRowOrderChange = spy();
+        const onRowOrderChange = vi.fn();
         render(
           <div style={{ width: 500, height: 500 }}>
             <DataGridPremium {...baselineProps} onRowOrderChange={onRowOrderChange} />
@@ -253,7 +252,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
 
         await waitFor(() => {
           // Verify callback was called
-          expect(onRowOrderChange.callCount).to.equal(1);
+          expect(onRowOrderChange.mock.calls.length).to.equal(1);
         });
 
         // Verify group counts updated
@@ -273,7 +272,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
       });
 
       it('should reorder groups at the same level when groups are expanded and the source group is drop on "above" portion of the target group', async () => {
-        const onRowOrderChange = spy();
+        const onRowOrderChange = vi.fn();
         render(
           <div style={{ width: 500, height: 500 }}>
             <DataGridPremium {...baselineProps} onRowOrderChange={onRowOrderChange} />
@@ -289,7 +288,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
 
         await waitFor(() => {
           // Verify callback was called
-          expect(onRowOrderChange.callCount).to.equal(1);
+          expect(onRowOrderChange.mock.calls.length).to.equal(1);
         });
 
         // Verify new group order: B, A, C
@@ -303,7 +302,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
       });
 
       it('should handle leaf to group "above" when previous leaf exists', async () => {
-        const onRowOrderChange = spy();
+        const onRowOrderChange = vi.fn();
         render(
           <div style={{ width: 500, height: 500 }}>
             <DataGridPremium {...baselineProps} onRowOrderChange={onRowOrderChange} />
@@ -320,7 +319,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
 
         await waitFor(() => {
           // Verify callback was called
-          expect(onRowOrderChange.callCount).to.equal(1);
+          expect(onRowOrderChange.mock.calls.length).to.equal(1);
         });
 
         // Verify Item C1 is now the last item in Category A
@@ -334,7 +333,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
       });
 
       it('should handle leaf to group "below" when group is expanded', async () => {
-        const onRowOrderChange = spy();
+        const onRowOrderChange = vi.fn();
         render(
           <div style={{ width: 500, height: 500 }}>
             <DataGridPremium {...baselineProps} onRowOrderChange={onRowOrderChange} />
@@ -351,7 +350,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
 
         await waitFor(() => {
           // Verify callback was called
-          expect(onRowOrderChange.callCount).to.equal(1);
+          expect(onRowOrderChange.mock.calls.length).to.equal(1);
         });
 
         // Verify Item A1 is now the first item in Category B
@@ -365,7 +364,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
       });
 
       it('should reorder group rows with collapsed groups', async () => {
-        const onRowOrderChange = spy();
+        const onRowOrderChange = vi.fn();
         render(
           <div style={{ width: 500, height: 500 }}>
             <DataGridPremium
@@ -395,7 +394,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
 
         await waitFor(() => {
           // Verify callback was called
-          expect(onRowOrderChange.callCount).to.equal(1);
+          expect(onRowOrderChange.mock.calls.length).to.equal(1);
         });
 
         // Verify new order: B, C, A
@@ -416,7 +415,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
 
         await waitFor(() => {
           // Verify callback was called
-          expect(onRowOrderChange.callCount).to.equal(2);
+          expect(onRowOrderChange.mock.calls.length).to.equal(2);
         });
 
         // Verify new order: C, B, A
@@ -582,7 +581,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
 
     describe('Usage with `groupingValueSetter`', () => {
       it('should call groupingValueSetter when moving leaf between groups with complex category data', async () => {
-        const groupingValueSetter = spy((groupingValue, row, _column, _apiRef) => {
+        const groupingValueSetter = vi.fn((groupingValue, row, _column, _apiRef) => {
           // Update category with complex nested data structure
           return {
             ...row,
@@ -629,7 +628,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
           autoHeight: isJSDOM,
         };
 
-        const onRowOrderChange = spy();
+        const onRowOrderChange = vi.fn();
         const apiRef = React.createRef<GridApi>();
         render(
           <div style={{ width: 500, height: 500 }}>
@@ -662,15 +661,15 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
 
         await waitFor(() => {
           // Verify callback was called
-          expect(onRowOrderChange.callCount).to.equal(1);
+          expect(onRowOrderChange.mock.calls.length).to.equal(1);
         });
 
         // Verify groupingValueSetter was called
-        expect(groupingValueSetter.callCount).to.equal(1);
-        expect(groupingValueSetter.firstCall.args[0]).to.equal('Clothing'); // groupingValue should be 'Clothing'
+        expect(groupingValueSetter.mock.calls.length).to.equal(1);
+        expect(groupingValueSetter.mock.calls[0][0]).to.equal('Clothing'); // groupingValue should be 'Clothing'
 
         // Verify the row passed to the setter matches iPhone data
-        const passedRow = groupingValueSetter.firstCall.args[1];
+        const passedRow = groupingValueSetter.mock.calls[0][1];
         expect(passedRow.name).to.equal('iPhone');
         expect(passedRow.price).to.equal(999);
 
@@ -711,7 +710,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
 
     describe('Valid reorder cases', () => {
       it('should reorder leaves within same department', async () => {
-        const onRowOrderChange = spy();
+        const onRowOrderChange = vi.fn();
         render(
           <div style={{ width: 500, height: 500 }}>
             <DataGridPremium {...baselineProps} onRowOrderChange={onRowOrderChange} />
@@ -733,7 +732,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
 
         await waitFor(() => {
           // Verify callback was called
-          expect(onRowOrderChange.callCount).to.equal(1);
+          expect(onRowOrderChange.mock.calls.length).to.equal(1);
         });
 
         // Verify new order
@@ -745,7 +744,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
       });
 
       it('should move leaf between departments in same company', async () => {
-        const onRowOrderChange = spy();
+        const onRowOrderChange = vi.fn();
         render(
           <div style={{ width: 500, height: 500 }}>
             <DataGridPremium {...baselineProps} onRowOrderChange={onRowOrderChange} />
@@ -770,7 +769,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
 
         await waitFor(() => {
           // Verify callback was called
-          expect(onRowOrderChange.callCount).to.equal(1);
+          expect(onRowOrderChange.mock.calls.length).to.equal(1);
         });
 
         // Verify John is now before Alice in Sales
@@ -784,7 +783,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
       });
 
       it('should reorder department groups within company', async () => {
-        const onRowOrderChange = spy();
+        const onRowOrderChange = vi.fn();
         render(
           <div style={{ width: 500, height: 500 }}>
             <DataGridPremium {...baselineProps} onRowOrderChange={onRowOrderChange} />
@@ -807,7 +806,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
 
         await waitFor(() => {
           // Verify callback was called
-          expect(onRowOrderChange.callCount).to.equal(1);
+          expect(onRowOrderChange.mock.calls.length).to.equal(1);
         });
 
         // Verify department order changed
@@ -820,7 +819,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
       });
 
       it('should reorder group rows with collapsed groups', async () => {
-        const onRowOrderChange = spy();
+        const onRowOrderChange = vi.fn();
         render(
           <div style={{ width: 500, height: 500 }}>
             <DataGridPremium
@@ -861,7 +860,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
 
         await waitFor(() => {
           // Verify callback was called
-          expect(onRowOrderChange.callCount).to.equal(1);
+          expect(onRowOrderChange.mock.calls.length).to.equal(1);
         });
 
         // Verify new order: Microsoft, Apple, Google
@@ -995,7 +994,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
 
     describe('Usage with `groupingValueSetter`', () => {
       it('should call groupingValueSetter for multiple grouping levels when moving between groups', async () => {
-        const companyValueSetter = spy((groupingValue, row, _column, _apiRef) => {
+        const companyValueSetter = vi.fn((groupingValue, row, _column, _apiRef) => {
           return {
             ...row,
             company: groupingValue,
@@ -1004,7 +1003,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
           };
         });
 
-        const deptValueSetter = spy((groupingValue, row, _column, _apiRef) => {
+        const deptValueSetter = vi.fn((groupingValue, row, _column, _apiRef) => {
           return {
             ...row,
             dept: groupingValue,
@@ -1041,7 +1040,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
         };
 
         const apiRef = React.createRef<GridApi>();
-        const onRowOrderChange = spy();
+        const onRowOrderChange = vi.fn();
         render(
           <div style={{ width: 500, height: 500 }}>
             <DataGridPremium
@@ -1073,22 +1072,22 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
         performDragReorder(johnRow, bobRow, 'above');
         await waitFor(() => {
           // Verify callback was called
-          expect(onRowOrderChange.callCount).to.equal(1);
+          expect(onRowOrderChange.mock.calls.length).to.equal(1);
         });
 
         // Verify both setters were called in the correct order
-        expect(companyValueSetter.callCount).to.equal(1);
-        expect(deptValueSetter.callCount).to.equal(1);
+        expect(companyValueSetter.mock.calls.length).to.equal(1);
+        expect(deptValueSetter.mock.calls.length).to.equal(1);
 
         // Verify company setter was called with correct parameters
-        expect(companyValueSetter.firstCall.args[0]).to.equal('Google'); // target company
-        const companySetterRow = companyValueSetter.firstCall.args[1];
+        expect(companyValueSetter.mock.calls[0][0]).to.equal('Google'); // target company
+        const companySetterRow = companyValueSetter.mock.calls[0][1];
         expect(companySetterRow.company).to.equal('Microsoft'); // Original company
         expect(companySetterRow.dept).to.equal('Engineering'); // Original dept
 
         // Verify dept setter was called with correct parameters
-        expect(deptValueSetter.firstCall.args[0]).to.equal('Engineering'); // target dept (Google has Engineering)
-        const deptSetterRow = deptValueSetter.firstCall.args[1];
+        expect(deptValueSetter.mock.calls[0][0]).to.equal('Engineering'); // target dept (Google has Engineering)
+        const deptSetterRow = deptValueSetter.mock.calls[0][1];
         expect(deptSetterRow.company).to.equal('Google'); // Already updated by company setter
 
         // Verify the final row data was updated correctly
@@ -1107,7 +1106,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
 
   describe('Edge cases', () => {
     it('should handle null grouping values', async () => {
-      const onRowOrderChange = spy();
+      const onRowOrderChange = vi.fn();
       render(
         <div style={{ width: 500, height: 500 }}>
           <DataGridPremium
@@ -1147,7 +1146,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
 
       await waitFor(() => {
         // Verify callback was called
-        expect(onRowOrderChange.callCount).to.equal(1);
+        expect(onRowOrderChange.mock.calls.length).to.equal(1);
       });
 
       // Verify order changed
@@ -1159,7 +1158,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
     });
 
     it('should call onRowOrderChange with correct parameters', async () => {
-      const onRowOrderChange = spy();
+      const onRowOrderChange = vi.fn();
 
       render(
         <div style={{ width: 500, height: 500 }}>
@@ -1192,10 +1191,10 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
 
       await waitFor(() => {
         // Verify callback was called
-        expect(onRowOrderChange.callCount).to.equal(1);
+        expect(onRowOrderChange.mock.calls.length).to.equal(1);
       });
 
-      const params = onRowOrderChange.firstCall.args[0];
+      const params = onRowOrderChange.mock.calls[0][0];
       expect(params.row.id).to.equal(1); // Item A1
       expect(params.oldIndex).to.be.a('number');
       expect(params.targetIndex).to.be.a('number');
@@ -1323,7 +1322,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
       };
 
       it('should call processRowUpdate when reordering between different parent groups', async () => {
-        const processRowUpdate = spy((newRow, _oldRow, _params) => ({
+        const processRowUpdate = vi.fn((newRow, _oldRow, _params) => ({
           ...newRow,
           category: newRow.category, // Preserve the new category from grouping rules
         }));
@@ -1342,11 +1341,11 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
 
         // Wait for async processRowUpdate to complete
         await waitFor(() => {
-          expect(processRowUpdate.callCount).to.equal(1);
+          expect(processRowUpdate.mock.calls.length).to.equal(1);
         });
 
         // Verify processRowUpdate was called with correct parameters
-        const args = processRowUpdate.firstCall.args;
+        const args = processRowUpdate.mock.calls[0];
         expect(args.length).to.equal(3);
         const [newRow, oldRow, params] = args;
         expect(newRow.id).to.equal(1);
@@ -1357,7 +1356,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
       });
 
       it('should handle processRowUpdate returning modified data', async () => {
-        const processRowUpdate = spy((newRow, _oldRow, _params) => ({
+        const processRowUpdate = vi.fn((newRow, _oldRow, _params) => ({
           ...newRow,
           name: `${newRow.name} (Modified)`,
         }));
@@ -1375,7 +1374,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
         performDragReorder(itemA1Row, itemB1Row, 'above');
 
         await waitFor(() => {
-          expect(processRowUpdate.callCount).to.equal(1);
+          expect(processRowUpdate.mock.calls.length).to.equal(1);
         });
 
         // Verify the modified name is displayed in the grid
@@ -1386,7 +1385,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
       });
 
       it('should handle processRowUpdate returning a Promise', async () => {
-        const processRowUpdate = spy(async (newRow, _oldRow, _params) => {
+        const processRowUpdate = vi.fn(async (newRow, _oldRow, _params) => {
           // Simulate async operation
           await new Promise<void>((resolve) => {
             setTimeout(resolve, 10);
@@ -1409,7 +1408,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
         performDragReorder(itemA1Row, itemB1Row, 'above');
 
         await waitFor(() => {
-          expect(processRowUpdate.callCount).to.equal(1);
+          expect(processRowUpdate.mock.calls.length).to.equal(1);
         });
 
         // Verify async result is applied
@@ -1420,10 +1419,10 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
       });
 
       it('should call onProcessRowUpdateError when processRowUpdate throws an error', async () => {
-        const processRowUpdate = spy((_newRow, _oldRow, _params) => {
+        const processRowUpdate = vi.fn((_newRow, _oldRow, _params) => {
           throw new Error('Validation failed');
         });
-        const onProcessRowUpdateError = spy();
+        const onProcessRowUpdateError = vi.fn();
 
         render(
           <div style={{ width: 500, height: 500 }}>
@@ -1448,15 +1447,15 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
         performDragReorder(itemA1Row, itemB1Row, 'above');
 
         await waitFor(() => {
-          expect(processRowUpdate.callCount).to.equal(1);
+          expect(processRowUpdate.mock.calls.length).to.equal(1);
         });
 
         await waitFor(() => {
-          expect(onProcessRowUpdateError.callCount).to.equal(1);
+          expect(onProcessRowUpdateError.mock.calls.length).to.equal(1);
         });
 
         // Verify error was passed to handler
-        const error = onProcessRowUpdateError.firstCall.args[0];
+        const error = onProcessRowUpdateError.mock.calls[0][0];
         expect(error.message).to.equal('Validation failed');
 
         // Verify row order was not changed due to error
@@ -1468,10 +1467,10 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
       });
 
       it('should call onProcessRowUpdateError when processRowUpdate Promise rejects', async () => {
-        const processRowUpdate = spy(async (_newRow, _oldRow, _params) => {
+        const processRowUpdate = vi.fn(async (_newRow, _oldRow, _params) => {
           throw new Error('Async validation failed');
         });
-        const onProcessRowUpdateError = spy();
+        const onProcessRowUpdateError = vi.fn();
 
         render(
           <div style={{ width: 500, height: 500 }}>
@@ -1489,21 +1488,21 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
         performDragReorder(itemA1Row, itemB1Row, 'above');
 
         await waitFor(() => {
-          expect(processRowUpdate.callCount).to.equal(1);
+          expect(processRowUpdate.mock.calls.length).to.equal(1);
         });
 
         await waitFor(() => {
-          expect(onProcessRowUpdateError.callCount).to.equal(1);
+          expect(onProcessRowUpdateError.mock.calls.length).to.equal(1);
         });
 
         // Verify error was passed to handler
-        const error = onProcessRowUpdateError.firstCall.args[0];
+        const error = onProcessRowUpdateError.mock.calls[0][0];
         expect(error.message).to.equal('Async validation failed');
       });
 
       it('should not call processRowUpdate when reordering within same parent group', async () => {
-        const processRowUpdate = spy();
-        const onRowOrderChange = spy();
+        const processRowUpdate = vi.fn();
+        const onRowOrderChange = vi.fn();
         render(
           <div style={{ width: 500, height: 500 }}>
             <DataGridPremium
@@ -1522,11 +1521,11 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
 
         await waitFor(() => {
           // Verify callback was called
-          expect(onRowOrderChange.callCount).to.equal(1);
+          expect(onRowOrderChange.mock.calls.length).to.equal(1);
         });
 
         // processRowUpdate should not be called for same-parent reorders
-        expect(processRowUpdate.callCount).to.equal(0);
+        expect(processRowUpdate.mock.calls.length).to.equal(0);
       });
     });
 
@@ -1550,8 +1549,8 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
       };
 
       it('should call dataSource.editRow when reordering between different parent groups', async () => {
-        const editRowSpy = spy();
-        const getRowsSpy = spy();
+        const editRowSpy = vi.fn();
+        const getRowsSpy = vi.fn();
         const dataSource: GridDataSource = {
           getRows: async (params) => {
             getRowsSpy(params);
@@ -1587,7 +1586,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
         );
 
         await waitFor(() => {
-          expect(getRowsSpy.callCount).to.equal(5);
+          expect(getRowsSpy.mock.calls.length).to.equal(5);
         });
 
         await waitFor(() => {
@@ -1614,11 +1613,11 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
         performDragReorder(itemA1Row, itemB1Row, 'above');
 
         await waitFor(() => {
-          expect(editRowSpy.callCount).to.equal(1);
+          expect(editRowSpy.mock.calls.length).to.equal(1);
         });
 
         // Verify correct parameters were passed
-        const params = editRowSpy.firstCall.args[0];
+        const params = editRowSpy.mock.calls[0][0];
         expect(params.rowId).to.equal(1);
         expect(params.previousRow.id).to.equal(1);
         expect(params.previousRow.category).to.equal('A');
@@ -1627,8 +1626,8 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
       });
 
       it('should not call dataSource.editRow when reordering within same parent group', async () => {
-        const editRowSpy = spy();
-        const getRowsSpy = spy();
+        const editRowSpy = vi.fn();
+        const getRowsSpy = vi.fn();
         const dataSource: GridDataSource = {
           getRows: async (params) => {
             getRowsSpy(params);
@@ -1664,7 +1663,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
         );
 
         await waitFor(() => {
-          expect(getRowsSpy.callCount).to.equal(5);
+          expect(getRowsSpy.mock.calls.length).to.equal(5);
         });
 
         await waitFor(() => {
@@ -1706,13 +1705,13 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
         });
 
         // Should not call editRow since group hasn't changed
-        expect(editRowSpy.callCount).to.equal(0);
+        expect(editRowSpy.mock.calls.length).to.equal(0);
       });
 
       it('should call dataSource.setGroupKey when available instead of direct field assignment', async () => {
-        const editRowSpy = spy();
-        const getRowsSpy = spy();
-        const setGroupKeySpy = spy((row, groupKey) => {
+        const editRowSpy = vi.fn();
+        const getRowsSpy = vi.fn();
+        const setGroupKeySpy = vi.fn((row, groupKey) => {
           const split = groupKey.split('-');
           const category = split[split.length - 1];
           return {
@@ -1757,7 +1756,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
         );
 
         await waitFor(() => {
-          expect(getRowsSpy.callCount).to.equal(5);
+          expect(getRowsSpy.mock.calls.length).to.equal(5);
         });
 
         await waitFor(() => {
@@ -1785,24 +1784,24 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
         performDragReorder(itemA1Row, itemB1Row, 'above');
 
         await waitFor(() => {
-          expect(setGroupKeySpy.callCount).to.equal(1);
+          expect(setGroupKeySpy.mock.calls.length).to.equal(1);
         });
 
         // Verify `setGroupKey()` was called with correct parameters
-        expect(setGroupKeySpy.firstCall.args[0]).to.deep.include({
+        expect(setGroupKeySpy.mock.calls[0][0]).to.deep.include({
           id: 1,
           category: 'A',
           name: 'Item A1',
           value: 10,
         });
-        expect(setGroupKeySpy.firstCall.args[1]).to.equal('autogenerated-parent-category-B'); // Group key of the target row's parent group
+        expect(setGroupKeySpy.mock.calls[0][1]).to.equal('autogenerated-parent-category-B'); // Group key of the target row's parent group
 
         await waitFor(() => {
-          expect(editRowSpy.callCount).to.equal(1);
+          expect(editRowSpy.mock.calls.length).to.equal(1);
         });
 
         // Verify updateRow was called with the result from `setGroupKey()`
-        const updateRowParams = editRowSpy.firstCall.args[0];
+        const updateRowParams = editRowSpy.mock.calls[0][0];
         expect(updateRowParams.updatedRow).to.deep.include({
           id: 1,
           category: 'B',
@@ -2224,7 +2223,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
           },
         ];
 
-        const processRowUpdate = spy((newRow: any) => ({
+        const processRowUpdate = vi.fn((newRow: any) => ({
           ...newRow,
           lastModified: Date.now(),
         }));
@@ -2270,7 +2269,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
 
         await waitFor(() => {
           // Verify processRowUpdate was called for each leaf row (Alice and Bob)
-          expect(processRowUpdate.callCount).to.equal(2);
+          expect(processRowUpdate.mock.calls.length).to.equal(2);
         });
 
         await waitFor(() => {
@@ -2310,7 +2309,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
           { id: 5, company: 'Company C', department: 'Engineering', name: 'Eve' },
         ];
 
-        const processRowUpdate = spy((newRow: any) => newRow);
+        const processRowUpdate = vi.fn((newRow: any) => newRow);
         const apiRef: RefObject<GridApi | null> = { current: null };
 
         render(
@@ -2378,7 +2377,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
 
         await waitFor(() => {
           // If processRowUpdate was called, the functionality is working
-          expect(processRowUpdate.callCount).to.be.greaterThan(0);
+          expect(processRowUpdate.mock.calls.length).to.be.greaterThan(0);
         });
 
         // Basic verification that the operation completed successfully
@@ -2397,14 +2396,14 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
         ];
 
         // processRowUpdate that fails for Bob (id: 2)
-        const processRowUpdate = spy((newRow: any) => {
+        const processRowUpdate = vi.fn((newRow: any) => {
           if (newRow.id === 2) {
             throw new Error('Update failed for Bob');
           }
           return newRow;
         });
 
-        const onProcessRowUpdateError = spy();
+        const onProcessRowUpdateError = vi.fn();
 
         const apiRef: RefObject<GridApi | null> = { current: null };
 
@@ -2444,12 +2443,12 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
 
         await waitFor(() => {
           // Verify processRowUpdate was called 3 times (for Alice, Bob, Charlie)
-          expect(processRowUpdate.callCount).to.equal(3);
+          expect(processRowUpdate.mock.calls.length).to.equal(3);
         });
 
         await waitFor(() => {
           // Verify error callback was called for Bob
-          expect(onProcessRowUpdateError.callCount).to.equal(1);
+          expect(onProcessRowUpdateError.mock.calls.length).to.equal(1);
         });
 
         await waitFor(() => {
@@ -2497,14 +2496,14 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
         ];
 
         // processRowUpdate that fails for Bob (id: 2)
-        const processRowUpdate = spy((newRow: any) => {
+        const processRowUpdate = vi.fn((newRow: any) => {
           if (newRow.id === 2) {
             throw new Error('Update failed for Bob');
           }
           return newRow;
         });
 
-        const onProcessRowUpdateError = spy();
+        const onProcessRowUpdateError = vi.fn();
         const apiRef: RefObject<GridApi | null> = { current: null };
 
         render(
@@ -2542,11 +2541,11 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
         performDragReorder(marketingRow, salesRow, 'above');
 
         await waitFor(() => {
-          expect(processRowUpdate.callCount).to.equal(3);
+          expect(processRowUpdate.mock.calls.length).to.equal(3);
         });
 
         await waitFor(() => {
-          expect(onProcessRowUpdateError.callCount).to.equal(1);
+          expect(onProcessRowUpdateError.mock.calls.length).to.equal(1);
         });
 
         // Verify duplicate Marketing groups exist under different companies
@@ -2607,14 +2606,14 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
         ];
 
         // processRowUpdate that fails for Alice (id: 1)
-        const processRowUpdate = spy((newRow: any) => {
+        const processRowUpdate = vi.fn((newRow: any) => {
           if (newRow.id === 1) {
             throw new Error('Update failed for Alice');
           }
           return newRow;
         });
 
-        const onProcessRowUpdateError = spy();
+        const onProcessRowUpdateError = vi.fn();
         const apiRef: RefObject<GridApi | null> = { current: null };
 
         render(
@@ -2656,11 +2655,11 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
         performDragReorder(engineeringARow, salesBRow, 'above');
 
         await waitFor(() => {
-          expect(processRowUpdate.callCount).to.equal(2);
+          expect(processRowUpdate.mock.calls.length).to.equal(2);
         });
 
         await waitFor(() => {
-          expect(onProcessRowUpdateError.callCount).to.equal(1);
+          expect(onProcessRowUpdateError.mock.calls.length).to.equal(1);
         });
 
         // Verify both companies now have Engineering departments (duplication allowed)
@@ -3163,7 +3162,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
           },
         ];
 
-        const regionGroupingValueSetter = spy((groupingValue, row) => ({
+        const regionGroupingValueSetter = vi.fn((groupingValue, row) => ({
           ...row,
           metadata: {
             ...row.metadata,
@@ -3219,12 +3218,12 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
 
         await waitFor(() => {
           // Verify groupingValueSetter was called
-          expect(regionGroupingValueSetter.callCount).to.equal(1);
+          expect(regionGroupingValueSetter.mock.calls.length).to.equal(1);
         });
 
         await waitFor(() => {
           // Verify the setter was called with correct parameters
-          expect(regionGroupingValueSetter.firstCall.args[0]).to.equal('EU'); // target region
+          expect(regionGroupingValueSetter.mock.calls[0][0]).to.equal('EU'); // target region
         });
 
         await waitFor(() => {
@@ -3289,7 +3288,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
         ];
 
         const apiRef: RefObject<GridApi | null> = { current: null };
-        const processRowUpdate = spy((newRow) => newRow);
+        const processRowUpdate = vi.fn((newRow) => newRow);
 
         render(
           <div style={{ width: 600, height: 500 }}>
@@ -3335,7 +3334,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
 
         // Wait for state update
         await waitFor(() => {
-          expect(processRowUpdate.callCount).to.be.greaterThan(0);
+          expect(processRowUpdate.mock.calls.length).to.be.greaterThan(0);
         });
 
         // After moving Avatar to Warner Bros:
@@ -3357,7 +3356,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
         expect(jamesCameronGroup).to.equal(undefined, 'James Cameron group should be removed');
 
         // Verify Avatar was moved successfully
-        const updatedAvatarRow = processRowUpdate.lastCall?.args[0];
+        const updatedAvatarRow = processRowUpdate.mock.lastCall?.[0];
         expect(updatedAvatarRow?.company).to.equal(
           'Warner Bros',
           'Avatar should be moved to Warner Bros',
@@ -3380,7 +3379,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
         ];
 
         const apiRef: RefObject<GridApi | null> = { current: null };
-        const processRowUpdate = spy((newRow) => newRow);
+        const processRowUpdate = vi.fn((newRow) => newRow);
 
         render(
           <div style={{ width: 600, height: 500 }}>
@@ -3431,7 +3430,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
 
         // Wait for state update
         await waitFor(() => {
-          expect(processRowUpdate.callCount).to.be.greaterThan(0);
+          expect(processRowUpdate.mock.calls.length).to.be.greaterThan(0);
         });
 
         // After moving Analytics department to TechCorp:
@@ -3450,7 +3449,7 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Row reorder with row grouping', 
         expect(dataCorpGroup).to.equal(undefined, 'DataCorp group should be removed');
 
         // Verify David was moved successfully
-        const updatedRows = processRowUpdate.getCalls().map((call) => call.args[0]);
+        const updatedRows = processRowUpdate.mock.calls.map((call) => call[0]);
         const davidRow = updatedRows.find((row: any) => row.name === 'David');
         expect(davidRow?.company).to.equal('TechCorp', 'David should be moved to TechCorp');
       });

--- a/packages/x-data-grid-pro/src/tests/detailPanel.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/detailPanel.DataGridPro.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { spy } from 'sinon';
 import type { RefObject } from '@mui/x-internals/types';
 import {
   DataGridPro,
@@ -12,7 +11,7 @@ import { useBasicDemoData } from '@mui/x-data-grid-generator';
 import { createRenderer, screen, waitFor, act, reactMajor } from '@mui/internal-test-utils';
 import { $, $$, grid, getRow, getCell, getColumnValues } from 'test/utils/helperFn';
 import { isJSDOM } from 'test/utils/skipIf';
-import { describe, it, expect } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 
 describe('<DataGridPro /> - Detail panel', () => {
   const { render } = createRenderer();
@@ -298,7 +297,7 @@ describe('<DataGridPro /> - Detail panel', () => {
   });
 
   it('should cache the content of getDetailPanelContent', async () => {
-    const getDetailPanelContent = spy(() => <div>Detail</div>);
+    const getDetailPanelContent = vi.fn(() => <div>Detail</div>);
     const { setProps, user } = render(
       <TestCase
         columns={[{ field: 'brand' }]}
@@ -323,23 +322,23 @@ describe('<DataGridPro /> - Detail panel', () => {
     // + 2x when sortedRowsSet is fired
     const expectedCallCount = reactMajor >= 19 ? 6 : 10;
 
-    expect(getDetailPanelContent.callCount).to.equal(expectedCallCount);
+    expect(getDetailPanelContent.mock.calls.length).to.equal(expectedCallCount);
     await user.click(screen.getByRole('button', { name: 'Expand' }));
-    expect(getDetailPanelContent.callCount).to.equal(expectedCallCount);
+    expect(getDetailPanelContent.mock.calls.length).to.equal(expectedCallCount);
 
     await user.click(screen.getByRole('button', { name: /next page/i }));
-    expect(getDetailPanelContent.callCount).to.equal(expectedCallCount);
+    expect(getDetailPanelContent.mock.calls.length).to.equal(expectedCallCount);
 
-    const getDetailPanelContent2 = spy(() => <div>Detail</div>);
+    const getDetailPanelContent2 = vi.fn(() => <div>Detail</div>);
     setProps({ getDetailPanelContent: getDetailPanelContent2 });
     await user.click(screen.getByRole('button', { name: 'Expand' }));
-    expect(getDetailPanelContent2.callCount).to.equal(2); // Called 2x by the effect
+    expect(getDetailPanelContent2.mock.calls.length).to.equal(2); // Called 2x by the effect
     await user.click(screen.getByRole('button', { name: /previous page/i }));
-    expect(getDetailPanelContent2.callCount).to.equal(2);
+    expect(getDetailPanelContent2.mock.calls.length).to.equal(2);
   });
 
   it('should cache the content of getDetailPanelHeight', async () => {
-    const getDetailPanelHeight = spy(() => 100);
+    const getDetailPanelHeight = vi.fn(() => 100);
     const { setProps, user } = render(
       <TestCase
         columns={[{ field: 'brand' }]}
@@ -365,26 +364,26 @@ describe('<DataGridPro /> - Detail panel', () => {
     // + 2x when sortedRowsSet is fired
     const expectedCallCount = reactMajor >= 19 ? 6 : 10;
 
-    expect(getDetailPanelHeight.callCount).to.equal(expectedCallCount);
+    expect(getDetailPanelHeight.mock.calls.length).to.equal(expectedCallCount);
     await user.click(screen.getByRole('button', { name: 'Expand' }));
-    expect(getDetailPanelHeight.callCount).to.equal(expectedCallCount);
+    expect(getDetailPanelHeight.mock.calls.length).to.equal(expectedCallCount);
 
     await user.click(screen.getByRole('button', { name: /next page/i }));
-    expect(getDetailPanelHeight.callCount).to.equal(expectedCallCount);
+    expect(getDetailPanelHeight.mock.calls.length).to.equal(expectedCallCount);
 
-    const getDetailPanelHeight2 = spy(() => 200);
+    const getDetailPanelHeight2 = vi.fn(() => 200);
     setProps({ getDetailPanelHeight: getDetailPanelHeight2 });
     await user.click(screen.getByRole('button', { name: 'Expand' }));
-    expect(getDetailPanelHeight2.callCount).to.equal(2); // Called 2x by the effect
+    expect(getDetailPanelHeight2.mock.calls.length).to.equal(2); // Called 2x by the effect
     await user.click(screen.getByRole('button', { name: /previous page/i }));
-    expect(getDetailPanelHeight2.callCount).to.equal(2);
+    expect(getDetailPanelHeight2.mock.calls.length).to.equal(2);
   });
 
   // Doesn't work with mocked window.getComputedStyle
   it.skipIf(isJSDOM)(
     'should update the panel height if getDetailPanelHeight is changed while the panel is open',
     async () => {
-      const getDetailPanelHeight = spy(() => 100);
+      const getDetailPanelHeight = vi.fn(() => 100);
       const { setProps, user } = render(
         <TestCase
           columns={[{ field: 'brand' }]}
@@ -407,7 +406,7 @@ describe('<DataGridPro /> - Detail panel', () => {
       const virtualScroller = grid('virtualScroller')!;
       expect(virtualScroller.scrollHeight).to.equal(208);
 
-      const getDetailPanelHeight2 = spy(() => 200);
+      const getDetailPanelHeight2 = vi.fn(() => 200);
       setProps({ getDetailPanelHeight: getDetailPanelHeight2 });
 
       expect(detailPanel).toHaveComputedStyle({ height: '200px' });
@@ -416,7 +415,7 @@ describe('<DataGridPro /> - Detail panel', () => {
   );
 
   it('should only call getDetailPanelHeight on the rows that have detail content', () => {
-    const getDetailPanelHeight = spy(({ row }) => row.id + 100); // Use `row` to allow to assert its args below
+    const getDetailPanelHeight = vi.fn(({ row }) => row.id + 100); // Use `row` to allow to assert its args below
     render(
       <TestCase
         columns={[{ field: 'brand' }]}
@@ -438,12 +437,12 @@ describe('<DataGridPro /> - Detail panel', () => {
     // + 1x when sortedRowsSet is fired
     const expectedCallCount = reactMajor >= 19 ? 3 : 5;
 
-    expect(getDetailPanelHeight.callCount).to.equal(expectedCallCount);
-    expect(getDetailPanelHeight.lastCall.args[0].id).to.equal(0);
+    expect(getDetailPanelHeight.mock.calls.length).to.equal(expectedCallCount);
+    expect(getDetailPanelHeight.mock.lastCall?.[0].id).to.equal(0);
   });
 
   it('should not select the row when opening the detail panel', async () => {
-    const handleRowSelectionModelChange = spy();
+    const handleRowSelectionModelChange = vi.fn();
     const { user } = render(
       <TestCase
         getDetailPanelContent={() => <div>Detail</div>}
@@ -453,7 +452,7 @@ describe('<DataGridPro /> - Detail panel', () => {
     );
     expect(screen.queryByText('Detail')).to.equal(null);
     await user.click(getCell(1, 0));
-    expect(handleRowSelectionModelChange.callCount).to.equal(0);
+    expect(handleRowSelectionModelChange.mock.calls.length).to.equal(0);
   });
 
   // See https://github.com/mui/mui-x/issues/4607
@@ -543,7 +542,7 @@ describe('<DataGridPro /> - Detail panel', () => {
 
   describe('prop: onDetailPanelsExpandedRowIds', () => {
     it('should call when a row is expanded or closed', async () => {
-      const handleDetailPanelsExpandedRowIdsChange = spy();
+      const handleDetailPanelsExpandedRowIdsChange = vi.fn();
       const { user } = render(
         <TestCase
           getDetailPanelContent={() => <div>Detail</div>}
@@ -551,19 +550,19 @@ describe('<DataGridPro /> - Detail panel', () => {
         />,
       );
       await user.click(screen.getAllByRole('button', { name: 'Expand' })[0]); // Expand the 1st row
-      expect(handleDetailPanelsExpandedRowIdsChange.lastCall.args[0]).to.deep.equal(new Set([0]));
+      expect(handleDetailPanelsExpandedRowIdsChange.mock.lastCall?.[0]).to.deep.equal(new Set([0]));
       await user.click(screen.getAllByRole('button', { name: 'Expand' })[0]); // Expand the 2nd row
-      expect(handleDetailPanelsExpandedRowIdsChange.lastCall.args[0]).to.deep.equal(
+      expect(handleDetailPanelsExpandedRowIdsChange.mock.lastCall?.[0]).to.deep.equal(
         new Set([0, 1]),
       );
       await user.click(screen.getAllByRole('button', { name: 'Collapse' })[0]); // Close the 1st row
-      expect(handleDetailPanelsExpandedRowIdsChange.lastCall.args[0]).to.deep.equal(new Set([1]));
+      expect(handleDetailPanelsExpandedRowIdsChange.mock.lastCall?.[0]).to.deep.equal(new Set([1]));
       await user.click(screen.getAllByRole('button', { name: 'Collapse' })[0]); // Close the 2nd row
-      expect(handleDetailPanelsExpandedRowIdsChange.lastCall.args[0]).to.deep.equal(new Set([]));
+      expect(handleDetailPanelsExpandedRowIdsChange.mock.lastCall?.[0]).to.deep.equal(new Set([]));
     });
 
     it('should not change the open detail panels when called while detailPanelsExpandedRowIds is the same', async () => {
-      const handleDetailPanelsExpandedRowIdsChange = spy();
+      const handleDetailPanelsExpandedRowIdsChange = vi.fn();
       const { user } = render(
         <TestCase
           getDetailPanelContent={({ id }) => <div>Row {id}</div>}
@@ -573,7 +572,7 @@ describe('<DataGridPro /> - Detail panel', () => {
       );
       expect(screen.getByText('Row 0')).not.to.equal(null);
       await user.click(screen.getByRole('button', { name: 'Collapse' }));
-      expect(handleDetailPanelsExpandedRowIdsChange.lastCall.args[0]).to.deep.equal(new Set([]));
+      expect(handleDetailPanelsExpandedRowIdsChange.mock.lastCall?.[0]).to.deep.equal(new Set([]));
       expect(screen.getByText('Row 0')).not.to.equal(null);
     });
   });

--- a/packages/x-data-grid-pro/src/tests/events.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/events.DataGridPro.test.tsx
@@ -13,8 +13,7 @@ import type {
   GridEventListener,
 } from '@mui/x-data-grid-pro';
 import { getCell, getColumnHeaderCell, includeRowSelection } from 'test/utils/helperFn';
-import { spy } from 'sinon';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
 
 describe('<DataGridPro /> - Events params', () => {
   const { render } = createRenderer();
@@ -201,18 +200,18 @@ describe('<DataGridPro /> - Events params', () => {
     });
 
     it('should allow to prevent the default behavior', () => {
-      const handleCellDoubleClick = spy((params, event) => {
+      const handleCellDoubleClick = vi.fn((params, event) => {
         event.defaultMuiPrevented = true;
       });
       render(<TestEvents onCellDoubleClick={handleCellDoubleClick} />);
       const cell = getCell(1, 1);
       fireEvent.doubleClick(cell);
-      expect(handleCellDoubleClick.callCount).to.equal(1);
+      expect(handleCellDoubleClick.mock.calls.length).to.equal(1);
       expect(cell).not.to.have.class(gridClasses['row--editing']);
     });
 
     it('should allow to prevent the default behavior while allowing the event to propagate', async () => {
-      const handleCellEditStop = spy((params, event) => {
+      const handleCellEditStop = vi.fn((params, event) => {
         event.defaultMuiPrevented = true;
       });
       render(<TestEvents onCellEditStop={handleCellEditStop} />);
@@ -223,24 +222,24 @@ describe('<DataGridPro /> - Events params', () => {
 
       const input = cell.querySelector('input')!;
       fireEvent.keyDown(input, { key: 'Enter' });
-      expect(handleCellEditStop.callCount).to.equal(1);
+      expect(handleCellEditStop.mock.calls.length).to.equal(1);
       expect(cell).to.have.class(gridClasses['cell--editing']);
     });
 
     it('should select a row by default', () => {
-      const handleRowSelectionModelChange = spy();
+      const handleRowSelectionModelChange = vi.fn();
       render(<TestEvents onRowSelectionModelChange={handleRowSelectionModelChange} />);
 
       const cell11 = getCell(1, 1);
       fireEvent.click(cell11);
-      expect(handleRowSelectionModelChange.callCount).to.equal(1);
-      expect(handleRowSelectionModelChange.lastCall.firstArg).to.deep.equal(
+      expect(handleRowSelectionModelChange.mock.calls.length).to.equal(1);
+      expect(handleRowSelectionModelChange.mock.lastCall?.[0]).to.deep.equal(
         includeRowSelection([2]),
       );
     });
 
     it('should not select a row if props.disableRowSelectionOnClick', () => {
-      const handleRowSelectionModelChange = spy();
+      const handleRowSelectionModelChange = vi.fn();
       render(
         <TestEvents
           onRowSelectionModelChange={handleRowSelectionModelChange}
@@ -249,7 +248,7 @@ describe('<DataGridPro /> - Events params', () => {
       );
       const cell11 = getCell(1, 1);
       fireEvent.click(cell11);
-      expect(handleRowSelectionModelChange.callCount).to.equal(0);
+      expect(handleRowSelectionModelChange.mock.calls.length).to.equal(0);
     });
   });
 
@@ -328,7 +327,7 @@ describe('<DataGridPro /> - Events params', () => {
 
   // Needs layout
   it('lazy loaded grid should load the rest of the rows when mounted when virtualization is disabled', () => {
-    const handleFetchRows = spy();
+    const handleFetchRows = vi.fn();
     render(
       <TestEvents
         onFetchRows={handleFetchRows}
@@ -339,15 +338,15 @@ describe('<DataGridPro /> - Events params', () => {
         rowCount={50}
       />,
     );
-    expect(handleFetchRows.callCount).to.equal(1);
-    expect(handleFetchRows.lastCall.firstArg).to.contain({
+    expect(handleFetchRows.mock.calls.length).to.equal(1);
+    expect(handleFetchRows.mock.lastCall?.[0]).to.contain({
       firstRowToRender: 3,
       lastRowToRender: 50,
     });
   });
 
   it('publishing renderedRowsIntervalChange should call onFetchRows callback when rows lazy loading is enabled', () => {
-    const handleFetchRows = spy();
+    const handleFetchRows = vi.fn();
     render(
       <TestEvents
         onFetchRows={handleFetchRows}
@@ -359,7 +358,7 @@ describe('<DataGridPro /> - Events params', () => {
       />,
     );
     // Since rowheight < viewport height, onmount calls fetchRows directly
-    expect(handleFetchRows.callCount).to.equal(1);
+    expect(handleFetchRows.mock.calls.length).to.equal(1);
     act(() => {
       apiRef.current?.publishEvent('renderedRowsIntervalChange', {
         firstRowIndex: 3,
@@ -368,20 +367,20 @@ describe('<DataGridPro /> - Events params', () => {
         lastColumnIndex: 0,
       });
     });
-    expect(handleFetchRows.callCount).to.equal(2);
-    expect(handleFetchRows.lastCall.firstArg).to.contain({
+    expect(handleFetchRows.mock.calls.length).to.equal(2);
+    expect(handleFetchRows.mock.lastCall?.[0]).to.contain({
       firstRowToRender: 3,
       lastRowToRender: 10,
     });
   });
 
   it('should publish "unmount" event when unmounting the Grid', () => {
-    const onUnmount = spy();
+    const onUnmount = vi.fn();
 
     const { unmount } = render(<TestEvents />);
 
     act(() => apiRef.current?.subscribeEvent('unmount', onUnmount));
     unmount();
-    expect(onUnmount.calledOnce).to.equal(true);
+    expect(onUnmount.mock.calls.length).to.equal(1);
   });
 });

--- a/packages/x-data-grid-pro/src/tests/multiSelect.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/multiSelect.DataGridPro.test.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
 import { createRenderer, screen, act, waitFor } from '@mui/internal-test-utils';
-import { spy } from 'sinon';
 import type { RefObject } from '@mui/x-internals/types';
 import { useGridApiRef, DataGridPro, gridClasses } from '@mui/x-data-grid-pro';
 import type { GridApi, DataGridProProps } from '@mui/x-data-grid-pro';
 import { getColumnValues } from 'test/utils/helperFn';
 import { isJSDOM } from 'test/utils/skipIf';
-import { describe, it, expect } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 
 describe('<DataGridPro /> - Column type: multiSelect', () => {
   const { render } = createRenderer();
@@ -78,7 +77,7 @@ describe('<DataGridPro /> - Column type: multiSelect', () => {
   });
 
   it('should support function valueOptions', () => {
-    const valueOptions = spy(() => ['A', 'B', 'C']);
+    const valueOptions = vi.fn(() => ['A', 'B', 'C']);
     render(
       <TestCaseMultiSelect
         rows={[{ id: 1, tags: ['A', 'B'] }]}

--- a/packages/x-data-grid-pro/src/tests/rowPinning.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/rowPinning.DataGridPro.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { spy } from 'sinon';
 import type { RefObject } from '@mui/x-internals/types';
 import { DataGridPro, gridClasses, useGridApiRef } from '@mui/x-data-grid-pro';
 import type { GridApi, GridRowsProp, DataGridProProps, GridColDef } from '@mui/x-data-grid-pro';
@@ -17,7 +16,7 @@ import {
   microtasks,
 } from 'test/utils/helperFn';
 import { isJSDOM } from 'test/utils/skipIf';
-import { describe, it, expect } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 
 describe('<DataGridPro /> - Row pinning', () => {
   const { render } = createRenderer();
@@ -722,7 +721,7 @@ describe('<DataGridPro /> - Row pinning', () => {
 
   // flaky in JSDOM
   it.skipIf(isJSDOM)('should support cell editing', async () => {
-    const processRowUpdate = spy((row) => ({ ...row, currencyPair: 'USD-GBP' }));
+    const processRowUpdate = vi.fn((row) => ({ ...row, currencyPair: 'USD-GBP' }));
     const columns: GridColDef[] = [{ field: 'id' }, { field: 'name', editable: true }];
     const { user } = render(
       <div style={{ width: 400, height: 400 }}>
@@ -753,13 +752,13 @@ describe('<DataGridPro /> - Row pinning', () => {
     await user.keyboard('{Enter}');
 
     expect(cell.textContent).to.equal('Marcus');
-    expect(processRowUpdate.callCount).to.equal(1);
-    expect(processRowUpdate.lastCall.args[0]).to.deep.equal({ id: 3, name: 'Marcus' });
+    expect(processRowUpdate.mock.calls.length).to.equal(1);
+    expect(processRowUpdate.mock.lastCall?.[0]).to.deep.equal({ id: 3, name: 'Marcus' });
   });
 
   // flaky in JSDOM
   it.skipIf(isJSDOM)('should support row editing', async () => {
-    const processRowUpdate = spy((row) => ({ ...row, currencyPair: 'USD-GBP' }));
+    const processRowUpdate = vi.fn((row) => ({ ...row, currencyPair: 'USD-GBP' }));
     const columns: GridColDef[] = [{ field: 'id' }, { field: 'name', editable: true }];
     const { user } = render(
       <div style={{ width: 400, height: 400 }}>
@@ -791,8 +790,8 @@ describe('<DataGridPro /> - Row pinning', () => {
     await user.keyboard('{Enter}');
 
     expect(cell.textContent).to.equal('Marcus');
-    expect(processRowUpdate.callCount).to.equal(1);
-    expect(processRowUpdate.lastCall.args[0]).to.deep.equal({ id: 3, name: 'Marcus' });
+    expect(processRowUpdate.mock.calls.length).to.equal(1);
+    expect(processRowUpdate.mock.lastCall?.[0]).to.deep.equal({ id: 3, name: 'Marcus' });
   });
 
   it('should support `updateRows`', async () => {

--- a/packages/x-data-grid-pro/src/tests/treeData.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/treeData.DataGridPro.test.tsx
@@ -9,7 +9,6 @@ import {
 } from 'test/utils/helperFn';
 import { fireUserEvent } from 'test/utils/fireUserEvent';
 import * as React from 'react';
-import { spy } from 'sinon';
 import {
   DataGridPro,
   GRID_TREE_DATA_GROUPING_FIELD,
@@ -24,7 +23,7 @@ import type {
   GridPaginationModel,
   GridColDef,
 } from '@mui/x-data-grid-pro';
-import { describe, it, expect } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 
 const isJSDOM = /jsdom/.test(window.navigator.userAgent);
 
@@ -302,16 +301,16 @@ describe('<DataGridPro /> - Tree data', () => {
 
   describe('prop: isGroupExpandedByDefault', () => {
     it('should expand groups according to isGroupExpandedByDefault when defined', () => {
-      const isGroupExpandedByDefault = spy((node: GridGroupNode) => node.id === 'A');
+      const isGroupExpandedByDefault = vi.fn((node: GridGroupNode) => node.id === 'A');
 
       render(<Test isGroupExpandedByDefault={isGroupExpandedByDefault} />);
-      expect(isGroupExpandedByDefault.callCount).to.equal(reactMajor >= 19 ? 4 : 8); // Should not be called on leaves
+      expect(isGroupExpandedByDefault.mock.calls.length).to.equal(reactMajor >= 19 ? 4 : 8); // Should not be called on leaves
       const { childrenExpanded, children, childrenFromPath, ...node } = apiRef.current?.state.rows
         .tree.A as GridGroupNode;
-      const callForNodeA = isGroupExpandedByDefault
-        .getCalls()
-        .find((call) => call.firstArg.id === node.id)!;
-      expect(callForNodeA.firstArg).to.deep.includes(node);
+      const callForNodeA = isGroupExpandedByDefault.mock.calls.find(
+        (call) => call[0].id === node.id,
+      )!;
+      expect(callForNodeA[0]).to.deep.includes(node);
       expect(getColumnValues(1)).to.deep.equal(['A', 'A.A', 'A.B', 'B', 'C']);
     });
 

--- a/packages/x-data-grid/src/hooks/utils/useGridEvent.test.tsx
+++ b/packages/x-data-grid/src/hooks/utils/useGridEvent.test.tsx
@@ -1,13 +1,12 @@
-import { spy } from 'sinon';
 import { createRenderer, reactMajor } from '@mui/internal-test-utils';
 import { sleep } from 'test/utils/helperFn';
 import { isJSDOM } from 'test/utils/skipIf';
-import { describe, it, expect } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 import { useGridEvent, internal_registryContainer } from './useGridEvent';
 import { FinalizationRegistryBasedCleanupTracking } from '../../utils/cleanupTracking/FinalizationRegistryBasedCleanupTracking';
 import { TimerBasedCleanupTracking } from '../../utils/cleanupTracking/TimerBasedCleanupTracking';
 
-const noop = spy();
+const noop = vi.fn();
 
 describe('useGridEvent', () => {
   const { render } = createRenderer();
@@ -19,9 +18,9 @@ describe('useGridEvent', () => {
     )('should unsubscribe event listeners registered by uncommitted components', async () => {
       internal_registryContainer.current = new FinalizationRegistryBasedCleanupTracking();
 
-      const unsubscribe = spy();
+      const unsubscribe = vi.fn();
       const apiRef = {
-        current: { subscribeEvent: spy(() => unsubscribe) },
+        current: { subscribeEvent: vi.fn(() => unsubscribe) },
       };
 
       function Test() {
@@ -38,14 +37,14 @@ describe('useGridEvent', () => {
       // Since React 19, StrictMode works differently
       // https://react.dev/blog/2024/04/25/react-19-upgrade-guide#strict-mode-improvements
       const expectedCallCount = reactMajor >= 19 ? 1 : 3;
-      expect(apiRef.current.subscribeEvent.callCount).to.equal(expectedCallCount);
+      expect(apiRef.current.subscribeEvent.mock.calls.length).to.equal(expectedCallCount);
 
       unmount();
       global.gc?.(); // Triggers garbage collector
       await sleep(50);
 
       // Ensure that both event listeners were unsubscribed
-      expect(unsubscribe.callCount).to.equal(expectedCallCount);
+      expect(unsubscribe.mock.calls.length).to.equal(expectedCallCount);
     });
   });
 
@@ -53,9 +52,9 @@ describe('useGridEvent', () => {
     it('should unsubscribe event listeners registered by uncommitted components', async () => {
       internal_registryContainer.current = new TimerBasedCleanupTracking(50);
 
-      const unsubscribe = spy();
+      const unsubscribe = vi.fn();
       const apiRef = {
-        current: { subscribeEvent: spy(() => unsubscribe) },
+        current: { subscribeEvent: vi.fn(() => unsubscribe) },
       };
 
       function Test() {
@@ -72,13 +71,13 @@ describe('useGridEvent', () => {
       // Since React 19, StrictMode works differently
       // https://react.dev/blog/2024/04/25/react-19-upgrade-guide#strict-mode-improvements
       const expectedCallCount = reactMajor >= 19 ? 2 : 3;
-      expect(apiRef.current.subscribeEvent.callCount).to.equal(expectedCallCount);
+      expect(apiRef.current.subscribeEvent.mock.calls.length).to.equal(expectedCallCount);
 
       unmount();
       await sleep(60);
 
       // Ensure that all event listeners were unsubscribed
-      expect(unsubscribe.callCount).to.equal(expectedCallCount);
+      expect(unsubscribe.mock.calls.length).to.equal(expectedCallCount);
     });
   });
 });

--- a/packages/x-data-grid/src/tests/quickFiltering.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/quickFiltering.DataGrid.test.tsx
@@ -1,10 +1,9 @@
 import { createRenderer, screen, reactMajor, waitFor, act } from '@mui/internal-test-utils';
-import { spy } from 'sinon';
 import { DataGrid, GridLogicOperator, getGridStringQuickFilterFn } from '@mui/x-data-grid';
 import type { DataGridProps, GetApplyQuickFilterFn, GridFilterModel } from '@mui/x-data-grid';
 import { getColumnValues, sleep } from 'test/utils/helperFn';
 import { isJSDOM } from 'test/utils/skipIf';
-import { describe, it, expect } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 
 describe('<DataGrid /> - Quick filter', () => {
   const { render } = createRenderer();
@@ -64,7 +63,7 @@ describe('<DataGrid /> - Quick filter', () => {
     });
 
     it('should allow to customize input splitting', async () => {
-      const onFilterModelChange = spy();
+      const onFilterModelChange = vi.fn();
 
       const { user } = render(
         <TestCase
@@ -80,13 +79,13 @@ describe('<DataGrid /> - Quick filter', () => {
         />,
       );
 
-      expect(onFilterModelChange.callCount).to.equal(0);
+      expect(onFilterModelChange.mock.calls.length).to.equal(0);
 
       await user.click(screen.getByRole('button', { name: 'Search' }));
       await user.type(screen.getByRole('searchbox'), 'adid, nik');
 
       await waitFor(() => {
-        expect(onFilterModelChange.lastCall.firstArg).to.deep.equal({
+        expect(onFilterModelChange.mock.lastCall?.[0]).to.deep.equal({
           items: [],
           logicOperator: 'and',
           quickFilterValues: ['adid', 'nik'],
@@ -382,7 +381,7 @@ describe('<DataGrid /> - Quick filter', () => {
     });
 
     it('should apply filters on column visibility change when quickFilterExcludeHiddenColumns=true', () => {
-      const getApplyQuickFilterFnSpy = spy(getGridStringQuickFilterFn);
+      const getApplyQuickFilterFnSpy = vi.fn(getGridStringQuickFilterFn);
       const { setProps } = render(
         <TestCase
           columns={[
@@ -408,19 +407,19 @@ describe('<DataGrid /> - Quick filter', () => {
       const initialCallCount = reactMajor >= 19 ? 1 : 2;
 
       expect(getColumnValues(0)).to.deep.equal(['1']);
-      expect(getApplyQuickFilterFnSpy.callCount).to.equal(initialCallCount);
+      expect(getApplyQuickFilterFnSpy.mock.calls.length).to.equal(initialCallCount);
 
       setProps({ columnVisibilityModel: { brand: false } });
       expect(getColumnValues(0)).to.deep.equal([]);
-      expect(getApplyQuickFilterFnSpy.callCount).to.equal(initialCallCount + 1);
+      expect(getApplyQuickFilterFnSpy.mock.calls.length).to.equal(initialCallCount + 1);
 
       setProps({ columnVisibilityModel: { brand: true } });
       expect(getColumnValues(0)).to.deep.equal(['1']);
-      expect(getApplyQuickFilterFnSpy.callCount).to.equal(initialCallCount + 2);
+      expect(getApplyQuickFilterFnSpy.mock.calls.length).to.equal(initialCallCount + 2);
     });
 
     it('should not apply filters on column visibility change when quickFilterExcludeHiddenColumns=true but no quick filter values', () => {
-      const getApplyQuickFilterFnSpy = spy(getGridStringQuickFilterFn);
+      const getApplyQuickFilterFnSpy = vi.fn(getGridStringQuickFilterFn);
       const { setProps } = render(
         <TestCase
           columns={[
@@ -439,19 +438,19 @@ describe('<DataGrid /> - Quick filter', () => {
       );
 
       expect(getColumnValues(0)).to.deep.equal(['0', '1', '2']);
-      expect(getApplyQuickFilterFnSpy.callCount).to.equal(0);
+      expect(getApplyQuickFilterFnSpy.mock.calls.length).to.equal(0);
 
       setProps({ columnVisibilityModel: { brand: false } });
       expect(getColumnValues(0)).to.deep.equal(['0', '1', '2']);
-      expect(getApplyQuickFilterFnSpy.callCount).to.equal(0);
+      expect(getApplyQuickFilterFnSpy.mock.calls.length).to.equal(0);
 
       setProps({ columnVisibilityModel: { brand: true } });
       expect(getColumnValues(0)).to.deep.equal(['0', '1', '2']);
-      expect(getApplyQuickFilterFnSpy.callCount).to.equal(0);
+      expect(getApplyQuickFilterFnSpy.mock.calls.length).to.equal(0);
     });
 
     it('should not apply filters on column visibility change when quickFilterExcludeHiddenColumns=false', () => {
-      const getApplyQuickFilterFnSpy = spy(getGridStringQuickFilterFn);
+      const getApplyQuickFilterFnSpy = vi.fn(getGridStringQuickFilterFn);
       const { setProps } = render(
         <TestCase
           columns={[
@@ -474,15 +473,15 @@ describe('<DataGrid /> - Quick filter', () => {
       const initialCallCount = reactMajor >= 19 ? 1 : 2;
 
       expect(getColumnValues(0)).to.deep.equal(['1']);
-      expect(getApplyQuickFilterFnSpy.callCount).to.equal(initialCallCount);
+      expect(getApplyQuickFilterFnSpy.mock.calls.length).to.equal(initialCallCount);
 
       setProps({ columnVisibilityModel: { brand: false } });
       expect(getColumnValues(0)).to.deep.equal(['1']);
-      expect(getApplyQuickFilterFnSpy.callCount).to.equal(initialCallCount);
+      expect(getApplyQuickFilterFnSpy.mock.calls.length).to.equal(initialCallCount);
 
       setProps({ columnVisibilityModel: { brand: true } });
       expect(getColumnValues(0)).to.deep.equal(['1']);
-      expect(getApplyQuickFilterFnSpy.callCount).to.equal(initialCallCount);
+      expect(getApplyQuickFilterFnSpy.mock.calls.length).to.equal(initialCallCount);
     });
   });
 

--- a/packages/x-data-grid/src/tests/rowSpanning.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/rowSpanning.DataGrid.test.tsx
@@ -1,12 +1,11 @@
 import type { RefObject } from '@mui/x-internals/types';
 import { createRenderer, fireEvent, act } from '@mui/internal-test-utils';
-import { spy } from 'sinon';
 import { DataGrid, useGridApiRef } from '@mui/x-data-grid';
 import type { DataGridProps, GridApi } from '@mui/x-data-grid';
 import { unwrapPrivateAPI } from '@mui/x-data-grid/internals';
 import { getCell, getActiveCell, microtasks } from 'test/utils/helperFn';
 import { isJSDOM } from 'test/utils/skipIf';
-import { describe, it, expect } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 
 describe.skipIf(isJSDOM)('<DataGrid /> - Row spanning', () => {
   const { render } = createRenderer();
@@ -262,7 +261,7 @@ describe.skipIf(isJSDOM)('<DataGrid /> - Row spanning', () => {
 
   describe('rows update', () => {
     it('should update the row spanning state when the rows are updated', () => {
-      const rowSpanValueGetter = spy((value) => value);
+      const rowSpanValueGetter = vi.fn((value) => value);
       let rowSpanningStateUpdates = 0;
       let spannedCells = {};
       render(

--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.test.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { spy } from 'sinon';
 import { screen, fireEvent, createEvent, within, waitFor } from '@mui/internal-test-utils';
 import {
   adapterToUse,
@@ -17,7 +16,7 @@ import {
 } from '@mui/x-date-pickers-pro/DateRangePickerDay';
 import { describeConformance } from 'test/utils/describeConformance';
 import type { PickerValidDate } from '@mui/x-date-pickers/models';
-import { describe, it, expect } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 import type { RangePosition } from '../models';
 
 const getPickerDay = (name: string, picker = 'January 2018') =>
@@ -44,7 +43,7 @@ describe('<DateRangeCalendar />', () => {
 
   describe('Selection', () => {
     it('should select the range from the next month', async () => {
-      const onChange = spy();
+      const onChange = vi.fn();
 
       const { user } = render(
         <DateRangeCalendar
@@ -66,19 +65,19 @@ describe('<DateRangeCalendar />', () => {
 
       await user.click(getPickerDay('19', 'March 2019'));
 
-      expect(onChange.callCount).to.equal(2);
+      expect(onChange.mock.calls.length).to.equal(2);
 
-      const rangeOn1stCall = onChange.firstCall.firstArg;
+      const rangeOn1stCall = onChange.mock.calls[0][0];
       expect(rangeOn1stCall[0]).to.toEqualDateTime(new Date(2019, 0, 1));
       expect(rangeOn1stCall[1]).to.equal(null);
 
-      const rangeOn2ndCall = onChange.lastCall.firstArg;
+      const rangeOn2ndCall = onChange.mock.lastCall?.[0];
       expect(rangeOn2ndCall[0]).to.toEqualDateTime(new Date(2019, 0, 1));
       expect(rangeOn2ndCall[1]).to.toEqualDateTime(new Date(2019, 2, 19));
     });
 
     it('should continue start selection if selected "end" date is before start', async () => {
-      const onChange = spy();
+      const onChange = vi.fn();
 
       const { user } = render(
         <DateRangeCalendar onChange={onChange} referenceDate={adapterToUse.date('2019-01-01')} />,
@@ -91,8 +90,8 @@ describe('<DateRangeCalendar />', () => {
 
       await user.click(getPickerDay('30', 'January 2019'));
 
-      expect(onChange.callCount).to.equal(3);
-      const range = onChange.lastCall.firstArg;
+      expect(onChange.mock.calls.length).to.equal(3);
+      const range = onChange.mock.lastCall?.[0];
       expect(range[0]).to.toEqualDateTime(new Date(2019, 0, 19));
       expect(range[1]).to.toEqualDateTime(new Date(2019, 0, 30));
     });
@@ -108,7 +107,7 @@ describe('<DateRangeCalendar />', () => {
     });
 
     it('prop: disableDragEditing - should not allow dragging range', () => {
-      const onChange = spy();
+      const onChange = vi.fn();
       render(
         <DateRangeCalendar
           onChange={onChange}
@@ -122,12 +121,12 @@ describe('<DateRangeCalendar />', () => {
 
       executeDateDrag(startDay, targetDay);
 
-      expect(onChange.callCount).to.equal(0);
+      expect(onChange.mock.calls.length).to.equal(0);
     });
 
     describe('dragging behavior', () => {
       it('should not emit "onChange" when dragging is ended where it was started', () => {
-        const onChange = spy();
+        const onChange = vi.fn();
         render(
           <DateRangeCalendar
             onChange={onChange}
@@ -137,15 +136,15 @@ describe('<DateRangeCalendar />', () => {
 
         const startDay = screen.getByRole('gridcell', { name: '31', selected: true });
         const dragToDay = screen.getByRole('gridcell', { name: '30' });
-        expect(onChange.callCount).to.equal(0);
+        expect(onChange.mock.calls.length).to.equal(0);
 
         executeDateDrag(startDay, dragToDay, startDay);
 
-        expect(onChange.callCount).to.equal(0);
+        expect(onChange.mock.calls.length).to.equal(0);
       });
 
       it('should emit "onChange" when dragging end date', () => {
-        const onChange = spy();
+        const onChange = vi.fn();
         const initialValue: [any, any] = [
           adapterToUse.date('2018-01-10'),
           adapterToUse.date('2018-01-31'),
@@ -159,9 +158,9 @@ describe('<DateRangeCalendar />', () => {
           screen.getByRole('gridcell', { name: '29' }),
         );
 
-        expect(onChange.callCount).to.equal(1);
-        expect(onChange.lastCall.args[0][0]).toEqualDateTime(initialValue[0]);
-        expect(onChange.lastCall.args[0][1]).toEqualDateTime(new Date(2018, 0, 29));
+        expect(onChange.mock.calls.length).to.equal(1);
+        expect(onChange.mock.lastCall?.[0][0]).toEqualDateTime(initialValue[0]);
+        expect(onChange.mock.lastCall?.[0][1]).toEqualDateTime(new Date(2018, 0, 29));
         expect(document.activeElement).toHaveAccessibleName('29');
 
         // test range expansion
@@ -170,9 +169,9 @@ describe('<DateRangeCalendar />', () => {
           screen.getByRole('gridcell', { name: '30' }),
         );
 
-        expect(onChange.callCount).to.equal(2);
-        expect(onChange.lastCall.args[0][0]).toEqualDateTime(initialValue[0]);
-        expect(onChange.lastCall.args[0][1]).toEqualDateTime(new Date(2018, 0, 30));
+        expect(onChange.mock.calls.length).to.equal(2);
+        expect(onChange.mock.lastCall?.[0][0]).toEqualDateTime(initialValue[0]);
+        expect(onChange.mock.lastCall?.[0][1]).toEqualDateTime(new Date(2018, 0, 30));
         expect(document.activeElement).toHaveAccessibleName('30');
 
         // test range flip
@@ -181,14 +180,14 @@ describe('<DateRangeCalendar />', () => {
           getPickerDay('2'),
         );
 
-        expect(onChange.callCount).to.equal(3);
-        expect(onChange.lastCall.args[0][0]).toEqualDateTime(new Date(2018, 0, 2));
-        expect(onChange.lastCall.args[0][1]).toEqualDateTime(initialValue[0]);
+        expect(onChange.mock.calls.length).to.equal(3);
+        expect(onChange.mock.lastCall?.[0][0]).toEqualDateTime(new Date(2018, 0, 2));
+        expect(onChange.mock.lastCall?.[0][1]).toEqualDateTime(initialValue[0]);
         expect(document.activeElement).toHaveAccessibleName('2');
       });
 
       it('should emit "onChange" when dragging start date', () => {
-        const onChange = spy();
+        const onChange = vi.fn();
         const initialValue: [any, any] = [
           adapterToUse.date('2018-01-01'),
           adapterToUse.date('2018-01-20'),
@@ -198,25 +197,25 @@ describe('<DateRangeCalendar />', () => {
         // test range reduction
         executeDateDrag(getPickerDay('1'), getPickerDay('2'), getPickerDay('3'));
 
-        expect(onChange.callCount).to.equal(1);
-        expect(onChange.lastCall.args[0][0]).toEqualDateTime(new Date(2018, 0, 3));
-        expect(onChange.lastCall.args[0][1]).toEqualDateTime(initialValue[1]);
+        expect(onChange.mock.calls.length).to.equal(1);
+        expect(onChange.mock.lastCall?.[0][0]).toEqualDateTime(new Date(2018, 0, 3));
+        expect(onChange.mock.lastCall?.[0][1]).toEqualDateTime(initialValue[1]);
         expect(document.activeElement).toHaveAccessibleName('3');
 
         // test range expansion
         executeDateDrag(getPickerDay('3'), getPickerDay('1'));
 
-        expect(onChange.callCount).to.equal(2);
-        expect(onChange.lastCall.args[0][0]).toEqualDateTime(initialValue[0]);
-        expect(onChange.lastCall.args[0][1]).toEqualDateTime(initialValue[1]);
+        expect(onChange.mock.calls.length).to.equal(2);
+        expect(onChange.mock.lastCall?.[0][0]).toEqualDateTime(initialValue[0]);
+        expect(onChange.mock.lastCall?.[0][1]).toEqualDateTime(initialValue[1]);
         expect(document.activeElement).toHaveAccessibleName('1');
 
         // test range flip
         executeDateDrag(getPickerDay('1'), getPickerDay('22'));
 
-        expect(onChange.callCount).to.equal(3);
-        expect(onChange.lastCall.args[0][0]).toEqualDateTime(initialValue[1]);
-        expect(onChange.lastCall.args[0][1]).toEqualDateTime(new Date(2018, 0, 22));
+        expect(onChange.mock.calls.length).to.equal(3);
+        expect(onChange.mock.lastCall?.[0][0]).toEqualDateTime(initialValue[1]);
+        expect(onChange.mock.lastCall?.[0][1]).toEqualDateTime(new Date(2018, 0, 22));
         expect(document.activeElement).toHaveAccessibleName('22');
       });
 
@@ -251,7 +250,7 @@ describe('<DateRangeCalendar />', () => {
       });
 
       it('should not initiate drag on non-draggable dates', () => {
-        const onChange = spy();
+        const onChange = vi.fn();
         render(
           <DateRangeCalendar
             onChange={onChange}
@@ -266,11 +265,11 @@ describe('<DateRangeCalendar />', () => {
         executeDateDrag(middleDay, targetDay);
 
         // No change should occur since middle day is not draggable
-        expect(onChange.callCount).to.equal(0);
+        expect(onChange.mock.calls.length).to.equal(0);
       });
 
       it('should ignore secondary multi-touch pointers (isPrimary === false)', () => {
-        const onChange = spy();
+        const onChange = vi.fn();
         render(
           <DateRangeCalendar
             onChange={onChange}
@@ -291,12 +290,12 @@ describe('<DateRangeCalendar />', () => {
 
         // The first finger's gesture survives intact — exactly one drop, from
         // pointerId 1.
-        expect(onChange.callCount).to.equal(1);
-        expect(onChange.lastCall.args[0][1]).toEqualDateTime(new Date(2018, 0, 29));
+        expect(onChange.mock.calls.length).to.equal(1);
+        expect(onChange.mock.lastCall?.[0][1]).toEqualDateTime(new Date(2018, 0, 29));
       });
 
       it('should recover from a stuck gesture when a fresh primary pointerdown arrives', () => {
-        const onChange = spy();
+        const onChange = vi.fn();
         render(
           <DateRangeCalendar
             onChange={onChange}
@@ -316,14 +315,14 @@ describe('<DateRangeCalendar />', () => {
         fireEvent.pointerOver(endDay, { pointerId: 2 });
         fireEvent.pointerUp(endDay, { pointerId: 2 });
 
-        expect(onChange.callCount).to.equal(1);
-        expect(onChange.lastCall.args[0][1]).toEqualDateTime(new Date(2018, 0, 29));
+        expect(onChange.mock.calls.length).to.equal(1);
+        expect(onChange.mock.lastCall?.[0][1]).toEqualDateTime(new Date(2018, 0, 29));
       });
 
       it('should commit the drop when the gesture is canceled after movement', () => {
         // `pointercancel` after the user has crossed cells should be treated
         // as "UA interrupted, not the user" and commit the drop.
-        const onChange = spy();
+        const onChange = vi.fn();
         render(
           <DateRangeCalendar
             onChange={onChange}
@@ -338,12 +337,12 @@ describe('<DateRangeCalendar />', () => {
         fireEvent.pointerOver(endDay, { pointerId: 1 });
         fireEvent.pointerCancel(document, { pointerId: 1 });
 
-        expect(onChange.callCount).to.equal(1);
-        expect(onChange.lastCall.args[0][1]).toEqualDateTime(new Date(2018, 0, 29));
+        expect(onChange.mock.calls.length).to.equal(1);
+        expect(onChange.mock.lastCall?.[0][1]).toEqualDateTime(new Date(2018, 0, 29));
       });
 
       it('should not commit a drop on pointercancel before any movement', () => {
-        const onChange = spy();
+        const onChange = vi.fn();
         render(
           <DateRangeCalendar
             onChange={onChange}
@@ -356,11 +355,11 @@ describe('<DateRangeCalendar />', () => {
         fireEvent.pointerDown(startDay, { pointerId: 1, button: 0, isPrimary: true });
         fireEvent.pointerCancel(document, { pointerId: 1 });
 
-        expect(onChange.callCount).to.equal(0);
+        expect(onChange.mock.calls.length).to.equal(0);
       });
 
       it('should clean up listeners after pointercancel and allow a new drag', () => {
-        const onChange = spy();
+        const onChange = vi.fn();
         render(
           <DateRangeCalendar
             onChange={onChange}
@@ -380,14 +379,14 @@ describe('<DateRangeCalendar />', () => {
         // properly torn down.
         executeDateDrag(otherEndpoint, newEndDay);
 
-        expect(onChange.callCount).to.equal(1);
+        expect(onChange.mock.calls.length).to.equal(1);
       });
 
       it('should suppress the click that follows a moved drag', () => {
         // The browser fires a synthesized click after pointerup. Without
         // suppression it would re-enter the day's normal selection logic and
         // overwrite the drop.
-        const onChange = spy();
+        const onChange = vi.fn();
         render(
           <DateRangeCalendar
             onChange={onChange}
@@ -403,15 +402,15 @@ describe('<DateRangeCalendar />', () => {
         fireEvent.click(endDay);
 
         // Exactly one onChange — from the drop, not double-counted by the click.
-        expect(onChange.callCount).to.equal(1);
-        expect(onChange.lastCall.args[0][1]).toEqualDateTime(new Date(2018, 0, 29));
+        expect(onChange.mock.calls.length).to.equal(1);
+        expect(onChange.mock.lastCall?.[0][1]).toEqualDateTime(new Date(2018, 0, 29));
       });
 
       it('should cancel the drop when the pointer is released outside any cell', () => {
         // Native HTML5 drag cancels when the user releases outside any drop
         // target. Match that — releasing into a gap or off the calendar
         // entirely must not commit the last cell the user happened to hover.
-        const onChange = spy();
+        const onChange = vi.fn();
         render(
           <DateRangeCalendar
             onChange={onChange}
@@ -427,14 +426,14 @@ describe('<DateRangeCalendar />', () => {
         // `event.target` doesn't resolve to a cell, so the drop is cancelled.
         fireEvent.pointerUp(document.body, { pointerId: 1 });
 
-        expect(onChange.callCount).to.equal(0);
+        expect(onChange.mock.calls.length).to.equal(0);
       });
 
       it('should cancel the drop when the pointer is released on a disabled day', () => {
         // `pointerup` lands on disabled `<button>` elements in real browsers,
         // and `handleDrop` doesn't re-validate the date — without an explicit
         // guard the gesture would route an invalid date through `onChange`.
-        const onChange = spy();
+        const onChange = vi.fn();
         render(
           <DateRangeCalendar
             onChange={onChange}
@@ -449,7 +448,7 @@ describe('<DateRangeCalendar />', () => {
 
         executeDateDrag(startDay, disabledDay);
 
-        expect(onChange.callCount).to.equal(0);
+        expect(onChange.mock.calls.length).to.equal(0);
       });
 
       it('should notify the parent of the source endpoint on first cross-cell move', () => {
@@ -457,7 +456,7 @@ describe('<DateRangeCalendar />', () => {
         // `onDatePositionChange` on the first real move — that's what tells
         // the calendar which side of the range the drag is editing. Range
         // flip / preview correctness depends on it.
-        const onRangePositionChange = spy();
+        const onRangePositionChange = vi.fn();
         render(
           <DateRangeCalendar
             defaultValue={[adapterToUse.date('2018-01-10'), adapterToUse.date('2018-01-31')]}
@@ -470,23 +469,23 @@ describe('<DateRangeCalendar />', () => {
 
         // No callback until real movement crosses into a different cell.
         fireEvent.pointerDown(endDay, { pointerId: 1, button: 0, isPrimary: true });
-        expect(onRangePositionChange.callCount).to.equal(0);
+        expect(onRangePositionChange.mock.calls.length).to.equal(0);
 
         // First cross-cell move announces the source endpoint.
         fireEvent.pointerOver(targetDay, { pointerId: 1 });
-        expect(onRangePositionChange.callCount).to.equal(1);
-        expect(onRangePositionChange.lastCall.args[0]).to.equal('end');
+        expect(onRangePositionChange.mock.calls.length).to.equal(1);
+        expect(onRangePositionChange.mock.lastCall?.[0]).to.equal('end');
 
         // Subsequent moves don't re-announce — the source position is fixed
         // for the gesture.
         fireEvent.pointerOver(getPickerDay('28'), { pointerId: 1 });
-        expect(onRangePositionChange.callCount).to.equal(1);
+        expect(onRangePositionChange.mock.calls.length).to.equal(1);
 
         fireEvent.pointerUp(getPickerDay('28'), { pointerId: 1 });
       });
 
       it('should cancel an in-flight drag on Escape', () => {
-        const onChange = spy();
+        const onChange = vi.fn();
         render(
           <DateRangeCalendar
             onChange={onChange}
@@ -502,7 +501,7 @@ describe('<DateRangeCalendar />', () => {
         // pointerup arriving after Escape is a no-op (cleanup already ran).
         fireEvent.pointerUp(document, { pointerId: 1 });
 
-        expect(onChange.callCount).to.equal(0);
+        expect(onChange.mock.calls.length).to.equal(0);
       });
 
       it('should preventDefault on `touchmove` during a touch drag', () => {
@@ -566,7 +565,7 @@ describe('<DateRangeCalendar />', () => {
         // release. If the user lifts over a TouchRipple span or text node
         // inside the button, `finalizeGesture` must walk up to find the
         // owning day cell rather than dropping on `null`.
-        const onChange = spy();
+        const onChange = vi.fn();
         render(
           <DateRangeCalendar
             onChange={onChange}
@@ -586,8 +585,8 @@ describe('<DateRangeCalendar />', () => {
         // the day button via the `.closest('button')` / data-attribute walk.
         fireEvent.pointerUp(endDayChild, { pointerId: 1 });
 
-        expect(onChange.callCount).to.equal(1);
-        expect(onChange.lastCall.args[0][1]).toEqualDateTime(new Date(2018, 0, 29));
+        expect(onChange.mock.calls.length).to.equal(1);
+        expect(onChange.mock.lastCall?.[0][1]).toEqualDateTime(new Date(2018, 0, 29));
       });
     });
   });
@@ -756,7 +755,7 @@ describe('<DateRangeCalendar />', () => {
 
   ['readOnly', 'disabled'].forEach((prop) => {
     it(`prop: ${prop}="true" should not allow date editing`, async () => {
-      const handleChange = spy();
+      const handleChange = vi.fn();
       const { user } = render(
         <DateRangeCalendar
           value={[adapterToUse.date('2018-01-01'), adapterToUse.date('2018-01-10')]}
@@ -777,10 +776,10 @@ describe('<DateRangeCalendar />', () => {
         screen.getByRole('gridcell', { name: '1', selected: true }),
         getPickerDay('5'),
       );
-      expect(handleChange.callCount).to.equal(0);
+      expect(handleChange.mock.calls.length).to.equal(0);
 
       await user.setup({ pointerEventsCheck: 0 }).click(getPickerDay('2'));
-      expect(handleChange.callCount).to.equal(0);
+      expect(handleChange.mock.calls.length).to.equal(0);
     });
   });
 
@@ -901,41 +900,45 @@ describe('<DateRangeCalendar />', () => {
 
   describe('Performance', () => {
     it('should only render the new start day when selecting a start day without a previously selected start day', () => {
-      const RenderCount = spy((props) => <DateRangePickerDay {...props} />);
+      const RenderCount = vi.fn((props: React.ComponentProps<typeof DateRangePickerDay>) => (
+        <DateRangePickerDay {...props} />
+      ));
 
       render(
         <DateRangeCalendar
           referenceDate={adapterToUse.date('2018-01-01')}
           slots={{
-            day: React.memo(RenderCount),
+            day: React.memo(RenderCount) as typeof DateRangePickerDay,
           }}
         />,
       );
 
-      const renderCountBeforeChange = RenderCount.callCount;
+      const renderCountBeforeChange = RenderCount.mock.calls.length;
       // sticking with `fireEvent` for simplified performance test
       fireEvent.click(getPickerDay('2'));
-      expect(RenderCount.callCount - renderCountBeforeChange).to.equal(2); // 2 render * 1 day
+      expect(RenderCount.mock.calls.length - renderCountBeforeChange).to.equal(2); // 2 render * 1 day
     });
 
     it('should only render the day inside range when selecting the end day', () => {
-      const RenderCount = spy((props) => <DateRangePickerDay {...props} />);
+      const RenderCount = vi.fn((props: React.ComponentProps<typeof DateRangePickerDay>) => (
+        <DateRangePickerDay {...props} />
+      ));
 
       render(
         <DateRangeCalendar
           referenceDate={adapterToUse.date('2018-01-01')}
           slots={{
-            day: React.memo(RenderCount),
+            day: React.memo(RenderCount) as typeof DateRangePickerDay,
           }}
         />,
       );
 
       fireEvent.click(getPickerDay('2'));
 
-      const renderCountBeforeChange = RenderCount.callCount;
+      const renderCountBeforeChange = RenderCount.mock.calls.length;
       // sticking with `fireEvent` for simplified performance test
       fireEvent.click(getPickerDay('4'));
-      expect(RenderCount.callCount - renderCountBeforeChange).to.equal(6); // 2 render * 3 day
+      expect(RenderCount.mock.calls.length - renderCountBeforeChange).to.equal(6); // 2 render * 3 day
     });
   });
 });

--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.test.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.test.tsx
@@ -14,6 +14,7 @@ import {
   DateRangePickerDay,
   dateRangePickerDayClasses as dayClasses,
 } from '@mui/x-date-pickers-pro/DateRangePickerDay';
+import type { DateRangePickerDayProps } from '@mui/x-date-pickers-pro/DateRangePickerDay';
 import { describeConformance } from 'test/utils/describeConformance';
 import type { PickerValidDate } from '@mui/x-date-pickers/models';
 import { vi, describe, it, expect } from 'vitest';
@@ -901,7 +902,7 @@ describe('<DateRangeCalendar />', () => {
   describe('Performance', () => {
     it('should only render the new start day when selecting a start day without a previously selected start day', () => {
       const renderCount = vi.fn();
-      const RenderCount = React.memo((props: React.ComponentProps<typeof DateRangePickerDay>) => {
+      const RenderCount = React.memo((props: DateRangePickerDayProps) => {
         renderCount();
         return <DateRangePickerDay {...props} />;
       });
@@ -923,7 +924,7 @@ describe('<DateRangeCalendar />', () => {
 
     it('should only render the day inside range when selecting the end day', () => {
       const renderCount = vi.fn();
-      const RenderCount = React.memo((props: React.ComponentProps<typeof DateRangePickerDay>) => {
+      const RenderCount = React.memo((props: DateRangePickerDayProps) => {
         renderCount();
         return <DateRangePickerDay {...props} />;
       });

--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.test.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.test.tsx
@@ -900,45 +900,49 @@ describe('<DateRangeCalendar />', () => {
 
   describe('Performance', () => {
     it('should only render the new start day when selecting a start day without a previously selected start day', () => {
-      const RenderCount = vi.fn((props: React.ComponentProps<typeof DateRangePickerDay>) => (
-        <DateRangePickerDay {...props} />
-      ));
+      const renderCount = vi.fn();
+      const RenderCount = React.memo((props: React.ComponentProps<typeof DateRangePickerDay>) => {
+        renderCount();
+        return <DateRangePickerDay {...props} />;
+      });
 
       render(
         <DateRangeCalendar
           referenceDate={adapterToUse.date('2018-01-01')}
           slots={{
-            day: React.memo(RenderCount) as typeof DateRangePickerDay,
+            day: RenderCount,
           }}
         />,
       );
 
-      const renderCountBeforeChange = RenderCount.mock.calls.length;
+      const renderCountBeforeChange = renderCount.mock.calls.length;
       // sticking with `fireEvent` for simplified performance test
       fireEvent.click(getPickerDay('2'));
-      expect(RenderCount.mock.calls.length - renderCountBeforeChange).to.equal(2); // 2 render * 1 day
+      expect(renderCount.mock.calls.length - renderCountBeforeChange).to.equal(2); // 2 render * 1 day
     });
 
     it('should only render the day inside range when selecting the end day', () => {
-      const RenderCount = vi.fn((props: React.ComponentProps<typeof DateRangePickerDay>) => (
-        <DateRangePickerDay {...props} />
-      ));
+      const renderCount = vi.fn();
+      const RenderCount = React.memo((props: React.ComponentProps<typeof DateRangePickerDay>) => {
+        renderCount();
+        return <DateRangePickerDay {...props} />;
+      });
 
       render(
         <DateRangeCalendar
           referenceDate={adapterToUse.date('2018-01-01')}
           slots={{
-            day: React.memo(RenderCount) as typeof DateRangePickerDay,
+            day: RenderCount,
           }}
         />,
       );
 
       fireEvent.click(getPickerDay('2'));
 
-      const renderCountBeforeChange = RenderCount.mock.calls.length;
+      const renderCountBeforeChange = renderCount.mock.calls.length;
       // sticking with `fireEvent` for simplified performance test
       fireEvent.click(getPickerDay('4'));
-      expect(RenderCount.mock.calls.length - renderCountBeforeChange).to.equal(6); // 2 render * 3 day
+      expect(renderCount.mock.calls.length - renderCountBeforeChange).to.equal(6); // 2 render * 3 day
     });
   });
 });

--- a/packages/x-date-pickers/src/AdapterMoment/AdapterMoment.test.tsx
+++ b/packages/x-date-pickers/src/AdapterMoment/AdapterMoment.test.tsx
@@ -4,7 +4,6 @@ import momentTZ from 'moment-timezone';
 import { DateTimeField } from '@mui/x-date-pickers/DateTimeField';
 import { AdapterMoment } from '@mui/x-date-pickers/AdapterMoment';
 import type { AdapterFormats, PickerValidDate } from '@mui/x-date-pickers/models';
-import { spy } from 'sinon';
 import {
   createPickerRenderer,
   expectFieldValue,
@@ -16,7 +15,7 @@ import 'moment/locale/de';
 import 'moment/locale/fr';
 import 'moment/locale/ko';
 import 'moment/locale/ru';
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 describe('<AdapterMoment />', () => {
   const commonParams = {
@@ -181,10 +180,10 @@ describe('<AdapterMoment />', () => {
   });
 
   it('should use moment custom instance if provided', () => {
-    const spiedInstance = spy(moment);
+    const spiedInstance = vi.fn(moment);
 
     const adapter = new AdapterMoment({ instance: spiedInstance as unknown as typeof moment });
     adapter.date()!;
-    expect(spiedInstance.callCount).to.equal(1);
+    expect(spiedInstance.mock.calls.length).to.equal(1);
   });
 });

--- a/packages/x-date-pickers/src/DateCalendar/tests/DateCalendar.test.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/tests/DateCalendar.test.tsx
@@ -763,39 +763,47 @@ describe('<DateCalendar />', () => {
 
   describe('Performance', () => {
     it('should only render newly selected day when selecting a day without a previously selected day', async () => {
-      const RenderCount = vi.fn((props: PickerDayProps) => <PickerDay {...props} />);
+      const renderCount = vi.fn();
+      const RenderCount = React.memo((props: PickerDayProps) => {
+        renderCount();
+        return <PickerDay {...props} />;
+      });
 
       const { user } = render(
         <DateCalendar
           referenceDate={adapterToUse.date('2019-01-02')}
           slots={{
-            day: React.memo(RenderCount) as typeof PickerDay,
+            day: RenderCount,
           }}
         />,
       );
 
-      const renderCountBeforeChange = RenderCount.mock.calls.length;
+      const renderCountBeforeChange = renderCount.mock.calls.length;
       await user.click(screen.getByRole('gridcell', { name: '2' }));
       // 2 render (one to update tabIndex + autoFocus, one to update selection) * 2 (because dev mode)
-      expect(RenderCount.mock.calls.length - renderCountBeforeChange).to.equal(4);
+      expect(renderCount.mock.calls.length - renderCountBeforeChange).to.equal(4);
     });
 
     it('should only re-render previously selected day and newly selected day when selecting a day', async () => {
-      const RenderCount = vi.fn((props: PickerDayProps) => <PickerDay {...props} />);
+      const renderCount = vi.fn();
+      const RenderCount = React.memo((props: PickerDayProps) => {
+        renderCount();
+        return <PickerDay {...props} />;
+      });
 
       const { user } = render(
         <DateCalendar
           defaultValue={adapterToUse.date('2019-04-29')}
           slots={{
-            day: React.memo(RenderCount) as typeof PickerDay,
+            day: RenderCount,
           }}
         />,
       );
 
-      const renderCountBeforeChange = RenderCount.mock.calls.length;
+      const renderCountBeforeChange = renderCount.mock.calls.length;
       await user.click(screen.getByRole('gridcell', { name: '2' }));
       // 2 render (one to update tabIndex + autoFocus, one to update selection) * 2 days * 2 (because dev mode)
-      expect(RenderCount.mock.calls.length - renderCountBeforeChange).to.equal(8);
+      expect(renderCount.mock.calls.length - renderCountBeforeChange).to.equal(8);
     });
   });
 });

--- a/packages/x-date-pickers/src/DateCalendar/tests/DateCalendar.test.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/tests/DateCalendar.test.tsx
@@ -5,14 +5,13 @@ import { PickerDay } from '@mui/x-date-pickers/PickerDay';
 import type { PickerDayProps } from '@mui/x-date-pickers/PickerDay';
 import { createPickerRenderer, adapterToUse } from 'test/utils/pickers';
 import { isJSDOM } from 'test/utils/skipIf';
-import { spy } from 'sinon';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 describe('<DateCalendar />', () => {
   const { render } = createPickerRenderer();
 
   it('switches between views uncontrolled', async () => {
-    const handleViewChange = spy();
+    const handleViewChange = vi.fn();
     const { user } = render(
       <DateCalendar
         defaultValue={adapterToUse.date('2019-01-01')}
@@ -22,14 +21,14 @@ describe('<DateCalendar />', () => {
 
     await user.click(screen.getByLabelText(/switch to year view/i));
 
-    expect(handleViewChange.callCount).to.equal(1);
+    expect(handleViewChange.mock.calls.length).to.equal(1);
     expect(screen.queryByLabelText(/switch to year view/i)).to.equal(null);
     expect(screen.getByLabelText('year view is open, switch to calendar view')).toBeVisible();
   });
 
   it('should allow month and view changing, but not selection when readOnly prop is passed', async () => {
-    const onChangeMock = spy();
-    const onMonthChangeMock = spy();
+    const onChangeMock = vi.fn();
+    const onMonthChangeMock = vi.fn();
     const { user } = render(
       <DateCalendar
         value={adapterToUse.date('2019-01-01')}
@@ -40,23 +39,23 @@ describe('<DateCalendar />', () => {
     );
 
     await user.click(screen.getByTitle('Previous month'));
-    expect(onMonthChangeMock.callCount).to.equal(1);
+    expect(onMonthChangeMock.mock.calls.length).to.equal(1);
 
     await user.click(screen.getByTitle('Next month'));
-    expect(onMonthChangeMock.callCount).to.equal(2);
+    expect(onMonthChangeMock.mock.calls.length).to.equal(2);
 
     await waitFor(() => expect(screen.getAllByRole('rowgroup').length).to.equal(1));
 
     await user.click(screen.getByRole('gridcell', { name: '5' }));
-    expect(onChangeMock.callCount).to.equal(0);
+    expect(onChangeMock.mock.calls.length).to.equal(0);
 
     await user.click(screen.getByText('January 2019'));
     expect(screen.queryByLabelText('year view is open, switch to calendar view')).toBeVisible();
   });
 
   it('should not allow interaction when disabled prop is passed', async () => {
-    const onChangeMock = spy();
-    const onMonthChangeMock = spy();
+    const onChangeMock = vi.fn();
+    const onMonthChangeMock = vi.fn();
     const { user } = render(
       <DateCalendar
         value={adapterToUse.date('2019-01-01')}
@@ -71,18 +70,18 @@ describe('<DateCalendar />', () => {
     expect(screen.queryByLabelText('year view is open, switch to calendar view')).to.equal(null);
 
     await user.setup({ pointerEventsCheck: 0 }).click(screen.getByTitle('Previous month'));
-    expect(onMonthChangeMock.callCount).to.equal(0);
+    expect(onMonthChangeMock.mock.calls.length).to.equal(0);
 
     await user.setup({ pointerEventsCheck: 0 }).click(screen.getByTitle('Next month'));
-    expect(onMonthChangeMock.callCount).to.equal(0);
+    expect(onMonthChangeMock.mock.calls.length).to.equal(0);
 
     await user.setup({ pointerEventsCheck: 0 }).click(screen.getByRole('gridcell', { name: '5' }));
-    expect(onChangeMock.callCount).to.equal(0);
+    expect(onChangeMock.mock.calls.length).to.equal(0);
   });
 
   it('should display disabled days when disabled prop is passed', () => {
-    const onChangeMock = spy();
-    const onMonthChangeMock = spy();
+    const onChangeMock = vi.fn();
+    const onMonthChangeMock = vi.fn();
     render(
       <DateCalendar
         value={adapterToUse.date('2019-01-01')}
@@ -225,7 +224,7 @@ describe('<DateCalendar />', () => {
 
     // test: https://github.com/mui/mui-x/issues/12373
     it('should not reset day to `startOfDay` if value already exists when finding the closest enabled date', async () => {
-      const onChange = spy();
+      const onChange = vi.fn();
       const defaultDate = adapterToUse.date('2019-01-02T11:12:13.550Z');
       const { user } = render(
         <DateCalendar onChange={onChange} disablePast defaultValue={defaultDate} />,
@@ -245,7 +244,7 @@ describe('<DateCalendar />', () => {
       // select the current year with a date in the past to trigger "findClosestEnabledDate"
       await user.click(screen.getByRole('radio', { name: '2019' }));
 
-      expect(onChange.lastCall.firstArg).toEqualDateTime(defaultDate);
+      expect(onChange.mock.lastCall?.[0]).toEqualDateTime(defaultDate);
     });
   });
 
@@ -277,7 +276,7 @@ describe('<DateCalendar />', () => {
     });
 
     it('should use `referenceDate` when no value defined', async () => {
-      const onChange = spy();
+      const onChange = vi.fn();
 
       const { user } = render(
         <DateCalendar
@@ -291,12 +290,12 @@ describe('<DateCalendar />', () => {
       expect(screen.getByRole('gridcell', { name: '17' })).to.have.attribute('tabindex', '0');
 
       await user.click(screen.getByRole('gridcell', { name: '2' }));
-      expect(onChange.callCount).to.equal(1);
-      expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2022, 3, 2, 12, 30));
+      expect(onChange.mock.calls.length).to.equal(1);
+      expect(onChange.mock.lastCall?.[0]).toEqualDateTime(new Date(2022, 3, 2, 12, 30));
     });
 
     it('should not use `referenceDate` when a value is defined', async () => {
-      const onChange = spy();
+      const onChange = vi.fn();
 
       const { user } = render(
         <DateCalendar
@@ -308,12 +307,12 @@ describe('<DateCalendar />', () => {
       );
 
       await user.click(screen.getByRole('gridcell', { name: '2' }));
-      expect(onChange.callCount).to.equal(1);
-      expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2019, 0, 2, 12, 20));
+      expect(onChange.mock.calls.length).to.equal(1);
+      expect(onChange.mock.lastCall?.[0]).toEqualDateTime(new Date(2019, 0, 2, 12, 20));
     });
 
     it('should not use `referenceDate` when a defaultValue is defined', async () => {
-      const onChange = spy();
+      const onChange = vi.fn();
 
       const { user } = render(
         <DateCalendar
@@ -325,12 +324,12 @@ describe('<DateCalendar />', () => {
       );
 
       await user.click(screen.getByRole('gridcell', { name: '2' }));
-      expect(onChange.callCount).to.equal(1);
-      expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2019, 0, 2, 12, 20));
+      expect(onChange.mock.calls.length).to.equal(1);
+      expect(onChange.mock.lastCall?.[0]).toEqualDateTime(new Date(2019, 0, 2, 12, 20));
     });
 
     it('should keep the time of the currently provided date', async () => {
-      const onChange = spy();
+      const onChange = vi.fn();
 
       const { user } = render(
         <DateCalendar
@@ -341,8 +340,8 @@ describe('<DateCalendar />', () => {
       );
 
       await user.click(screen.getByRole('gridcell', { name: '2' }));
-      expect(onChange.callCount).to.equal(1);
-      expect(onChange.lastCall.firstArg).toEqualDateTime(
+      expect(onChange.mock.calls.length).to.equal(1);
+      expect(onChange.mock.lastCall?.[0]).toEqualDateTime(
         adapterToUse.date('2018-01-02T11:11:11.111'),
       );
     });
@@ -449,7 +448,7 @@ describe('<DateCalendar />', () => {
 
   describe('view: month', () => {
     it('should select the closest enabled date in the month if the current date is disabled', async () => {
-      const onChange = spy();
+      const onChange = vi.fn();
 
       const { user } = render(
         <DateCalendar
@@ -466,12 +465,12 @@ describe('<DateCalendar />', () => {
       const april = screen.getByText('Apr', { selector: 'button' });
       await user.click(april);
 
-      expect(onChange.callCount).to.equal(1);
-      expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2019, 3, 6));
+      expect(onChange.mock.calls.length).to.equal(1);
+      expect(onChange.mock.lastCall?.[0]).toEqualDateTime(new Date(2019, 3, 6));
     });
 
     it('should respect minDate when selecting closest enabled date', async () => {
-      const onChange = spy();
+      const onChange = vi.fn();
 
       const { user } = render(
         <DateCalendar
@@ -486,12 +485,12 @@ describe('<DateCalendar />', () => {
       const april = screen.getByText('Apr', { selector: 'button' });
       await user.click(april);
 
-      expect(onChange.callCount).to.equal(1);
-      expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2019, 3, 7));
+      expect(onChange.mock.calls.length).to.equal(1);
+      expect(onChange.mock.lastCall?.[0]).toEqualDateTime(new Date(2019, 3, 7));
     });
 
     it('should respect maxDate when selecting closest enabled date', async () => {
-      const onChange = spy();
+      const onChange = vi.fn();
 
       const { user } = render(
         <DateCalendar
@@ -506,12 +505,12 @@ describe('<DateCalendar />', () => {
       const april = screen.getByText('Apr', { selector: 'button' });
       await user.click(april);
 
-      expect(onChange.callCount).to.equal(1);
-      expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2019, 3, 22));
+      expect(onChange.mock.calls.length).to.equal(1);
+      expect(onChange.mock.lastCall?.[0]).toEqualDateTime(new Date(2019, 3, 22));
     });
 
     it('should go to next view without changing the date when no date of the new month is enabled', async () => {
-      const onChange = spy();
+      const onChange = vi.fn();
 
       const { user } = render(
         <DateCalendar
@@ -526,12 +525,12 @@ describe('<DateCalendar />', () => {
       const april = screen.getByText('Apr', { selector: 'button' });
       await user.click(april);
 
-      expect(onChange.callCount).to.equal(0);
+      expect(onChange.mock.calls.length).to.equal(0);
       expect(screen.getByTestId('calendar-month-and-year-text')).to.have.text('April 2019');
     });
 
     it('should use `referenceDate` when no value defined', async () => {
-      const onChange = spy();
+      const onChange = vi.fn();
 
       const { user } = render(
         <DateCalendar
@@ -545,12 +544,12 @@ describe('<DateCalendar />', () => {
       const april = screen.getByText('Apr', { selector: 'button' });
       await user.click(april);
 
-      expect(onChange.callCount).to.equal(1);
-      expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2018, 3, 1, 12, 30));
+      expect(onChange.mock.calls.length).to.equal(1);
+      expect(onChange.mock.lastCall?.[0]).toEqualDateTime(new Date(2018, 3, 1, 12, 30));
     });
 
     it('should not use `referenceDate` when a value is defined', async () => {
-      const onChange = spy();
+      const onChange = vi.fn();
 
       const { user } = render(
         <DateCalendar
@@ -565,12 +564,12 @@ describe('<DateCalendar />', () => {
       const april = screen.getByText('Apr', { selector: 'button' });
       await user.click(april);
 
-      expect(onChange.callCount).to.equal(1);
-      expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2019, 3, 1, 12, 20));
+      expect(onChange.mock.calls.length).to.equal(1);
+      expect(onChange.mock.lastCall?.[0]).toEqualDateTime(new Date(2019, 3, 1, 12, 20));
     });
 
     it('should not use `referenceDate` when a defaultValue is defined', async () => {
-      const onChange = spy();
+      const onChange = vi.fn();
 
       const { user } = render(
         <DateCalendar
@@ -585,8 +584,8 @@ describe('<DateCalendar />', () => {
       const april = screen.getByText('Apr', { selector: 'button' });
       await user.click(april);
 
-      expect(onChange.callCount).to.equal(1);
-      expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2019, 3, 1, 12, 20));
+      expect(onChange.mock.calls.length).to.equal(1);
+      expect(onChange.mock.lastCall?.[0]).toEqualDateTime(new Date(2019, 3, 1, 12, 20));
     });
   });
 
@@ -598,7 +597,7 @@ describe('<DateCalendar />', () => {
     });
 
     it('should select the closest enabled date in the month if the current date is disabled', async () => {
-      const onChange = spy();
+      const onChange = vi.fn();
 
       const { user } = render(
         <DateCalendar
@@ -615,12 +614,12 @@ describe('<DateCalendar />', () => {
       const year2022 = screen.getByText('2022', { selector: 'button' });
       await user.click(year2022);
 
-      expect(onChange.callCount).to.equal(1);
-      expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2022, 4, 1));
+      expect(onChange.mock.calls.length).to.equal(1);
+      expect(onChange.mock.lastCall?.[0]).toEqualDateTime(new Date(2022, 4, 1));
     });
 
     it('should respect minDate when selecting closest enabled date', async () => {
-      const onChange = spy();
+      const onChange = vi.fn();
 
       const { user } = render(
         <DateCalendar
@@ -635,12 +634,12 @@ describe('<DateCalendar />', () => {
       const year2017 = screen.getByText('2017', { selector: 'button' });
       await user.click(year2017);
 
-      expect(onChange.callCount).to.equal(1);
-      expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2017, 4, 12));
+      expect(onChange.mock.calls.length).to.equal(1);
+      expect(onChange.mock.lastCall?.[0]).toEqualDateTime(new Date(2017, 4, 12));
     });
 
     it('should respect maxDate when selecting closest enabled date', async () => {
-      const onChange = spy();
+      const onChange = vi.fn();
 
       const { user } = render(
         <DateCalendar
@@ -655,12 +654,12 @@ describe('<DateCalendar />', () => {
       const year2022 = screen.getByText('2022', { selector: 'button' });
       await user.click(year2022);
 
-      expect(onChange.callCount).to.equal(1);
-      expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2022, 2, 31));
+      expect(onChange.mock.calls.length).to.equal(1);
+      expect(onChange.mock.lastCall?.[0]).toEqualDateTime(new Date(2022, 2, 31));
     });
 
     it('should go to next view without changing the date when no date of the new year is enabled', async () => {
-      const onChange = spy();
+      const onChange = vi.fn();
 
       const { user } = render(
         <DateCalendar
@@ -675,7 +674,7 @@ describe('<DateCalendar />', () => {
       const year2022 = screen.getByText('2022', { selector: 'button' });
       await user.click(year2022);
 
-      expect(onChange.callCount).to.equal(0);
+      expect(onChange.mock.calls.length).to.equal(0);
       expect(screen.getByTestId('calendar-month-and-year-text')).to.have.text('January 2022');
     });
 
@@ -703,7 +702,7 @@ describe('<DateCalendar />', () => {
     });
 
     it('should use `referenceDate` when no value defined', async () => {
-      const onChange = spy();
+      const onChange = vi.fn();
 
       const { user } = render(
         <DateCalendar
@@ -717,12 +716,12 @@ describe('<DateCalendar />', () => {
       const year2022 = screen.getByText('2022', { selector: 'button' });
       await user.click(year2022);
 
-      expect(onChange.callCount).to.equal(1);
-      expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2022, 0, 1, 12, 30));
+      expect(onChange.mock.calls.length).to.equal(1);
+      expect(onChange.mock.lastCall?.[0]).toEqualDateTime(new Date(2022, 0, 1, 12, 30));
     });
 
     it('should not use `referenceDate` when a value is defined', async () => {
-      const onChange = spy();
+      const onChange = vi.fn();
 
       const { user } = render(
         <DateCalendar
@@ -737,12 +736,12 @@ describe('<DateCalendar />', () => {
       const year2022 = screen.getByText('2022', { selector: 'button' });
       await user.click(year2022);
 
-      expect(onChange.callCount).to.equal(1);
-      expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2022, 0, 1, 12, 20));
+      expect(onChange.mock.calls.length).to.equal(1);
+      expect(onChange.mock.lastCall?.[0]).toEqualDateTime(new Date(2022, 0, 1, 12, 20));
     });
 
     it('should not use `referenceDate` when a defaultValue is defined', async () => {
-      const onChange = spy();
+      const onChange = vi.fn();
 
       const { user } = render(
         <DateCalendar
@@ -757,46 +756,46 @@ describe('<DateCalendar />', () => {
       const year2022 = screen.getByText('2022', { selector: 'button' });
       await user.click(year2022);
 
-      expect(onChange.callCount).to.equal(1);
-      expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2022, 0, 1, 12, 20));
+      expect(onChange.mock.calls.length).to.equal(1);
+      expect(onChange.mock.lastCall?.[0]).toEqualDateTime(new Date(2022, 0, 1, 12, 20));
     });
   });
 
   describe('Performance', () => {
     it('should only render newly selected day when selecting a day without a previously selected day', async () => {
-      const RenderCount = spy((props) => <PickerDay {...props} />);
+      const RenderCount = vi.fn((props: PickerDayProps) => <PickerDay {...props} />);
 
       const { user } = render(
         <DateCalendar
           referenceDate={adapterToUse.date('2019-01-02')}
           slots={{
-            day: React.memo(RenderCount),
+            day: React.memo(RenderCount) as typeof PickerDay,
           }}
         />,
       );
 
-      const renderCountBeforeChange = RenderCount.callCount;
+      const renderCountBeforeChange = RenderCount.mock.calls.length;
       await user.click(screen.getByRole('gridcell', { name: '2' }));
       // 2 render (one to update tabIndex + autoFocus, one to update selection) * 2 (because dev mode)
-      expect(RenderCount.callCount - renderCountBeforeChange).to.equal(4);
+      expect(RenderCount.mock.calls.length - renderCountBeforeChange).to.equal(4);
     });
 
     it('should only re-render previously selected day and newly selected day when selecting a day', async () => {
-      const RenderCount = spy((props) => <PickerDay {...props} />);
+      const RenderCount = vi.fn((props: PickerDayProps) => <PickerDay {...props} />);
 
       const { user } = render(
         <DateCalendar
           defaultValue={adapterToUse.date('2019-04-29')}
           slots={{
-            day: React.memo(RenderCount),
+            day: React.memo(RenderCount) as typeof PickerDay,
           }}
         />,
       );
 
-      const renderCountBeforeChange = RenderCount.callCount;
+      const renderCountBeforeChange = RenderCount.mock.calls.length;
       await user.click(screen.getByRole('gridcell', { name: '2' }));
       // 2 render (one to update tabIndex + autoFocus, one to update selection) * 2 days * 2 (because dev mode)
-      expect(RenderCount.callCount - renderCountBeforeChange).to.equal(8);
+      expect(RenderCount.mock.calls.length - renderCountBeforeChange).to.equal(8);
     });
   });
 });

--- a/packages/x-date-pickers/src/DesktopDatePicker/tests/DesktopDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/tests/DesktopDatePicker.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { spy } from 'sinon';
 import type { TransitionProps } from '@mui/material/transitions';
 import { inputBaseClasses } from '@mui/material/InputBase';
 import { act, screen, waitFor } from '@mui/internal-test-utils';
@@ -19,7 +18,7 @@ describe('<DesktopDatePicker />', () => {
 
   describe('Views', () => {
     it('should switch between views uncontrolled', async () => {
-      const handleViewChange = spy();
+      const handleViewChange = vi.fn();
       const { user } = render(
         <DesktopDatePicker
           open
@@ -31,13 +30,13 @@ describe('<DesktopDatePicker />', () => {
 
       // Parent element is used to avoid the ripple effect triggering act warnings.
       await user.click(screen.getByLabelText(/switch to year view/i).parentElement!);
-      expect(handleViewChange.callCount).to.equal(1);
+      expect(handleViewChange.mock.calls.length).to.equal(1);
       expect(screen.queryByLabelText(/switch to year view/i)).to.equal(null);
       expect(screen.getByLabelText('year view is open, switch to calendar view')).toBeVisible();
     });
 
     it('should go to the first view when re-opening the picker', async () => {
-      const handleViewChange = spy();
+      const handleViewChange = vi.fn();
       const { user } = render(
         <DesktopDatePicker
           defaultValue={adapterToUse.date('2018-01-01')}
@@ -49,18 +48,18 @@ describe('<DesktopDatePicker />', () => {
       await openPicker(user, { type: 'date' });
 
       await user.click(screen.getByLabelText(/switch to year view/i));
-      expect(handleViewChange.callCount).to.equal(1);
+      expect(handleViewChange.mock.calls.length).to.equal(1);
 
       // Dismiss the picker
       await user.keyboard('[Escape]');
 
       await openPicker(user, { type: 'date' });
-      expect(handleViewChange.callCount).to.equal(2);
-      expect(handleViewChange.lastCall.firstArg).to.equal('day');
+      expect(handleViewChange.mock.calls.length).to.equal(2);
+      expect(handleViewChange.mock.lastCall?.[0]).to.equal('day');
     });
 
     it('should go to the `openTo` view when re-opening the picker', async () => {
-      const handleViewChange = spy();
+      const handleViewChange = vi.fn();
       const { user } = render(
         <DesktopDatePicker
           defaultValue={adapterToUse.date('2018-01-01')}
@@ -74,14 +73,14 @@ describe('<DesktopDatePicker />', () => {
       await openPicker(user, { type: 'date' });
 
       await user.click(screen.getByLabelText(/switch to year view/i));
-      expect(handleViewChange.callCount).to.equal(1);
+      expect(handleViewChange.mock.calls.length).to.equal(1);
 
       // Dismiss the picker
       await user.keyboard('[Escape]');
 
       await openPicker(user, { type: 'date' });
-      expect(handleViewChange.callCount).to.equal(2);
-      expect(handleViewChange.lastCall.firstArg).to.equal('month');
+      expect(handleViewChange.mock.calls.length).to.equal(2);
+      expect(handleViewChange.mock.lastCall?.[0]).to.equal('month');
     });
 
     it('should go to the relevant `view` when `views` prop changes', async () => {
@@ -185,8 +184,8 @@ describe('<DesktopDatePicker />', () => {
     });
 
     it('does not scroll when opened', () => {
-      const handleClose = spy();
-      const handleOpen = spy();
+      const handleClose = vi.fn();
+      const handleOpen = vi.fn();
       function BottomAnchoredDesktopTimePicker() {
         const [anchorEl, anchorElRef] = React.useState<HTMLElement | null>(null);
 
@@ -223,28 +222,28 @@ describe('<DesktopDatePicker />', () => {
         screen.getByLabelText(/choose date/i).click();
       });
 
-      expect(handleClose.callCount).to.equal(0);
-      expect(handleOpen.callCount).to.equal(1);
+      expect(handleClose.mock.calls.length).to.equal(0);
+      expect(handleOpen.mock.calls.length).to.equal(1);
       expect(window.scrollY, 'focus caused scroll').to.equal(scrollYBeforeOpen);
     });
   });
 
   describe('picker state', () => {
     it('should open when clicking "Choose date"', async () => {
-      const onOpen = spy();
+      const onOpen = vi.fn();
 
       const { user } = render(<DesktopDatePicker onOpen={onOpen} />);
 
       await user.click(screen.getByLabelText(/Choose date/));
 
-      expect(onOpen.callCount).to.equal(1);
+      expect(onOpen.mock.calls.length).to.equal(1);
       expect(screen.queryByRole('dialog')).toBeVisible();
     });
 
     it('should call onAccept when selecting the same date after changing the year', async () => {
-      const onChange = spy();
-      const onAccept = spy();
-      const onClose = spy();
+      const onChange = vi.fn();
+      const onAccept = vi.fn();
+      const onClose = vi.fn();
 
       const { user } = render(
         <DesktopDatePicker
@@ -260,17 +259,17 @@ describe('<DesktopDatePicker />', () => {
 
       // Select year
       await user.click(screen.getByRole('radio', { name: '2025' }));
-      expect(onChange.callCount).to.equal(1);
-      expect(onChange.lastCall.args[0]).toEqualDateTime(new Date(2025, 0, 1));
-      expect(onAccept.callCount).to.equal(0);
-      expect(onClose.callCount).to.equal(0);
+      expect(onChange.mock.calls.length).to.equal(1);
+      expect(onChange.mock.lastCall?.[0]).toEqualDateTime(new Date(2025, 0, 1));
+      expect(onAccept.mock.calls.length).to.equal(0);
+      expect(onClose.mock.calls.length).to.equal(0);
 
       // Change the date (same value)
       await user.click(screen.getByRole('gridcell', { name: '1' }));
-      expect(onChange.callCount).to.equal(1); // Don't call onChange again since the value did not change
-      expect(onAccept.callCount).to.equal(1);
-      expect(onAccept.lastCall.args[0]).toEqualDateTime(new Date(2025, 0, 1));
-      expect(onClose.callCount).to.equal(1);
+      expect(onChange.mock.calls.length).to.equal(1); // Don't call onChange again since the value did not change
+      expect(onAccept.mock.calls.length).to.equal(1);
+      expect(onAccept.mock.lastCall?.[0]).toEqualDateTime(new Date(2025, 0, 1));
+      expect(onClose.mock.calls.length).to.equal(1);
     });
 
     // Ensures the case in https://github.com/mui/mui-x/issues/18491 works correctly
@@ -292,9 +291,9 @@ describe('<DesktopDatePicker />', () => {
         );
       }
 
-      const onChange = spy();
-      const onAccept = spy();
-      const onClose = spy();
+      const onChange = vi.fn();
+      const onAccept = vi.fn();
+      const onClose = vi.fn();
 
       const { user } = render(
         <TestCase onChange={onChange} onAccept={onAccept} onClose={onClose} />,
@@ -304,18 +303,18 @@ describe('<DesktopDatePicker />', () => {
 
       // Change the day
       await user.click(screen.getByRole('gridcell', { name: '2' }));
-      expect(onChange.callCount).to.equal(1);
-      expect(onAccept.callCount).to.equal(1);
-      expect(onAccept.lastCall.args[0]).toEqualDateTime(new Date(2018, 0, 2));
-      expect(onClose.callCount).to.equal(1);
+      expect(onChange.mock.calls.length).to.equal(1);
+      expect(onAccept.mock.calls.length).to.equal(1);
+      expect(onAccept.mock.lastCall?.[0]).toEqualDateTime(new Date(2018, 0, 2));
+      expect(onClose.mock.calls.length).to.equal(1);
       await openPicker(user, { type: 'date' });
 
       // Change to the initial day
       await user.click(screen.getByRole('gridcell', { name: '1' }));
-      expect(onChange.callCount).to.equal(2);
-      expect(onAccept.callCount).to.equal(2);
-      expect(onAccept.lastCall.args[0]).toEqualDateTime(new Date(2018, 0, 1));
-      expect(onClose.callCount).to.equal(2);
+      expect(onChange.mock.calls.length).to.equal(2);
+      expect(onAccept.mock.calls.length).to.equal(2);
+      expect(onAccept.mock.lastCall?.[0]).toEqualDateTime(new Date(2018, 0, 1));
+      expect(onClose.mock.calls.length).to.equal(2);
     });
   });
 
@@ -481,37 +480,41 @@ describe('<DesktopDatePicker />', () => {
 
   describe('performance', () => {
     it('should not re-render the `PickersActionBar` on date change', async () => {
-      const RenderCount = spy((props) => <PickersActionBar {...props} />);
+      const RenderCount = vi.fn((props: React.ComponentProps<typeof PickersActionBar>) => (
+        <PickersActionBar {...props} />
+      ));
 
       const { user } = render(
         <DesktopDatePicker
-          slots={{ actionBar: React.memo(RenderCount) }}
+          slots={{ actionBar: React.memo(RenderCount) as unknown as typeof PickersActionBar }}
           closeOnSelect={false}
           open
         />,
       );
 
-      const renderCountBeforeChange = RenderCount.callCount;
+      const renderCountBeforeChange = RenderCount.mock.calls.length;
       await user.click(screen.getByRole('gridcell', { name: '2' }));
       await user.click(screen.getByRole('gridcell', { name: '3' }));
-      expect(RenderCount.callCount - renderCountBeforeChange).to.equal(0); // no re-renders after selecting new values
+      expect(RenderCount.mock.calls.length - renderCountBeforeChange).to.equal(0); // no re-renders after selecting new values
     });
 
     it('should not re-render the `PickersActionBar` on date change with custom callback actions with root component updates', async () => {
-      const RenderCount = spy((props) => <PickersActionBar {...props} />);
+      const RenderCount = vi.fn((props: React.ComponentProps<typeof PickersActionBar>) => (
+        <PickersActionBar {...props} />
+      ));
       const actions: PickersActionBarAction[] = ['clear', 'today'];
 
       const { setProps, user } = render(
         <DesktopDatePicker
           defaultValue={adapterToUse.date('2018-01-01')}
-          slots={{ actionBar: React.memo(RenderCount) }}
+          slots={{ actionBar: React.memo(RenderCount) as unknown as typeof PickersActionBar }}
           slotProps={{ actionBar: () => ({ actions }) }}
           closeOnSelect={false}
           open
         />,
       );
 
-      const renderCountBeforeChange = RenderCount.callCount;
+      const renderCountBeforeChange = RenderCount.mock.calls.length;
 
       await act(async () => {
         setProps({ defaultValue: adapterToUse.date('2018-01-04') });
@@ -519,7 +522,7 @@ describe('<DesktopDatePicker />', () => {
 
       await user.click(screen.getByRole('gridcell', { name: '2' }));
       await user.click(screen.getByRole('gridcell', { name: '3' }));
-      expect(RenderCount.callCount - renderCountBeforeChange).to.equal(0); // no re-renders after selecting new values and causing a root component re-render
+      expect(RenderCount.mock.calls.length - renderCountBeforeChange).to.equal(0); // no re-renders after selecting new values and causing a root component re-render
     });
   });
 

--- a/packages/x-date-pickers/src/DesktopDatePicker/tests/DesktopDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/tests/DesktopDatePicker.test.tsx
@@ -6,7 +6,10 @@ import type { DesktopDatePickerProps } from '@mui/x-date-pickers/DesktopDatePick
 import { DesktopDatePicker } from '@mui/x-date-pickers/DesktopDatePicker';
 import { createPickerRenderer, adapterToUse, openPicker } from 'test/utils/pickers';
 import { isJSDOM } from 'test/utils/skipIf';
-import type { PickersActionBarAction } from '@mui/x-date-pickers/PickersActionBar';
+import type {
+  PickersActionBarAction,
+  PickersActionBarProps,
+} from '@mui/x-date-pickers/PickersActionBar';
 import { PickersActionBar } from '@mui/x-date-pickers/PickersActionBar';
 import type { PickerValidDate } from '@mui/x-date-pickers/models';
 import type { InputAdornmentProps } from '@mui/material/InputAdornment';
@@ -481,7 +484,7 @@ describe('<DesktopDatePicker />', () => {
   describe('performance', () => {
     it('should not re-render the `PickersActionBar` on date change', async () => {
       const renderCount = vi.fn();
-      const RenderCount = React.memo((props: React.ComponentProps<typeof PickersActionBar>) => {
+      const RenderCount = React.memo((props: PickersActionBarProps) => {
         renderCount();
         return <PickersActionBar {...props} />;
       });
@@ -498,7 +501,7 @@ describe('<DesktopDatePicker />', () => {
 
     it('should not re-render the `PickersActionBar` on date change with custom callback actions with root component updates', async () => {
       const renderCount = vi.fn();
-      const RenderCount = React.memo((props: React.ComponentProps<typeof PickersActionBar>) => {
+      const RenderCount = React.memo((props: PickersActionBarProps) => {
         renderCount();
         return <PickersActionBar {...props} />;
       });

--- a/packages/x-date-pickers/src/DesktopDatePicker/tests/DesktopDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/tests/DesktopDatePicker.test.tsx
@@ -480,41 +480,41 @@ describe('<DesktopDatePicker />', () => {
 
   describe('performance', () => {
     it('should not re-render the `PickersActionBar` on date change', async () => {
-      const RenderCount = vi.fn((props: React.ComponentProps<typeof PickersActionBar>) => (
-        <PickersActionBar {...props} />
-      ));
+      const renderCount = vi.fn();
+      const RenderCount = React.memo((props: React.ComponentProps<typeof PickersActionBar>) => {
+        renderCount();
+        return <PickersActionBar {...props} />;
+      });
 
       const { user } = render(
-        <DesktopDatePicker
-          slots={{ actionBar: React.memo(RenderCount) as unknown as typeof PickersActionBar }}
-          closeOnSelect={false}
-          open
-        />,
+        <DesktopDatePicker slots={{ actionBar: RenderCount }} closeOnSelect={false} open />,
       );
 
-      const renderCountBeforeChange = RenderCount.mock.calls.length;
+      const renderCountBeforeChange = renderCount.mock.calls.length;
       await user.click(screen.getByRole('gridcell', { name: '2' }));
       await user.click(screen.getByRole('gridcell', { name: '3' }));
-      expect(RenderCount.mock.calls.length - renderCountBeforeChange).to.equal(0); // no re-renders after selecting new values
+      expect(renderCount.mock.calls.length - renderCountBeforeChange).to.equal(0); // no re-renders after selecting new values
     });
 
     it('should not re-render the `PickersActionBar` on date change with custom callback actions with root component updates', async () => {
-      const RenderCount = vi.fn((props: React.ComponentProps<typeof PickersActionBar>) => (
-        <PickersActionBar {...props} />
-      ));
+      const renderCount = vi.fn();
+      const RenderCount = React.memo((props: React.ComponentProps<typeof PickersActionBar>) => {
+        renderCount();
+        return <PickersActionBar {...props} />;
+      });
       const actions: PickersActionBarAction[] = ['clear', 'today'];
 
       const { setProps, user } = render(
         <DesktopDatePicker
           defaultValue={adapterToUse.date('2018-01-01')}
-          slots={{ actionBar: React.memo(RenderCount) as unknown as typeof PickersActionBar }}
+          slots={{ actionBar: RenderCount }}
           slotProps={{ actionBar: () => ({ actions }) }}
           closeOnSelect={false}
           open
         />,
       );
 
-      const renderCountBeforeChange = RenderCount.mock.calls.length;
+      const renderCountBeforeChange = renderCount.mock.calls.length;
 
       await act(async () => {
         setProps({ defaultValue: adapterToUse.date('2018-01-04') });
@@ -522,7 +522,7 @@ describe('<DesktopDatePicker />', () => {
 
       await user.click(screen.getByRole('gridcell', { name: '2' }));
       await user.click(screen.getByRole('gridcell', { name: '3' }));
-      expect(RenderCount.mock.calls.length - renderCountBeforeChange).to.equal(0); // no re-renders after selecting new values and causing a root component re-render
+      expect(renderCount.mock.calls.length - renderCountBeforeChange).to.equal(0); // no re-renders after selecting new values and causing a root component re-render
     });
   });
 

--- a/packages/x-scheduler-internals/src/internals/utils/SchedulerStore/tests/editing.SchedulerStore.test.ts
+++ b/packages/x-scheduler-internals/src/internals/utils/SchedulerStore/tests/editing.SchedulerStore.test.ts
@@ -1,4 +1,3 @@
-import { spy } from 'sinon';
 import {
   adapter,
   EventBuilder,
@@ -9,7 +8,7 @@ import {
 import type { SchedulerEvent } from '@mui/x-scheduler-internals/models';
 import { EventCalendarStore } from '@mui/x-scheduler-internals/use-event-calendar';
 import { EventCalendarPremiumStore } from '@mui/x-scheduler-internals-premium/use-event-calendar-premium';
-import { describe, it, expect } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 import { schedulerOtherSelectors } from '../../../../scheduler-selectors';
 import { processDate } from '../../../../process-date';
 import { getOccurrenceKey, getRecurringOccurrenceKey } from '../../event-utils';
@@ -199,18 +198,18 @@ storeClasses.forEach((storeClass) => {
       }
 
       it('should not re-run `onEventEditingStart` when the occurrence is already open in the surface', () => {
-        const onEventEditingStart = spy();
+        const onEventEditingStart = vi.fn();
         const store = new storeClass.Value({ ...DEFAULT_PARAMS, onEventEditingStart }, adapter);
         const occurrence = buildOccurrence();
 
         expect(store.startEditing(occurrence)).to.equal(true);
         expect(store.startEditing(occurrence)).to.equal(true);
 
-        expect(onEventEditingStart.calledOnce).to.equal(true);
+        expect(onEventEditingStart.mock.calls.length).to.equal(1);
       });
 
       it('should run `onEventEditingStart` again when the previous start was canceled', () => {
-        const onEventEditingStart = spy((_occurrence: any, eventDetails: any) =>
+        const onEventEditingStart = vi.fn((_occurrence: any, eventDetails: any) =>
           eventDetails.cancel(),
         );
         const store = new storeClass.Value({ ...DEFAULT_PARAMS, onEventEditingStart }, adapter);
@@ -219,19 +218,19 @@ storeClasses.forEach((storeClass) => {
         expect(store.startEditing(occurrence)).to.equal(false);
         expect(store.startEditing(occurrence)).to.equal(false);
 
-        expect(onEventEditingStart.callCount).to.equal(2);
+        expect(onEventEditingStart.mock.calls.length).to.equal(2);
       });
 
       it('should run `onEventEditingStart` when the armed occurrence opens the surface', () => {
-        const onEventEditingStart = spy();
+        const onEventEditingStart = vi.fn();
         const store = new storeClass.Value({ ...DEFAULT_PARAMS, onEventEditingStart }, adapter);
         const occurrence = buildOccurrence();
 
         store.startEditing(occurrence, 'armed');
-        expect(onEventEditingStart.callCount).to.equal(0);
+        expect(onEventEditingStart.mock.calls.length).to.equal(0);
 
         store.setEditingMode('edit');
-        expect(onEventEditingStart.calledOnce).to.equal(true);
+        expect(onEventEditingStart.mock.calls.length).to.equal(1);
       });
     });
 
@@ -248,30 +247,30 @@ storeClasses.forEach((storeClass) => {
       }
 
       it('should expose the trigger as `anchor` when no dedicated anchor is provided', () => {
-        const onEventEditingStart = spy();
+        const onEventEditingStart = vi.fn();
         const store = new storeClass.Value({ ...DEFAULT_PARAMS, onEventEditingStart }, adapter);
         const trigger = document.createElement('button');
 
         store.startEditing(buildOccurrence(), 'edit', undefined, trigger);
 
-        expect(onEventEditingStart.lastCall.args[1].trigger).to.equal(trigger);
-        expect(onEventEditingStart.lastCall.args[1].anchor).to.equal(trigger);
+        expect(onEventEditingStart.mock.lastCall?.[1].trigger).to.equal(trigger);
+        expect(onEventEditingStart.mock.lastCall?.[1].anchor).to.equal(trigger);
       });
 
       it('should expose the dedicated anchor without replacing the trigger', () => {
-        const onEventEditingStart = spy();
+        const onEventEditingStart = vi.fn();
         const store = new storeClass.Value({ ...DEFAULT_PARAMS, onEventEditingStart }, adapter);
         const trigger = document.createElement('button');
         const anchor = document.createElement('div');
 
         store.startEditing(buildOccurrence(), 'edit', undefined, trigger, anchor);
 
-        expect(onEventEditingStart.lastCall.args[1].trigger).to.equal(trigger);
-        expect(onEventEditingStart.lastCall.args[1].anchor).to.equal(anchor);
+        expect(onEventEditingStart.mock.lastCall?.[1].trigger).to.equal(trigger);
+        expect(onEventEditingStart.mock.lastCall?.[1].anchor).to.equal(anchor);
       });
 
       it('should forward the dedicated anchor when the armed occurrence opens the surface', () => {
-        const onEventEditingStart = spy();
+        const onEventEditingStart = vi.fn();
         const store = new storeClass.Value({ ...DEFAULT_PARAMS, onEventEditingStart }, adapter);
         const trigger = document.createElement('button');
         const anchor = document.createElement('div');
@@ -279,8 +278,8 @@ storeClasses.forEach((storeClass) => {
         store.startEditing(buildOccurrence(), 'armed');
         store.setEditingMode('edit', undefined, trigger, anchor);
 
-        expect(onEventEditingStart.lastCall.args[1].trigger).to.equal(trigger);
-        expect(onEventEditingStart.lastCall.args[1].anchor).to.equal(anchor);
+        expect(onEventEditingStart.mock.lastCall?.[1].trigger).to.equal(trigger);
+        expect(onEventEditingStart.mock.lastCall?.[1].anchor).to.equal(anchor);
       });
     });
   });

--- a/packages/x-scheduler-internals/src/internals/utils/SchedulerStore/tests/event.SchedulerStore.test.ts
+++ b/packages/x-scheduler-internals/src/internals/utils/SchedulerStore/tests/event.SchedulerStore.test.ts
@@ -1,4 +1,3 @@
-import { spy } from 'sinon';
 import {
   adapter,
   adapterFr,
@@ -11,7 +10,7 @@ import type {
   SchedulerEventModelStructure,
 } from '@mui/x-scheduler-internals/models';
 import { processDate } from '@mui/x-scheduler-internals/process-date';
-import { describe, it, expect } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 import { schedulerEventSelectors } from '../../../../scheduler-selectors';
 
 const TEST_RESOURCES = [ResourceBuilder.new().build()];
@@ -91,7 +90,7 @@ storeClasses.forEach((storeClass) => {
       });
 
       it('should use the provided event model structure to write event properties', () => {
-        const onEventsChange = spy();
+        const onEventsChange = vi.fn();
 
         const events: MyEvent[] = [
           {
@@ -116,8 +115,8 @@ storeClasses.forEach((storeClass) => {
         });
 
         // Should call onEventsChange with the updated event using the custom model structure
-        expect(onEventsChange.calledOnce).to.equal(true);
-        expect(onEventsChange.lastCall.firstArg).to.deep.equal([
+        expect(onEventsChange.mock.calls.length).to.equal(1);
+        expect(onEventsChange.mock.lastCall?.[0]).to.deep.equal([
           {
             myId: '1',
             myTitle: 'Event 1 updated',
@@ -129,7 +128,7 @@ storeClasses.forEach((storeClass) => {
       });
 
       it('should use the provided event model structure to create an event', () => {
-        const onEventsChange = spy();
+        const onEventsChange = vi.fn();
 
         const events: MyEvent[] = [];
 
@@ -145,8 +144,8 @@ storeClasses.forEach((storeClass) => {
         });
 
         // Should call onEventsChange with the created event using the custom model structure
-        expect(onEventsChange.calledOnce).to.equal(true);
-        expect(onEventsChange.lastCall.firstArg).to.deep.equal([
+        expect(onEventsChange.mock.calls.length).to.equal(1);
+        expect(onEventsChange.mock.lastCall?.[0]).to.deep.equal([
           {
             myId: createdId,
             myTitle: 'Event 1',
@@ -158,7 +157,7 @@ storeClasses.forEach((storeClass) => {
       });
 
       it('should carry custom fields without resurrecting stale mapped keys on a duplicate', () => {
-        const onEventsChange = spy();
+        const onEventsChange = vi.fn();
         const events: MyEvent[] = [
           {
             myId: '1',
@@ -179,7 +178,7 @@ storeClasses.forEach((storeClass) => {
         const end = adapter.date('2025-07-01T12:00:00.000Z', 'default');
         const duplicatedId = store.duplicateEventOccurrence('1', start, end);
 
-        const duplicated = onEventsChange.lastCall.firstArg.find(
+        const duplicated = onEventsChange.mock.lastCall?.[0].find(
           (event) => event.myId === duplicatedId,
         );
         // The mapped start comes from the setter, not the stale key carried by the custom-data merge.
@@ -195,7 +194,7 @@ storeClasses.forEach((storeClass) => {
           end: string;
         }
 
-        const idGetter = spy((event: MyEvent2) => event.myId);
+        const idGetter = vi.fn((event: MyEvent2) => event.myId);
 
         const eventModelStructure2: SchedulerEventModelStructure<MyEvent2> = {
           id: {
@@ -227,7 +226,7 @@ storeClasses.forEach((storeClass) => {
         );
 
         // Called to convert Event 1 on mount.
-        expect(idGetter.callCount).to.equal(1);
+        expect(idGetter.mock.calls.length).to.equal(1);
         const processedEvent1 = schedulerEventSelectors.processedEvent(store.state, '1');
         const initialEventIdList = store.state.eventIdList;
         const initialEventModelLookup = store.state.eventModelLookup;
@@ -244,7 +243,7 @@ storeClasses.forEach((storeClass) => {
         );
 
         // Not called again when updating a non-related parameter.
-        expect(idGetter.callCount).to.equal(1);
+        expect(idGetter.mock.calls.length).to.equal(1);
 
         store.updateStateFromParameters(
           {
@@ -256,7 +255,7 @@ storeClasses.forEach((storeClass) => {
           adapter,
         );
 
-        expect(idGetter.callCount).to.equal(1);
+        expect(idGetter.mock.calls.length).to.equal(1);
         expect(store.state.eventIdList).to.equal(initialEventIdList);
         expect(store.state.eventModelLookup).to.equal(initialEventModelLookup);
         expect(store.state.processedEventLookup).to.equal(initialProcessedEventLookup);
@@ -282,7 +281,7 @@ storeClasses.forEach((storeClass) => {
         );
 
         // Only the new model is processed.
-        expect(idGetter.callCount).to.equal(2);
+        expect(idGetter.mock.calls.length).to.equal(2);
         expect(schedulerEventSelectors.processedEvent(store.state, '1')).to.equal(processedEvent1);
         const processedEvent2 = schedulerEventSelectors.processedEvent(store.state, '2');
 
@@ -297,7 +296,7 @@ storeClasses.forEach((storeClass) => {
           adapter,
         );
 
-        expect(idGetter.callCount).to.equal(3);
+        expect(idGetter.mock.calls.length).to.equal(3);
         expect(schedulerEventSelectors.processedEvent(store.state, '1')).to.equal(processedEvent1);
         expect(schedulerEventSelectors.processedEvent(store.state, '2')).not.to.equal(
           processedEvent2,
@@ -316,7 +315,7 @@ storeClasses.forEach((storeClass) => {
         );
 
         // The display timezone affects every processed event.
-        expect(idGetter.callCount).to.equal(5);
+        expect(idGetter.mock.calls.length).to.equal(5);
         expect(schedulerEventSelectors.processedEvent(store.state, '1')).not.to.equal(
           processedEvent1,
         );
@@ -336,7 +335,7 @@ storeClasses.forEach((storeClass) => {
           adapterFr,
         );
 
-        expect(idGetter.callCount).to.equal(7);
+        expect(idGetter.mock.calls.length).to.equal(7);
         expect(schedulerEventSelectors.processedEvent(store.state, '2')).not.to.equal(
           event2BeforeAdapterChange,
         );
@@ -354,7 +353,7 @@ storeClasses.forEach((storeClass) => {
         );
 
         // Called again to convert Event 1 and Event 2 because props.eventModelStructure changed.
-        expect(idGetter.callCount).to.equal(9);
+        expect(idGetter.mock.calls.length).to.equal(9);
 
         const processedEventsBeforeReorder = store.state.processedEventLookup;
         store.updateStateFromParameters(
@@ -368,7 +367,7 @@ storeClasses.forEach((storeClass) => {
           adapterFr,
         );
 
-        expect(idGetter.callCount).to.equal(9);
+        expect(idGetter.mock.calls.length).to.equal(9);
         expect(store.state.eventIdList).to.deep.equal(['2', '1']);
         expect(store.state.processedEventLookup.get('1')).to.equal(
           processedEventsBeforeReorder.get('1'),
@@ -430,7 +429,7 @@ storeClasses.forEach((storeClass) => {
 
     describe('Method: updateEvent', () => {
       it('should replace matching id and emit onEventsChange with the updated events', () => {
-        const onEventsChange = spy();
+        const onEventsChange = vi.fn();
         const event1 = EventBuilder.new().build();
         const event2 = EventBuilder.new().build();
 
@@ -448,8 +447,8 @@ storeClasses.forEach((storeClass) => {
           end: adapter.date('2025-07-01T12:30:00Z', 'default'),
         });
 
-        expect(onEventsChange.calledOnce).to.equal(true);
-        const updatedEvents = onEventsChange.lastCall.firstArg;
+        expect(onEventsChange.mock.calls.length).to.equal(1);
+        const updatedEvents = onEventsChange.mock.lastCall?.[0];
 
         expect(updatedEvents).to.have.length(2);
         expect(updatedEvents[0].title).to.equal(event1.title);
@@ -460,7 +459,7 @@ storeClasses.forEach((storeClass) => {
       });
 
       it('should update start/end as instants, preserve unrelated properties, and keep event.timezone', () => {
-        const onEventsChange = spy();
+        const onEventsChange = vi.fn();
 
         const dataTimezone = 'America/New_York';
         const displayTimezone = 'Europe/Paris';
@@ -488,7 +487,7 @@ storeClasses.forEach((storeClass) => {
           end: newEnd,
         });
 
-        const updated = onEventsChange.lastCall.firstArg[0];
+        const updated = onEventsChange.mock.lastCall?.[0][0];
 
         expect(updated.title).to.equal('Updated title');
         expect(updated.description).to.equal(event.description);
@@ -501,7 +500,7 @@ storeClasses.forEach((storeClass) => {
       });
 
       it('should preserve unknown custom properties on the event model', () => {
-        const onEventsChange = spy();
+        const onEventsChange = vi.fn();
         const event = {
           ...EventBuilder.new().title('Original title').build(),
           priority: 'high',
@@ -514,7 +513,7 @@ storeClasses.forEach((storeClass) => {
 
         store.updateEvent({ id: event.id, title: 'Updated title' });
 
-        const updated = onEventsChange.lastCall.firstArg[0];
+        const updated = onEventsChange.mock.lastCall?.[0][0];
         expect(updated.title).to.equal('Updated title');
         expect(updated.priority).to.equal('high');
       });
@@ -560,7 +559,7 @@ storeClasses.forEach((storeClass) => {
 
     describe('Method: deleteEvent', () => {
       it('should remove by id and call onEventsChange with the updated events', () => {
-        const onEventsChange = spy();
+        const onEventsChange = vi.fn();
         const event1 = EventBuilder.new().build();
         const event2 = EventBuilder.new().build();
         const event3 = EventBuilder.new().build();
@@ -575,15 +574,15 @@ storeClasses.forEach((storeClass) => {
         );
         store.deleteEvent(event2.id);
 
-        expect(onEventsChange.calledOnce).to.equal(true);
-        const updatedEvents = onEventsChange.lastCall.firstArg;
+        expect(onEventsChange.mock.calls.length).to.equal(1);
+        const updatedEvents = onEventsChange.mock.lastCall?.[0];
         expect(updatedEvents).to.deep.equal([event1, event3]);
       });
     });
 
     describe('Method: createEvent', () => {
       it('should append the new event and emit onEventsChange with the updated list', () => {
-        const onEventsChange = spy();
+        const onEventsChange = vi.fn();
         const event1 = EventBuilder.new().build();
 
         const store = new storeClass.Value(
@@ -595,15 +594,15 @@ storeClasses.forEach((storeClass) => {
 
         const createdId = store.createEvent(newEvent);
 
-        expect(onEventsChange.calledOnce).to.equal(true);
-        expect(onEventsChange.lastCall.firstArg).to.deep.equal([
+        expect(onEventsChange.mock.calls.length).to.equal(1);
+        expect(onEventsChange.mock.lastCall?.[0]).to.deep.equal([
           event1,
           { ...newEvent, id: createdId },
         ]);
       });
 
       it('should not inject timezone into the created event model', () => {
-        const onEventsChange = spy();
+        const onEventsChange = vi.fn();
 
         const store = new storeClass.Value(
           {
@@ -618,14 +617,14 @@ storeClasses.forEach((storeClass) => {
         const newEvent = EventBuilder.new().toCreationProperties();
         const createdId = store.createEvent(newEvent);
 
-        expect(onEventsChange.calledOnce).to.equal(true);
-        expect(onEventsChange.lastCall.firstArg).to.deep.equal([{ ...newEvent, id: createdId }]);
+        expect(onEventsChange.mock.calls.length).to.equal(1);
+        expect(onEventsChange.mock.lastCall?.[0]).to.deep.equal([{ ...newEvent, id: createdId }]);
       });
     });
 
     describe('Method: duplicateEventOccurrence', () => {
       it('should duplicate the event occurrence and emit onEventsChange with the updated list', () => {
-        const onEventsChange = spy();
+        const onEventsChange = vi.fn();
         const event = EventBuilder.new().build();
 
         const store = new storeClass.Value(
@@ -637,8 +636,8 @@ storeClasses.forEach((storeClass) => {
         const end = adapter.date('2025-07-01T10:00:00Z', 'default');
         const duplicatedId = store.duplicateEventOccurrence(event.id, start, end);
 
-        expect(onEventsChange.calledOnce).to.equal(true);
-        expect(onEventsChange.lastCall.firstArg).to.deep.equal([
+        expect(onEventsChange.mock.calls.length).to.equal(1);
+        expect(onEventsChange.mock.lastCall?.[0]).to.deep.equal([
           event,
           {
             ...event,
@@ -653,7 +652,7 @@ storeClasses.forEach((storeClass) => {
       it.skipIf(storeClass.name === 'EventCalendarStore')(
         'should remove rrule and exDates from the original event',
         () => {
-          const onEventsChange = spy();
+          const onEventsChange = vi.fn();
           const event = EventBuilder.new().recurrent('DAILY').exDates(['2025-07-14Z']).build();
 
           const store = new storeClass.Value(
@@ -669,8 +668,8 @@ storeClasses.forEach((storeClass) => {
           delete originalEventWithoutRecurrence.rrule;
           delete originalEventWithoutRecurrence.exDates;
 
-          expect(onEventsChange.calledOnce).to.equal(true);
-          expect(onEventsChange.lastCall.firstArg).to.deep.equal([
+          expect(onEventsChange.mock.calls.length).to.equal(1);
+          expect(onEventsChange.mock.lastCall?.[0]).to.deep.equal([
             event,
             {
               ...originalEventWithoutRecurrence,
@@ -684,7 +683,7 @@ storeClasses.forEach((storeClass) => {
       );
 
       it('should carry unknown custom properties onto the duplicated event', () => {
-        const onEventsChange = spy();
+        const onEventsChange = vi.fn();
         const event = {
           ...EventBuilder.new().build(),
           priority: 'high',
@@ -699,7 +698,7 @@ storeClasses.forEach((storeClass) => {
         const end = adapter.date('2025-07-01T10:00:00Z', 'default');
         const duplicatedId = store.duplicateEventOccurrence(event.id, start, end);
 
-        const duplicated = onEventsChange.lastCall.firstArg.find(
+        const duplicated = onEventsChange.mock.lastCall?.[0].find(
           (event) => event.id === duplicatedId,
         );
         expect(duplicated.priority).to.equal('high');
@@ -742,7 +741,7 @@ storeClasses.forEach((storeClass) => {
       });
 
       it('should paste a copied event and emit onEventsChange with the updated list (only changes start date)', () => {
-        const onEventsChange = spy();
+        const onEventsChange = vi.fn();
         const event = EventBuilder.new().build();
 
         const store = new storeClass.Value(
@@ -755,8 +754,8 @@ storeClasses.forEach((storeClass) => {
           start: adapter.date('2025-07-01T09:00:00Z', 'default'),
         });
 
-        expect(onEventsChange.calledOnce).to.equal(true);
-        expect(onEventsChange.lastCall.firstArg).to.deep.equal([
+        expect(onEventsChange.mock.calls.length).to.equal(1);
+        expect(onEventsChange.mock.lastCall?.[0]).to.deep.equal([
           event,
           {
             ...event,
@@ -769,7 +768,7 @@ storeClasses.forEach((storeClass) => {
       });
 
       it('should carry unknown custom properties onto the pasted event (copy)', () => {
-        const onEventsChange = spy();
+        const onEventsChange = vi.fn();
         const event = {
           ...EventBuilder.new().build(),
           priority: 'high',
@@ -785,14 +784,14 @@ storeClasses.forEach((storeClass) => {
           start: adapter.date('2025-07-01T09:00:00Z', 'default'),
         });
 
-        const pasted = onEventsChange.lastCall.firstArg.find(
+        const pasted = onEventsChange.mock.lastCall?.[0].find(
           (event) => event.id === createdEventId,
         );
         expect(pasted.priority).to.equal('high');
       });
 
       it('should paste a copied event and emit onEventsChange with the updated list (only changes resource)', () => {
-        const onEventsChange = spy();
+        const onEventsChange = vi.fn();
         const resource1 = ResourceBuilder.new().build();
         const resource2 = ResourceBuilder.new().build();
         const event = EventBuilder.new().resource(resource1).build();
@@ -807,8 +806,8 @@ storeClasses.forEach((storeClass) => {
           resource: resource2.id,
         });
 
-        expect(onEventsChange.calledOnce).to.equal(true);
-        expect(onEventsChange.lastCall.firstArg).to.deep.equal([
+        expect(onEventsChange.mock.calls.length).to.equal(1);
+        expect(onEventsChange.mock.lastCall?.[0]).to.deep.equal([
           event,
           {
             ...event,
@@ -820,7 +819,7 @@ storeClasses.forEach((storeClass) => {
       });
 
       it('should paste a copied event and emit onEventsChange with the updated list (only changes allDay)', () => {
-        const onEventsChange = spy();
+        const onEventsChange = vi.fn();
         const event = EventBuilder.new().build();
 
         const store = new storeClass.Value(
@@ -833,8 +832,8 @@ storeClasses.forEach((storeClass) => {
           allDay: true,
         });
 
-        expect(onEventsChange.calledOnce).to.equal(true);
-        expect(onEventsChange.lastCall.firstArg).to.deep.equal([
+        expect(onEventsChange.mock.calls.length).to.equal(1);
+        expect(onEventsChange.mock.lastCall?.[0]).to.deep.equal([
           event,
           {
             ...event,
@@ -846,7 +845,7 @@ storeClasses.forEach((storeClass) => {
       });
 
       it('should paste a cut event and emit onEventsChange with the updated list (only changes start date)', () => {
-        const onEventsChange = spy();
+        const onEventsChange = vi.fn();
         const event = EventBuilder.new().build();
 
         const store = new storeClass.Value(
@@ -859,8 +858,8 @@ storeClasses.forEach((storeClass) => {
           start: adapter.date('2025-07-01T09:00:00Z', 'default'),
         });
 
-        expect(onEventsChange.calledOnce).to.equal(true);
-        expect(onEventsChange.lastCall.firstArg).to.deep.equal([
+        expect(onEventsChange.mock.calls.length).to.equal(1);
+        expect(onEventsChange.mock.lastCall?.[0]).to.deep.equal([
           {
             ...event,
             id: createdEventId,
@@ -871,7 +870,7 @@ storeClasses.forEach((storeClass) => {
       });
 
       it('should paste a cut event and emit onEventsChange with the updated list (only changes resource)', () => {
-        const onEventsChange = spy();
+        const onEventsChange = vi.fn();
         const resource1 = ResourceBuilder.new().build();
         const resource2 = ResourceBuilder.new().build();
         const event = EventBuilder.new().resource(resource1).build();
@@ -886,8 +885,8 @@ storeClasses.forEach((storeClass) => {
           resource: resource2.id,
         });
 
-        expect(onEventsChange.calledOnce).to.equal(true);
-        expect(onEventsChange.lastCall.firstArg).to.deep.equal([
+        expect(onEventsChange.mock.calls.length).to.equal(1);
+        expect(onEventsChange.mock.lastCall?.[0]).to.deep.equal([
           {
             ...event,
             id: createdEventId,
@@ -897,7 +896,7 @@ storeClasses.forEach((storeClass) => {
       });
 
       it('should paste a cut event and emit onEventsChange with the updated list (only changes allDay)', () => {
-        const onEventsChange = spy();
+        const onEventsChange = vi.fn();
         const event = EventBuilder.new().build();
 
         const store = new storeClass.Value(
@@ -910,8 +909,8 @@ storeClasses.forEach((storeClass) => {
           allDay: true,
         });
 
-        expect(onEventsChange.calledOnce).to.equal(true);
-        expect(onEventsChange.lastCall.firstArg).to.deep.equal([
+        expect(onEventsChange.mock.calls.length).to.equal(1);
+        expect(onEventsChange.mock.lastCall?.[0]).to.deep.equal([
           {
             ...event,
             id: createdEventId,
@@ -921,7 +920,7 @@ storeClasses.forEach((storeClass) => {
       });
 
       it('should clear the clipboard after pasting a cut event so a second paste is a no-op', () => {
-        const onEventsChange = spy();
+        const onEventsChange = vi.fn();
         const event = EventBuilder.new().build();
 
         const store = new storeClass.Value(
@@ -933,18 +932,18 @@ storeClasses.forEach((storeClass) => {
         store.pasteEvent({ start: adapter.date('2025-07-01T09:00:00Z', 'default') });
 
         expect(store.state.copiedEvent).to.equal(null);
-        expect(onEventsChange.calledOnce).to.equal(true);
+        expect(onEventsChange.mock.calls.length).to.equal(1);
 
         const result = store.pasteEvent({
           start: adapter.date('2025-07-02T09:00:00Z', 'default'),
         });
 
         expect(result).to.equal(null);
-        expect(onEventsChange.calledOnce).to.equal(true);
+        expect(onEventsChange.mock.calls.length).to.equal(1);
       });
 
       it('should keep the clipboard after pasting a copied event so it can be pasted again', () => {
-        const onEventsChange = spy();
+        const onEventsChange = vi.fn();
         const event = EventBuilder.new().build();
 
         const store = new storeClass.Value(
@@ -964,7 +963,7 @@ storeClasses.forEach((storeClass) => {
         expect(firstPastedId).not.to.equal(null);
         expect(secondPastedId).not.to.equal(null);
         expect(firstPastedId).not.to.equal(secondPastedId);
-        expect(onEventsChange.calledTwice).to.equal(true);
+        expect(onEventsChange.mock.calls.length).to.equal(2);
       });
     });
 

--- a/packages/x-scheduler-internals/src/internals/utils/SchedulerStore/tests/resource.SchedulerStore.test.ts
+++ b/packages/x-scheduler-internals/src/internals/utils/SchedulerStore/tests/resource.SchedulerStore.test.ts
@@ -1,10 +1,9 @@
-import { spy } from 'sinon';
 import type {
   SchedulerResourceId,
   SchedulerResourceModelStructure,
 } from '@mui/x-scheduler-internals/models';
 import { adapter, ResourceBuilder, storeClasses } from 'test/utils/scheduler';
-import { describe, it, expect } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 import { schedulerResourceSelectors } from '../../../../scheduler-selectors';
 
 const DEFAULT_PARAMS = { events: [], resources: [ResourceBuilder.new().build()] };
@@ -52,7 +51,7 @@ storeClasses.forEach((storeClass) => {
           title: string;
         }
 
-        const idGetter = spy((event: MyResource2) => event.myId);
+        const idGetter = vi.fn((event: MyResource2) => event.myId);
 
         const resourceModelStructure2: SchedulerResourceModelStructure<MyResource2> = {
           id: {
@@ -78,7 +77,7 @@ storeClasses.forEach((storeClass) => {
         );
 
         // Called to convert Resource 1 on mount.
-        expect(idGetter.callCount).to.equal(1);
+        expect(idGetter.mock.calls.length).to.equal(1);
 
         store.updateStateFromParameters(
           {
@@ -91,7 +90,7 @@ storeClasses.forEach((storeClass) => {
         );
 
         // Not called again when updating a non-related parameter.
-        expect(idGetter.callCount).to.equal(1);
+        expect(idGetter.mock.calls.length).to.equal(1);
 
         const resources2: MyResource2[] = [
           {
@@ -115,7 +114,7 @@ storeClasses.forEach((storeClass) => {
         );
 
         // Called again to convert Resource 1 and Resource 2 because props.events changed.
-        expect(idGetter.callCount).to.equal(3);
+        expect(idGetter.mock.calls.length).to.equal(3);
 
         store.updateStateFromParameters(
           {
@@ -128,7 +127,7 @@ storeClasses.forEach((storeClass) => {
         );
 
         // Called again to convert Resource 1 and Resource 2 because props.resourceModelStructure changed.
-        expect(idGetter.callCount).to.equal(5);
+        expect(idGetter.mock.calls.length).to.equal(5);
       });
     });
 
@@ -186,7 +185,7 @@ storeClasses.forEach((storeClass) => {
 
     describe('Method: setVisibleResources', () => {
       it('should update visibleResources and call onVisibleResourcesChange when is uncontrolled', () => {
-        const onVisibleResourcesChange = spy();
+        const onVisibleResourcesChange = vi.fn();
         const store = new storeClass.Value(
           { ...DEFAULT_PARAMS, onVisibleResourcesChange },
           adapter,
@@ -196,12 +195,12 @@ storeClasses.forEach((storeClass) => {
         store.setVisibleResources(newVisibleResources, new Event('click'));
 
         expect(store.state.visibleResources).to.equal(newVisibleResources);
-        expect(onVisibleResourcesChange.calledOnce).to.equal(true);
-        expect(onVisibleResourcesChange.lastCall.firstArg).to.equal(newVisibleResources);
+        expect(onVisibleResourcesChange.mock.calls.length).to.equal(1);
+        expect(onVisibleResourcesChange.mock.lastCall?.[0]).to.equal(newVisibleResources);
       });
 
       it('should not change the state but call onVisibleResourcesChange when is controlled', () => {
-        const onVisibleResourcesChange = spy();
+        const onVisibleResourcesChange = vi.fn();
         const controlledVisibleResources: Record<SchedulerResourceId, boolean> = { r1: true };
 
         const store = new storeClass.Value(
@@ -217,12 +216,12 @@ storeClasses.forEach((storeClass) => {
         store.setVisibleResources(newVisibleResources, new Event('click'));
 
         expect(store.state.visibleResources).to.equal(controlledVisibleResources);
-        expect(onVisibleResourcesChange.calledOnce).to.equal(true);
-        expect(onVisibleResourcesChange.lastCall.firstArg).to.equal(newVisibleResources);
+        expect(onVisibleResourcesChange.mock.calls.length).to.equal(1);
+        expect(onVisibleResourcesChange.mock.lastCall?.[0]).to.equal(newVisibleResources);
       });
 
       it('should do nothing if visibleResources is the same reference (no state change, no callback)', () => {
-        const onVisibleResourcesChange = spy();
+        const onVisibleResourcesChange = vi.fn();
         const visibleResources: Record<SchedulerResourceId, boolean> = { r1: false };
 
         const store = new storeClass.Value(
@@ -237,7 +236,7 @@ storeClasses.forEach((storeClass) => {
         store.setVisibleResources(visibleResources, new Event('click'));
 
         expect(store.state.visibleResources).to.equal(visibleResources);
-        expect(onVisibleResourcesChange.called).to.equal(false);
+        expect(onVisibleResourcesChange.mock.calls.length).to.equal(0);
       });
     });
 
@@ -334,7 +333,7 @@ storeClasses.forEach((storeClass) => {
 
     describe('Method: setCollapsedResources', () => {
       it('should update collapsedResources and call onCollapsedResourcesChange when is uncontrolled', () => {
-        const onCollapsedResourcesChange = spy();
+        const onCollapsedResourcesChange = vi.fn();
         const store = new storeClass.Value(
           { ...DEFAULT_PARAMS, onCollapsedResourcesChange },
           adapter,
@@ -344,12 +343,12 @@ storeClasses.forEach((storeClass) => {
         store.setCollapsedResources(newCollapsedResources, new Event('click'));
 
         expect(store.state.collapsedResources).to.equal(newCollapsedResources);
-        expect(onCollapsedResourcesChange.calledOnce).to.equal(true);
-        expect(onCollapsedResourcesChange.lastCall.firstArg).to.equal(newCollapsedResources);
+        expect(onCollapsedResourcesChange.mock.calls.length).to.equal(1);
+        expect(onCollapsedResourcesChange.mock.lastCall?.[0]).to.equal(newCollapsedResources);
       });
 
       it('should not change the state but call onCollapsedResourcesChange when is controlled', () => {
-        const onCollapsedResourcesChange = spy();
+        const onCollapsedResourcesChange = vi.fn();
         const controlledCollapsedResources: Record<SchedulerResourceId, boolean> = { r1: true };
 
         const store = new storeClass.Value(
@@ -365,12 +364,12 @@ storeClasses.forEach((storeClass) => {
         store.setCollapsedResources(newCollapsedResources, new Event('click'));
 
         expect(store.state.collapsedResources).to.equal(controlledCollapsedResources);
-        expect(onCollapsedResourcesChange.calledOnce).to.equal(true);
-        expect(onCollapsedResourcesChange.lastCall.firstArg).to.equal(newCollapsedResources);
+        expect(onCollapsedResourcesChange.mock.calls.length).to.equal(1);
+        expect(onCollapsedResourcesChange.mock.lastCall?.[0]).to.equal(newCollapsedResources);
       });
 
       it('should do nothing if collapsedResources is the same reference (no state change, no callback)', () => {
-        const onCollapsedResourcesChange = spy();
+        const onCollapsedResourcesChange = vi.fn();
         const collapsedResources: Record<SchedulerResourceId, boolean> = { r1: true };
 
         const store = new storeClass.Value(
@@ -385,11 +384,11 @@ storeClasses.forEach((storeClass) => {
         store.setCollapsedResources(collapsedResources, new Event('click'));
 
         expect(store.state.collapsedResources).to.equal(collapsedResources);
-        expect(onCollapsedResourcesChange.called).to.equal(false);
+        expect(onCollapsedResourcesChange.mock.calls.length).to.equal(0);
       });
 
       it('should forward the triggering event through the change event details', () => {
-        const onCollapsedResourcesChange = spy();
+        const onCollapsedResourcesChange = vi.fn();
         const store = new storeClass.Value(
           { ...DEFAULT_PARAMS, onCollapsedResourcesChange },
           adapter,
@@ -398,13 +397,13 @@ storeClasses.forEach((storeClass) => {
         const event = new Event('click');
         store.setCollapsedResources({ r1: true }, event);
 
-        const eventDetails = onCollapsedResourcesChange.lastCall.args[1];
+        const eventDetails = onCollapsedResourcesChange.mock.lastCall?.[1];
         expect(eventDetails.event).to.equal(event);
         expect(eventDetails.reason).to.equal('none');
       });
 
       it('should not update the state when the change event details are canceled', () => {
-        const onCollapsedResourcesChange = spy(
+        const onCollapsedResourcesChange = vi.fn(
           (
             _collapsedResources: Record<SchedulerResourceId, boolean>,
             eventDetails: {
@@ -421,7 +420,7 @@ storeClasses.forEach((storeClass) => {
 
         store.setCollapsedResources({ r1: true }, new Event('click'));
 
-        expect(onCollapsedResourcesChange.calledOnce).to.equal(true);
+        expect(onCollapsedResourcesChange.mock.calls.length).to.equal(1);
         expect(store.state.collapsedResources).to.deep.equal({});
       });
     });
@@ -440,7 +439,7 @@ storeClasses.forEach((storeClass) => {
       });
 
       it('should call onCollapsedResourcesChange when uncontrolled', () => {
-        const onCollapsedResourcesChange = spy();
+        const onCollapsedResourcesChange = vi.fn();
         const store = new storeClass.Value(
           { ...DEFAULT_PARAMS, onCollapsedResourcesChange },
           adapter,
@@ -450,8 +449,8 @@ storeClasses.forEach((storeClass) => {
         store.toggleResourceCollapse(id, undefined);
 
         expect(store.state.collapsedResources).to.deep.equal({ [id]: true });
-        expect(onCollapsedResourcesChange.callCount).to.equal(1);
-        expect(onCollapsedResourcesChange.lastCall.firstArg).to.deep.equal({ [id]: true });
+        expect(onCollapsedResourcesChange.mock.calls.length).to.equal(1);
+        expect(onCollapsedResourcesChange.mock.lastCall?.[0]).to.deep.equal({ [id]: true });
       });
 
       it('should expand a resource collapsed through defaultCollapsedResources', () => {
@@ -467,7 +466,7 @@ storeClasses.forEach((storeClass) => {
       });
 
       it('should call onCollapsedResourcesChange and not mutate state when controlled', () => {
-        const onCollapsedResourcesChange = spy();
+        const onCollapsedResourcesChange = vi.fn();
         const store = new storeClass.Value(
           { ...DEFAULT_PARAMS, collapsedResources: {}, onCollapsedResourcesChange },
           adapter,
@@ -476,8 +475,8 @@ storeClasses.forEach((storeClass) => {
 
         store.toggleResourceCollapse(id, undefined);
 
-        expect(onCollapsedResourcesChange.callCount).to.equal(1);
-        expect(onCollapsedResourcesChange.lastCall.firstArg).to.deep.equal({ [id]: true });
+        expect(onCollapsedResourcesChange.mock.calls.length).to.equal(1);
+        expect(onCollapsedResourcesChange.mock.lastCall?.[0]).to.deep.equal({ [id]: true });
         // Controlled: state is not updated internally.
         expect(store.state.collapsedResources).to.deep.equal({});
       });

--- a/packages/x-scheduler-internals/src/use-event-calendar/tests/core.EventCalendarStore.test.ts
+++ b/packages/x-scheduler-internals/src/use-event-calendar/tests/core.EventCalendarStore.test.ts
@@ -1,8 +1,7 @@
 import { adapter, ResourceBuilder } from 'test/utils/scheduler';
 import { createRenderer } from '@mui/internal-test-utils/createRenderer';
-import { spy } from 'sinon';
 import { EMPTY_OBJECT } from '@base-ui/utils/empty';
-import { describe, it, expect } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 import {
   DEFAULT_PREFERENCES_MENU_CONFIG,
   DEFAULT_VIEW,
@@ -117,58 +116,58 @@ describe('Core - EventCalendarStore', () => {
       });
 
       it('should call `onEventEditingStart` with the occurrence before recording the editing state', () => {
-        const onEventEditingStart = spy();
+        const onEventEditingStart = vi.fn();
         const store = new EventCalendarStore({ ...DEFAULT_PARAMS, onEventEditingStart }, adapter);
         const edited = occurrence('event-1');
 
         store.startEditing(edited);
 
-        expect(onEventEditingStart.calledOnce).to.equal(true);
-        expect(onEventEditingStart.lastCall.firstArg).to.equal(edited);
-        expect(onEventEditingStart.lastCall.args[1].reason).to.equal('edit');
-        expect(onEventEditingStart.lastCall.args[1].occurrence).to.equal(edited);
+        expect(onEventEditingStart.mock.calls.length).to.equal(1);
+        expect(onEventEditingStart.mock.lastCall?.[0]).to.equal(edited);
+        expect(onEventEditingStart.mock.lastCall?.[1].reason).to.equal('edit');
+        expect(onEventEditingStart.mock.lastCall?.[1].occurrence).to.equal(edited);
         expect(store.state.editingOccurrence).to.deep.equal({ occurrence: edited, mode: 'edit' });
       });
 
       it('should not call `onEventEditingStart` when arming, then call it on the armed → edit transition', () => {
-        const onEventEditingStart = spy();
+        const onEventEditingStart = vi.fn();
         const store = new EventCalendarStore({ ...DEFAULT_PARAMS, onEventEditingStart }, adapter);
         const edited = occurrence('event-1');
 
         store.startEditing(edited, 'armed');
-        expect(onEventEditingStart.callCount).to.equal(0);
+        expect(onEventEditingStart.mock.calls.length).to.equal(0);
 
         const nativeEvent = new Event('click');
         store.setEditingMode('edit', nativeEvent);
-        expect(onEventEditingStart.calledOnce).to.equal(true);
-        expect(onEventEditingStart.lastCall.firstArg).to.equal(edited);
-        expect(onEventEditingStart.lastCall.args[1].event).to.equal(nativeEvent);
+        expect(onEventEditingStart.mock.calls.length).to.equal(1);
+        expect(onEventEditingStart.mock.lastCall?.[0]).to.equal(edited);
+        expect(onEventEditingStart.mock.lastCall?.[1].event).to.equal(nativeEvent);
       });
 
       it('should disarm when `onEventEditingStart` cancels the armed → edit transition', () => {
-        const onEventEditingStart = spy((_occurrence, eventDetails) => eventDetails.cancel());
+        const onEventEditingStart = vi.fn((_occurrence, eventDetails) => eventDetails.cancel());
         const store = new EventCalendarStore({ ...DEFAULT_PARAMS, onEventEditingStart }, adapter);
         store.startEditing(occurrence('event-1'), 'armed');
 
         store.setEditingMode('edit');
 
-        expect(onEventEditingStart.calledOnce).to.equal(true);
+        expect(onEventEditingStart.mock.calls.length).to.equal(1);
         // The armed state keeps document-wide guards active, so a canceled edit fully disarms.
         expect(store.state.editingOccurrence).to.equal(null);
       });
 
       it('should not record the editing state when `onEventEditingStart` cancels', () => {
-        const onEventEditingStart = spy((_occurrence, eventDetails) => eventDetails.cancel());
+        const onEventEditingStart = vi.fn((_occurrence, eventDetails) => eventDetails.cancel());
         const store = new EventCalendarStore({ ...DEFAULT_PARAMS, onEventEditingStart }, adapter);
 
         store.startEditing(occurrence('event-1'));
 
-        expect(onEventEditingStart.calledOnce).to.equal(true);
+        expect(onEventEditingStart.mock.calls.length).to.equal(1);
         expect(store.state.editingOccurrence).to.equal(null);
       });
 
       it('should clear the creation placeholder when `onEventEditingStart` cancels a creation', () => {
-        const onEventEditingStart = spy((_occurrence, eventDetails) => eventDetails.cancel());
+        const onEventEditingStart = vi.fn((_occurrence, eventDetails) => eventDetails.cancel());
         const store = new EventCalendarStore({ ...DEFAULT_PARAMS, onEventEditingStart }, adapter);
         const placeholder = {
           type: 'creation',
@@ -180,16 +179,16 @@ describe('Core - EventCalendarStore', () => {
 
         store.startEditing(occurrence('event-1'));
 
-        expect(onEventEditingStart.lastCall.args[1].reason).to.equal('creation');
-        expect(onEventEditingStart.lastCall.args[1].occurrence).to.equal(
-          onEventEditingStart.lastCall.firstArg,
+        expect(onEventEditingStart.mock.lastCall?.[1].reason).to.equal('creation');
+        expect(onEventEditingStart.mock.lastCall?.[1].occurrence).to.equal(
+          onEventEditingStart.mock.lastCall?.[0],
         );
         expect(store.state.editingOccurrence).to.equal(null);
         expect(store.state.occurrencePlaceholder).to.equal(null);
       });
 
       it('should forward the native event that initiated the creation placeholder', () => {
-        const onEventEditingStart = spy();
+        const onEventEditingStart = vi.fn();
         const store = new EventCalendarStore({ ...DEFAULT_PARAMS, onEventEditingStart }, adapter);
         const nativeEvent = new Event('click');
         const placeholder = {
@@ -202,7 +201,7 @@ describe('Core - EventCalendarStore', () => {
 
         store.startEditing(occurrence('event-1'));
 
-        expect(onEventEditingStart.lastCall.args[1].event).to.equal(nativeEvent);
+        expect(onEventEditingStart.mock.lastCall?.[1].event).to.equal(nativeEvent);
       });
     });
 

--- a/packages/x-scheduler-internals/src/use-event-calendar/tests/date.EventCalendarStore.test.ts
+++ b/packages/x-scheduler-internals/src/use-event-calendar/tests/date.EventCalendarStore.test.ts
@@ -1,6 +1,5 @@
-import { spy } from 'sinon';
 import { adapter } from 'test/utils/scheduler';
-import { describe, it, expect } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 import { EventCalendarStore } from '../EventCalendarStore';
 import type { CalendarView } from '../../models';
 
@@ -9,8 +8,8 @@ const DEFAULT_PARAMS = { events: [] };
 describe('Date - EventCalendarStore', () => {
   describe('Method: switchToDay', () => {
     it('should update store and calls both callbacks when both change when is uncontrolled', () => {
-      const onVisibleDateChange = spy();
-      const onViewChange = spy();
+      const onVisibleDateChange = vi.fn();
+      const onViewChange = vi.fn();
 
       const initialDate = adapter.date('2025-08-01T00:00:00Z', 'default');
       const nextDate = adapter.date('2025-08-02T00:00:00Z', 'default');
@@ -31,15 +30,15 @@ describe('Date - EventCalendarStore', () => {
       expect(store.state.view).to.equal('day');
       expect(store.state.visibleDate).toEqualDateTime(nextDate);
 
-      expect(onVisibleDateChange.calledOnce).to.equal(true);
-      expect(onVisibleDateChange.lastCall.firstArg).toEqualDateTime(nextDate);
-      expect(onViewChange.calledOnce).to.equal(true);
-      expect(onViewChange.lastCall.firstArg).to.equal('day');
+      expect(onVisibleDateChange.mock.calls.length).to.equal(1);
+      expect(onVisibleDateChange.mock.lastCall?.[0]).toEqualDateTime(nextDate);
+      expect(onViewChange.mock.calls.length).to.equal(1);
+      expect(onViewChange.mock.lastCall?.[0]).to.equal('day');
     });
 
     it('should NOT mutate store but calls both callbacks when both change when is controlled', () => {
-      const onVisibleDateChange = spy();
-      const onViewChange = spy();
+      const onVisibleDateChange = vi.fn();
+      const onViewChange = vi.fn();
 
       const initialDate = adapter.date('2025-08-01T00:00:00Z', 'default');
       const nextDate = adapter.date('2025-08-02T00:00:00Z', 'default');
@@ -60,15 +59,15 @@ describe('Date - EventCalendarStore', () => {
       expect(store.state.view).to.equal('week');
       expect(store.state.visibleDate).toEqualDateTime(initialDate);
 
-      expect(onVisibleDateChange.calledOnce).to.equal(true);
-      expect(onVisibleDateChange.lastCall.firstArg).toEqualDateTime(nextDate);
-      expect(onViewChange.calledOnce).to.equal(true);
-      expect(onViewChange.lastCall.firstArg).to.equal('day');
+      expect(onVisibleDateChange.mock.calls.length).to.equal(1);
+      expect(onVisibleDateChange.mock.lastCall?.[0]).toEqualDateTime(nextDate);
+      expect(onViewChange.mock.calls.length).to.equal(1);
+      expect(onViewChange.mock.lastCall?.[0]).to.equal('day');
     });
 
     it('should update date in store and calls onVisibleDateChange if only date changes when is uncontrolled', () => {
-      const onVisibleDateChange = spy();
-      const onViewChange = spy();
+      const onVisibleDateChange = vi.fn();
+      const onViewChange = vi.fn();
 
       const currentDate = adapter.date('2025-08-01T00:00:00Z', 'default');
       const nextDate = adapter.date('2025-08-02T00:00:00Z', 'default');
@@ -88,13 +87,13 @@ describe('Date - EventCalendarStore', () => {
 
       expect(store.state.view).to.equal('day');
       expect(store.state.visibleDate).toEqualDateTime(nextDate);
-      expect(onVisibleDateChange.calledOnce).to.equal(true);
-      expect(onViewChange.called).to.equal(false);
+      expect(onVisibleDateChange.mock.calls.length).to.equal(1);
+      expect(onViewChange.mock.calls.length).to.equal(0);
     });
 
     it('should update date and calls only onVisibleDateChange when is partially controlled (view controlled, visibleDate uncontrolled)', () => {
-      const onVisibleDateChange = spy();
-      const onViewChange = spy();
+      const onVisibleDateChange = vi.fn();
+      const onViewChange = vi.fn();
 
       const currentDate = adapter.date('2025-08-01T00:00:00Z', 'default');
       const nextDate = adapter.date('2025-08-02T00:00:00Z', 'default');
@@ -114,13 +113,13 @@ describe('Date - EventCalendarStore', () => {
 
       expect(store.state.view).to.equal('day');
       expect(store.state.visibleDate).toEqualDateTime(nextDate);
-      expect(onVisibleDateChange.calledOnce).to.equal(true);
-      expect(onViewChange.called).to.equal(false);
+      expect(onVisibleDateChange.mock.calls.length).to.equal(1);
+      expect(onViewChange.mock.calls.length).to.equal(0);
     });
 
     it('should update view and calls only onViewChange when is partially controlled (view uncontrolled, visibleDate controlled)', () => {
-      const onVisibleDateChange = spy();
-      const onViewChange = spy();
+      const onVisibleDateChange = vi.fn();
+      const onViewChange = vi.fn();
 
       const currentDate = adapter.date('2025-08-01T00:00:00Z', 'default');
 
@@ -139,14 +138,14 @@ describe('Date - EventCalendarStore', () => {
 
       expect(store.state.view).to.equal('day');
       expect(store.state.visibleDate).toEqualDateTime(currentDate);
-      expect(onVisibleDateChange.calledOnce).to.equal(false);
-      expect(onViewChange.calledOnce).to.equal(true);
-      expect(onViewChange.lastCall.firstArg).to.equal('day');
+      expect(onVisibleDateChange.mock.calls.length).not.to.equal(1);
+      expect(onViewChange.mock.calls.length).to.equal(1);
+      expect(onViewChange.mock.lastCall?.[0]).to.equal('day');
     });
 
     it('should do nothing if nothing changes, does not update store or call callbacks', () => {
-      const onVisibleDateChange = spy();
-      const onViewChange = spy();
+      const onVisibleDateChange = vi.fn();
+      const onViewChange = vi.fn();
 
       const sameDate = adapter.date('2025-08-02T00:00:00Z', 'default');
       const store = new EventCalendarStore(
@@ -164,8 +163,8 @@ describe('Date - EventCalendarStore', () => {
 
       expect(store.state.view).to.equal('day');
       expect(store.state.visibleDate).toEqualDateTime(sameDate);
-      expect(onVisibleDateChange.called).to.equal(false);
-      expect(onViewChange.called).to.equal(false);
+      expect(onVisibleDateChange.mock.calls.length).to.equal(0);
+      expect(onViewChange.mock.calls.length).to.equal(0);
     });
 
     it('should throw if the view is not an allowed view', () => {
@@ -182,9 +181,9 @@ describe('Date - EventCalendarStore', () => {
 
   describe('Method: goToPreviousVisibleDate', () => {
     it('should respect the date returned by setSiblingVisibleDateGetter', () => {
-      const onVisibleDateChange = spy();
+      const onVisibleDateChange = vi.fn();
       const targetDate = adapter.date('2025-07-03T00:00:00Z', 'default');
-      const siblingVisibleDateGetter = spy(() => targetDate);
+      const siblingVisibleDateGetter = vi.fn((_parameters: { delta: 1 | -1 }) => targetDate);
 
       const store = new EventCalendarStore(
         {
@@ -201,16 +200,16 @@ describe('Date - EventCalendarStore', () => {
         visibleDaysSelector: () => [],
       });
       store.goToPreviousVisibleDate({} as any);
-      expect(onVisibleDateChange.lastCall.firstArg).toEqualDateTime(targetDate);
-      expect(siblingVisibleDateGetter.lastCall.firstArg.delta).toEqual(-1);
+      expect(onVisibleDateChange.mock.lastCall?.[0]).toEqualDateTime(targetDate);
+      expect(siblingVisibleDateGetter.mock.lastCall?.[0].delta).toEqual(-1);
     });
   });
 
   describe('Method: goToNextVisibleDate', () => {
     it('should respect the date returned by setSiblingVisibleDateGetter', () => {
-      const onVisibleDateChange = spy();
+      const onVisibleDateChange = vi.fn();
       const targetDate = adapter.date('2025-07-03T00:00:00Z', 'default');
-      const siblingVisibleDateGetter = spy(() => targetDate);
+      const siblingVisibleDateGetter = vi.fn((_parameters: { delta: 1 | -1 }) => targetDate);
 
       const store = new EventCalendarStore(
         {
@@ -227,8 +226,8 @@ describe('Date - EventCalendarStore', () => {
         visibleDaysSelector: () => [],
       });
       store.goToNextVisibleDate({} as any);
-      expect(onVisibleDateChange.lastCall.firstArg).toEqualDateTime(targetDate);
-      expect(siblingVisibleDateGetter.lastCall.firstArg.delta).toEqual(1);
+      expect(onVisibleDateChange.mock.lastCall?.[0]).toEqualDateTime(targetDate);
+      expect(siblingVisibleDateGetter.mock.lastCall?.[0].delta).toEqual(1);
     });
   });
 });

--- a/packages/x-scheduler-internals/src/use-event-calendar/tests/view.EventCalendarStore.test.ts
+++ b/packages/x-scheduler-internals/src/use-event-calendar/tests/view.EventCalendarStore.test.ts
@@ -1,6 +1,5 @@
-import { spy } from 'sinon';
 import { adapter } from 'test/utils/scheduler';
-import { describe, it, expect } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 import { EventCalendarStore } from '../EventCalendarStore';
 import type { EventCalendarState } from '../EventCalendarStore.types';
 
@@ -9,18 +8,18 @@ const DEFAULT_PARAMS = { events: [] };
 describe('View - EventCalendarStore', () => {
   describe('Method: setView', () => {
     it('should update view and call onViewChange when value changes and is uncontrolled', () => {
-      const onViewChange = spy();
+      const onViewChange = vi.fn();
       const store = new EventCalendarStore({ ...DEFAULT_PARAMS, onViewChange }, adapter);
 
       store.setView('day', {} as any);
 
       expect(store.state.view).to.equal('day');
-      expect(onViewChange.calledOnce).to.equal(true);
-      expect(onViewChange.lastCall.firstArg).to.equal('day');
+      expect(onViewChange.mock.calls.length).to.equal(1);
+      expect(onViewChange.mock.lastCall?.[0]).to.equal('day');
     });
 
     it('should NOT mutate store but calls onViewChange when is controlled', () => {
-      const onViewChange = spy();
+      const onViewChange = vi.fn();
       const store = new EventCalendarStore(
         { ...DEFAULT_PARAMS, view: 'week', onViewChange },
         adapter,
@@ -29,12 +28,12 @@ describe('View - EventCalendarStore', () => {
       store.setView('day', {} as any);
 
       expect(store.state.view).to.equal('week');
-      expect(onViewChange.calledOnce).to.equal(true);
-      expect(onViewChange.lastCall.firstArg).to.equal('day');
+      expect(onViewChange.mock.calls.length).to.equal(1);
+      expect(onViewChange.mock.lastCall?.[0]).to.equal('day');
     });
 
     it('should do nothing if setting the same view: no state change, no callback', () => {
-      const onViewChange = spy();
+      const onViewChange = vi.fn();
       const store = new EventCalendarStore(
         { ...DEFAULT_PARAMS, defaultView: 'month', onViewChange },
         adapter,
@@ -43,7 +42,7 @@ describe('View - EventCalendarStore', () => {
       store.setView('month', {} as any);
 
       expect(store.state.view).to.equal('month');
-      expect(onViewChange.called).to.equal(false);
+      expect(onViewChange.mock.calls.length).to.equal(0);
     });
 
     it('should throw when switching to a view not included in the allowed views', () => {
@@ -169,7 +168,7 @@ describe('View - EventCalendarStore', () => {
     it('should set definition and cleanup to null', () => {
       const store = new EventCalendarStore(DEFAULT_PARAMS, adapter);
 
-      const siblingVisibleDateGetter = spy(
+      const siblingVisibleDateGetter = vi.fn(
         ({ state }: { state: EventCalendarState }) => state.visibleDate,
       );
       const cleanup = store.setViewDefinition({

--- a/packages/x-scheduler-premium/src/event-timeline-premium/EventTimelinePremium.test.tsx
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/EventTimelinePremium.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { spy } from 'sinon';
 import { act, screen, waitFor, within } from '@mui/internal-test-utils';
 import {
   EventTimelinePremium,
@@ -23,7 +22,7 @@ import type {
 } from '@mui/x-scheduler-internals/models';
 import type { EventTimelinePremiumPreset } from '@mui/x-scheduler-internals-premium/models';
 import type { EventTimelineLocaleText } from '@mui/x-scheduler/models';
-import { describe, it, expect } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 
 const engineering = ResourceBuilder.new().build();
 const design = ResourceBuilder.new().build();
@@ -228,7 +227,7 @@ describe('<EventTimelinePremium />', () => {
     });
 
     it('should call onCollapsedResourcesChange when the cell is clicked', async () => {
-      const onCollapsedResourcesChange = spy();
+      const onCollapsedResourcesChange = vi.fn();
       const { user } = renderTimeline({
         resources: nestedResources,
         events: [],
@@ -237,8 +236,8 @@ describe('<EventTimelinePremium />', () => {
 
       await user.click(getTitleCell(parent.id)!);
 
-      expect(onCollapsedResourcesChange.callCount).to.equal(1);
-      expect(onCollapsedResourcesChange.lastCall.firstArg).to.deep.equal({ [parent.id]: true });
+      expect(onCollapsedResourcesChange.mock.calls.length).to.equal(1);
+      expect(onCollapsedResourcesChange.mock.lastCall?.[0]).to.deep.equal({ [parent.id]: true });
     });
 
     it('should toggle collapse with the keyboard', async () => {
@@ -256,7 +255,7 @@ describe('<EventTimelinePremium />', () => {
     });
 
     it('should toggle collapse with the Space key and emit the shared collapsed state', async () => {
-      const onCollapsedResourcesChange = spy();
+      const onCollapsedResourcesChange = vi.fn();
       const { user } = renderTimeline({
         resources: nestedResources,
         events: [],
@@ -273,7 +272,7 @@ describe('<EventTimelinePremium />', () => {
         expect(screen.queryByText(child.title)).to.equal(null);
       });
       expect(parentCell.getAttribute('aria-expanded')).to.equal('false');
-      expect(onCollapsedResourcesChange.lastCall.firstArg).to.deep.equal({ [parent.id]: true });
+      expect(onCollapsedResourcesChange.mock.lastCall?.[0]).to.deep.equal({ [parent.id]: true });
     });
 
     it('should move focus to the parent when a controlled collapse removes the focused child row', async () => {
@@ -636,7 +635,7 @@ describe('<EventTimelinePremium />', () => {
   describe('lazy loading', () => {
     it('should call dataSource.getEvents when the timeline mounts', async () => {
       const dataSource = {
-        getEvents: spy(async () => baseEvents),
+        getEvents: vi.fn(async () => baseEvents),
         persistEvents: async () => ({ success: true }),
       };
 
@@ -649,12 +648,12 @@ describe('<EventTimelinePremium />', () => {
         />,
       );
 
-      await waitFor(() => expect(dataSource.getEvents.callCount).to.equal(1));
+      await waitFor(() => expect(dataSource.getEvents.mock.calls.length).to.equal(1));
     });
 
     it('should call dataSource.getEvents again when navigating to a different range', async () => {
       const dataSource = {
-        getEvents: spy(async () => baseEvents),
+        getEvents: vi.fn(async () => baseEvents),
         persistEvents: async () => ({ success: true }),
       };
 
@@ -683,10 +682,12 @@ describe('<EventTimelinePremium />', () => {
         ).to.equal(0);
       });
 
-      const initialCount = dataSource.getEvents.callCount;
+      const initialCount = dataSource.getEvents.mock.calls.length;
       await user.click(screen.getByRole('button', { name: 'Next' }));
 
-      await waitFor(() => expect(dataSource.getEvents.callCount).to.be.greaterThan(initialCount));
+      await waitFor(() =>
+        expect(dataSource.getEvents.mock.calls.length).to.be.greaterThan(initialCount),
+      );
     });
 
     it('should render the skeleton while events are loading and remove it once they resolve', async () => {
@@ -1003,7 +1004,7 @@ describe('<EventTimelinePremium />', () => {
       .build();
 
     it('should be called with the occurrence when activating an event and still open the built-in dialog', async () => {
-      const onEventEditingStart = spy();
+      const onEventEditingStart = vi.fn();
       const { user } = renderTimeline({ events: [standupEvent], onEventEditingStart });
 
       await user.click(screen.getByText('Standup'));
@@ -1011,19 +1012,19 @@ describe('<EventTimelinePremium />', () => {
       await waitFor(() => {
         expect(screen.queryByRole('dialog')).not.to.equal(null);
       });
-      expect(onEventEditingStart.calledOnce).to.equal(true);
-      expect(onEventEditingStart.lastCall.firstArg.id).to.equal(standupEvent.id);
-      expect(onEventEditingStart.lastCall.args[1].reason).to.equal('edit');
-      expect(onEventEditingStart.lastCall.args[1].event.type).to.equal('click');
+      expect(onEventEditingStart.mock.calls.length).to.equal(1);
+      expect(onEventEditingStart.mock.lastCall?.[0].id).to.equal(standupEvent.id);
+      expect(onEventEditingStart.mock.lastCall?.[1].reason).to.equal('edit');
+      expect(onEventEditingStart.mock.lastCall?.[1].event.type).to.equal('click');
     });
 
     it('should keep the built-in dialog closed when the handler cancels', async () => {
-      const onEventEditingStart = spy((_occurrence, eventDetails) => eventDetails.cancel());
+      const onEventEditingStart = vi.fn((_occurrence, eventDetails) => eventDetails.cancel());
       const { user } = renderTimeline({ events: [standupEvent], onEventEditingStart });
 
       await user.click(screen.getByText('Standup'));
 
-      expect(onEventEditingStart.calledOnce).to.equal(true);
+      expect(onEventEditingStart.mock.calls.length).to.equal(1);
       expect(screen.queryByRole('dialog')).to.equal(null);
     });
 
@@ -1033,14 +1034,14 @@ describe('<EventTimelinePremium />', () => {
         .singleDay('2025-07-03T09:00:00Z')
         .resources([engineering, design])
         .build();
-      const onEventEditingStart = spy((_occurrence, eventDetails) => eventDetails.cancel());
+      const onEventEditingStart = vi.fn((_occurrence, eventDetails) => eventDetails.cancel());
       const { user } = renderTimeline({ events: [sharedEvent], onEventEditingStart });
 
       const designRow = document.querySelector(`[data-resource-id="${design.id}"]`) as HTMLElement;
       await user.click(within(designRow).getByText('Shared event'));
 
-      expect(onEventEditingStart.calledOnce).to.equal(true);
-      expect(onEventEditingStart.lastCall.firstArg.id).to.equal(sharedEvent.id);
+      expect(onEventEditingStart.mock.calls.length).to.equal(1);
+      expect(onEventEditingStart.mock.lastCall?.[0].id).to.equal(sharedEvent.id);
       expect(screen.queryByRole('dialog')).to.equal(null);
     });
 
@@ -1051,7 +1052,7 @@ describe('<EventTimelinePremium />', () => {
         .resource(readOnlyResource)
         .title('Locked')
         .build();
-      const onEventEditingStart = spy();
+      const onEventEditingStart = vi.fn();
       const { user } = renderTimeline({
         resources: [readOnlyResource],
         events: [lockedEvent],
@@ -1063,23 +1064,23 @@ describe('<EventTimelinePremium />', () => {
       await waitFor(() => {
         expect(screen.queryByRole('dialog')).not.to.equal(null);
       });
-      expect(onEventEditingStart.lastCall.args[1].reason).to.equal('view');
+      expect(onEventEditingStart.mock.lastCall?.[1].reason).to.equal('view');
     });
 
     it('should expose the persistent row as `anchor` when the handler cancels an event creation', async () => {
-      const onEventEditingStart = spy((_occurrence, eventDetails) => eventDetails.cancel());
+      const onEventEditingStart = vi.fn((_occurrence, eventDetails) => eventDetails.cancel());
       const { user } = renderTimeline({ events: [standupEvent], onEventEditingStart });
 
       const row = document.querySelector(`[data-resource-id="${engineering.id}"]`) as HTMLElement;
       await act(async () => row.focus());
       await user.keyboard('{Enter}');
 
-      expect(onEventEditingStart.calledOnce).to.equal(true);
-      expect(onEventEditingStart.lastCall.args[1].reason).to.equal('creation');
+      expect(onEventEditingStart.mock.calls.length).to.equal(1);
+      expect(onEventEditingStart.mock.lastCall?.[1].reason).to.equal('creation');
       expect(screen.queryByRole('dialog')).to.equal(null);
 
-      expect(onEventEditingStart.lastCall.args[1].trigger.isConnected).to.equal(false);
-      expect(onEventEditingStart.lastCall.args[1].anchor).to.equal(row);
+      expect(onEventEditingStart.mock.lastCall?.[1].trigger.isConnected).to.equal(false);
+      expect(onEventEditingStart.mock.lastCall?.[1].anchor).to.equal(row);
       expect(row.isConnected).to.equal(true);
     });
   });

--- a/packages/x-scheduler/src/compact-day-view/tests/eventToolbar.CompactDayView.test.tsx
+++ b/packages/x-scheduler/src/compact-day-view/tests/eventToolbar.CompactDayView.test.tsx
@@ -1,8 +1,7 @@
-import { spy } from 'sinon';
 import { screen, within, fireEvent } from '@mui/internal-test-utils';
 import { createSchedulerRenderer, EventBuilder } from 'test/utils/scheduler';
 import { StandaloneCompactDayView } from '@mui/x-scheduler/compact-day-view';
-import { describe, it, expect } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 
 /**
  * The compact (touch) layout arms an event on tap, docking an Edit/Delete toolbar at the bottom of
@@ -12,7 +11,7 @@ describe('CompactDayView - event toolbar', () => {
   const { render } = createSchedulerRenderer({ clockConfig: new Date('2025-07-03Z') });
 
   function renderEvent(
-    onEventsChange = spy(),
+    onEventsChange = vi.fn(),
     { readOnly = false, onEventEditingStart = undefined as any } = {},
   ) {
     const event = EventBuilder.new()
@@ -40,28 +39,30 @@ describe('CompactDayView - event toolbar', () => {
   }
 
   it('should keep arming built-in and only fire `onEventEditingStart` when the toolbar Edit is tapped', () => {
-    const onEventEditingStart = spy((_occurrence: any, eventDetails: any) => eventDetails.cancel());
-    renderEvent(spy(), { onEventEditingStart });
+    const onEventEditingStart = vi.fn((_occurrence: any, eventDetails: any) =>
+      eventDetails.cancel(),
+    );
+    renderEvent(vi.fn(), { onEventEditingStart });
 
     // Arming (toolbar + resize affordances) is not the editing surface: no callback yet.
     const eventElement = getEvent();
     fireEvent.click(eventElement);
-    expect(onEventEditingStart.callCount).to.equal(0);
+    expect(onEventEditingStart.mock.calls.length).to.equal(0);
     expect(eventElement).to.have.attribute('data-armed');
 
     // Tapping Edit is what opens the surface. Canceling disarms: the armed state keeps
     // document-wide guards that must not stay active under the consumer's custom UI.
     const editButton = screen.getByRole('button', { name: 'Edit event' });
     fireEvent.click(editButton);
-    expect(onEventEditingStart.calledOnce).to.equal(true);
-    expect(onEventEditingStart.lastCall.args[1].event.type).to.equal('click');
-    expect(onEventEditingStart.lastCall.args[1].trigger).to.equal(editButton);
+    expect(onEventEditingStart.mock.calls.length).to.equal(1);
+    expect(onEventEditingStart.mock.lastCall?.[1].event.type).to.equal('click');
+    expect(onEventEditingStart.mock.lastCall?.[1].trigger).to.equal(editButton);
     expect(screen.queryByRole('textbox', { name: /Event title/i })).to.equal(null);
     expect(eventElement).not.to.have.attribute('data-armed');
     expect(screen.queryByRole('button', { name: 'Edit event' })).to.equal(null);
 
     expect(editButton.isConnected).to.equal(false);
-    expect(onEventEditingStart.lastCall.args[1].anchor).to.equal(eventElement);
+    expect(onEventEditingStart.mock.lastCall?.[1].anchor).to.equal(eventElement);
     expect(eventElement.isConnected).to.equal(true);
   });
 
@@ -106,8 +107,8 @@ describe('CompactDayView - event toolbar', () => {
     fireEvent.click(getEvent());
     fireEvent.click(screen.getByRole('button', { name: 'Delete event' }));
 
-    expect(onEventsChange.callCount).to.equal(1);
-    expect(onEventsChange.firstCall.args[0]).to.have.length(0);
+    expect(onEventsChange.mock.calls.length).to.equal(1);
+    expect(onEventsChange.mock.calls[0][0]).to.have.length(0);
     // The delete and edit flows are independent: deleting must not open the editing drawer.
     expect(screen.queryByRole('textbox', { name: /Event title/i })).to.equal(null);
     expect(screen.queryByRole('button', { name: 'Edit event' })).to.equal(null);
@@ -125,11 +126,11 @@ describe('CompactDayView - event toolbar', () => {
     expect(screen.queryByRole('button', { name: /Morning Meeting/i })).to.equal(null);
     expect(screen.queryByRole('button', { name: 'Edit event' })).to.equal(null);
     expect(screen.queryByRole('button', { name: 'Delete event' })).to.equal(null);
-    expect(onEventsChange.called).to.equal(false);
+    expect(onEventsChange.mock.calls.length).to.equal(0);
   });
 
   it('should not arm a read-only event: it opens the read-only summary directly', () => {
-    renderEvent(spy(), { readOnly: true });
+    renderEvent(vi.fn(), { readOnly: true });
     fireEvent.click(getEvent());
 
     // No action toolbar for a read-only event.

--- a/packages/x-scheduler/src/event-calendar/EventCalendar.test.tsx
+++ b/packages/x-scheduler/src/event-calendar/EventCalendar.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { spy } from 'sinon';
 import { act, screen, waitFor, within } from '@mui/internal-test-utils';
 import { isJSDOM } from 'test/utils/skipIf';
 import {
@@ -13,7 +12,7 @@ import {
 import { EventCalendar, eventCalendarClasses } from '@mui/x-scheduler/event-calendar';
 import { EventCalendarStore } from '@mui/x-scheduler-internals/use-event-calendar';
 import { SchedulerStoreContext } from '@mui/x-scheduler-internals/use-scheduler-store-context';
-import { describe, it, expect } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 import { ErrorContainer } from '../internals/components/error-container';
 import { SharedComponentsStyledContext } from '../internals/components/SharedComponentsStyledContext';
 import {
@@ -445,7 +444,7 @@ describe('EventCalendar', () => {
 
   describe('onEventEditingStart', () => {
     it('should be called with the occurrence when activating an event and still open the built-in dialog', async () => {
-      const onEventEditingStart = spy();
+      const onEventEditingStart = vi.fn();
       const { user } = render(
         <EventCalendar events={[event1]} onEventEditingStart={onEventEditingStart} />,
       );
@@ -456,26 +455,26 @@ describe('EventCalendar', () => {
       await waitFor(() => {
         expect(screen.queryByRole('dialog')).not.to.equal(null);
       });
-      expect(onEventEditingStart.calledOnce).to.equal(true);
-      expect(onEventEditingStart.lastCall.firstArg.id).to.equal(event1.id);
-      expect(onEventEditingStart.lastCall.args[1].reason).to.equal('edit');
-      expect(onEventEditingStart.lastCall.args[1].trigger).to.equal(eventButton);
+      expect(onEventEditingStart.mock.calls.length).to.equal(1);
+      expect(onEventEditingStart.mock.lastCall?.[0].id).to.equal(event1.id);
+      expect(onEventEditingStart.mock.lastCall?.[1].reason).to.equal('edit');
+      expect(onEventEditingStart.mock.lastCall?.[1].trigger).to.equal(eventButton);
     });
 
     it('should keep the built-in dialog closed when the handler cancels', async () => {
-      const onEventEditingStart = spy((_occurrence, eventDetails) => eventDetails.cancel());
+      const onEventEditingStart = vi.fn((_occurrence, eventDetails) => eventDetails.cancel());
       const { user } = render(
         <EventCalendar events={[event1]} onEventEditingStart={onEventEditingStart} />,
       );
 
       await user.click(screen.getByRole('button', { name: /Running/i }));
 
-      expect(onEventEditingStart.calledOnce).to.equal(true);
+      expect(onEventEditingStart.mock.calls.length).to.equal(1);
       expect(screen.queryByRole('dialog')).to.equal(null);
     });
 
     it('should keep the built-in dialog closed when the handler cancels a keyboard activation', async () => {
-      const onEventEditingStart = spy((_occurrence, eventDetails) => eventDetails.cancel());
+      const onEventEditingStart = vi.fn((_occurrence, eventDetails) => eventDetails.cancel());
       const { user } = render(
         <EventCalendar events={[event1]} onEventEditingStart={onEventEditingStart} />,
       );
@@ -485,34 +484,34 @@ describe('EventCalendar', () => {
       expect(eventButton).to.equal(document.activeElement);
       await user.keyboard('{Enter}');
 
-      expect(onEventEditingStart.calledOnce).to.equal(true);
+      expect(onEventEditingStart.mock.calls.length).to.equal(1);
       expect(screen.queryByRole('dialog')).to.equal(null);
     });
 
     it('should keep the built-in dialog closed when the handler cancels an event creation', async () => {
-      const onEventEditingStart = spy((_occurrence, eventDetails) => eventDetails.cancel());
+      const onEventEditingStart = vi.fn((_occurrence, eventDetails) => eventDetails.cancel());
       const { user } = render(
         <EventCalendar events={[]} defaultView="month" onEventEditingStart={onEventEditingStart} />,
       );
 
       await user.click(withinMonthView().getAllByRole('gridcell')[10]);
 
-      expect(onEventEditingStart.calledOnce).to.equal(true);
-      expect(onEventEditingStart.lastCall.args[1].reason).to.equal('creation');
-      expect(onEventEditingStart.lastCall.args[1].event.type).to.equal('click');
-      const draft = onEventEditingStart.lastCall.args[1].occurrence;
+      expect(onEventEditingStart.mock.calls.length).to.equal(1);
+      expect(onEventEditingStart.mock.lastCall?.[1].reason).to.equal('creation');
+      expect(onEventEditingStart.mock.lastCall?.[1].event.type).to.equal('click');
+      const draft = onEventEditingStart.mock.lastCall?.[1].occurrence;
       expect(draft.allDay).to.equal(true);
       expect(draft.displayTimezone.start.timestamp).to.be.lessThan(
         draft.displayTimezone.end.timestamp,
       );
-      expect(onEventEditingStart.lastCall.args[1].trigger).to.equal(
+      expect(onEventEditingStart.mock.lastCall?.[1].trigger).to.equal(
         withinMonthView().getAllByRole('gridcell')[10],
       );
       expect(screen.queryByRole('dialog')).to.equal(null);
     });
 
     it('should report a `view` reason when the whole calendar is read-only', async () => {
-      const onEventEditingStart = spy();
+      const onEventEditingStart = vi.fn();
       const { user } = render(
         <EventCalendar events={[event1]} readOnly onEventEditingStart={onEventEditingStart} />,
       );
@@ -522,8 +521,8 @@ describe('EventCalendar', () => {
       await waitFor(() => {
         expect(screen.queryByRole('dialog')).not.to.equal(null);
       });
-      expect(onEventEditingStart.calledOnce).to.equal(true);
-      expect(onEventEditingStart.lastCall.args[1].reason).to.equal('view');
+      expect(onEventEditingStart.mock.calls.length).to.equal(1);
+      expect(onEventEditingStart.mock.lastCall?.[1].reason).to.equal('view');
     });
 
     it('should report a `view` reason when the event belongs to a read-only resource', async () => {
@@ -533,7 +532,7 @@ describe('EventCalendar', () => {
         .span('2025-05-26T07:30:00Z', '2025-05-26T08:15:00Z')
         .resource(readOnlyResource)
         .build();
-      const onEventEditingStart = spy();
+      const onEventEditingStart = vi.fn();
       const { user } = render(
         <EventCalendar
           events={[lockedEvent]}
@@ -547,7 +546,7 @@ describe('EventCalendar', () => {
       await waitFor(() => {
         expect(screen.queryByRole('dialog')).not.to.equal(null);
       });
-      expect(onEventEditingStart.lastCall.args[1].reason).to.equal('view');
+      expect(onEventEditingStart.mock.lastCall?.[1].reason).to.equal('view');
     });
 
     it('should keep the built-in view-only dialog closed when the handler cancels a read-only activation', async () => {
@@ -556,15 +555,15 @@ describe('EventCalendar', () => {
         .span('2025-05-26T07:30:00Z', '2025-05-26T08:15:00Z')
         .readOnly()
         .build();
-      const onEventEditingStart = spy((_occurrence, eventDetails) => eventDetails.cancel());
+      const onEventEditingStart = vi.fn((_occurrence, eventDetails) => eventDetails.cancel());
       const { user } = render(
         <EventCalendar events={[readOnlyEvent]} onEventEditingStart={onEventEditingStart} />,
       );
 
       await user.click(screen.getByRole('button', { name: /Locked/i }));
 
-      expect(onEventEditingStart.calledOnce).to.equal(true);
-      expect(onEventEditingStart.lastCall.args[1].reason).to.equal('view');
+      expect(onEventEditingStart.mock.calls.length).to.equal(1);
+      expect(onEventEditingStart.mock.lastCall?.[1].reason).to.equal('view');
       expect(screen.queryByRole('dialog')).to.equal(null);
     });
   });

--- a/packages/x-scheduler/src/internals/components/event-dialog/form/EventDialogFormStore.test.ts
+++ b/packages/x-scheduler/src/internals/components/event-dialog/form/EventDialogFormStore.test.ts
@@ -1,7 +1,6 @@
-import { spy } from 'sinon';
 import { clearWarningsCache } from '@mui/x-internals/warning';
 import { EventBuilder } from 'test/utils/scheduler';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
 import type { EventDialogFormParameters } from './EventDialogFormStore';
 import { EventDialogFormStore, eventDialogFormSelectors } from './EventDialogFormStore';
 
@@ -72,23 +71,23 @@ describe('EventDialogFormStore', () => {
     });
 
     it('should call onValuesChange with the new values and the changed keys', () => {
-      const onValuesChange = spy();
+      const onValuesChange = vi.fn();
       const store = createFormStore({ title: 'Meeting' }, { onValuesChange });
       store.setValue('title', 'Updated');
-      expect(onValuesChange.calledOnce).to.equal(true);
-      expect(onValuesChange.lastCall.args[0]).to.deep.equal({ title: 'Updated' });
-      expect(onValuesChange.lastCall.args[1]).to.deep.equal(['title']);
+      expect(onValuesChange.mock.calls.length).to.equal(1);
+      expect(onValuesChange.mock.lastCall?.[0]).to.deep.equal({ title: 'Updated' });
+      expect(onValuesChange.mock.lastCall?.[1]).to.deep.equal(['title']);
     });
   });
 
   describe('setValues', () => {
     it('should merge several keys in a single update', () => {
       const store = createFormStore({ a: 1, b: 2, c: 3 });
-      const listener = spy();
+      const listener = vi.fn();
       store.subscribe(listener);
       store.setValues({ a: 10, b: 20 });
       expect(store.state.values).to.deep.equal({ a: 10, b: 20, c: 3 });
-      expect(listener.callCount).to.equal(1);
+      expect(listener.mock.calls.length).to.equal(1);
     });
 
     it('should accept a functional updater receiving the current values', () => {
@@ -98,16 +97,16 @@ describe('EventDialogFormStore', () => {
     });
 
     it('should notify nobody when the changes object is empty', () => {
-      const onValuesChange = spy();
+      const onValuesChange = vi.fn();
       const store = createFormStore({ title: 'Meeting' }, { onValuesChange });
-      const listener = spy();
+      const listener = vi.fn();
       store.subscribe(listener);
 
       store.setValues({});
       store.setValues(() => ({}));
 
-      expect(listener.callCount).to.equal(0);
-      expect(onValuesChange.called).to.equal(false);
+      expect(listener.mock.calls.length).to.equal(0);
+      expect(onValuesChange.mock.calls.length).to.equal(0);
     });
 
     it('should clear the errors of all the written keys', async () => {
@@ -128,13 +127,13 @@ describe('EventDialogFormStore', () => {
 
   describe('seedDefault', () => {
     it('should seed a missing key without marking it dirty or notifying onValuesChange', () => {
-      const onValuesChange = spy();
+      const onValuesChange = vi.fn();
       const store = createFormStore({ title: '' }, { onValuesChange });
       store.seedDefault('notes', 'default');
 
       expect(store.state.values).to.deep.equal({ title: '', notes: 'default' });
       expect(store.getDirtyValues()).to.deep.equal({});
-      expect(onValuesChange.called).to.equal(false);
+      expect(onValuesChange.mock.calls.length).to.equal(0);
     });
 
     it('should not overwrite a key already present in the values', () => {
@@ -244,10 +243,10 @@ describe('EventDialogFormStore', () => {
       store.registerValidator('priority', () => 'Priority required');
       await store.validateAll();
 
-      const listener = spy();
+      const listener = vi.fn();
       store.subscribe(listener);
       store.clearErrors(['title']);
-      expect(listener.callCount).to.equal(0);
+      expect(listener.mock.calls.length).to.equal(0);
       expect(store.state.errors).to.deep.equal({ priority: ['Priority required'] });
     });
   });
@@ -306,23 +305,23 @@ describe('EventDialogFormStore', () => {
 
     it('should not run the later validators of a field after one fails', async () => {
       const store = createFormStore({ title: '' });
-      const later = spy(() => null);
+      const later = vi.fn(() => null);
       store.registerValidator('title', () => 'Required');
       store.registerValidator('title', later);
       await store.validateAll();
-      expect(later.called).to.equal(false);
+      expect(later.mock.calls.length).to.equal(0);
       expect(store.state.errors).to.deep.equal({ title: ['Required'] });
     });
 
     it('should settle in one pass when a validator writes back the same value', async () => {
       const store = createFormStore({ title: 'Meeting' });
-      const validator = spy((value: unknown) => {
+      const validator = vi.fn((value: unknown) => {
         store.setValue('title', value as string);
         return null;
       });
       store.registerValidator('title', validator);
       expect(await store.validateAll()).to.equal(true);
-      expect(validator.callCount).to.equal(1);
+      expect(validator.mock.calls.length).to.equal(1);
       expect(store.state.errors).to.deep.equal({});
     });
 

--- a/packages/x-scheduler/src/month-view/tests/MonthView.test.tsx
+++ b/packages/x-scheduler/src/month-view/tests/MonthView.test.tsx
@@ -1,4 +1,3 @@
-import { spy } from 'sinon';
 import { config } from 'react-transition-group';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import type { Theme } from '@mui/material/styles';
@@ -15,7 +14,7 @@ import {
 import { act, screen, within, waitFor } from '@mui/internal-test-utils';
 import { SchedulerStoreContext } from '@mui/x-scheduler-internals/use-scheduler-store-context';
 import { MonthView } from '@mui/x-scheduler/month-view';
-import { describe, it, expect } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 import { EventCalendarProvider } from '../../internals/components/EventCalendarProvider';
 import { EventCalendar, eventCalendarClasses } from '../../event-calendar';
 import { EventDialogProvider } from '../../internals/components/event-dialog';
@@ -76,8 +75,8 @@ describe('<MonthView />', () => {
   });
 
   it('should move to the day view when a day is clicked', async () => {
-    const handleViewChange = spy();
-    const handleVisibleDateChange = spy();
+    const handleViewChange = vi.fn();
+    const handleVisibleDateChange = vi.fn();
     const { user } = render(
       <EventCalendarProvider
         {...standaloneDefaults}
@@ -92,10 +91,10 @@ describe('<MonthView />', () => {
     const button = screen.getByRole('button', { name: '15' });
     await user.click(button);
 
-    expect(handleViewChange.calledOnce).to.equal(true);
-    expect(handleViewChange.firstCall.firstArg).to.equal('day');
-    expect(handleVisibleDateChange.calledOnce).to.equal(true);
-    expect(handleVisibleDateChange.firstCall.firstArg).toEqualDateTime(
+    expect(handleViewChange.mock.calls.length).to.equal(1);
+    expect(handleViewChange.mock.calls[0][0]).to.equal('day');
+    expect(handleVisibleDateChange.mock.calls.length).to.equal(1);
+    expect(handleVisibleDateChange.mock.calls[0][0]).toEqualDateTime(
       adapter.date('2025-05-15T00:00:00Z', 'default'),
     );
   });
@@ -212,7 +211,7 @@ describe('<MonthView />', () => {
     });
 
     it('should close the popover when `onEventEditingStart` cancels an activation from it', async () => {
-      const onEventEditingStart = spy((_occurrence: any, eventDetails: any) =>
+      const onEventEditingStart = vi.fn((_occurrence: any, eventDetails: any) =>
         eventDetails.cancel(),
       );
       const { user, popover } = await renderAndOpenPopover({ onEventEditingStart });
@@ -220,7 +219,7 @@ describe('<MonthView />', () => {
       const firstEventButton = within(popover).getAllByRole('button')[0];
       await user.click(firstEventButton);
 
-      expect(onEventEditingStart.calledOnce).to.equal(true);
+      expect(onEventEditingStart.mock.calls.length).to.equal(1);
       expect(screen.queryByRole('dialog')).to.equal(null);
       await waitFor(() => {
         expect(document.body.contains(popover)).to.equal(false);
@@ -228,8 +227,8 @@ describe('<MonthView />', () => {
 
       expect(firstEventButton.isConnected).to.equal(false);
       const moreButton = screen.getByRole('button', { name: /more/i });
-      expect(onEventEditingStart.lastCall.args[1].trigger).to.equal(firstEventButton);
-      expect(onEventEditingStart.lastCall.args[1].anchor).to.equal(moreButton);
+      expect(onEventEditingStart.mock.lastCall?.[1].trigger).to.equal(firstEventButton);
+      expect(onEventEditingStart.mock.lastCall?.[1].anchor).to.equal(moreButton);
       expect(moreButton.isConnected).to.equal(true);
     });
 
@@ -244,27 +243,27 @@ describe('<MonthView />', () => {
           removeEventListener: () => {},
         }) as any) as any;
       try {
-        const onEventEditingStart = spy((_occurrence: any, eventDetails: any) =>
+        const onEventEditingStart = vi.fn((_occurrence: any, eventDetails: any) =>
           eventDetails.cancel(),
         );
         const { user, popover } = await renderAndOpenPopover({ onEventEditingStart });
 
         const firstEventButton = within(popover).getAllByRole('button')[0];
         await user.click(firstEventButton);
-        expect(onEventEditingStart.callCount).to.equal(0);
+        expect(onEventEditingStart.mock.calls.length).to.equal(0);
 
         const editButton = screen.getByRole('button', { name: 'Edit event' });
         await user.click(editButton);
 
-        expect(onEventEditingStart.calledOnce).to.equal(true);
+        expect(onEventEditingStart.mock.calls.length).to.equal(1);
         await waitFor(() => {
           expect(document.body.contains(popover)).to.equal(false);
         });
 
         expect(firstEventButton.isConnected).to.equal(false);
         const moreButton = screen.getByRole('button', { name: /more/i });
-        expect(onEventEditingStart.lastCall.args[1].trigger).to.equal(editButton);
-        expect(onEventEditingStart.lastCall.args[1].anchor).to.equal(moreButton);
+        expect(onEventEditingStart.mock.lastCall?.[1].trigger).to.equal(editButton);
+        expect(onEventEditingStart.mock.lastCall?.[1].anchor).to.equal(moreButton);
         expect(moreButton.isConnected).to.equal(true);
       } finally {
         window.matchMedia = originalMatchMedia;
@@ -296,7 +295,7 @@ describe('<MonthView />', () => {
     });
 
     it('should return focus to the trigger when the editing dialog is submitted', async () => {
-      const onEventsChange = spy();
+      const onEventsChange = vi.fn();
       const { user, popover } = await renderAndOpenPopover({ onEventsChange });
 
       const firstEventButton = within(popover).getAllByRole('button')[0];
@@ -310,7 +309,7 @@ describe('<MonthView />', () => {
 
       // The dialog closing is only meaningful if the form actually submitted.
       await waitFor(() => {
-        expect(onEventsChange.callCount).to.equal(1);
+        expect(onEventsChange.mock.calls.length).to.equal(1);
       });
       await waitFor(() => {
         expect(screen.queryByRole('dialog')).to.equal(null);
@@ -402,7 +401,7 @@ describe('<MonthView />', () => {
   describe('creation placeholder updates', () => {
     it('should not re-fire `onEventEditingStart` when the built-in form updates the creation placeholder', async () => {
       let store: AnyEventCalendarStore | null = null;
-      const onEventEditingStart = spy();
+      const onEventEditingStart = vi.fn();
       const { user } = render(
         <EventCalendarProvider events={[]} resources={[]} onEventEditingStart={onEventEditingStart}>
           <EventDialogProvider>
@@ -421,7 +420,7 @@ describe('<MonthView />', () => {
       await waitFor(() => {
         expect(screen.queryByRole('dialog')).not.to.equal(null);
       });
-      expect(onEventEditingStart.calledOnce).to.equal(true);
+      expect(onEventEditingStart.mock.calls.length).to.equal(1);
 
       // Mirrors the built-in form pushing a date change into the draft while the dialog is open.
       const placeholder = store!.state.occurrencePlaceholder!;
@@ -432,7 +431,7 @@ describe('<MonthView />', () => {
         });
       });
 
-      expect(onEventEditingStart.calledOnce).to.equal(true);
+      expect(onEventEditingStart.mock.calls.length).to.equal(1);
       expect(screen.queryByRole('dialog')).not.to.equal(null);
     });
   });
@@ -670,7 +669,7 @@ describe('<MonthView />', () => {
 
   describe('time navigation', () => {
     it('should go to start of previous month when clicking on the Previous Month button', async () => {
-      const onVisibleDateChange = spy();
+      const onVisibleDateChange = vi.fn();
 
       const { user } = render(
         <EventCalendar
@@ -684,13 +683,13 @@ describe('<MonthView />', () => {
       const toolbar = withinEventCalendarToolbar();
       // eslint-disable-next-line testing-library/prefer-screen-queries -- scoped query within toolbar
       await user.click(toolbar.getByRole('button', { name: /previous month/i }));
-      expect(onVisibleDateChange.lastCall.firstArg).toEqualDateTime(
+      expect(onVisibleDateChange.mock.lastCall?.[0]).toEqualDateTime(
         adapter.addMonths(adapter.startOfMonth(DEFAULT_TESTING_VISIBLE_DATE), -1),
       );
     });
 
     it('should go to start of next month when clicking on the Next Month button', async () => {
-      const onVisibleDateChange = spy();
+      const onVisibleDateChange = vi.fn();
 
       const { user } = render(
         <EventCalendar
@@ -704,7 +703,7 @@ describe('<MonthView />', () => {
       const toolbar = withinEventCalendarToolbar();
       // eslint-disable-next-line testing-library/prefer-screen-queries -- scoped query within toolbar
       await user.click(toolbar.getByRole('button', { name: /next month/i }));
-      expect(onVisibleDateChange.lastCall.firstArg).toEqualDateTime(
+      expect(onVisibleDateChange.mock.lastCall?.[0]).toEqualDateTime(
         adapter.addMonths(adapter.startOfMonth(DEFAULT_TESTING_VISIBLE_DATE), 1),
       );
     });

--- a/packages/x-scheduler/src/week-view/tests/eventCreation.WeekView.test.tsx
+++ b/packages/x-scheduler/src/week-view/tests/eventCreation.WeekView.test.tsx
@@ -1,10 +1,9 @@
-import { spy } from 'sinon';
 import type { AnyEventCalendarStore } from 'test/utils/scheduler';
 import { createSchedulerRenderer, SchedulerStoreRunner } from 'test/utils/scheduler';
 import { act, screen } from '@mui/internal-test-utils';
 import { SchedulerStoreContext } from '@mui/x-scheduler-internals/use-scheduler-store-context';
 import { WeekView } from '@mui/x-scheduler/week-view';
-import { describe, it, expect } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 import { EventCalendarProvider } from '../../internals/components/EventCalendarProvider';
 import { eventCalendarClasses } from '../../event-calendar';
 import { EventDialogProvider } from '../../internals/components/event-dialog';
@@ -14,7 +13,9 @@ describe('<WeekView /> event creation', () => {
 
   it('should fire `onEventEditingStart` once with the initiating keydown and drop the draft when canceling a keyboard creation', async () => {
     let store: AnyEventCalendarStore | null = null;
-    const onEventEditingStart = spy((_occurrence: any, eventDetails: any) => eventDetails.cancel());
+    const onEventEditingStart = vi.fn((_occurrence: any, eventDetails: any) =>
+      eventDetails.cancel(),
+    );
     const { user } = render(
       <EventCalendarProvider events={[]} resources={[]} onEventEditingStart={onEventEditingStart}>
         <EventDialogProvider>
@@ -38,11 +39,11 @@ describe('<WeekView /> event creation', () => {
     });
     await user.keyboard('{Enter}');
 
-    expect(onEventEditingStart.calledOnce).to.equal(true);
-    expect(onEventEditingStart.lastCall.args[1].reason).to.equal('creation');
-    expect(onEventEditingStart.lastCall.args[1].event.type).to.equal('keydown');
+    expect(onEventEditingStart.mock.calls.length).to.equal(1);
+    expect(onEventEditingStart.mock.lastCall?.[1].reason).to.equal('creation');
+    expect(onEventEditingStart.mock.lastCall?.[1].event.type).to.equal('keydown');
     // The trigger is the built-in dialog's anchor for this path, i.e. the column's interactive layer.
-    expect(onEventEditingStart.lastCall.args[1].trigger).to.equal(
+    expect(onEventEditingStart.mock.lastCall?.[1].trigger).to.equal(
       column.querySelector(`.${eventCalendarClasses.dayTimeGridColumnInteractiveLayer}`),
     );
     expect(screen.queryByRole('dialog')).to.equal(null);

--- a/packages/x-tree-view-pro/src/internals/plugins/lazyLoading/TreeViewLazyLoadingPlugin.test.tsx
+++ b/packages/x-tree-view-pro/src/internals/plugins/lazyLoading/TreeViewLazyLoadingPlugin.test.tsx
@@ -1,8 +1,7 @@
 import { act, fireEvent, screen } from '@mui/internal-test-utils';
 import * as React from 'react';
-import { spy } from 'sinon';
 import { describeTreeView } from 'test/utils/tree-view/describeTreeView';
-import { describe, it, expect } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 import type { RichTreeViewProStore } from '../../RichTreeViewProStore';
 
 interface ItemType {
@@ -42,7 +41,7 @@ describeTreeView<RichTreeViewProStore<any, any>>(
     describe('interaction', () => {
       it('should keep the loading icon visible while loading when parameters references change', async () => {
         let resolveFetch: (() => void) | undefined;
-        const getTreeItems = spy(
+        const getTreeItems = vi.fn(
           () =>
             new Promise<ItemType[]>((resolve) => {
               resolveFetch = () => resolve([{ id: '1-1', childrenCount: 0 }]);
@@ -78,7 +77,7 @@ describeTreeView<RichTreeViewProStore<any, any>>(
           resolveFetch!();
         });
 
-        expect(getTreeItems.callCount).to.equal(1);
+        expect(getTreeItems.mock.calls.length).to.equal(1);
         expect(view.getItemIconContainer('1').querySelector('[role="progressbar"]')).to.equal(null);
       });
 
@@ -101,8 +100,8 @@ describeTreeView<RichTreeViewProStore<any, any>>(
       });
 
       it('should not update the selection when expanding a selected item in single selection', async () => {
-        const onSelectedItemsChange = spy();
-        const onItemSelectionToggle = spy();
+        const onSelectedItemsChange = vi.fn();
+        const onItemSelectionToggle = vi.fn();
 
         const view = render({
           items: [{ id: '1', childrenCount: 1 }],
@@ -126,12 +125,12 @@ describeTreeView<RichTreeViewProStore<any, any>>(
 
         expect(view.isItemExpanded('1')).to.equal(true);
         expect(view.isItemSelected('1')).to.equal(true);
-        expect(onSelectedItemsChange.callCount).to.equal(0);
-        expect(onItemSelectionToggle.callCount).to.equal(0);
+        expect(onSelectedItemsChange.mock.calls.length).to.equal(0);
+        expect(onItemSelectionToggle.mock.calls.length).to.equal(0);
       });
 
       it('should not update the selection when expanding a selected item without descendants propagation', async () => {
-        const onSelectedItemsChange = spy();
+        const onSelectedItemsChange = vi.fn();
 
         const view = render({
           items: [{ id: '1', childrenCount: 1 }],
@@ -155,7 +154,7 @@ describeTreeView<RichTreeViewProStore<any, any>>(
 
         expect(view.isItemExpanded('1')).to.equal(true);
         expect(view.getSelectedTreeItems()).to.deep.equal(['1']);
-        expect(onSelectedItemsChange.callCount).to.equal(0);
+        expect(onSelectedItemsChange.mock.calls.length).to.equal(0);
       });
 
       it('should propagate the selection to the lazy loaded children when expanding a selected item', async () => {
@@ -385,7 +384,7 @@ describeTreeView<RichTreeViewProStore<any, any>>(
 
       it('should not apply a stale expand response over a newer forced refresh', async () => {
         const resolvers: Array<(items: ItemType[]) => void> = [];
-        const getTreeItems = spy(
+        const getTreeItems = vi.fn(
           () =>
             new Promise<ItemType[]>((resolve) => {
               resolvers.push(resolve);
@@ -401,13 +400,13 @@ describeTreeView<RichTreeViewProStore<any, any>>(
 
         // expanding item '1' starts the first (expand) fetch
         fireEvent.click(view.getItemContent('1'));
-        expect(getTreeItems.callCount).to.equal(1);
+        expect(getTreeItems.mock.calls.length).to.equal(1);
 
         // a forced refresh starts before the expand fetch resolves, starting a second fetch
         await act(async () => {
           view.apiRef.current.updateItemChildren('1');
         });
-        expect(getTreeItems.callCount).to.equal(2);
+        expect(getTreeItems.mock.calls.length).to.equal(2);
 
         // the newer (forced refresh) request resolves first with the fresh children
         await act(async () => {
@@ -427,19 +426,19 @@ describeTreeView<RichTreeViewProStore<any, any>>(
         expect(view.isItemExpanded('1')).to.equal(false);
         fireEvent.click(view.getItemContent('1'));
         await awaitMockFetch();
-        expect(getTreeItems.callCount).to.equal(2);
+        expect(getTreeItems.mock.calls.length).to.equal(2);
         expect(view.getAllTreeItemIds()).to.deep.equal(['1', 'fresh']);
       });
 
       it('should still propagate selection to children when an expand fetch resolves before a racing refresh', async () => {
         const resolvers: Array<(items: ItemType[]) => void> = [];
-        const getTreeItems = spy(
+        const getTreeItems = vi.fn(
           () =>
             new Promise<ItemType[]>((resolve) => {
               resolvers.push(resolve);
             }),
         );
-        const onSelectedItemsChange = spy();
+        const onSelectedItemsChange = vi.fn();
 
         const view = render({
           items: [{ id: '1', childrenCount: 1 }],
@@ -455,13 +454,13 @@ describeTreeView<RichTreeViewProStore<any, any>>(
 
         // expanding the already-selected item '1' starts the expand fetch
         fireEvent.click(view.getItemContent('1'));
-        expect(getTreeItems.callCount).to.equal(1);
+        expect(getTreeItems.mock.calls.length).to.equal(1);
 
         // a forced refresh starts before the expand fetch resolves
         await act(async () => {
           view.apiRef.current.updateItemChildren('1');
         });
-        expect(getTreeItems.callCount).to.equal(2);
+        expect(getTreeItems.mock.calls.length).to.equal(2);
 
         // the expand fetch resolves first, then the refresh resolves with the same children
         await act(async () => {
@@ -473,7 +472,7 @@ describeTreeView<RichTreeViewProStore<any, any>>(
 
         // the child loaded for the selected parent must be selected through descendant propagation
         expect(view.getAllTreeItemIds()).to.deep.equal(['1', '1-1']);
-        expect(onSelectedItemsChange.lastCall.args[1]).to.include('1-1');
+        expect(onSelectedItemsChange.mock.lastCall?.[1]).to.include('1-1');
       });
 
       it('should use the data from props.items on mount', () => {
@@ -514,7 +513,7 @@ describeTreeView<RichTreeViewProStore<any, any>>(
       });
 
       it('should not refetch children from props.items when re-expanding a preloaded item', async () => {
-        const getTreeItems = spy(mockFetchData);
+        const getTreeItems = vi.fn(mockFetchData);
         const view = render({
           items: [{ id: '1', childrenCount: 1, children: [{ id: '1-1' }] }],
           defaultExpandedItems: ['1'],
@@ -533,13 +532,13 @@ describeTreeView<RichTreeViewProStore<any, any>>(
         fireEvent.click(view.getItemContent('1'));
         await awaitMockFetch();
 
-        expect(getTreeItems.callCount).to.equal(0);
+        expect(getTreeItems.mock.calls.length).to.equal(0);
         expect(view.isItemExpanded('1')).to.equal(true);
         expect(view.getAllTreeItemIds()).to.deep.equal(['1', '1-1']);
       });
 
       it('should still fetch a genuinely lazy sibling that ships no inline children', async () => {
-        const getTreeItems = spy(mockFetchData);
+        const getTreeItems = vi.fn(mockFetchData);
         const view = render({
           items: [
             { id: '1', childrenCount: 1, children: [{ id: '1-1' }] },
@@ -558,14 +557,14 @@ describeTreeView<RichTreeViewProStore<any, any>>(
         fireEvent.click(view.getItemContent('2'));
         await awaitMockFetch();
 
-        expect(getTreeItems.callCount).to.equal(1);
-        expect(getTreeItems.lastCall.firstArg).to.equal('2');
+        expect(getTreeItems.mock.calls.length).to.equal(1);
+        expect(getTreeItems.mock.lastCall?.[0]).to.equal('2');
         expect(view.getAllTreeItemIds()).to.deep.equal(['1', '1-1', '2', '2-1']);
       });
     });
     describe('onItemsLazyLoaded', () => {
       it('should call onItemsLazyLoaded with (items, null) when root items are fetched', async () => {
-        const onItemsLazyLoaded = spy();
+        const onItemsLazyLoaded = vi.fn();
         render({
           items: [],
           dataSource: {
@@ -576,7 +575,7 @@ describeTreeView<RichTreeViewProStore<any, any>>(
         });
 
         await awaitMockFetch();
-        expect(onItemsLazyLoaded.lastCall.args[0]).to.deep.equal({
+        expect(onItemsLazyLoaded.mock.lastCall?.[0]).to.deep.equal({
           items: [{ id: '1', childrenCount: 1 }],
           parentId: null,
           isCacheHit: false,
@@ -584,7 +583,7 @@ describeTreeView<RichTreeViewProStore<any, any>>(
       });
 
       it('should call onItemsLazyLoaded with (items, parentId) when child items are fetched', async () => {
-        const onItemsLazyLoaded = spy();
+        const onItemsLazyLoaded = vi.fn();
         const view = render({
           items: [{ id: '1', childrenCount: 1 }],
           dataSource: {
@@ -594,12 +593,12 @@ describeTreeView<RichTreeViewProStore<any, any>>(
           onItemsLazyLoaded,
         });
 
-        expect(onItemsLazyLoaded.callCount).to.equal(0);
+        expect(onItemsLazyLoaded.mock.calls.length).to.equal(0);
 
         fireEvent.click(view.getItemContent('1'));
         await awaitMockFetch();
-        expect(onItemsLazyLoaded.callCount).to.equal(1);
-        expect(onItemsLazyLoaded.lastCall.args[0]).to.deep.equal({
+        expect(onItemsLazyLoaded.mock.calls.length).to.equal(1);
+        expect(onItemsLazyLoaded.mock.lastCall?.[0]).to.deep.equal({
           items: [{ id: '1-1', childrenCount: 1 }],
           parentId: '1',
           isCacheHit: false,
@@ -607,7 +606,7 @@ describeTreeView<RichTreeViewProStore<any, any>>(
       });
 
       it('should call onItemsLazyLoaded on cache hit when the same item is expanded again', async () => {
-        const onItemsLazyLoaded = spy();
+        const onItemsLazyLoaded = vi.fn();
         const view = render({
           items: [{ id: '1', childrenCount: 1 }],
           dataSource: {
@@ -620,21 +619,21 @@ describeTreeView<RichTreeViewProStore<any, any>>(
         // First expansion — server fetch
         fireEvent.click(view.getItemContent('1'));
         await awaitMockFetch();
-        expect(onItemsLazyLoaded.callCount).to.equal(1);
-        expect(onItemsLazyLoaded.lastCall.args[0].isCacheHit).to.equal(false);
+        expect(onItemsLazyLoaded.mock.calls.length).to.equal(1);
+        expect(onItemsLazyLoaded.mock.lastCall?.[0].isCacheHit).to.equal(false);
 
         // Collapse
         fireEvent.click(view.getItemContent('1'));
         // Second expansion — cache hit
         fireEvent.click(view.getItemContent('1'));
         await awaitMockFetch();
-        expect(onItemsLazyLoaded.callCount).to.equal(2);
-        expect(onItemsLazyLoaded.lastCall.args[0].parentId).to.equal('1');
-        expect(onItemsLazyLoaded.lastCall.args[0].isCacheHit).to.equal(true);
+        expect(onItemsLazyLoaded.mock.calls.length).to.equal(2);
+        expect(onItemsLazyLoaded.mock.lastCall?.[0].parentId).to.equal('1');
+        expect(onItemsLazyLoaded.mock.lastCall?.[0].isCacheHit).to.equal(true);
       });
 
       it('should call onItemsLazyLoaded with isCacheHit=true when re-expanding a preloaded item', async () => {
-        const onItemsLazyLoaded = spy();
+        const onItemsLazyLoaded = vi.fn();
         const view = render({
           items: [{ id: '1', childrenCount: 1, children: [{ id: '1-1' }] }],
           defaultExpandedItems: ['1'],
@@ -646,20 +645,20 @@ describeTreeView<RichTreeViewProStore<any, any>>(
         });
 
         // Children come from props.items, so nothing loads on mount.
-        expect(onItemsLazyLoaded.callCount).to.equal(0);
+        expect(onItemsLazyLoaded.mock.calls.length).to.equal(0);
 
         // Seeded cache makes re-expanding a cache hit, not a fetch.
         fireEvent.click(view.getItemContent('1'));
         fireEvent.click(view.getItemContent('1'));
         await awaitMockFetch();
 
-        expect(onItemsLazyLoaded.callCount).to.equal(1);
-        expect(onItemsLazyLoaded.lastCall.args[0].parentId).to.equal('1');
-        expect(onItemsLazyLoaded.lastCall.args[0].isCacheHit).to.equal(true);
+        expect(onItemsLazyLoaded.mock.calls.length).to.equal(1);
+        expect(onItemsLazyLoaded.mock.lastCall?.[0].parentId).to.equal('1');
+        expect(onItemsLazyLoaded.mock.lastCall?.[0].isCacheHit).to.equal(true);
       });
 
       it('should call onItemsLazyLoaded on mount when items=[] and root items are auto-fetched', async () => {
-        const onItemsLazyLoaded = spy();
+        const onItemsLazyLoaded = vi.fn();
         render({
           items: [],
           dataSource: {
@@ -670,8 +669,8 @@ describeTreeView<RichTreeViewProStore<any, any>>(
         });
 
         await awaitMockFetch();
-        expect(onItemsLazyLoaded.callCount).to.equal(1);
-        expect(onItemsLazyLoaded.lastCall.args[0]).to.deep.equal({
+        expect(onItemsLazyLoaded.mock.calls.length).to.equal(1);
+        expect(onItemsLazyLoaded.mock.lastCall?.[0]).to.deep.equal({
           items: [{ id: '1', childrenCount: 1 }],
           parentId: null,
           isCacheHit: false,
@@ -679,7 +678,7 @@ describeTreeView<RichTreeViewProStore<any, any>>(
       });
 
       it('should not call onItemsLazyLoaded when getTreeItems throws', async () => {
-        const onItemsLazyLoaded = spy();
+        const onItemsLazyLoaded = vi.fn();
         const errorFetchData = async (): Promise<ItemType[]> => {
           return new Promise((_, reject) => {
             setTimeout(() => reject(new Error('Failed')), 0);
@@ -697,13 +696,13 @@ describeTreeView<RichTreeViewProStore<any, any>>(
 
         fireEvent.click(view.getItemContent('1'));
         await awaitMockFetch();
-        expect(onItemsLazyLoaded.callCount).to.equal(0);
+        expect(onItemsLazyLoaded.mock.calls.length).to.equal(0);
       });
 
       it('should pre-cache inline nested children so expanding them requires no extra fetch', async () => {
         let fetchCount = 0;
         let view: ReturnType<typeof render>;
-        const onItemsLazyLoaded = spy(({ items }) => {
+        const onItemsLazyLoaded = vi.fn(({ items }) => {
           items.forEach((item) => {
             if (item.children && item.children.length > 0) {
               view.apiRef.current.setItemExpansion({
@@ -751,7 +750,7 @@ describeTreeView<RichTreeViewProStore<any, any>>(
         expect(view.isItemExpanded('1-1')).to.equal(true);
         expect(view.getAllTreeItemIds()).to.deep.equal(['1', '1-1', '1-1-1']);
         // onItemsLazyLoaded should fire exactly once — not cascade for auto-expanded children
-        expect(onItemsLazyLoaded.callCount).to.equal(1);
+        expect(onItemsLazyLoaded.mock.calls.length).to.equal(1);
       });
     });
 
@@ -774,7 +773,7 @@ describeTreeView<RichTreeViewProStore<any, any>>(
         expect(view.getAllTreeItemIds()).to.deep.equal(['1']);
       });
       it('should call onItemsLazyLoaded with isCacheHit=false when updateItemChildren is called', async () => {
-        const onItemsLazyLoaded = spy();
+        const onItemsLazyLoaded = vi.fn();
         const view = render({
           items: [{ id: '1', childrenCount: 1 }],
           dataSource: {
@@ -789,8 +788,8 @@ describeTreeView<RichTreeViewProStore<any, any>>(
         });
         await awaitMockFetch();
 
-        expect(onItemsLazyLoaded.callCount).to.equal(1);
-        expect(onItemsLazyLoaded.lastCall.args[0]).to.deep.equal({
+        expect(onItemsLazyLoaded.mock.calls.length).to.equal(1);
+        expect(onItemsLazyLoaded.mock.lastCall?.[0]).to.deep.equal({
           items: [{ id: '1-1', childrenCount: 1 }],
           parentId: '1',
           isCacheHit: false,

--- a/packages/x-tree-view/src/internals/plugins/items/TreeViewItemsPlugin.test.tsx
+++ b/packages/x-tree-view/src/internals/plugins/items/TreeViewItemsPlugin.test.tsx
@@ -1,8 +1,7 @@
-import { spy } from 'sinon';
 import { act, fireEvent, reactMajor, waitFor } from '@mui/internal-test-utils';
 import { describeTreeView } from 'test/utils/tree-view/describeTreeView';
 import { TreeItemLabel } from '@mui/x-tree-view/TreeItem';
-import { describe, it, expect } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 import type { TreeViewAnyStore } from '../../models';
 
 // This suite covers the items API shared by every Tree View variant.
@@ -86,7 +85,7 @@ Two items were provided with the same id in the \`items\` prop: "1"`,
       });
 
       it('should update indexes when two items are swapped', async () => {
-        const onSelectedItemsChange = spy();
+        const onSelectedItemsChange = vi.fn();
 
         const view = render({
           items: [{ id: '1' }, { id: '2' }, { id: '3' }],
@@ -102,7 +101,7 @@ Two items were provided with the same id in the \`items\` prop: "1"`,
         await view.user.keyboard('{Shift>}');
         await view.user.click(view.getItemContent('3'));
         await view.user.keyboard('{/Shift}');
-        expect(onSelectedItemsChange.lastCall.args[1]).to.deep.equal(['1', '3']);
+        expect(onSelectedItemsChange.mock.lastCall?.[1]).to.deep.equal(['1', '3']);
       });
 
       it('should not mark an item as expandable if its children is an empty array', () => {
@@ -223,7 +222,7 @@ Two items were provided with the same id in the \`items\` prop: "1"`,
 
     describe('onItemClick prop', () => {
       it('should call onItemClick when clicking on the content of an item', async () => {
-        const onItemClick = spy();
+        const onItemClick = vi.fn();
 
         const view = render({
           items: [{ id: '1' }],
@@ -231,12 +230,12 @@ Two items were provided with the same id in the \`items\` prop: "1"`,
         });
 
         await view.user.click(view.getItemContent('1'));
-        expect(onItemClick.callCount).to.equal(1);
-        expect(onItemClick.lastCall.lastArg).to.equal('1');
+        expect(onItemClick.mock.calls.length).to.equal(1);
+        expect(onItemClick.mock.lastCall?.at(-1)).to.equal('1');
       });
 
       it('should not call onItemClick for the ancestors on the clicked item', async () => {
-        const onItemClick = spy();
+        const onItemClick = vi.fn();
 
         const view = render({
           items: [{ id: '1', children: [{ id: '1.1' }] }],
@@ -245,8 +244,8 @@ Two items were provided with the same id in the \`items\` prop: "1"`,
         });
 
         await view.user.click(view.getItemContent('1.1'));
-        expect(onItemClick.callCount).to.equal(1);
-        expect(onItemClick.lastCall.lastArg).to.equal('1.1');
+        expect(onItemClick.mock.calls.length).to.equal(1);
+        expect(onItemClick.mock.lastCall?.at(-1)).to.equal('1.1');
       });
     });
 
@@ -254,17 +253,17 @@ Two items were provided with the same id in the \`items\` prop: "1"`,
       it.skipIf(!isRichTreeView)(
         'should not re-render any children when the Tree View re-renders (flat tree)',
         () => {
-          const spyLabel = spy((props) => <TreeItemLabel {...props} />);
+          const spyLabel = vi.fn((props) => <TreeItemLabel {...props} />);
           const view = render({
             items: Array.from({ length: 10 }, (_, i) => ({ id: i.toString() })),
             slotProps: { item: { slots: { label: spyLabel } } },
           });
 
-          spyLabel.resetHistory();
+          spyLabel.mockClear();
 
           view.setProps({ onClick: () => {} });
 
-          const renders = spyLabel.getCalls().map((call) => call.args[0].children);
+          const renders = spyLabel.mock.calls.map((call) => call[0].children);
           expect(renders).to.deep.equal([]);
         },
       );
@@ -272,18 +271,18 @@ Two items were provided with the same id in the \`items\` prop: "1"`,
       it.skipIf(!isRichTreeView)(
         'should not re-render every children when updating the state on an item (flat tree)',
         () => {
-          const spyLabel = spy((props) => <TreeItemLabel {...props} />);
+          const spyLabel = vi.fn((props) => <TreeItemLabel {...props} />);
           const view = render({
             items: Array.from({ length: 10 }, (_, i) => ({ id: i.toString() })),
             selectedItems: [],
             slotProps: { item: { slots: { label: spyLabel } } },
           });
 
-          spyLabel.resetHistory();
+          spyLabel.mockClear();
 
           view.setProps({ selectedItems: ['1'] });
 
-          const renders = spyLabel.getCalls().map((call) => call.args[0].children);
+          const renders = spyLabel.mock.calls.map((call) => call[0].children);
 
           // 2 renders of the 1st item to remove to tabIndex={0}
           // 2 renders of the selected item to change its visual state
@@ -294,7 +293,7 @@ Two items were provided with the same id in the \`items\` prop: "1"`,
       it.skipIf(!isRichTreeView)(
         'should not re-render any children when the Tree View re-renders (nested tree)',
         () => {
-          const spyLabel = spy((props) => <TreeItemLabel {...props} />);
+          const spyLabel = vi.fn((props) => <TreeItemLabel {...props} />);
           const view = render({
             items: Array.from({ length: 5 }, (_, i) => ({
               id: i.toString(),
@@ -303,11 +302,11 @@ Two items were provided with the same id in the \`items\` prop: "1"`,
             slotProps: { item: { slots: { label: spyLabel } } },
           });
 
-          spyLabel.resetHistory();
+          spyLabel.mockClear();
 
           view.setProps({ onClick: () => {} });
 
-          const renders = spyLabel.getCalls().map((call) => call.args[0].children);
+          const renders = spyLabel.mock.calls.map((call) => call[0].children);
           expect(renders).to.deep.equal([]);
         },
       );
@@ -315,7 +314,7 @@ Two items were provided with the same id in the \`items\` prop: "1"`,
       it.skipIf(!isRichTreeView)(
         'should not re-render every children when updating the state on an item (nested tree)',
         () => {
-          const spyLabel = spy((props) => <TreeItemLabel {...props} />);
+          const spyLabel = vi.fn((props) => <TreeItemLabel {...props} />);
           const view = render({
             items: Array.from({ length: 5 }, (_, i) => ({
               id: i.toString(),
@@ -326,11 +325,11 @@ Two items were provided with the same id in the \`items\` prop: "1"`,
             slotProps: { item: { slots: { label: spyLabel } } },
           });
 
-          spyLabel.resetHistory();
+          spyLabel.mockClear();
 
           view.setProps({ selectedItems: ['1'] });
 
-          const renders = spyLabel.getCalls().map((call) => call.args[0].children);
+          const renders = spyLabel.mock.calls.map((call) => call[0].children);
 
           // 2 renders of the 1st item to remove to tabIndex={0}
           // 2 renders of the selected item to change its visual state


### PR DESCRIPTION
Second step away from Sinon, following #23443.

That PR took the files where every spy was a bare `spy()`. This one extends the same rule one notch, to `spy(fn)`: the spies that wrap a function, which map directly to `vi.fn(fn)`. Sinon stays a dependency and `test/setupVitest.ts` keeps calling `sinon.restore()`, because 44 files still import it.

## Scope rule

A file is in scope only when all of these hold:

1. Its single Sinon import is `import { spy } from 'sinon';`
2. It never calls `spy(obj, 'method')`
3. It uses no `stub`, no `useFakeTimers`, and none of the Sinon types
4. The spies are read only through accessors that map onto the Vitest mock API

That leaves 33 files. Everything with real semantic weight is still untouched and can follow in later PRs: `spy(obj, 'method')` to `vi.spyOn`, `stub`, the Sinon fake timers, and the `SinonSpy`/`SinonStub` types.

## Mapping applied

```
spy()               -> vi.fn()
spy(fn)             -> vi.fn(fn)
.callCount          -> .mock.calls.length
.args               -> .mock.calls
.lastCall           -> .mock.lastCall
.lastCall.args[n]   -> .mock.lastCall?.[n]
.lastCall.firstArg  -> .mock.lastCall?.[0]
.firstCall.args     -> .mock.calls[0]
.getCalls()         -> .mock.calls
.resetHistory()     -> .mockClear()
.calledOnce         -> .mock.calls.length === 1
.called             -> .mock.calls.length > 0
call.args[n]        -> call[n]        (when iterating the call list)
```

Chai-style assertions are kept as they were.

## What needed real types

This is the one way the step differs from #23443. `vi.fn()` is loosely typed, but `vi.fn(fn)` takes its type from the wrapped function, so a few call sites stopped compiling and needed more than a mechanical rewrite:

- The render-count tests (`DateCalendar`, `DesktopDatePicker`, `DateRangeCalendar`) passed a spy straight into a `slots` prop. That worked while a Sinon spy was effectively `any`, but a `Mock<T>` keeps only `T`'s call signature, so `React.memo(mock)` is not a valid `ElementType`. Typing the mock does not help: `vi.fn<typeof Component>(...)` compiles but hits the same wall, and `PickersActionBar` would have needed a double cast because its type carries a required `propTypes`. These now count renders from inside a real function component, with the mock as a plain call counter, so no cast is needed anywhere.
- `siblingVisibleDateGetter` in `date.EventCalendarStore.test.ts` was `vi.fn(() => targetDate)`, which types `mock.lastCall` as an empty tuple even though the caller passes a parameter. It now declares the parameter its assertion reads.
- A few `.lastCall` reads that the accessor rewrite did not reach, and `call.args[n]` inside `.find()`/`.map()` over the call list, were fixed by hand.

## Status

`typescript` and `eslint` are clean.

The browser suite is fully green: **761 files passed, 4 skipped, 0 failures**.

The jsdom suite is green too, once the branch picked up #23447. Before that merge it showed failures in `x-telemetry` (`get-context.test.ts`, `get-project-id.test.ts`); those were the known module-isolation problem in those tests, not this change, and they reproduced on `master` on the same machine, varying run to run.

`test_browser_react_18` failed once on an earlier push, on an un-awaited `act(...)` warning in `filtering.DataGridPro.test.tsx`, a file this PR does not touch. It did not reproduce against React 18 locally, on the package or on the full browser suite, and it passes on the current run.

Note that the local suites need `CI=true` to be meaningful. `vitest.shared.mts` gates `testTimeout`, `retry` and `maxWorkers` behind `process.env.CI`, so a plain local run uses a short timeout with one browser per core; when a test times out inside `act()` the shared page is poisoned and every later file fails.
