### PR TITLE
[code-infra] Replace the sinon spy types with the Vitest ones

### DIFF
--- a/packages/x-data-grid-premium/src/tests/aggregation.DataGridPremium.test.tsx
+++ b/packages/x-data-grid-premium/src/tests/aggregation.DataGridPremium.test.tsx
@@ -911,6 +911,7 @@ describe('<DataGridPremium /> - Aggregation', () => {
       const callForAggCell = renderCell.mock.calls.find(
         (call) => call[0].rowNode.type === 'pinnedRow' && call[0].aggregation,
       );
+      expect(callForAggCell).not.to.equal(undefined);
       expect(callForAggCell?.[0].aggregation?.hasCellUnit).to.equal(true);
     });
 
@@ -941,6 +942,7 @@ describe('<DataGridPremium /> - Aggregation', () => {
       const callForAggCell = renderCell.mock.calls.find(
         (call) => call[0].rowNode.type === 'pinnedRow' && call[0].aggregation,
       );
+      expect(callForAggCell).not.to.equal(undefined);
       expect(callForAggCell?.[0].aggregation?.hasCellUnit).to.equal(false);
     });
   });

--- a/packages/x-data-grid-premium/src/tests/aggregation.DataGridPremium.test.tsx
+++ b/packages/x-data-grid-premium/src/tests/aggregation.DataGridPremium.test.tsx
@@ -2,8 +2,6 @@ import type { RefObject } from '@mui/x-internals/types';
 import { createRenderer, screen, within, act, fireEvent, waitFor } from '@mui/internal-test-utils';
 import { getCell, getColumnHeaderCell, getColumnValues, microtasks } from 'test/utils/helperFn';
 import { fireUserEvent } from 'test/utils/fireUserEvent';
