### PR TITLE
[code-infra] Cap the workers of the browser test projects

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -24,6 +24,10 @@ const getProjects = () => {
     const isBrowser = process.env.BROWSER === 'true';
     // We delete the env to prevent it from being used in the tests
     delete process.env.BROWSER;
+    // Each config file is bundled separately, so the shared config can no longer read the
+    // environment variable by the time it is loaded. This global is set before the project
+    // configs are resolved, which makes it the place where they can pick the mode up.
+    (globalThis as { MUI_BROWSER_TESTS?: boolean }).MUI_BROWSER_TESTS = isBrowser;
     if (isBrowser) {
       return 'browser';
     }

--- a/vitest.shared.mts
+++ b/vitest.shared.mts
@@ -4,6 +4,9 @@ import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import { playwright } from '@vitest/browser-playwright';
 
+// Set by the root config before the project configs are resolved.
+const isBrowserRun = (globalThis as { MUI_BROWSER_TESTS?: boolean }).MUI_BROWSER_TESTS === true;
+
 const CURRENT_DIR = dirname(fileURLToPath(import.meta.url));
 const WORKSPACE_ROOT = resolve(CURRENT_DIR, './');
 
@@ -117,6 +120,15 @@ export default defineConfig({
     },
     // Disable isolation to speed up the tests.
     isolate: false,
+    // Every project gets its own workers, so the default lets a full run open a browser page
+    // per core in each of the ~20 browser projects at once. The pages then starve each other,
+    // and the Playwright commands that wait for the renderer to acknowledge an input event
+    // (the pointer reset in the setup hook) block for tens of seconds, which times the hook
+    // out. Capping the workers keeps the full browser run both green and faster. The jsdom
+    // projects are much cheaper per worker, so they keep the default outside of the CI.
+    ...(isBrowserRun && {
+      maxWorkers: 2,
+    }),
     // Performance improvements for the tests.
     // https://vitest.dev/guide/improving-performance.html#improving-performance
     ...(process.env.CI && {


### PR DESCRIPTION
A full `pnpm test:browser` run fails with `Error: Hook timed out in 30000ms` on the `beforeAll` of `test/setupVitest.ts`, on a handful of files locally and on ~110 of them on a busier machine.

## What happens

Each project starts its own pool of workers, so a full browser run ends up with a browser page per core in each of the ~20 browser projects at once. The pages starve each other, and the pointer reset of the setup hook waits for the renderer to acknowledge the input event.

Timings taken over a full run:

| Step | Average | Max |
| --- | --- | --- |
| `setupCrashHandler` | 60ms | 544ms |
| Command roundtrip (no-op command) | 162ms | 2.5s |
| `resetMousePosition` | 10.2s | 65.6s |

The roundtrip to the server is fine, the time is spent inside `page.mouse.move()` (timing it on the server side gives the same numbers). The pages never crash, they are only starved.

## The fix

Cap the workers of the browser projects to the value the CI already uses. The cap is limited to the browser projects: the jsdom ones are much cheaper per worker and keep the default. The shared config reads the mode from a global because the root config deletes `process.env.BROWSER` before the project configs are bundled, and each config file is bundled separately, so a shared module re-evaluates and sees the variable already gone.

## Result

Full browser run, 765 files, on an 11-core machine:

| | Before | After |
| --- | --- | --- |
| Hook timeouts | 111 | 0 |
| Duration | 203s | 144s |
| Setup | 5475s | 712s |

Neighbouring values were measured too: 5 workers still times out on 22 files, 3 workers is clean but leaves less headroom (setup 1046s).

The 4 tests that still fail on the full run are pre-existing flakes: they pass when their file is rerun, and the `EventDialog` one fails on `master` as well.