### PR TITLE
[code-infra] Run the browser tests with one page per project

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,6 +108,12 @@ jobs:
           path: test-results
   test_browser:
     <<: *default-job
+    environment:
+      <<: *default-environment
+      # Vitest opens `maxWorkers` pages per project and keeps them until the run ends
+      # (https://github.com/vitest-dev/vitest/issues/10990), so this halves the peak
+      # renderer count. The `--maxWorkers` CLI flag does not reach the projects.
+      VITEST_MAX_WORKERS: '1'
     executor:
       name: code-infra/mui-node-browser
       playwright-img-version: v1.62.1-noble


### PR DESCRIPTION
Vitest opens `maxWorkers` pages per project and keeps every one of them alive until the whole run ends ([vitest#10990](https://github.com/vitest-dev/vitest/issues/10990)). The peak renderer count is therefore `projects * maxWorkers`, not anything bounded by the work left to do. With 21 browser projects and `maxWorkers: 2` that is 42 Chromium renderers alive at once, which is what puts `test_browser` near the memory ceiling of its container and produces the intermittent `Browser page crashed` / `Browser connection was closed` failures.

Setting `VITEST_MAX_WORKERS=1` halves that.

## Measured

Full suite, cold dependency cache, same machine. Memory is `phys_footprint` summed across the renderer processes - RSS is not trustworthy here because it counts shared pages once per process, and it reported only a 10% drop for the same change.

| | before | after |
| --- | --- | --- |
| peak renderer processes | 43 | **21** |
| total renderer footprint | 11535 MB | **6702 MB (-42%)** |
| footprint per renderer | 275 MB | 335 MB |
| wall time | 175s | ~190s (+10%) |
| result | 739 passed, 8 skipped | 739 passed, 8 skipped |

Footprint per renderer goes up, because each remaining page now runs about twice as many files and `isolate` is off, so it accumulates more. Halving the process count more than compensates.

On a 16 GB container this is roughly 11.5 GB -> 6.7 GB of renderers, which turns "running at the ceiling" into about 5 GB of headroom.

### CircieCI results

https://app.circleci.com/pipelines/github/mui/mui-x/139278/workflows/a5ed8196-8eb3-431f-9b0d-13b66be8fece/jobs/903571/resources CI is sitting happily at ~75% RAM usage.

Looks like a decent compromise for the time being.

## Why the env var and not a flag

`--maxWorkers=1` on the command line does **not** reach the projects: the per-project value from `vitest.shared.mts` wins, so the flag looks like a no-op. Vitest applies `VITEST_MAX_WORKERS` last, inside each project's own config resolution, so it is the one that propagates.

Same four projects (`x-charts*`), same run, for illustration:

| setting | renderers |
| --- | --- |
| `VITEST_MAX_WORKERS=1` | 4 |
| current config (`maxWorkers: 2`) | 8 |
| CLI `--maxWorkers=1` | 8 |
| `VITEST_MAX_WORKERS=7` | 23 |

Worth noting the last row: higher values are much worse, roughly 6 renderers per project.

## Scope

One env var on the `test_browser` job, so it covers `test_browser` and `test_browser_react_18` and nothing else. `maxWorkers: 2` stays in `vitest.shared.mts` for local runs and for the jsdom job, which shards with `--no-file-parallelism` and does not have this problem.

This does not fix the underlying issue - pages of finished projects still stay open until the end of the run, which is what [vitest#10991](https://github.com/vitest-dev/vitest/pull/10991) addresses. It buys enough headroom in the meantime, without sharding, report merging, or waiting on an upstream release.

## Confirmed on CI

The table above was measured on a macOS laptop, so the container was the real test. It agrees: the `test_browser` job now peaks **under 75% of the container's RAM**, where it previously ran at the ceiling. All 12 CircleCI jobs pass.

One note for anyone reading the check history: `test_browser_react_18` failed once on an earlier run, on `dependencyArrows.EventTimelinePremium.test.tsx`. That is the roaming act-warning flake on that job, not this change - three unrelated branches hit it on three different files within 40 minutes that morning, one of them going green on retry, and it passed here on a re-run of identical code. `x-scheduler-premium` also passes locally at both `VITEST_MAX_WORKERS=1` and `=2`.