-import { spy } from 'sinon';
-import type { SinonSpy } from 'sinon';
 import {
   DataGridPremium,
   GRID_AGGREGATION_FUNCTIONS,
@@ -18,7 +16,8 @@ import type {
   GridColDef,
 } from '@mui/x-data-grid-premium';
 import { isJSDOM } from 'test/utils/skipIf';
-import { describe, it, expect } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
+import type { Mock } from 'vitest';
 
 const baselineProps: DataGridPremiumProps = {
   autoHeight: isJSDOM,
@@ -86,7 +85,7 @@ describe('<DataGridPremium /> - Aggregation', () => {
 
     describe('prop: aggregationModel', () => {
       it('should not call onAggregationModelChange on initialisation or on aggregationModel prop change', async () => {
-        const onAggregationModelChange = spy();
+        const onAggregationModelChange = vi.fn();
 
         const { setProps } = await render(
           <Test
@@ -95,10 +94,10 @@ describe('<DataGridPremium /> - Aggregation', () => {
           />,
         );
 
-        expect(onAggregationModelChange.callCount).to.equal(0);
+        expect(onAggregationModelChange.mock.calls.length).to.equal(0);
         setProps({ id: 'min' });
 
-        expect(onAggregationModelChange.callCount).to.equal(0);
+        expect(onAggregationModelChange.mock.calls.length).to.equal(0);
       });
 
       it('should allow to update the aggregation model from the outside', async () => {
@@ -887,7 +886,9 @@ describe('<DataGridPremium /> - Aggregation', () => {
     });
 
     it('should pass aggregation meta with `hasCellUnit: true` if the aggregation function have no hasCellUnit property', async () => {
-      const renderCell: SinonSpy<[GridRenderCellParams]> = spy((params) => `- ${params.value}`);
+      const renderCell: Mock<(params: GridRenderCellParams) => string> = vi.fn(
+        (params) => `- ${params.value}`,
+      );
 
       const customAggregationFunction: GridAggregationFunction = {
         apply: () => 'Agg value',
@@ -907,14 +908,16 @@ describe('<DataGridPremium /> - Aggregation', () => {
         />,
       );
 
-      const callForAggCell = renderCell
-        .getCalls()
-        .find((call) => call.firstArg.rowNode.type === 'pinnedRow' && call.firstArg.aggregation);
-      expect(callForAggCell!.firstArg.aggregation.hasCellUnit).to.equal(true);
+      const callForAggCell = renderCell.mock.calls.find(
+        (call) => call[0].rowNode.type === 'pinnedRow' && call[0].aggregation,
+      );
+      expect(callForAggCell?.[0].aggregation?.hasCellUnit).to.equal(true);
     });
 
     it('should pass aggregation meta with `hasCellUnit: false` if the aggregation function have `hasCellUnit: false`', async () => {
-      const renderCell: SinonSpy<[GridRenderCellParams]> = spy((params) => `- ${params.value}`);
+      const renderCell: Mock<(params: GridRenderCellParams) => string> = vi.fn(
+        (params) => `- ${params.value}`,
+      );
 
       const customAggregationFunction: GridAggregationFunction = {
         apply: () => 'Agg value',
@@ -935,10 +938,10 @@ describe('<DataGridPremium /> - Aggregation', () => {
         />,
       );
 
-      const callForAggCell = renderCell
-        .getCalls()
-        .find((call) => call.firstArg.rowNode.type === 'pinnedRow' && call.firstArg.aggregation);
-      expect(callForAggCell!.firstArg.aggregation.hasCellUnit).to.equal(false);
+      const callForAggCell = renderCell.mock.calls.find(
+        (call) => call[0].rowNode.type === 'pinnedRow' && call[0].aggregation,
+      );
+      expect(callForAggCell?.[0].aggregation?.hasCellUnit).to.equal(false);
     });
   });
 

--- a/packages/x-data-grid/src/tests/cells.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/cells.DataGrid.test.tsx
@@ -412,7 +412,9 @@ describe('<DataGrid /> - Cells', () => {
 
           const customContent = screen.getByTestId('custom-content');
           expect(customContent.textContent).to.equal('Custom: Test content');
-          expect(customRenderContent.mock.calls).to.deep.include(['Test content']);
+          expect(
+            customRenderContent.mock.calls.some((call) => call[0] === 'Test content'),
+          ).to.equal(true);
         });
       });
     });

--- a/packages/x-data-grid/src/tests/cells.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/cells.DataGrid.test.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
-import { spy } from 'sinon';
 import { createRenderer, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import { DataGrid, renderLongTextCell } from '@mui/x-data-grid';
 import type { GridApi, GridValueFormatter } from '@mui/x-data-grid';
 import { getCell, openLongTextEditPopup, openLongTextViewPopup } from 'test/utils/helperFn';
 import { getBasicGridData } from '@mui/x-data-grid-generator';
 import { isJSDOM } from 'test/utils/skipIf';
-import { describe, it, expect } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 
 describe('<DataGrid /> - Cells', () => {
   const { render } = createRenderer();
@@ -150,7 +149,7 @@ describe('<DataGrid /> - Cells', () => {
   });
 
   it('should call the valueFormatter with the correct params', () => {
-    const valueFormatter = spy<GridValueFormatter<{ id: number; isActive: boolean }>>((value) =>
+    const valueFormatter = vi.fn<GridValueFormatter<{ id: number; isActive: boolean }>>((value) =>
       value ? 'Yes' : 'No',
     );
     render(
@@ -168,10 +167,10 @@ describe('<DataGrid /> - Cells', () => {
       </div>,
     );
     expect(getCell(0, 0)).to.have.text('Yes');
-    // expect(valueFormatter.lastCall.args[0]).to.have.keys('id', 'field', 'value', 'api');
-    expect(valueFormatter.lastCall.args[0]).to.equal(true);
-    expect(valueFormatter.lastCall.args[1]).to.deep.equal({ id: 0, isActive: true });
-    expect(valueFormatter.lastCall.args[2].field).to.equal('isActive');
+    // expect(valueFormatter.mock.lastCall?.[0]).to.have.keys('id', 'field', 'value', 'api');
+    expect(valueFormatter.mock.lastCall?.[0]).to.equal(true);
+    expect(valueFormatter.mock.lastCall?.[1]).to.deep.equal({ id: 0, isActive: true });
+    expect(valueFormatter.mock.lastCall?.[2].field).to.equal('isActive');
   });
 
   it('should throw when focusing cell without updating the state', async () => {
@@ -338,7 +337,7 @@ describe('<DataGrid /> - Cells', () => {
 
         // Regression test for https://github.com/mui/mui-x/issues/22382
         it('should not submit a surrounding form when clicking the expand button', async () => {
-          const handleSubmit = spy((event: React.FormEvent) => {
+          const handleSubmit = vi.fn((event: React.FormEvent) => {
             event.preventDefault();
           });
 
@@ -359,11 +358,11 @@ describe('<DataGrid /> - Cells', () => {
           expect(expandButton).not.to.equal(null);
           await user.click(expandButton!);
 
-          expect(handleSubmit.callCount).to.equal(0);
+          expect(handleSubmit.mock.calls.length).to.equal(0);
         });
 
         it('should not submit a surrounding form when clicking the collapse button', async () => {
-          const handleSubmit = spy((event: React.FormEvent) => {
+          const handleSubmit = vi.fn((event: React.FormEvent) => {
             event.preventDefault();
           });
 
@@ -384,11 +383,11 @@ describe('<DataGrid /> - Cells', () => {
           // until its open transition settles, which never happens under jsdom.
           fireEvent.click(collapseButton);
 
-          expect(handleSubmit.callCount).to.equal(0);
+          expect(handleSubmit.mock.calls.length).to.equal(0);
         });
 
         it('should render custom content via renderContent prop', async () => {
-          const customRenderContent = spy((value: string | null) => (
+          const customRenderContent = vi.fn((value: string | null) => (
             <span data-testid="custom-content">Custom: {value}</span>
           ));
 
@@ -413,7 +412,7 @@ describe('<DataGrid /> - Cells', () => {
 
           const customContent = screen.getByTestId('custom-content');
           expect(customContent.textContent).to.equal('Custom: Test content');
-          expect(customRenderContent.calledWith('Test content')).to.equal(true);
+          expect(customRenderContent.mock.calls).to.deep.include(['Test content']);
         });
       });
     });

--- a/packages/x-data-grid/src/tests/dataSource.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/dataSource.DataGrid.test.tsx
@@ -14,6 +14,7 @@ import type {
 } from '@mui/x-data-grid';
 import { actSleep, getCell } from 'test/utils/helperFn';
 import { vi, describe, it, expect } from 'vitest';
+import type { Mock } from 'vitest';
 import { getKeyDefault } from '../hooks/features/dataSource/cache';
 import { TestCache } from '../internals/utils';
 
@@ -167,6 +168,7 @@ describe('<DataGrid /> - Data source', () => {
 
   describe('incomplete filter items', () => {
     const getSentFilterItems = () => {
+      expect(fetchRowsSpy.mock.calls.length).to.be.greaterThan(0);
       const url = new URL(fetchRowsSpy.mock.lastCall?.[0]);
       return JSON.parse(url.searchParams.get('filterModel')!).items;
     };
@@ -933,9 +935,7 @@ describe('<DataGrid /> - Data source', () => {
       });
 
       await waitFor(() => {
-        expect((secondDataSource.getRows as ReturnType<typeof vi.fn>).mock.calls.length).to.equal(
-          1,
-        );
+        expect((secondDataSource.getRows as Mock).mock.calls.length).to.equal(1);
       });
       // Previous row remains visible while the new dataSource is fetched.
       expect(localApiRef.current?.getRowsCount()).to.equal(1);
@@ -1187,7 +1187,7 @@ describe('<DataGrid /> - Data source', () => {
       await user.keyboard('{Enter} updated{Enter}');
 
       expect(editRowSpy.mock.calls.length).to.equal(1);
-      expect(editRowSpy.mock.lastCall?.[0].updatedRow.commodity).to.contain('updated');
+      expect(editRowSpy.mock.calls[0][0].updatedRow.commodity).to.contain('updated');
 
       await waitFor(() => {
         expect(clearSpy.mock.calls.length).to.equal(1);
@@ -1234,7 +1234,7 @@ describe('<DataGrid /> - Data source', () => {
       await user.keyboard('{Enter}{Enter}');
 
       expect(editRowSpy.mock.calls.length).to.equal(1);
-      expect(editRowSpy.mock.lastCall?.[0].updatedRow.commodity).to.contain('-edited');
+      expect(editRowSpy.mock.calls[0][0].updatedRow.commodity).to.contain('-edited');
     });
 
     it('should store the row verbatim when `updateRow()` returns a replace update', async () => {

--- a/packages/x-data-grid/src/tests/dataSource.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/dataSource.DataGrid.test.tsx
@@ -12,9 +12,8 @@ import type {
   GridLogicOperator,
   GridGetRowsResponse,
 } from '@mui/x-data-grid';
-import { spy } from 'sinon';
 import { actSleep, getCell } from 'test/utils/helperFn';
-import { describe, it, expect } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 import { getKeyDefault } from '../hooks/features/dataSource/cache';
 import { TestCache } from '../internals/utils';
 
@@ -26,15 +25,15 @@ const SUPPORTS_ACTIVITY = 'Activity' in React;
 
 describe('<DataGrid /> - Data source', () => {
   const { render } = createRenderer();
-  const fetchRowsSpy = spy();
-  const editRowSpy = spy();
+  const fetchRowsSpy = vi.fn();
+  const editRowSpy = vi.fn();
   let apiRef: RefObject<GridApi | null>;
   let mockServer: ReturnType<typeof useMockServer>;
 
   // TODO: Resets strictmode calls, need to find a better fix for this, maybe an AbortController?
   function Reset() {
     React.useLayoutEffect(() => {
-      fetchRowsSpy.resetHistory();
+      fetchRowsSpy.mockClear();
     }, []);
     return null;
   }
@@ -138,44 +137,44 @@ describe('<DataGrid /> - Data source', () => {
   it('should fetch the data on initial render', async () => {
     render(<TestDataSource />);
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.equal(1);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(1);
     });
   });
 
   it('should re-fetch the data on data source change', async () => {
     const { setProps } = render(<TestDataSource />);
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.equal(1);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(1);
     });
     setProps({ dataSourceKey: 2 });
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.equal(2);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(2);
     });
   });
 
   it('should re-fetch the data on filter change', async () => {
     const { setProps } = render(<TestDataSource />);
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.equal(1);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(1);
     });
     setProps({
       filterModel: { items: [{ field: 'id', value: 'abc', operator: 'doesNotContain' }] },
     });
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.equal(2);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(2);
     });
   });
 
   describe('incomplete filter items', () => {
     const getSentFilterItems = () => {
-      const url = new URL(fetchRowsSpy.lastCall.args[0]);
+      const url = new URL(fetchRowsSpy.mock.lastCall?.[0]);
       return JSON.parse(url.searchParams.get('filterModel')!).items;
     };
 
     const renderAndWaitForInitialFetch = async () => {
       render(<TestDataSource columns={[{ field: 'id' }]} dataSourceCache={null} />);
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(1);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(1);
       });
     };
 
@@ -191,13 +190,13 @@ describe('<DataGrid /> - Data source', () => {
 
       await upsertFilterItem({ id: 1, field: 'id', operator: 'contains', value: '1' });
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(2);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(2);
       });
 
       await upsertFilterItem({ id: 1, field: 'id', operator: 'contains' });
 
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(3);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(3);
       });
       expect(getSentFilterItems()).to.deep.equal([]);
     });
@@ -207,13 +206,13 @@ describe('<DataGrid /> - Data source', () => {
 
       await upsertFilterItem({ id: 1, field: 'id', operator: 'isAnyOf', value: ['1'] });
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(2);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(2);
       });
 
       await upsertFilterItem({ id: 1, field: 'id', operator: 'isAnyOf', value: [] });
 
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(3);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(3);
       });
       expect(getSentFilterItems()).to.deep.equal([]);
     });
@@ -226,7 +225,7 @@ describe('<DataGrid /> - Data source', () => {
       await upsertFilterItem({ id: 1, field: 'id', operator: 'isEmpty' });
 
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(2);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(2);
       });
       expect(getSentFilterItems()).to.deep.equal([{ id: 1, field: 'id', operator: 'isEmpty' }]);
     });
@@ -238,7 +237,7 @@ describe('<DataGrid /> - Data source', () => {
       await upsertFilterItem({ id: 1, field: 'id', operator: 'contains' });
       await actSleep(50);
 
-      expect(fetchRowsSpy.callCount).to.equal(1);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(1);
     });
 
     it('should re-fetch when an incomplete item becomes complete', async () => {
@@ -246,12 +245,12 @@ describe('<DataGrid /> - Data source', () => {
 
       await upsertFilterItem({ id: 1, field: 'id', operator: 'contains' });
       await actSleep(50);
-      expect(fetchRowsSpy.callCount).to.equal(1);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(1);
 
       await upsertFilterItem({ id: 1, field: 'id', operator: 'contains', value: '1' });
 
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(2);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(2);
       });
       expect(getSentFilterItems()).to.deep.equal([
         { id: 1, field: 'id', operator: 'contains', value: '1' },
@@ -263,7 +262,7 @@ describe('<DataGrid /> - Data source', () => {
     const renderAndWaitForInitialFetch = async () => {
       render(<TestDataSource columns={[{ field: 'id' }]} dataSourceCache={null} />);
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(1);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(1);
       });
     };
 
@@ -275,7 +274,7 @@ describe('<DataGrid /> - Data source', () => {
         apiRef.current!.upsertFilterItem({ id: 1, field: 'id', operator: 'contains', value: '1' });
       });
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(2);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(2);
       });
 
       await act(async () => {
@@ -283,7 +282,7 @@ describe('<DataGrid /> - Data source', () => {
       });
       await actSleep(50);
 
-      expect(fetchRowsSpy.callCount).to.equal(2);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(2);
     });
 
     it('should not re-fetch when the quick filter values only contain falsy entries', async () => {
@@ -294,7 +293,7 @@ describe('<DataGrid /> - Data source', () => {
       });
       await actSleep(50);
 
-      expect(fetchRowsSpy.callCount).to.equal(1);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(1);
     });
 
     it('should not re-fetch when the quick filter logic operator changes below two values', async () => {
@@ -304,7 +303,7 @@ describe('<DataGrid /> - Data source', () => {
         apiRef.current!.setQuickFilterValues(['abc']);
       });
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(2);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(2);
       });
 
       await act(async () => {
@@ -315,7 +314,7 @@ describe('<DataGrid /> - Data source', () => {
       });
       await actSleep(50);
 
-      expect(fetchRowsSpy.callCount).to.equal(2);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(2);
     });
 
     // `passFilterLogic` runs every value through the logic operator, so a falsy one added
@@ -327,7 +326,7 @@ describe('<DataGrid /> - Data source', () => {
         apiRef.current!.setQuickFilterValues(['abc']);
       });
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(2);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(2);
       });
 
       await act(async () => {
@@ -335,7 +334,7 @@ describe('<DataGrid /> - Data source', () => {
       });
 
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(3);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(3);
       });
     });
 
@@ -347,9 +346,9 @@ describe('<DataGrid /> - Data source', () => {
       });
 
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(2);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(2);
       });
-      const url = new URL(fetchRowsSpy.lastCall.args[0]);
+      const url = new URL(fetchRowsSpy.mock.lastCall?.[0]);
       expect(JSON.parse(url.searchParams.get('filterModel')!).quickFilterValues).to.deep.equal([
         'abc',
       ]);
@@ -359,29 +358,29 @@ describe('<DataGrid /> - Data source', () => {
   it('should re-fetch the data on sort change', async () => {
     const { setProps } = render(<TestDataSource />);
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.equal(1);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(1);
     });
     setProps({ sortModel: [{ field: 'id', sort: 'asc' }] });
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.equal(2);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(2);
     });
   });
 
   it('should re-fetch the data on pagination change', async () => {
     const { setProps } = render(<TestDataSource />);
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.equal(1);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(1);
     });
     setProps({ paginationModel: { page: 1, pageSize: 10 } });
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.equal(2);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(2);
     });
   });
 
   it('should re-fetch the data once if multiple models have changed', async () => {
     const { setProps } = render(<TestDataSource />);
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.equal(1);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(1);
     });
 
     setProps({
@@ -391,7 +390,7 @@ describe('<DataGrid /> - Data source', () => {
     });
 
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.equal(2);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(2);
     });
   });
 
@@ -411,17 +410,17 @@ describe('<DataGrid /> - Data source', () => {
       it('should not re-fetch the data when the Activity becomes visible', async () => {
         const { setProps } = render(<TestDataSource />);
         await waitFor(() => {
-          expect(fetchRowsSpy.callCount).to.equal(1);
+          expect(fetchRowsSpy.mock.calls.length).to.equal(1);
         });
         await toggleActivity(setProps);
-        expect(fetchRowsSpy.callCount).to.equal(1);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(1);
       });
 
       it('should keep a request in flight when the Activity is hidden', async () => {
         const { promise, resolve } = Promise.withResolvers<void>();
         const { setProps } = render(<TestDataSource stallResponsePromise={promise} />);
         await waitFor(() => {
-          expect(fetchRowsSpy.callCount).to.equal(1);
+          expect(fetchRowsSpy.mock.calls.length).to.equal(1);
         });
         await toggleActivity(setProps);
         await act(async () => {
@@ -430,14 +429,14 @@ describe('<DataGrid /> - Data source', () => {
         await waitFor(() => {
           expect(apiRef.current?.getRowsCount()).to.be.above(0);
         });
-        expect(fetchRowsSpy.callCount).to.equal(1);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(1);
       });
 
       it('should apply a response that settles while the Activity is hidden', async () => {
         const { promise, resolve } = Promise.withResolvers<void>();
         const { setProps } = render(<TestDataSource stallResponsePromise={promise} />);
         await waitFor(() => {
-          expect(fetchRowsSpy.callCount).to.equal(1);
+          expect(fetchRowsSpy.mock.calls.length).to.equal(1);
         });
         await act(async () => {
           setProps({ activityMode: 'hidden' });
@@ -451,21 +450,21 @@ describe('<DataGrid /> - Data source', () => {
         await act(async () => {
           setProps({ activityMode: 'visible' });
         });
-        expect(fetchRowsSpy.callCount).to.equal(1);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(1);
       });
 
       it('should re-fetch the data when the Activity becomes visible after a failed request', async () => {
-        const onDataSourceError = spy();
+        const onDataSourceError = vi.fn();
         const { setProps } = render(
           <TestDataSource shouldRequestsFail onDataSourceError={onDataSourceError} />,
         );
         await waitFor(() => {
-          expect(onDataSourceError.callCount).to.equal(1);
+          expect(onDataSourceError.mock.calls.length).to.equal(1);
         });
-        const callCountBeforeToggle = fetchRowsSpy.callCount;
+        const callCountBeforeToggle = fetchRowsSpy.mock.calls.length;
         await toggleActivity(setProps);
         await waitFor(() => {
-          expect(fetchRowsSpy.callCount).to.be.above(callCountBeforeToggle);
+          expect(fetchRowsSpy.mock.calls.length).to.be.above(callCountBeforeToggle);
         });
       });
 
@@ -473,14 +472,14 @@ describe('<DataGrid /> - Data source', () => {
         const { promise, resolve } = Promise.withResolvers<void>();
         const { setProps } = render(<TestDataSource />);
         await waitFor(() => {
-          expect(fetchRowsSpy.callCount).to.equal(1);
+          expect(fetchRowsSpy.mock.calls.length).to.equal(1);
         });
         setProps({
           stallResponsePromise: promise,
           filterModel: { items: [{ field: 'id', value: 'abc', operator: 'doesNotContain' }] },
         });
         await waitFor(() => {
-          expect(fetchRowsSpy.callCount).to.equal(2);
+          expect(fetchRowsSpy.mock.calls.length).to.equal(2);
         });
         await act(async () => {
           setProps({ activityMode: 'hidden' });
@@ -494,45 +493,45 @@ describe('<DataGrid /> - Data source', () => {
         await act(async () => {
           setProps({ activityMode: 'visible' });
         });
-        expect(fetchRowsSpy.callCount).to.equal(2);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(2);
       });
     });
   }
 
   describe('Cache', () => {
     it('should cache the data using the default cache', async () => {
-      const pageChangeSpy = spy();
+      const pageChangeSpy = vi.fn();
       render(<TestDataSource onPaginationModelChange={pageChangeSpy} />);
 
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(1);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(1);
       });
-      expect(pageChangeSpy.callCount).to.equal(0);
+      expect(pageChangeSpy.mock.calls.length).to.equal(0);
 
       act(() => {
         apiRef.current?.setPage(1);
       });
 
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(2);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(2);
       });
-      expect(pageChangeSpy.callCount).to.equal(1);
+      expect(pageChangeSpy.mock.calls.length).to.equal(1);
 
       act(() => {
         apiRef.current?.setPage(0);
       });
 
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(2);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(2);
       });
-      expect(pageChangeSpy.callCount).to.equal(2);
+      expect(pageChangeSpy.mock.calls.length).to.equal(2);
     });
 
     it('should cache the data using the custom cache', async () => {
       const testCache = new TestCache();
       render(<TestDataSource dataSourceCache={testCache} />);
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(1);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(1);
       });
       expect(testCache.size()).to.equal(1);
     });
@@ -543,71 +542,71 @@ describe('<DataGrid /> - Data source', () => {
         <TestDataSource dataSourceCache={testCache} paginationModel={{ page: 0, pageSize: 20 }} />,
       );
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(1);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(1);
       });
       expect(testCache.size()).to.equal(2); // 2 chunks of 10 rows
     });
 
     it('should use the cached data when the same query is made again', async () => {
       const testCache = new TestCache();
-      const pageChangeSpy = spy();
+      const pageChangeSpy = vi.fn();
       render(
         <TestDataSource dataSourceCache={testCache} onPaginationModelChange={pageChangeSpy} />,
       );
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(1);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(1);
       });
       expect(testCache.size()).to.equal(1);
-      expect(pageChangeSpy.callCount).to.equal(0);
+      expect(pageChangeSpy.mock.calls.length).to.equal(0);
 
       act(() => {
         apiRef.current?.setPage(1);
       });
 
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(2);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(2);
       });
       await waitFor(() => {
         expect(testCache.size()).to.equal(2);
       });
-      expect(pageChangeSpy.callCount).to.equal(1);
+      expect(pageChangeSpy.mock.calls.length).to.equal(1);
 
       act(() => {
         apiRef.current?.setPage(0);
       });
 
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(2);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(2);
       });
       expect(testCache.size()).to.equal(2);
-      expect(pageChangeSpy.callCount).to.equal(2);
+      expect(pageChangeSpy.mock.calls.length).to.equal(2);
     });
 
     it('should allow to disable the default cache', async () => {
-      const pageChangeSpy = spy();
+      const pageChangeSpy = vi.fn();
       render(<TestDataSource dataSourceCache={null} onPaginationModelChange={pageChangeSpy} />);
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(1);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(1);
       });
-      expect(pageChangeSpy.callCount).to.equal(0);
+      expect(pageChangeSpy.mock.calls.length).to.equal(0);
 
       act(() => {
         apiRef.current?.setPage(1);
       });
 
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(2);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(2);
       });
-      expect(pageChangeSpy.callCount).to.equal(1);
+      expect(pageChangeSpy.mock.calls.length).to.equal(1);
 
       act(() => {
         apiRef.current?.setPage(0);
       });
 
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(3);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(3);
       });
-      expect(pageChangeSpy.callCount).to.equal(2);
+      expect(pageChangeSpy.mock.calls.length).to.equal(2);
     });
 
     it('should not apply a stale in-flight response after a cache-hit navigation', async () => {
@@ -628,7 +627,7 @@ describe('<DataGrid /> - Data source', () => {
         Promise.withResolvers<GridGetRowsResponse>();
       const localApiRef = React.createRef<GridApi | null>() as RefObject<GridApi | null>;
       let callIndex = 0;
-      const getRows = spy((params: GridGetRowsParams) => {
+      const getRows = vi.fn((params: GridGetRowsParams) => {
         const index = callIndex;
         callIndex += 1;
         if (index === 0) {
@@ -673,7 +672,7 @@ describe('<DataGrid /> - Data source', () => {
         localApiRef.current?.setPage(1);
       });
       await waitFor(() => {
-        expect(getRows.callCount).to.equal(2);
+        expect(getRows.mock.calls.length).to.equal(2);
       });
 
       // Navigate back to page 0 which is now served by the cache.
@@ -699,7 +698,7 @@ describe('<DataGrid /> - Data source', () => {
 
       // Wait for initial fetch
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(1);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(1);
       });
       expect(testCache.size()).to.equal(1);
 
@@ -709,7 +708,7 @@ describe('<DataGrid /> - Data source', () => {
       });
 
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(2);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(2);
       });
       // Cache should still be updated with new data
       expect(testCache.size()).to.equal(1);
@@ -721,14 +720,14 @@ describe('<DataGrid /> - Data source', () => {
 
       // Should not trigger another fetch since data is cached
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(2);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(2);
       });
     });
   });
 
   describe('Revalidation', () => {
     it('should periodically revalidate the current query when dataSourceRevalidateMs is set', async () => {
-      const localFetchRowsSpy = spy();
+      const localFetchRowsSpy = vi.fn();
       render(
         <TestDataSource
           dataSourceCache={null}
@@ -737,33 +736,33 @@ describe('<DataGrid /> - Data source', () => {
         />,
       );
       await waitFor(() => {
-        expect(localFetchRowsSpy.callCount).to.be.greaterThan(0);
+        expect(localFetchRowsSpy.mock.calls.length).to.be.greaterThan(0);
       });
 
-      localFetchRowsSpy.resetHistory();
+      localFetchRowsSpy.mockClear();
 
       await waitFor(() => {
-        expect(localFetchRowsSpy.callCount).to.be.greaterThan(1);
+        expect(localFetchRowsSpy.mock.calls.length).to.be.greaterThan(1);
       });
     });
   });
 
   describe('No rows overlay flicker', () => {
     it('should not render the "no rows" overlay between paginated re-fetches when the cache hits', async () => {
-      const NoRowsOverlay = spy(() => null);
+      const NoRowsOverlay = vi.fn(() => null);
       render(<TestDataSource slots={{ noRowsOverlay: NoRowsOverlay }} />);
 
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(1);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(1);
       });
-      NoRowsOverlay.resetHistory();
+      NoRowsOverlay.mockClear();
 
       act(() => {
         apiRef.current?.setPage(1);
       });
 
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(2);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(2);
       });
 
       act(() => {
@@ -774,34 +773,34 @@ describe('<DataGrid /> - Data source', () => {
         expect(apiRef.current?.getRowsCount()).to.be.greaterThan(0);
       });
 
-      expect(NoRowsOverlay.callCount).to.equal(0);
+      expect(NoRowsOverlay.mock.calls.length).to.equal(0);
     });
 
     it('should not render the "no rows" overlay between paginated re-fetches when the cache misses', async () => {
-      const NoRowsOverlay = spy(() => null);
+      const NoRowsOverlay = vi.fn(() => null);
       render(<TestDataSource dataSourceCache={null} slots={{ noRowsOverlay: NoRowsOverlay }} />);
 
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(1);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(1);
       });
-      NoRowsOverlay.resetHistory();
+      NoRowsOverlay.mockClear();
 
       act(() => {
         apiRef.current?.setPage(1);
       });
 
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(2);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(2);
       });
       await waitFor(() => {
         expect(apiRef.current?.getRowsCount()).to.be.greaterThan(0);
       });
 
-      expect(NoRowsOverlay.callCount).to.equal(0);
+      expect(NoRowsOverlay.mock.calls.length).to.equal(0);
     });
 
     it('should still render the "no rows" overlay when the response contains zero rows', async () => {
-      const NoRowsOverlay = spy(() => null);
+      const NoRowsOverlay = vi.fn(() => null);
       render(
         <TestDataSource
           dataSourceCache={null}
@@ -811,10 +810,10 @@ describe('<DataGrid /> - Data source', () => {
       );
 
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(1);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(1);
       });
       await waitFor(() => {
-        expect(NoRowsOverlay.callCount).to.be.greaterThan(0);
+        expect(NoRowsOverlay.mock.calls.length).to.be.greaterThan(0);
       });
     });
   });
@@ -831,7 +830,7 @@ describe('<DataGrid /> - Data source', () => {
         rowCount: 2,
       };
       let resolvedFirst = false;
-      const getRows = spy(() => {
+      const getRows = vi.fn(() => {
         if (!resolvedFirst) {
           resolvedFirst = true;
           return Promise.resolve(initialResponse);
@@ -873,7 +872,7 @@ describe('<DataGrid /> - Data source', () => {
       });
 
       await waitFor(() => {
-        expect(getRows.callCount).to.equal(2);
+        expect(getRows.mock.calls.length).to.equal(2);
       });
       // The previous row stays visible and the loading overlay is shown on top of it.
       expect(localApiRef.current?.getRowsCount()).to.equal(1);
@@ -897,7 +896,7 @@ describe('<DataGrid /> - Data source', () => {
         getRows: () => Promise.resolve({ rows: [{ id: 1, value: 'first' }], rowCount: 2 }),
       };
       const secondDataSource: GridDataSource = {
-        getRows: spy(() => promise),
+        getRows: vi.fn(() => promise),
       };
       let localApiRef: RefObject<GridApi | null> = { current: null };
       function Test(props: Partial<DataGridProps>) {
@@ -934,7 +933,9 @@ describe('<DataGrid /> - Data source', () => {
       });
 
       await waitFor(() => {
-        expect((secondDataSource.getRows as ReturnType<typeof spy>).callCount).to.equal(1);
+        expect((secondDataSource.getRows as ReturnType<typeof vi.fn>).mock.calls.length).to.equal(
+          1,
+        );
       });
       // Previous row remains visible while the new dataSource is fetched.
       expect(localApiRef.current?.getRowsCount()).to.equal(1);
@@ -960,7 +961,7 @@ describe('<DataGrid /> - Data source', () => {
         rowCount: 2,
       };
       let resolvedFirst = false;
-      const getRows = spy(() => {
+      const getRows = vi.fn(() => {
         if (!resolvedFirst) {
           resolvedFirst = true;
           return Promise.resolve(initialResponse);
@@ -1001,7 +1002,7 @@ describe('<DataGrid /> - Data source', () => {
       });
 
       await waitFor(() => {
-        expect(getRows.callCount).to.equal(2);
+        expect(getRows.mock.calls.length).to.equal(2);
       });
       // Without the prop, the previous rows are cleared while the new page is fetched.
       expect(localApiRef.current?.getRowsCount()).to.equal(0);
@@ -1016,7 +1017,7 @@ describe('<DataGrid /> - Data source', () => {
     });
 
     it('should not render the "no rows" overlay while keeping previous rows during fetch', async () => {
-      const NoRowsOverlay = spy(() => null);
+      const NoRowsOverlay = vi.fn(() => null);
       render(
         <TestDataSource
           dataSourceCache={null}
@@ -1026,22 +1027,22 @@ describe('<DataGrid /> - Data source', () => {
       );
 
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(1);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(1);
       });
-      NoRowsOverlay.resetHistory();
+      NoRowsOverlay.mockClear();
 
       act(() => {
         apiRef.current?.setPage(1);
       });
 
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(2);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(2);
       });
       await waitFor(() => {
         expect(apiRef.current?.getRowsCount()).to.be.greaterThan(0);
       });
 
-      expect(NoRowsOverlay.callCount).to.equal(0);
+      expect(NoRowsOverlay.mock.calls.length).to.equal(0);
     });
 
     it('should reset the rows when the refetch errors', async () => {
@@ -1053,7 +1054,7 @@ describe('<DataGrid /> - Data source', () => {
         rowCount: 2,
       };
       let firstCall = true;
-      const getRows = spy(() => {
+      const getRows = vi.fn(() => {
         if (firstCall) {
           firstCall = false;
           return Promise.resolve(initialResponse);
@@ -1061,7 +1062,7 @@ describe('<DataGrid /> - Data source', () => {
         return Promise.reject(new Error('Network error'));
       });
       const dataSource: GridDataSource = { getRows };
-      const onDataSourceError = spy();
+      const onDataSourceError = vi.fn();
       let localApiRef: RefObject<GridApi | null> = { current: null };
       function Test(props: Partial<DataGridProps>) {
         localApiRef = useGridApiRef();
@@ -1097,7 +1098,7 @@ describe('<DataGrid /> - Data source', () => {
       });
 
       await waitFor(() => {
-        expect(onDataSourceError.callCount).to.equal(1);
+        expect(onDataSourceError.mock.calls.length).to.equal(1);
       });
       // The previous rows are reset once the request fails.
       expect(localApiRef.current?.getRowsCount()).to.equal(0);
@@ -1108,17 +1109,17 @@ describe('<DataGrid /> - Data source', () => {
 
   describe('Error handling', () => {
     it('should call `onDataSourceError` when the data source returns an error', async () => {
-      const onDataSourceError = spy();
+      const onDataSourceError = vi.fn();
       render(<TestDataSource onDataSourceError={onDataSourceError} shouldRequestsFail />);
       await waitFor(() => {
-        expect(onDataSourceError.callCount).to.equal(1);
+        expect(onDataSourceError.mock.calls.length).to.equal(1);
       });
     });
 
     it('should not call `onDataSourceError` after unmount', async () => {
-      const onDataSourceError = spy();
+      const onDataSourceError = vi.fn();
       const { promise, reject } = Promise.withResolvers<GridGetRowsResponse>();
-      const getRows = spy(() => promise);
+      const getRows = vi.fn(() => promise);
       const dataSource: GridDataSource = {
         getRows,
       };
@@ -1138,18 +1139,18 @@ describe('<DataGrid /> - Data source', () => {
         </div>,
       );
       await waitFor(() => {
-        expect(getRows.called).to.equal(true);
+        expect(getRows.mock.calls.length).to.be.greaterThan(0);
       });
       unmount();
       reject();
       await promise.catch(() => 'rejected');
-      expect(onDataSourceError.notCalled).to.equal(true);
+      expect(onDataSourceError.mock.calls.length).to.equal(0);
     });
   });
 
   describe('Editing', () => {
     it('should call `editRow()` and clear the cache when a row is updated', async () => {
-      const clearSpy = spy();
+      const clearSpy = vi.fn();
       const cache = new Map<string, GridGetRowsResponse>();
       const dataSourceCache = {
         get: (key: GridGetRowsParams) => cache.get(getKeyDefault(key)),
@@ -1168,7 +1169,7 @@ describe('<DataGrid /> - Data source', () => {
       );
 
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(1);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(1);
       });
 
       await waitFor(() => {
@@ -1178,18 +1179,18 @@ describe('<DataGrid /> - Data source', () => {
       await user.click(cell);
       expect(cell).toHaveFocus();
 
-      clearSpy.resetHistory();
+      clearSpy.mockClear();
 
       expect(cache.size).to.equal(1);
 
       // edit the cell
       await user.keyboard('{Enter} updated{Enter}');
 
-      expect(editRowSpy.callCount).to.equal(1);
-      expect(editRowSpy.lastCall.args[0].updatedRow.commodity).to.contain('updated');
+      expect(editRowSpy.mock.calls.length).to.equal(1);
+      expect(editRowSpy.mock.lastCall?.[0].updatedRow.commodity).to.contain('updated');
 
       await waitFor(() => {
-        expect(clearSpy.callCount).to.equal(1);
+        expect(clearSpy.mock.calls.length).to.equal(1);
       });
     });
 
@@ -1217,7 +1218,7 @@ describe('<DataGrid /> - Data source', () => {
       );
 
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(1);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(1);
       });
 
       await waitFor(() => {
@@ -1227,13 +1228,13 @@ describe('<DataGrid /> - Data source', () => {
       await user.click(cell);
       expect(cell).toHaveFocus();
 
-      editRowSpy.resetHistory();
+      editRowSpy.mockClear();
 
       // edit the cell
       await user.keyboard('{Enter}{Enter}');
 
-      expect(editRowSpy.callCount).to.equal(1);
-      expect(editRowSpy.lastCall.args[0].updatedRow.commodity).to.contain('-edited');
+      expect(editRowSpy.mock.calls.length).to.equal(1);
+      expect(editRowSpy.mock.lastCall?.[0].updatedRow.commodity).to.contain('-edited');
     });
 
     it('should store the row verbatim when `updateRow()` returns a replace update', async () => {
@@ -1320,7 +1321,7 @@ describe('<DataGrid /> - Data source', () => {
       ];
 
       function createTestCase(updateRow: NonNullable<GridDataSource['updateRow']>) {
-        const clearSpy = spy();
+        const clearSpy = vi.fn();
         const cache = new Map<string, GridGetRowsResponse>();
         const dataSourceCache = {
           get: (key: GridGetRowsParams) => cache.get(getKeyDefault(key)),
@@ -1382,13 +1383,13 @@ describe('<DataGrid /> - Data source', () => {
         await waitFor(() => {
           expect(apiRef.current?.getRow(1)).not.to.equal(null);
         });
-        clearSpy.resetHistory();
+        clearSpy.mockClear();
 
         await editCommodityCell();
 
         expect(apiRef.current?.getRow(1)!.commodity).to.equal('Cobalt');
         // The row did not change, so the cached pages are still valid.
-        expect(clearSpy.callCount).to.equal(0);
+        expect(clearSpy.mock.calls.length).to.equal(0);
       });
 
       it('should clear the cache when the replacement changes the row', async () => {
@@ -1401,12 +1402,12 @@ describe('<DataGrid /> - Data source', () => {
         await waitFor(() => {
           expect(apiRef.current?.getRow(1)).not.to.equal(null);
         });
-        clearSpy.resetHistory();
+        clearSpy.mockClear();
 
         await editCommodityCell();
 
         expect(apiRef.current?.getRow(1)!.commodity).to.equal('Silver');
-        expect(clearSpy.callCount).to.equal(1);
+        expect(clearSpy.mock.calls.length).to.equal(1);
       });
     });
   });

--- a/packages/x-data-grid/src/tests/keyboard.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/keyboard.DataGrid.test.tsx
@@ -935,6 +935,10 @@ describe('<DataGrid /> - Keyboard', () => {
       await act(async () => cell.focus());
       await user.keyboard(`{${keyType}}`);
 
+      // Sinon's `lastCall` threw when the spy was never called. `mock.lastCall` is
+      // `undefined` instead, so assert the call to keep "never reset" a failure.
+      expect(valueSetterMock.mock.calls.length).to.be.greaterThan(0);
+
       return {
         cell: cell.textContent,
         deletedValue: valueSetterMock.mock.lastCall?.[0],

--- a/packages/x-data-grid/src/tests/keyboard.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/keyboard.DataGrid.test.tsx
@@ -935,8 +935,6 @@ describe('<DataGrid /> - Keyboard', () => {
       await act(async () => cell.focus());
       await user.keyboard(`{${keyType}}`);
 
-      // Sinon's `lastCall` threw when the spy was never called. `mock.lastCall` is
-      // `undefined` instead, so assert the call to keep "never reset" a failure.
       expect(valueSetterMock.mock.calls.length).to.be.greaterThan(0);
 
       return {

--- a/packages/x-data-grid/src/tests/keyboard.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/keyboard.DataGrid.test.tsx
@@ -1,5 +1,4 @@
 import { createRenderer, fireEvent, screen, act } from '@mui/internal-test-utils';
-import { spy } from 'sinon';
 import {
   getActiveCell,
   getActiveColumnHeader,
@@ -14,7 +13,7 @@ import type { DataGridProps, GridColDef, GridColType, GridValueSetter } from '@m
 import { useBasicDemoData, getBasicGridData } from '@mui/x-data-grid-generator';
 import RestoreIcon from '@mui/icons-material/Restore';
 import { isJSDOM } from 'test/utils/skipIf';
-import { describe, it, expect } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 
 const PAGE_SIZE = 10;
 const ROW_HEIGHT = 52;
@@ -630,7 +629,7 @@ describe('<DataGrid /> - Keyboard', () => {
   });
 
   it('should call preventDefault when using keyboard navigation', async () => {
-    const handleKeyDown = spy((event) => event.defaultPrevented);
+    const handleKeyDown = vi.fn((event) => event.defaultPrevented);
 
     const columns = [{ field: 'id' }, { field: 'name' }];
     const rows = [{ id: 1, name: 'John' }];
@@ -642,7 +641,7 @@ describe('<DataGrid /> - Keyboard', () => {
     );
     await user.click(getCell(0, 0));
     await user.keyboard('{ArrowRight}');
-    expect(handleKeyDown.returnValues).to.deep.equal([true]);
+    expect(handleKeyDown.mock.results.map((result) => result.value)).to.deep.equal([true]);
   });
 
   it('should sort column when pressing enter and column header is selected', async () => {
@@ -693,7 +692,7 @@ describe('<DataGrid /> - Keyboard', () => {
   });
 
   it('should not rerender when pressing a key inside an already focused cell', () => {
-    const renderCell = spy(() => <input type="text" data-testid="custom-input" />);
+    const renderCell = vi.fn(() => <input type="text" data-testid="custom-input" />);
     const columns = [{ field: 'name', renderCell }];
     const rows = [{ id: 1, name: 'John' }];
     render(
@@ -701,13 +700,13 @@ describe('<DataGrid /> - Keyboard', () => {
         <DataGrid rows={rows} columns={columns} />
       </div>,
     );
-    expect(renderCell.callCount).to.equal(2);
+    expect(renderCell.mock.calls.length).to.equal(2);
     const input = screen.getByTestId('custom-input');
     input.focus();
     fireEvent.keyDown(input, { key: 'a' });
-    expect(renderCell.callCount).to.equal(4);
+    expect(renderCell.mock.calls.length).to.equal(4);
     fireEvent.keyDown(input, { key: 'b' });
-    expect(renderCell.callCount).to.equal(4);
+    expect(renderCell.mock.calls.length).to.equal(4);
   });
 
   it('should not scroll horizontally when cell is wider than viewport', async () => {
@@ -897,7 +896,7 @@ describe('<DataGrid /> - Keyboard', () => {
       columns: GridColDef[],
       editMode: DataGridProps['editMode'],
     ) {
-      const valueSetterMock = spy<GridValueSetter<(typeof columns)[number]>>(
+      const valueSetterMock = vi.fn<GridValueSetter<(typeof columns)[number]>>(
         (value, row, column) => {
           return {
             ...row,
@@ -938,7 +937,7 @@ describe('<DataGrid /> - Keyboard', () => {
 
       return {
         cell: cell.textContent,
-        deletedValue: valueSetterMock.lastCall.args[0],
+        deletedValue: valueSetterMock.mock.lastCall?.[0],
       };
     }
 

--- a/packages/x-data-grid/src/tests/pagination.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/pagination.DataGrid.test.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
 import type { RefObject } from '@mui/x-internals/types';
-import { spy } from 'sinon';
-import type { SinonSpy } from 'sinon';
 import {
   createRenderer,
   fireEvent,
@@ -16,7 +14,8 @@ import { useBasicDemoData } from '@mui/x-data-grid-generator';
 import { getCell, getColumnValues, getRows } from 'test/utils/helperFn';
 import { fireUserEvent } from 'test/utils/fireUserEvent';
 import { isJSDOM } from 'test/utils/skipIf';
-import { describe, it, expect } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
+import type { Mock } from 'vitest';
 
 describe('<DataGrid /> - Pagination', () => {
   const { render } = createRenderer();
@@ -43,7 +42,7 @@ describe('<DataGrid /> - Pagination', () => {
     });
 
     it('should not call onPaginationModelChange on initialisation', () => {
-      const onPaginationModelChange = spy();
+      const onPaginationModelChange = vi.fn();
 
       render(
         <BaselineTestCase
@@ -53,7 +52,7 @@ describe('<DataGrid /> - Pagination', () => {
         />,
       );
 
-      expect(onPaginationModelChange.callCount).to.equal(0);
+      expect(onPaginationModelChange.mock.calls.length).to.equal(0);
     });
 
     it('should allow to update the paginationModel from the outside', () => {
@@ -75,7 +74,7 @@ describe('<DataGrid /> - Pagination', () => {
     });
 
     it('should call onPaginationModelChange and apply new page when clicking on next / previous button', () => {
-      const onPaginationModelChange = spy();
+      const onPaginationModelChange = vi.fn();
 
       render(
         <BaselineTestCase
@@ -86,13 +85,13 @@ describe('<DataGrid /> - Pagination', () => {
       );
 
       fireEvent.click(screen.getByRole('button', { name: /next page/i }));
-      expect(onPaginationModelChange.callCount).to.equal(1);
-      expect(onPaginationModelChange.lastCall.args[0].page).to.equal(1);
+      expect(onPaginationModelChange.mock.calls.length).to.equal(1);
+      expect(onPaginationModelChange.mock.lastCall?.[0].page).to.equal(1);
       expect(getColumnValues(0)).to.deep.equal(['1']);
 
       fireEvent.click(screen.getByRole('button', { name: /previous page/i }));
-      expect(onPaginationModelChange.callCount).to.equal(2);
-      expect(onPaginationModelChange.lastCall.args[0].page).to.equal(0);
+      expect(onPaginationModelChange.mock.calls.length).to.equal(2);
+      expect(onPaginationModelChange.mock.lastCall?.[0].page).to.equal(0);
       expect(getColumnValues(0)).to.deep.equal(['0']);
     });
 
@@ -106,7 +105,7 @@ describe('<DataGrid /> - Pagination', () => {
     });
 
     it('should call onPaginationModelChange and apply the new pageSize when clicking on a page size option and paginationModel is not controlled', () => {
-      const onPaginationModelChange = spy();
+      const onPaginationModelChange = vi.fn();
 
       render(
         <BaselineTestCase
@@ -118,19 +117,15 @@ describe('<DataGrid /> - Pagination', () => {
       expect(screen.queryAllByRole('option').length).to.equal(4);
 
       fireEvent.click(screen.queryAllByRole('option')[1]);
-      expect(onPaginationModelChange.callCount).to.equal(1);
-      expect(onPaginationModelChange.lastCall.args[0].pageSize).to.equal(2);
+      expect(onPaginationModelChange.mock.calls.length).to.equal(1);
+      expect(onPaginationModelChange.mock.lastCall?.[0].pageSize).to.equal(2);
       expect(getColumnValues(0)).to.deep.equal(['0', '1']);
     });
 
     it('should call onPaginationModelChange with the correct paginationModel when clicking on next / previous button when paginationModel is controlled', () => {
-      const onPaginationModelChange = spy();
+      const onPaginationModelChange = vi.fn();
 
-      function TestCase({
-        handlePaginationModelChange,
-      }: {
-        handlePaginationModelChange: SinonSpy;
-      }) {
+      function TestCase({ handlePaginationModelChange }: { handlePaginationModelChange: Mock }) {
         const [paginationModel, setPaginationModel] = React.useState({ pageSize: 1, page: 0 });
         return (
           <BaselineTestCase
@@ -147,16 +142,16 @@ describe('<DataGrid /> - Pagination', () => {
       render(<TestCase handlePaginationModelChange={onPaginationModelChange} />);
 
       fireEvent.click(screen.getByRole('button', { name: /next page/i }));
-      expect(onPaginationModelChange.lastCall.args[0]).to.deep.equal({ page: 1, pageSize: 1 });
+      expect(onPaginationModelChange.mock.lastCall?.[0]).to.deep.equal({ page: 1, pageSize: 1 });
       expect(getColumnValues(0)).to.deep.equal(['1']);
 
       fireEvent.click(screen.getByRole('button', { name: /previous page/i }));
-      expect(onPaginationModelChange.lastCall.args[0]).to.deep.equal({ page: 0, pageSize: 1 });
+      expect(onPaginationModelChange.mock.lastCall?.[0]).to.deep.equal({ page: 0, pageSize: 1 });
       expect(getColumnValues(0)).to.deep.equal(['0']);
     });
 
     it('should call onPaginationModelChange when clicking on next / previous button in "server" mode', () => {
-      const onPaginationModelChange = spy();
+      const onPaginationModelChange = vi.fn();
 
       render(
         <BaselineTestCase
@@ -168,10 +163,10 @@ describe('<DataGrid /> - Pagination', () => {
         />,
       );
       fireEvent.click(screen.getByRole('button', { name: /next page/i }));
-      expect(onPaginationModelChange.callCount).to.equal(1);
-      expect(onPaginationModelChange.lastCall.args[0]).to.deep.equal({ page: 1, pageSize: 1 });
+      expect(onPaginationModelChange.mock.calls.length).to.equal(1);
+      expect(onPaginationModelChange.mock.lastCall?.[0]).to.deep.equal({ page: 1, pageSize: 1 });
       fireEvent.click(screen.getByRole('button', { name: /previous page/i }));
-      expect(onPaginationModelChange.lastCall.args[0]).to.deep.equal({ page: 0, pageSize: 1 });
+      expect(onPaginationModelChange.mock.lastCall?.[0]).to.deep.equal({ page: 0, pageSize: 1 });
     });
 
     it('should not change the state when clicking on next button and a `paginationModel` prop is provided', () => {
@@ -204,7 +199,7 @@ describe('<DataGrid /> - Pagination', () => {
     });
 
     it('should go to last page when paginationModel is controlled and the current page is greater than the last page', async () => {
-      const onPaginationModelChange = spy();
+      const onPaginationModelChange = vi.fn();
       function TestCasePaginationFilteredData(props: Partial<DataGridProps>) {
         const [paginationModel, setPaginationModel] = React.useState({ page: 1, pageSize: 5 });
 
@@ -225,7 +220,7 @@ describe('<DataGrid /> - Pagination', () => {
         );
       }
       const { setProps } = render(<TestCasePaginationFilteredData />);
-      expect(onPaginationModelChange.callCount).to.equal(0);
+      expect(onPaginationModelChange.mock.calls.length).to.equal(0);
 
       setProps({
         filterModel: {
@@ -243,8 +238,8 @@ describe('<DataGrid /> - Pagination', () => {
       await waitFor(() => {
         expect(getColumnValues(0)).to.deep.equal(['0', '1', '2', '3']);
       });
-      expect(onPaginationModelChange.callCount).to.equal(1);
-      expect(onPaginationModelChange.lastCall.args[0]).to.deep.equal({ page: 0, pageSize: 5 });
+      expect(onPaginationModelChange.mock.calls.length).to.equal(1);
+      expect(onPaginationModelChange.mock.lastCall?.[0]).to.deep.equal({ page: 0, pageSize: 5 });
     });
 
     it('should scroll to the top of the page when changing page', () => {
@@ -275,7 +270,7 @@ describe('<DataGrid /> - Pagination', () => {
     });
 
     it('should call onPaginationModelChange with the correct page when clicking on a page size option when paginationModel is controlled', () => {
-      const onPaginationModelChange = spy();
+      const onPaginationModelChange = vi.fn();
 
       render(
         <BaselineTestCase
@@ -289,8 +284,8 @@ describe('<DataGrid /> - Pagination', () => {
       expect(screen.queryAllByRole('option').length).to.equal(3);
 
       fireEvent.click(screen.queryAllByRole('option')[1]);
-      expect(onPaginationModelChange.callCount).to.equal(1);
-      expect(onPaginationModelChange.lastCall.args[0]).to.deep.equal({ pageSize: 2, page: 0 });
+      expect(onPaginationModelChange.mock.calls.length).to.equal(1);
+      expect(onPaginationModelChange.mock.lastCall?.[0]).to.deep.equal({ pageSize: 2, page: 0 });
     });
 
     it('should not change the pageSize state when clicking on a page size option when paginationModel prop is provided', () => {
@@ -459,7 +454,7 @@ describe('<DataGrid /> - Pagination', () => {
     });
 
     it('should update the amount of rows rendered and call onPageSizeChange when changing the table height', async () => {
-      const onPaginationModelChange = spy();
+      const onPaginationModelChange = vi.fn();
 
       const nbRows = 27;
 
@@ -500,7 +495,7 @@ describe('<DataGrid /> - Pagination', () => {
       rows = document.querySelectorAll('.MuiDataGrid-virtualScrollerRenderZone [role="row"]');
       expect(rows.length).to.equal(expectedViewportRowsLengthAfter);
 
-      expect(onPaginationModelChange.lastCall.args[0].pageSize).to.equal(
+      expect(onPaginationModelChange.mock.lastCall?.[0].pageSize).to.equal(
         expectedViewportRowsLengthAfter,
       );
     });

--- a/packages/x-internals/src/useDisposable/useDisposable.test.tsx
+++ b/packages/x-internals/src/useDisposable/useDisposable.test.tsx
@@ -1,17 +1,17 @@
 import * as React from 'react';
-import { expect, describe, it } from 'vitest';
+import { vi, expect, describe, it } from 'vitest';
+import type { Mock } from 'vitest';
 import { createRenderer, act } from '@mui/internal-test-utils';
-import { spy, type SinonSpy } from 'sinon';
 import { disposeSymbol } from '../disposable';
 import { useDisposable } from './useDisposable';
 
 interface TestDisposable {
-  dispose: SinonSpy;
+  dispose: Mock;
   [disposeSymbol](): void;
 }
 
 function createDisposable(): TestDisposable {
-  const dispose = spy();
+  const dispose = vi.fn();
   return {
     dispose,
     [disposeSymbol]() {
@@ -48,7 +48,7 @@ describe('useDisposable', () => {
   function setup() {
     let instance: TestDisposable | undefined;
     let effectMounts = 0;
-    const factory = spy(() => {
+    const factory = vi.fn(() => {
       instance = createDisposable();
       return instance;
     });
@@ -79,14 +79,14 @@ describe('useDisposable', () => {
     // otherwise the assertions below wouldn't actually cover the double mount.
     expect(getEffectMounts()).to.equal(2);
     // The committed instance survives the cycle (React 18 adds a throwaway create).
-    expect(factory.callCount).to.equal(expected.factoryCallCount);
+    expect(factory.mock.calls.length).to.equal(expected.factoryCallCount);
     // ...and the simulated unmount does not dispose the committed instance.
-    expect(getInstance().dispose.callCount).to.equal(0);
+    expect(getInstance().dispose.mock.calls.length).to.equal(0);
 
     unmount();
 
     // The real unmount disposes exactly once, even inside `<StrictMode>`.
-    expect(getInstance().dispose.callCount).to.equal(1);
+    expect(getInstance().dispose.mock.calls.length).to.equal(1);
   });
 
   it('creates the instance once and disposes it on unmount (without StrictMode)', () => {
@@ -97,12 +97,12 @@ describe('useDisposable', () => {
     // No replay: a single mount, so the skip-the-simulated-unmount branch is
     // never taken.
     expect(getEffectMounts()).to.equal(1);
-    expect(factory.callCount).to.equal(1);
-    expect(getInstance().dispose.callCount).to.equal(0);
+    expect(factory.mock.calls.length).to.equal(1);
+    expect(getInstance().dispose.mock.calls.length).to.equal(0);
 
     unmount();
 
-    expect(getInstance().dispose.callCount).to.equal(1);
+    expect(getInstance().dispose.mock.calls.length).to.equal(1);
   });
 
   // Why this hook detects StrictMode instead of just disposing + recreating the
@@ -168,12 +168,12 @@ describe('useDisposable', () => {
     // disposed. React 18's throwaway create sits at index 0, shifting committed to 1.
     expect(created).to.have.length(expected.createdCount);
     expect(committedInstance).to.equal(created[expected.committedIndex]);
-    expect(created[expected.committedIndex].dispose.callCount).to.equal(1);
+    expect(created[expected.committedIndex].dispose.mock.calls.length).to.equal(1);
     // The live, non-disposed instance is the last one, rebuilt in the remount
     // effect — the component never re-rendered to pick it up (split-brain).
     const live = created[created.length - 1];
     expect(live).to.not.equal(committedInstance);
-    expect(live.dispose.callCount).to.equal(0);
+    expect(live.dispose.mock.calls.length).to.equal(0);
 
     unmount();
   });
@@ -217,18 +217,18 @@ describe('useDisposable', () => {
     render(<App />, { strict: false });
     expect(created).to.have.length(1);
     const first = created[0];
-    expect(first.dispose.callCount).to.equal(0);
+    expect(first.dispose.mock.calls.length).to.equal(0);
 
     // Hiding disconnects effects: the cleanup disposes the instance and clears
     // the ref.
     act(() => setMode('hidden'));
-    expect(first.dispose.callCount).to.equal(1);
+    expect(first.dispose.mock.calls.length).to.equal(1);
 
     // Revealing re-renders before re-running effects, so the component is
     // committed against a fresh, never-disposed instance — not the torn-down one.
     act(() => setMode('visible'));
     expect(created.length).to.be.greaterThan(1);
     expect(committed).to.equal(created[created.length - 1]);
-    expect(committed!.dispose.callCount).to.equal(0);
+    expect(committed!.dispose.mock.calls.length).to.equal(0);
   });
 });

--- a/packages/x-scheduler/src/internals/components/event-dialog/EventDialog.test.tsx
+++ b/packages/x-scheduler/src/internals/components/event-dialog/EventDialog.test.tsx
@@ -372,7 +372,7 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
       expect(screen.queryByRole('textbox', { name: 'Description' })).to.equal(null);
     });
 
-    function renderCreation(onEventsChange: Mock<(...args: any[]) => void>) {
+    function renderCreation(onEventsChange: Mock<(events: SchedulerEvent[]) => void>) {
       const start = adapter.date('2025-05-26T07:30:00Z', 'default');
       const end = adapter.date('2025-05-26T08:15:00Z', 'default');
       const creationOccurrence = EventBuilder.new()
@@ -417,7 +417,7 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
       await user.click(screen.getByRole('button', { name: 'Save' }));
 
       expect(onEventsChange.mock.calls.length).to.equal(1);
-      const [created] = onEventsChange.mock.lastCall?.[0] ?? [];
+      const [created] = onEventsChange.mock.calls[0][0];
       expect(created.priority).to.equal('high');
     });
 
@@ -430,7 +430,7 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
       await user.click(screen.getByRole('button', { name: 'Save' }));
 
       expect(onEventsChange.mock.calls.length).to.equal(1);
-      const [created] = onEventsChange.mock.lastCall?.[0] ?? [];
+      const [created] = onEventsChange.mock.calls[0][0];
       expect(created).not.to.have.property('priority');
     });
 
@@ -555,9 +555,7 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
       }).toWarnDev(['MUI X Scheduler: useEventDialogFormField() received the key "readOnly"']);
 
       expect(onEventsChange.mock.calls.length).to.equal(1);
-      const saved = onEventsChange.mock.lastCall?.[0].find(
-        (event: SchedulerEvent) => event.id === DEFAULT_EVENT.id,
-      );
+      const saved = onEventsChange.mock.calls[0][0].find((event) => event.id === DEFAULT_EVENT.id);
       expect(saved).not.to.have.property('readOnly');
       expect(saved.notes).to.equal('kept');
     });

--- a/packages/x-scheduler/src/internals/components/event-dialog/EventDialog.test.tsx
+++ b/packages/x-scheduler/src/internals/components/event-dialog/EventDialog.test.tsx
@@ -9,7 +9,6 @@ import {
   SchedulerStoreRunner,
 } from 'test/utils/scheduler';
 import { act, fireEvent, screen } from '@mui/internal-test-utils';
-import { spy } from 'sinon';
 import { clearWarningsCache } from '@mui/x-internals/warning';
 import type { SchedulerResource } from '@mui/x-scheduler-internals/models';
 import { SchedulerStoreContext } from '@mui/x-scheduler-internals/use-scheduler-store-context';
@@ -24,7 +23,8 @@ import {
   useEventDialogFormField,
   useEventDialogOccurrence,
 } from '@mui/x-scheduler/event-dialog';
-import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import { vi, describe, it, expect, afterEach, beforeEach } from 'vitest';
+import type { Mock } from 'vitest';
 import type { SchedulerSlotProps, SchedulerSlots } from '../../../models/slots';
 import { MonthView } from '../../../month-view';
 import { EventDialogContent, EventDialogProvider } from './EventDialog';
@@ -123,8 +123,8 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
   });
 
   it('should allow saving when shouldEventRequireResource is true but no resources are configured', async () => {
-    const onClose = spy();
-    const onEventsChange = spy();
+    const onClose = vi.fn();
+    const onEventsChange = vi.fn();
     const noResourceEvent: SchedulerEvent = EventBuilder.new()
       .title('Running')
       .description('Morning run')
@@ -159,8 +159,8 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
       'MUI X Scheduler: `shouldEventRequireResource` is `true` but no resources are configured.',
     ]);
 
-    expect(onClose.callCount).to.equal(1);
-    expect(onEventsChange.callCount).to.equal(1);
+    expect(onClose.mock.calls.length).to.equal(1);
+    expect(onEventsChange.mock.calls.length).to.equal(1);
     expect(screen.queryByRole('alert')).to.equal(null);
   });
 
@@ -372,7 +372,7 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
       expect(screen.queryByRole('textbox', { name: 'Description' })).to.equal(null);
     });
 
-    function renderCreation(onEventsChange: ReturnType<typeof spy>) {
+    function renderCreation(onEventsChange: Mock<(...args: any[]) => void>) {
       const start = adapter.date('2025-05-26T07:30:00Z', 'default');
       const end = adapter.date('2025-05-26T08:15:00Z', 'default');
       const creationOccurrence = EventBuilder.new()
@@ -407,7 +407,7 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
     }
 
     it('should save an edited custom field when creating an event', async () => {
-      const onEventsChange = spy();
+      const onEventsChange = vi.fn();
       const { user } = renderCreation(onEventsChange);
 
       await user.type(screen.getByRole('textbox', { name: /event title/i }), 'Meeting');
@@ -416,26 +416,26 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
       await user.type(priority, 'high');
       await user.click(screen.getByRole('button', { name: 'Save' }));
 
-      expect(onEventsChange.callCount).to.equal(1);
-      const [created] = onEventsChange.lastCall.firstArg;
+      expect(onEventsChange.mock.calls.length).to.equal(1);
+      const [created] = onEventsChange.mock.lastCall?.[0] ?? [];
       expect(created.priority).to.equal('high');
     });
 
     it('should omit an untouched default when creating an event', async () => {
-      const onEventsChange = spy();
+      const onEventsChange = vi.fn();
       const { user } = renderCreation(onEventsChange);
 
       expect(screen.getByRole('textbox', { name: 'Priority' })).to.have.value('normal');
       await user.type(screen.getByRole('textbox', { name: /event title/i }), 'Meeting');
       await user.click(screen.getByRole('button', { name: 'Save' }));
 
-      expect(onEventsChange.callCount).to.equal(1);
-      const [created] = onEventsChange.lastCall.firstArg;
+      expect(onEventsChange.mock.calls.length).to.equal(1);
+      const [created] = onEventsChange.mock.lastCall?.[0] ?? [];
       expect(created).not.to.have.property('priority');
     });
 
     it('should not re-render the slot content when a creation keystroke pushes the placeholder', () => {
-      const onRender = spy();
+      const onRender = vi.fn();
       function RenderProbe() {
         const priority = useEventDialogFormField('priority', { defaultValue: 'normal' });
         onRender();
@@ -489,13 +489,13 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
         </EventCalendarProvider>,
       );
 
-      const rendersBefore = onRender.callCount;
+      const rendersBefore = onRender.mock.calls.length;
       fireEvent.change(screen.getByLabelText(/start date/i), { target: { value: '2025-05-27' } });
 
       // The write pushes a placeholder into the scheduler store; the dialog must not
       // re-render wholesale for it, only the fields bound to the written keys.
       expect(screen.getByLabelText(/start date/i)).to.have.value('2025-05-27');
-      expect(onRender.callCount).to.equal(rendersBefore);
+      expect(onRender.mock.calls.length).to.equal(rendersBefore);
 
       const placeholder = schedulerOccurrencePlaceholderSelectors.value(schedulerStore.state)!;
       expect(adapter.formatByString(placeholder.start, 'yyyy-MM-dd')).to.equal('2025-05-27');
@@ -523,7 +523,7 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
     });
 
     it('should not let an edited custom field rewrite a built-in event property', async () => {
-      const onEventsChange = spy();
+      const onEventsChange = vi.fn();
       function CollidingSection() {
         // The wide `string` models a JS consumer: the literal is a type error.
         const readOnlyField = useEventDialogFormField('readOnly' as string);
@@ -554,8 +554,8 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
         await user.click(screen.getByRole('button', { name: 'Save' }));
       }).toWarnDev(['MUI X Scheduler: useEventDialogFormField() received the key "readOnly"']);
 
-      expect(onEventsChange.callCount).to.equal(1);
-      const saved = onEventsChange.lastCall.firstArg.find(
+      expect(onEventsChange.mock.calls.length).to.equal(1);
+      const saved = onEventsChange.mock.lastCall?.[0].find(
         (event: SchedulerEvent) => event.id === DEFAULT_EVENT.id,
       );
       expect(saved).not.to.have.property('readOnly');
@@ -687,24 +687,24 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
     });
 
     it('should keep the form usable when the slot renders no section at all', async () => {
-      const onEventsChange = spy();
+      const onEventsChange = vi.fn();
       const { user } = renderWithSlot({ eventDialogGeneralTab: () => null }, { onEventsChange });
 
       expect(screen.getByLabelText(/event title/i)).not.to.equal(null);
       await user.click(screen.getByRole('button', { name: 'Save' }));
-      expect(onEventsChange.callCount).to.equal(1);
+      expect(onEventsChange.mock.calls.length).to.equal(1);
     });
 
     it('should save a custom field edited from a section rendered by the slot', async () => {
-      const onEventsChange = spy();
+      const onEventsChange = vi.fn();
       const { user } = renderWithSlot({ eventDialogGeneralTab: CustomSection }, { onEventsChange });
 
       await user.clear(screen.getByRole('textbox', { name: 'Priority' }));
       await user.type(screen.getByRole('textbox', { name: 'Priority' }), 'high');
       await user.click(screen.getByRole('button', { name: 'Save' }));
 
-      expect(onEventsChange.callCount).to.equal(1);
-      expect(onEventsChange.lastCall.firstArg[0]).to.have.property('priority', 'high');
+      expect(onEventsChange.mock.calls.length).to.equal(1);
+      expect(onEventsChange.mock.lastCall?.[0][0]).to.have.property('priority', 'high');
     });
 
     it('should still submit a value written in a section the slot conditionally unmounted', async () => {
@@ -722,7 +722,7 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
         );
       }
 
-      const onEventsChange = spy();
+      const onEventsChange = vi.fn();
       const { user } = renderWithSlot(
         { eventDialogGeneralTab: ToggleableSections },
         { onEventsChange },
@@ -735,12 +735,12 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
 
       await user.click(screen.getByRole('button', { name: 'Save' }));
 
-      expect(onEventsChange.callCount).to.equal(1);
-      expect(onEventsChange.lastCall.firstArg[0]).to.have.property('priority', 'high');
+      expect(onEventsChange.mock.calls.length).to.equal(1);
+      expect(onEventsChange.mock.lastCall?.[0][0]).to.have.property('priority', 'high');
     });
 
     it('should block the submit when a validator of a section rendered by the slot fails', async () => {
-      const onEventsChange = spy();
+      const onEventsChange = vi.fn();
       function RequiredCustomSection() {
         const client = useEventDialogFormField('client', {
           defaultValue: '',
@@ -764,12 +764,12 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
       );
 
       await user.click(screen.getByRole('button', { name: 'Save' }));
-      expect(onEventsChange.callCount).to.equal(0);
+      expect(onEventsChange.mock.calls.length).to.equal(0);
       expect(screen.getByRole('alert')).to.have.text('Client is required');
 
       await user.type(screen.getByRole('textbox', { name: 'Client' }), 'Acme');
       await user.click(screen.getByRole('button', { name: 'Save' }));
-      expect(onEventsChange.callCount).to.equal(1);
+      expect(onEventsChange.mock.calls.length).to.equal(1);
     });
 
     it('should warn when the resource section is omitted while shouldEventRequireResource is enabled', async () => {
@@ -785,7 +785,7 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
     });
 
     it('should not warn and save the assigned resource when the slot keeps the resource section', async () => {
-      const onEventsChange = spy();
+      const onEventsChange = vi.fn();
       const { user } = renderWithSlot(
         { eventDialogGeneralTab: () => <EventDialogResourceAndColorSection /> },
         { shouldEventRequireResource: true, onEventsChange },
@@ -793,8 +793,11 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
 
       await user.click(screen.getByRole('button', { name: 'Save' }));
 
-      expect(onEventsChange.callCount).to.equal(1);
-      expect(onEventsChange.lastCall.firstArg[0]).to.have.property('resource', personalResource.id);
+      expect(onEventsChange.mock.calls.length).to.equal(1);
+      expect(onEventsChange.mock.lastCall?.[0][0]).to.have.property(
+        'resource',
+        personalResource.id,
+      );
     });
 
     it('should not warn when a section rendered by the slot validates the resource itself', async () => {
@@ -814,7 +817,7 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
     });
 
     it('should block the submit of an event without resource when the slot omits the resource section', async () => {
-      const onEventsChange = spy();
+      const onEventsChange = vi.fn();
       const noResourceEvent: SchedulerEvent = EventBuilder.new()
         .title('Running')
         .singleDay('2025-05-26T07:30:00Z', 45)
@@ -836,11 +839,11 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
         'MUI X Scheduler: `shouldEventRequireResource` is enabled but no field of the event dialog validates the resource.',
       ]);
 
-      expect(onEventsChange.callCount).to.equal(0);
+      expect(onEventsChange.mock.calls.length).to.equal(0);
     });
 
     it('should surface the required-resource error on a custom field bound to resourceIds', async () => {
-      const onEventsChange = spy();
+      const onEventsChange = vi.fn();
       const noResourceEvent: SchedulerEvent = EventBuilder.new()
         .title('Running')
         .singleDay('2025-05-26T07:30:00Z', 45)
@@ -868,7 +871,7 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
         'MUI X Scheduler: `shouldEventRequireResource` is enabled but no field of the event dialog validates the resource.',
       ]);
 
-      expect(onEventsChange.callCount).to.equal(0);
+      expect(onEventsChange.mock.calls.length).to.equal(0);
       expect(screen.getByRole('alert')).to.have.text('A resource is required.');
     });
 
@@ -911,7 +914,7 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
 
     invertedRangeScenarios.forEach(({ key, label, typed, alert }) => {
       it(`should block the submit of an inverted ${key} when the slot omits the date and time section`, async () => {
-        const onEventsChange = spy();
+        const onEventsChange = vi.fn();
 
         await expect(async () => {
           const { user } = renderWithSlot(
@@ -927,7 +930,7 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
           `MUI X Scheduler: The date range is invalid but no field of the event dialog validates the "${key}" field.`,
         ]);
 
-        expect(onEventsChange.callCount).to.equal(0);
+        expect(onEventsChange.mock.calls.length).to.equal(0);
         expect(screen.getByRole('alert')).to.have.text(alert);
       });
     });
@@ -960,7 +963,7 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
     });
 
     it('should block the submit of an unparseable date from a custom field', async () => {
-      const onEventsChange = spy();
+      const onEventsChange = vi.fn();
 
       await expect(async () => {
         const { user } = renderWithSlot(
@@ -975,12 +978,12 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
         'MUI X Scheduler: The value cannot be parsed into a date but no field of the event dialog validates the "endDate" field.',
       ]);
 
-      expect(onEventsChange.callCount).to.equal(0);
+      expect(onEventsChange.mock.calls.length).to.equal(0);
       expect(screen.getByRole('alert')).to.have.text('Enter a valid date.');
     });
 
     it('should block the submit of an overflowing date from a custom field', async () => {
-      const onEventsChange = spy();
+      const onEventsChange = vi.fn();
 
       await expect(async () => {
         const { user } = renderWithSlot(
@@ -996,12 +999,12 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
         'MUI X Scheduler: The value cannot be parsed into a date but no field of the event dialog validates the "endDate" field.',
       ]);
 
-      expect(onEventsChange.callCount).to.equal(0);
+      expect(onEventsChange.mock.calls.length).to.equal(0);
       expect(screen.getByRole('alert')).to.have.text('Enter a valid date.');
     });
 
     it('should block the submit of an emptied time from a custom field', async () => {
-      const onEventsChange = spy();
+      const onEventsChange = vi.fn();
 
       await expect(async () => {
         const { user } = renderWithSlot(
@@ -1014,12 +1017,12 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
         'MUI X Scheduler: The value cannot be parsed into a date but no field of the event dialog validates the "endTime" field.',
       ]);
 
-      expect(onEventsChange.callCount).to.equal(0);
+      expect(onEventsChange.mock.calls.length).to.equal(0);
       expect(screen.getByRole('alert')).to.have.text('Enter a valid time.');
     });
 
     it('should show the invalid-date error on the mounted start field without warning', async () => {
-      const onEventsChange = spy();
+      const onEventsChange = vi.fn();
       // A sibling section empties the built-in key; the mounted date and time
       // section must surface the error itself.
       function StartDateClearer() {
@@ -1044,13 +1047,13 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
       fireEvent.submit(screen.getByRole('button', { name: 'Save' }).closest('form')!);
       await screen.findAllByRole('alert');
 
-      expect(onEventsChange.callCount).to.equal(0);
+      expect(onEventsChange.mock.calls.length).to.equal(0);
       const alerts = screen.getAllByRole('alert').map((alert) => alert.textContent);
       expect(alerts).to.deep.equal(['Enter a valid date.']);
     });
 
     it('should ignore the time fields of an all-day event when validating', async () => {
-      const onEventsChange = spy();
+      const onEventsChange = vi.fn();
       function TimeClearer() {
         const startTime = useEventDialogFormField('startTime');
         return (
@@ -1068,11 +1071,11 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
       await user.click(screen.getByRole('switch', { name: /all day/i }));
       await user.click(screen.getByRole('button', { name: 'Save' }));
 
-      expect(onEventsChange.callCount).to.equal(1);
+      expect(onEventsChange.mock.calls.length).to.equal(1);
     });
 
     it('should keep a custom required-resource message over the generic one', async () => {
-      const onEventsChange = spy();
+      const onEventsChange = vi.fn();
       const noResourceEvent: SchedulerEvent = EventBuilder.new()
         .title('Running')
         .singleDay('2025-05-26T07:30:00Z', 45)
@@ -1097,12 +1100,12 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
       );
       await user.click(screen.getByRole('button', { name: 'Save' }));
 
-      expect(onEventsChange.callCount).to.equal(0);
+      expect(onEventsChange.mock.calls.length).to.equal(0);
       expect(screen.getByRole('alert')).to.have.text('Pick at least one room');
     });
 
     it('should recover the dialog when a validator throws', async () => {
-      const onEventsChange = spy();
+      const onEventsChange = vi.fn();
       function ThrowingSection() {
         useEventDialogFormField('client', {
           defaultValue: '',
@@ -1122,13 +1125,13 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
         'MUI X Scheduler: A form field validator threw or rejected during the submit.',
       ]);
 
-      expect(onEventsChange.callCount).to.equal(0);
+      expect(onEventsChange.mock.calls.length).to.equal(0);
       // The dialog stays usable: the pending state is released.
       expect(saveButton).not.to.have.attribute('disabled');
     });
 
     it('should store the generic range error when a registered validator passes', async () => {
-      const onEventsChange = spy();
+      const onEventsChange = vi.fn();
       const { user } = renderWithSlot(
         { eventDialogGeneralTab: createRangeField('endDate', 'End date', () => null) },
         { onEventsChange },
@@ -1139,12 +1142,12 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
       await user.type(endDateInput, '2025-05-20');
       await user.click(screen.getByRole('button', { name: 'Save' }));
 
-      expect(onEventsChange.callCount).to.equal(0);
+      expect(onEventsChange.mock.calls.length).to.equal(0);
       expect(screen.getByRole('alert')).to.have.text('End date cannot be before start date.');
     });
 
     it('should keep the first registered failing validator message for a shared key', async () => {
-      const onEventsChange = spy();
+      const onEventsChange = vi.fn();
       function CustomEndDateValidator() {
         useEventDialogFormField('endDate', {
           validate: () => 'Must stay within the project period',
@@ -1169,7 +1172,7 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
       await user.type(endDateInput, '2025-05-20');
       await user.click(screen.getByRole('button', { name: 'Save' }));
 
-      expect(onEventsChange.callCount).to.equal(0);
+      expect(onEventsChange.mock.calls.length).to.equal(0);
       // Effects register in tree order, so the earlier sibling's validator wins.
       expect(screen.getByRole('alert')).to.have.text('Must stay within the project period');
     });
@@ -1185,7 +1188,7 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
     });
 
     it('should keep a more specific validator message over the generic range error', async () => {
-      const onEventsChange = spy();
+      const onEventsChange = vi.fn();
       const { user } = renderWithSlot(
         {
           eventDialogGeneralTab: createRangeField(
@@ -1202,7 +1205,7 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
       await user.type(endDateInput, '2025-05-20');
       await user.click(screen.getByRole('button', { name: 'Save' }));
 
-      expect(onEventsChange.callCount).to.equal(0);
+      expect(onEventsChange.mock.calls.length).to.equal(0);
       expect(screen.getByRole('alert')).to.have.text('Must stay within the project period');
     });
 
@@ -1298,7 +1301,7 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
       }
 
       it('should validate the values as they are when the async validation settles, not as they were on submit', async () => {
-        const onEventsChange = spy();
+        const onEventsChange = vi.fn();
         const deferred = createDeferred();
         function AsyncValidatedSection() {
           const client = useEventDialogFormField('client', {
@@ -1326,12 +1329,12 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
         await user.clear(screen.getByRole('textbox', { name: 'Client' }));
         await act(async () => deferred.resolve(null));
 
-        expect(onEventsChange.callCount).to.equal(0);
+        expect(onEventsChange.mock.calls.length).to.equal(0);
         expect(screen.getByRole('alert')).to.have.text('Client is required');
       });
 
       it('should re-validate with the rule current when the async validation settles, not the one on submit', async () => {
-        const onEventsChange = spy();
+        const onEventsChange = vi.fn();
         const deferred = createDeferred();
         function TighteningSection() {
           const [strict, setStrict] = React.useState(false);
@@ -1358,13 +1361,13 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
         await user.click(screen.getByRole('button', { name: 'Tighten' }));
         await act(async () => deferred.resolve(null));
 
-        expect(onEventsChange.callCount).to.equal(0);
+        expect(onEventsChange.mock.calls.length).to.equal(0);
         expect(screen.getByRole('alert')).to.have.text('Blocked by the new rule');
       });
 
       it('should only run an async validator once for an uneventful submit', async () => {
         const deferred = createDeferred();
-        const validator = spy(() => deferred.promise);
+        const validator = vi.fn(() => deferred.promise);
         function AsyncValidatedSection() {
           useEventDialogFormField('client', {
             defaultValue: 'Acme',
@@ -1383,11 +1386,11 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
         await user.click(screen.getByRole('button', { name: 'Save' }));
         await act(async () => deferred.resolve(null));
 
-        expect(validator.callCount).to.equal(1);
+        expect(validator.mock.calls.length).to.equal(1);
       });
 
       it('should serialize with the display timezone current when the async validation settles', async () => {
-        const onEventsChange = spy();
+        const onEventsChange = vi.fn();
         const deferred = createDeferred();
         function AsyncValidatedSection() {
           useEventDialogFormField('client', {
@@ -1407,13 +1410,13 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
         setProps({ displayTimezone: 'America/New_York' });
         await act(async () => deferred.resolve(null));
 
-        expect(onEventsChange.callCount).to.equal(1);
-        const updated = onEventsChange.firstCall.firstArg[0];
+        expect(onEventsChange.mock.calls.length).to.equal(1);
+        const updated = onEventsChange.mock.calls[0][0][0];
         expect(new Date(updated.start).toISOString()).to.equal('2025-05-26T11:30:00.000Z');
       });
 
       it('should enforce a resource requirement enabled while the async validation was pending', async () => {
-        const onEventsChange = spy();
+        const onEventsChange = vi.fn();
         const deferred = createDeferred();
         const noResourceEvent: SchedulerEvent = EventBuilder.new()
           .title('Running')
@@ -1441,11 +1444,11 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
         setProps({ shouldEventRequireResource: true });
         await act(async () => deferred.resolve(null));
 
-        expect(onEventsChange.callCount).to.equal(0);
+        expect(onEventsChange.mock.calls.length).to.equal(0);
       });
 
       it('should ignore a submission that settles after its editing session ended', async () => {
-        const onEventsChange = spy();
+        const onEventsChange = vi.fn();
         const deferred = createDeferred();
         function AsyncValidatedSection() {
           useEventDialogFormField('client', {
@@ -1464,7 +1467,7 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
         unmount();
         await act(async () => deferred.resolve(null));
 
-        expect(onEventsChange.callCount).to.equal(0);
+        expect(onEventsChange.mock.calls.length).to.equal(0);
       });
 
       it('should disable the Save button while the submission is pending', async () => {
@@ -1519,7 +1522,7 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
       });
 
       it('should submit only once when Save is pressed twice while the validation is pending', async () => {
-        const onEventsChange = spy();
+        const onEventsChange = vi.fn();
         const deferred = createDeferred();
         function AsyncValidatedSection() {
           useEventDialogFormField('client', {
@@ -1540,7 +1543,7 @@ describe('<EventDialogContent /> — community (no recurring-events plugin)', ()
         fireEvent.submit(saveButton.closest('form')!);
         await act(async () => deferred.resolve(null));
 
-        expect(onEventsChange.callCount).to.equal(1);
+        expect(onEventsChange.mock.calls.length).to.equal(1);
       });
     });
   });


### PR DESCRIPTION
Third step away from Sinon, following #23443 and #23460.

Those two took the spies themselves. This one takes the type annotations, on the files that own their spies, plus the last few accessors with no direct equivalent. Sinon stays a dependency and `test/setupVitest.ts` keeps calling `sinon.restore()`, because 37 files still import it.

## Scope rule

A file is in scope when every Sinon import is `spy` and/or `SinonSpy`, and it uses no `spy(obj, 'method')`, no `stub`, no fake timers and no `sinon.assert`. That leaves 7 files.

The two shared spy helpers, `spyApi` in `test/utils/helperFn.ts` and `test/utils/scheduler/StoreSpy.tsx`, still return Sinon spies. They and their call sites are deliberately left out: changing them forces every consumer to move at once, including files that still need Sinon for other reasons, so they are better as their own step.

## The generic is not a rename

`SinonSpy<TArgs>` takes the argument tuple. `Mock<T>` takes the whole function type. So this:

```ts
const renderCell: SinonSpy<[GridRenderCellParams]> = spy((params) => `- ${params.value}`);
```

becomes:

```ts
const renderCell: Mock<(params: GridRenderCellParams) => string> = vi.fn(
  (params) => `- ${params.value}`,
);
```

Renaming the type alone would have compiled to something meaningless. `ReturnType<typeof spy>` is handled the same way, as a `Mock` of the signature the call site actually needs.

`spy<T>(fn)` already passes the function type, so it carries straight over to `vi.fn<T>(fn)`.

## Accessors with no one-to-one mapping

```
.returnValues       -> .mock.results.map((result) => result.value)
.calledWith(value)  -> .mock.calls.some((call) => call[0] === value)
```

Sinon's `calledWith` matches any call whose leading arguments match, so it is not `toHaveBeenCalledWith`, which is arity-exact. The explicit `some` keeps the original semantics.

Chai-style assertions are otherwise kept as they were.

## Status

`typescript` and `eslint` are clean, and the browser suite is fully green: **761 files passed, 4 skipped, 0 failures**.

The jsdom suite is green on CI as well. It shows intermittent failures in `x-telemetry/src/postinstall/get-project-id.test.ts` on my machine, but that file is not touched here, it passes when its package runs alone, and `test_unit` is green, so that is local environment noise rather than anything this change introduces.
