### PR TITLE
[code-infra] Move the shared spy helpers off Sinon

### DIFF
--- a/packages/x-data-grid-premium/src/tests/cellSelection.DataGridPremium.test.tsx
+++ b/packages/x-data-grid-premium/src/tests/cellSelection.DataGridPremium.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { stub, spy } from 'sinon';
+import { stub } from 'sinon';
 import type { SinonStub } from 'sinon';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import type { RefObject } from '@mui/x-internals/types';
@@ -9,7 +9,7 @@ import { DataGridPremium, useGridApiRef, gridClasses } from '@mui/x-data-grid-pr
 import type { DataGridPremiumProps, GridApi, GridColDef } from '@mui/x-data-grid-premium';
 import { getBasicGridData } from '@mui/x-data-grid-generator';
 import { isJSDOM, isOSX } from 'test/utils/skipIf';
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 describe('<DataGridPremium /> - Cell selection', () => {
   const { render } = createRenderer();
@@ -142,16 +142,16 @@ describe('<DataGridPremium /> - Cell selection', () => {
     });
 
     it('should call onCellSelectionModelChange', async () => {
-      const onCellSelectionModelChange = spy();
+      const onCellSelectionModelChange = vi.fn();
       const { user } = render(
         <TestDataGridSelection onCellSelectionModelChange={onCellSelectionModelChange} />,
       );
       const cell = getCell(0, 0);
       await user.click(cell);
-      onCellSelectionModelChange.resetHistory();
+      onCellSelectionModelChange.mockClear();
       fireEvent.keyDown(cell, { key: 'a', keyCode: 65, ctrlKey: true });
-      expect(onCellSelectionModelChange.callCount).to.equal(1);
-      expect(onCellSelectionModelChange.lastCall.args[0]).to.deep.equal(fullSelectionModel);
+      expect(onCellSelectionModelChange.mock.calls.length).to.equal(1);
+      expect(onCellSelectionModelChange.mock.lastCall?.[0]).to.deep.equal(fullSelectionModel);
     });
 
     it('should only select the cells of the current page', async () => {
@@ -237,8 +237,8 @@ describe('<DataGridPremium /> - Cell selection', () => {
       await user.keyboard('{Shift>}');
       await user.click(getCell(2, 1));
       await user.keyboard('{/Shift}');
-      expect(spiedSelectCellsBetweenRange.lastCall.args[0]).to.deep.equal({ id: 0, field: 'id' });
-      expect(spiedSelectCellsBetweenRange.lastCall.args[1]).to.deep.equal({
+      expect(spiedSelectCellsBetweenRange.mock.lastCall?.[0]).to.deep.equal({ id: 0, field: 'id' });
+      expect(spiedSelectCellsBetweenRange.mock.lastCall?.[1]).to.deep.equal({
         id: 2,
         field: 'currencyPair',
       });
@@ -343,8 +343,8 @@ describe('<DataGridPremium /> - Cell selection', () => {
       cell.focus();
       await user.click(cell);
       await user.keyboard('{Shift>}{ArrowDown}{/Shift}');
-      expect(spiedSelectCellsBetweenRange.lastCall.args[0]).to.deep.equal({ id: 0, field: 'id' });
-      expect(spiedSelectCellsBetweenRange.lastCall.args[1]).to.deep.equal({ id: 1, field: 'id' });
+      expect(spiedSelectCellsBetweenRange.mock.lastCall?.[0]).to.deep.equal({ id: 0, field: 'id' });
+      expect(spiedSelectCellsBetweenRange.mock.lastCall?.[1]).to.deep.equal({ id: 1, field: 'id' });
     });
 
     it('should call selectCellRange when ArrowUp is pressed', async () => {
@@ -356,8 +356,8 @@ describe('<DataGridPremium /> - Cell selection', () => {
       });
       await user.click(cell);
       await user.keyboard('{Shift>}{ArrowUp}{/Shift}');
-      expect(spiedSelectCellsBetweenRange.lastCall.args[0]).to.deep.equal({ id: 1, field: 'id' });
-      expect(spiedSelectCellsBetweenRange.lastCall.args[1]).to.deep.equal({ id: 0, field: 'id' });
+      expect(spiedSelectCellsBetweenRange.mock.lastCall?.[0]).to.deep.equal({ id: 1, field: 'id' });
+      expect(spiedSelectCellsBetweenRange.mock.lastCall?.[1]).to.deep.equal({ id: 0, field: 'id' });
     });
 
     it('should call selectCellRange when ArrowLeft is pressed', async () => {
@@ -367,11 +367,11 @@ describe('<DataGridPremium /> - Cell selection', () => {
       cell.focus();
       await user.click(cell);
       await user.keyboard('{Shift>}{ArrowLeft}{/Shift}');
-      expect(spiedSelectCellsBetweenRange.lastCall.args[0]).to.deep.equal({
+      expect(spiedSelectCellsBetweenRange.mock.lastCall?.[0]).to.deep.equal({
         id: 0,
         field: 'currencyPair',
       });
-      expect(spiedSelectCellsBetweenRange.lastCall.args[1]).to.deep.equal({ id: 0, field: 'id' });
+      expect(spiedSelectCellsBetweenRange.mock.lastCall?.[1]).to.deep.equal({ id: 0, field: 'id' });
     });
 
     it('should call selectCellRange when ArrowRight is pressed', async () => {
@@ -381,8 +381,8 @@ describe('<DataGridPremium /> - Cell selection', () => {
       cell.focus();
       await user.click(cell);
       await user.keyboard('{Shift>}{ArrowRight}{/Shift}');
-      expect(spiedSelectCellsBetweenRange.lastCall.args[0]).to.deep.equal({ id: 0, field: 'id' });
-      expect(spiedSelectCellsBetweenRange.lastCall.args[1]).to.deep.equal({
+      expect(spiedSelectCellsBetweenRange.mock.lastCall?.[0]).to.deep.equal({ id: 0, field: 'id' });
+      expect(spiedSelectCellsBetweenRange.mock.lastCall?.[1]).to.deep.equal({
         id: 0,
         field: 'currencyPair',
       });
@@ -400,8 +400,8 @@ describe('<DataGridPremium /> - Cell selection', () => {
 
   describe('Fill down', () => {
     it('should emit clipboard paste events once for a multi-column Ctrl+D fill', async () => {
-      const onClipboardPasteStart = spy();
-      const onClipboardPasteEnd = spy();
+      const onClipboardPasteStart = vi.fn();
+      const onClipboardPasteEnd = vi.fn();
       const columns: GridColDef[] = [
         { field: 'id' },
         { field: 'name', editable: true },
@@ -431,11 +431,11 @@ describe('<DataGridPremium /> - Cell selection', () => {
       fireEvent.keyDown(startCell, { key: 'd', keyCode: 68, ctrlKey: true });
 
       await waitFor(() => {
-        expect(onClipboardPasteStart.callCount).to.equal(1);
-        expect(onClipboardPasteEnd.callCount).to.equal(1);
+        expect(onClipboardPasteStart.mock.calls.length).to.equal(1);
+        expect(onClipboardPasteEnd.mock.calls.length).to.equal(1);
       });
 
-      expect(onClipboardPasteStart.lastCall.args[0]).to.deep.equal({
+      expect(onClipboardPasteStart.mock.lastCall?.[0]).to.deep.equal({
         data: [['Keyboard', '10']],
       });
       expect(getCell(1, 1)).to.have.text('Keyboard');
@@ -478,7 +478,7 @@ describe('<DataGridPremium /> - Cell selection', () => {
 
   describe('onCellSelectionModelChange', () => {
     it('should update the selection state when a cell is selected', async () => {
-      const onCellSelectionModelChange = spy();
+      const onCellSelectionModelChange = vi.fn();
       const { user } = render(
         <TestDataGridSelection
           cellSelectionModel={{}}
@@ -487,13 +487,13 @@ describe('<DataGridPremium /> - Cell selection', () => {
       );
       await user.click(getCell(0, 0));
 
-      expect(onCellSelectionModelChange.callCount).to.equal(1);
-      expect(onCellSelectionModelChange.lastCall.args[0]).to.deep.equal({ '0': { id: true } });
+      expect(onCellSelectionModelChange.mock.calls.length).to.equal(1);
+      expect(onCellSelectionModelChange.mock.lastCall?.[0]).to.deep.equal({ '0': { id: true } });
     });
 
     // Context: https://github.com/mui/mui-x/issues/14184
     it('should add the new cell selection range to the existing state', async () => {
-      const onCellSelectionModelChange = spy();
+      const onCellSelectionModelChange = vi.fn();
       const { user } = render(
         <TestDataGridSelection
           cellSelectionModel={{ '0': { id: true } }}
@@ -513,7 +513,7 @@ describe('<DataGridPremium /> - Cell selection', () => {
       ]);
       await user.keyboard(isOSX ? '{/Meta}' : '{/Control}');
 
-      expect(onCellSelectionModelChange.lastCall.args[0]).to.deep.equal({
+      expect(onCellSelectionModelChange.mock.lastCall?.[0]).to.deep.equal({
         '0': { id: true },
         '2': { id: true },
         '3': { id: true },
@@ -817,7 +817,7 @@ describe('<DataGridPremium /> - Cell selection', () => {
 
     describe('Ctrl+D - Fill down', () => {
       it('should fill down from focused cell when no selection exists', async () => {
-        const processRowUpdateSpy = spy((newRow) => newRow);
+        const processRowUpdateSpy = vi.fn((newRow) => newRow);
         const { user } = render(
           <TestDataGridSelection
             columns={fillColumns}
@@ -837,11 +837,11 @@ describe('<DataGridPremium /> - Cell selection', () => {
         await waitFor(() => {
           expect(getCell(2, 1).textContent).to.equal('Bob');
         });
-        expect(processRowUpdateSpy.callCount).to.equal(1);
+        expect(processRowUpdateSpy.mock.calls.length).to.equal(1);
       });
 
       it('should fill the cell below with the selected cell value', async () => {
-        const processRowUpdateSpy = spy((newRow) => newRow);
+        const processRowUpdateSpy = vi.fn((newRow) => newRow);
         const { user } = render(
           <TestDataGridSelection
             columns={fillColumns}
@@ -858,11 +858,11 @@ describe('<DataGridPremium /> - Cell selection', () => {
         await waitFor(() => {
           expect(getCell(1, 1).textContent).to.equal('Alice');
         });
-        expect(processRowUpdateSpy.callCount).to.equal(1);
+        expect(processRowUpdateSpy.mock.calls.length).to.equal(1);
       });
 
       it('should move selection to the filled cell after single-cell fill', async () => {
-        const processRowUpdateSpy = spy((newRow) => newRow);
+        const processRowUpdateSpy = vi.fn((newRow) => newRow);
         const { user } = render(
           <TestDataGridSelection
             columns={fillColumns}
@@ -884,7 +884,7 @@ describe('<DataGridPremium /> - Cell selection', () => {
       });
 
       it('should not fill if the column is not editable', async () => {
-        const processRowUpdateSpy = spy((newRow) => newRow);
+        const processRowUpdateSpy = vi.fn((newRow) => newRow);
         const { user } = render(
           <TestDataGridSelection
             columns={fillColumns}
@@ -898,12 +898,12 @@ describe('<DataGridPremium /> - Cell selection', () => {
         await user.click(cell);
         fireEvent.keyDown(cell, { key: 'd', keyCode: 68, ctrlKey: true });
 
-        expect(processRowUpdateSpy.callCount).to.equal(0);
+        expect(processRowUpdateSpy.mock.calls.length).to.equal(0);
         expect(getCell(1, 0).textContent).to.equal('1');
       });
 
       it('should not fill if the cell is in the last visible row', async () => {
-        const processRowUpdateSpy = spy((newRow) => newRow);
+        const processRowUpdateSpy = vi.fn((newRow) => newRow);
         const { user } = render(
           <TestDataGridSelection
             columns={fillColumns}
@@ -917,11 +917,11 @@ describe('<DataGridPremium /> - Cell selection', () => {
         await user.click(cell);
         fireEvent.keyDown(cell, { key: 'd', keyCode: 68, ctrlKey: true });
 
-        expect(processRowUpdateSpy.callCount).to.equal(0);
+        expect(processRowUpdateSpy.mock.calls.length).to.equal(0);
       });
 
       it('should fill all rows below the top row when multiple cells are selected', async () => {
-        const processRowUpdateSpy = spy((newRow) => newRow);
+        const processRowUpdateSpy = vi.fn((newRow) => newRow);
         const { user } = render(
           <TestDataGridSelection
             columns={fillColumns}
@@ -945,11 +945,11 @@ describe('<DataGridPremium /> - Cell selection', () => {
           expect(getCell(1, 1).textContent).to.equal('Alice');
         });
         expect(getCell(2, 1).textContent).to.equal('Alice');
-        expect(processRowUpdateSpy.callCount).to.equal(2);
+        expect(processRowUpdateSpy.mock.calls.length).to.equal(2);
       });
 
       it('should skip non-editable columns when filling with Ctrl+D', async () => {
-        const processRowUpdateSpy = spy((newRow) => newRow);
+        const processRowUpdateSpy = vi.fn((newRow) => newRow);
         const { user } = render(
           <TestDataGridSelection
             columns={fillColumns}
@@ -977,7 +977,7 @@ describe('<DataGridPremium /> - Cell selection', () => {
       });
 
       it('should fill down when a single row with multiple columns is selected', async () => {
-        const processRowUpdateSpy = spy((newRow) => newRow);
+        const processRowUpdateSpy = vi.fn((newRow) => newRow);
         const { user } = render(
           <TestDataGridSelection
             columns={fillColumns}
@@ -1001,11 +1001,11 @@ describe('<DataGridPremium /> - Cell selection', () => {
           expect(getCell(1, 1).textContent).to.equal('Alice');
         });
         expect(getCell(1, 2).textContent).to.equal('10');
-        expect(processRowUpdateSpy.callCount).to.equal(1);
+        expect(processRowUpdateSpy.mock.calls.length).to.equal(1);
       });
 
       it('should skip non-editable columns when filling single-row multi-column with Ctrl+D', async () => {
-        const processRowUpdateSpy = spy((newRow) => newRow);
+        const processRowUpdateSpy = vi.fn((newRow) => newRow);
         const { user } = render(
           <TestDataGridSelection
             columns={fillColumns}
@@ -1035,7 +1035,7 @@ describe('<DataGridPremium /> - Cell selection', () => {
 
     describe('Ctrl+R - Fill right', () => {
       it('should fill the cell to the right with the selected cell value', async () => {
-        const processRowUpdateSpy = spy((newRow) => newRow);
+        const processRowUpdateSpy = vi.fn((newRow) => newRow);
         const { user } = render(
           <TestDataGridSelection
             columns={fillColumns}
@@ -1053,11 +1053,11 @@ describe('<DataGridPremium /> - Cell selection', () => {
         await waitFor(() => {
           expect(getCell(0, 3).textContent).to.equal('10');
         });
-        expect(processRowUpdateSpy.callCount).to.equal(1);
+        expect(processRowUpdateSpy.mock.calls.length).to.equal(1);
       });
 
       it('should move selection to the filled cell after single-cell fill right', async () => {
-        const processRowUpdateSpy = spy((newRow) => newRow);
+        const processRowUpdateSpy = vi.fn((newRow) => newRow);
         const { user } = render(
           <TestDataGridSelection
             columns={fillColumns}
@@ -1080,7 +1080,7 @@ describe('<DataGridPremium /> - Cell selection', () => {
       });
 
       it('should not fill right if the target column is not editable', async () => {
-        const processRowUpdateSpy = spy((newRow) => newRow);
+        const processRowUpdateSpy = vi.fn((newRow) => newRow);
         const { user } = render(
           <TestDataGridSelection
             columns={fillColumns}
@@ -1095,12 +1095,12 @@ describe('<DataGridPremium /> - Cell selection', () => {
         await user.click(cell);
         fireEvent.keyDown(cell, { key: 'r', keyCode: 82, ctrlKey: true });
 
-        expect(processRowUpdateSpy.callCount).to.equal(0);
+        expect(processRowUpdateSpy.mock.calls.length).to.equal(0);
         expect(getCell(0, 4).textContent).to.equal('x');
       });
 
       it('should fill all columns to the right of the leftmost column when multiple cells are selected', async () => {
-        const processRowUpdateSpy = spy((newRow) => newRow);
+        const processRowUpdateSpy = vi.fn((newRow) => newRow);
         const { user } = render(
           <TestDataGridSelection
             columns={fillColumns}
@@ -1126,7 +1126,7 @@ describe('<DataGridPremium /> - Cell selection', () => {
       });
 
       it('should fill right when a single column with multiple rows is selected', async () => {
-        const processRowUpdateSpy = spy((newRow) => newRow);
+        const processRowUpdateSpy = vi.fn((newRow) => newRow);
         const { user } = render(
           <TestDataGridSelection
             columns={fillColumns}
@@ -1197,7 +1197,7 @@ describe('<DataGridPremium /> - Cell selection', () => {
 
       describe('Vertical fill', () => {
         it('should fill down when dragging the fill handle downward', async () => {
-          const processRowUpdateSpy = spy((newRow) => newRow);
+          const processRowUpdateSpy = vi.fn((newRow) => newRow);
           const { user } = render(
             <TestDataGridSelection
               columns={fillColumns}
@@ -1219,11 +1219,11 @@ describe('<DataGridPremium /> - Cell selection', () => {
             expect(getCell(1, 1).textContent).to.equal('Alice');
           });
           expect(getCell(2, 1).textContent).to.equal('Alice');
-          expect(processRowUpdateSpy.callCount).to.equal(2);
+          expect(processRowUpdateSpy.mock.calls.length).to.equal(2);
         });
 
         it('should start fill drag from the bottom-left corner in RTL', async () => {
-          const processRowUpdateSpy = spy((newRow) => newRow);
+          const processRowUpdateSpy = vi.fn((newRow) => newRow);
           const { user } = renderRtl(
             <TestDataGridSelection
               columns={fillColumns}
@@ -1245,11 +1245,11 @@ describe('<DataGridPremium /> - Cell selection', () => {
             expect(getCell(1, 1).textContent).to.equal('Alice');
           });
           expect(getCell(2, 1).textContent).to.equal('Alice');
-          expect(processRowUpdateSpy.callCount).to.equal(2);
+          expect(processRowUpdateSpy.mock.calls.length).to.equal(2);
         });
 
         it('should cycle source values when filling with multiple source rows', async () => {
-          const processRowUpdateSpy = spy((newRow) => newRow);
+          const processRowUpdateSpy = vi.fn((newRow) => newRow);
           const { user } = render(
             <TestDataGridSelection
               columns={fillColumns}
@@ -1282,7 +1282,7 @@ describe('<DataGridPremium /> - Cell selection', () => {
         });
 
         it('should extend selection to include filled cells', async () => {
-          const processRowUpdateSpy = spy((newRow) => newRow);
+          const processRowUpdateSpy = vi.fn((newRow) => newRow);
           const { user } = render(
             <TestDataGridSelection
               columns={fillColumns}
@@ -1309,7 +1309,7 @@ describe('<DataGridPremium /> - Cell selection', () => {
         });
 
         it('should fill multiple columns simultaneously', async () => {
-          const processRowUpdateSpy = spy((newRow) => newRow);
+          const processRowUpdateSpy = vi.fn((newRow) => newRow);
           const { user } = render(
             <TestDataGridSelection
               columns={fillColumns}
@@ -1343,7 +1343,7 @@ describe('<DataGridPremium /> - Cell selection', () => {
 
       describe('Horizontal fill', () => {
         it('should fill right when dragging the fill handle to the right', async () => {
-          const processRowUpdateSpy = spy((newRow) => newRow);
+          const processRowUpdateSpy = vi.fn((newRow) => newRow);
           const { user } = render(
             <TestDataGridSelection
               columns={fillColumns}
@@ -1368,7 +1368,7 @@ describe('<DataGridPremium /> - Cell selection', () => {
         });
 
         it('should only fill selected rows when horizontal filling with gaps', async () => {
-          const processRowUpdateSpy = spy((newRow) => newRow);
+          const processRowUpdateSpy = vi.fn((newRow) => newRow);
           const { user } = render(
             <TestDataGridSelection
               columns={fillColumns}
@@ -1396,12 +1396,12 @@ describe('<DataGridPremium /> - Cell selection', () => {
           });
           expect(getCell(2, 3).textContent).to.equal('30');
           // Row 1 should NOT be filled (it was not selected)
-          expect(processRowUpdateSpy.callCount).to.equal(2);
+          expect(processRowUpdateSpy.mock.calls.length).to.equal(2);
           expect(getCell(1, 3).textContent).to.equal('B');
         });
 
         it('should map source columns to target columns by offset', async () => {
-          const processRowUpdateSpy = spy((newRow) => newRow);
+          const processRowUpdateSpy = vi.fn((newRow) => newRow);
           const { user } = render(
             <TestDataGridSelection
               columns={fillColumns}
@@ -1433,7 +1433,7 @@ describe('<DataGridPremium /> - Cell selection', () => {
 
       describe('Fill preview', () => {
         it('should remove fill preview classes after mouse release', async () => {
-          const processRowUpdateSpy = spy((newRow) => newRow);
+          const processRowUpdateSpy = vi.fn((newRow) => newRow);
           const { user } = render(
             <TestDataGridSelection
               columns={fillColumns}
@@ -1465,7 +1465,7 @@ describe('<DataGridPremium /> - Cell selection', () => {
 
       describe('Non-editable columns', () => {
         it('should not update non-editable columns during fill', async () => {
-          const processRowUpdateSpy = spy((newRow) => newRow);
+          const processRowUpdateSpy = vi.fn((newRow) => newRow);
           const { user } = render(
             <TestDataGridSelection
               columns={fillColumns}
@@ -1501,7 +1501,7 @@ describe('<DataGridPremium /> - Cell selection', () => {
 
       describe('processRowUpdate integration', () => {
         it('should call processRowUpdate for each affected row', async () => {
-          const processRowUpdateSpy = spy((newRow) => newRow);
+          const processRowUpdateSpy = vi.fn((newRow) => newRow);
           const { user } = render(
             <TestDataGridSelection
               columns={fillColumns}
@@ -1520,20 +1520,20 @@ describe('<DataGridPremium /> - Cell selection', () => {
           await simulateFillDrag(handleCell, getCell(2, 1));
 
           await waitFor(() => {
-            expect(processRowUpdateSpy.callCount).to.equal(2);
+            expect(processRowUpdateSpy.mock.calls.length).to.equal(2);
           });
           // First call: row 1
-          expect(processRowUpdateSpy.args[0][0].name).to.equal('Alice');
-          expect((processRowUpdateSpy.args[0] as any)[1].name).to.equal('Bob');
+          expect(processRowUpdateSpy.mock.calls[0][0].name).to.equal('Alice');
+          expect((processRowUpdateSpy.mock.calls[0] as any)[1].name).to.equal('Bob');
           // Second call: row 2
-          expect(processRowUpdateSpy.args[1][0].name).to.equal('Alice');
-          expect((processRowUpdateSpy.args[1] as any)[1].name).to.equal('Charlie');
+          expect(processRowUpdateSpy.mock.calls[1][0].name).to.equal('Alice');
+          expect((processRowUpdateSpy.mock.calls[1] as any)[1].name).to.equal('Charlie');
         });
       });
 
       describe('pastedValueParser', () => {
         it('should use pastedValueParser when filling a number column', async () => {
-          const pastedValueParserSpy = spy((value: string) => Number(value) || 0);
+          const pastedValueParserSpy = vi.fn((value: string) => Number(value) || 0);
           const columnsWithParser = [
             { field: 'id', type: 'number' as const },
             { field: 'name', editable: true },
@@ -1545,7 +1545,7 @@ describe('<DataGridPremium /> - Cell selection', () => {
             },
             { field: 'category', editable: true },
           ];
-          const processRowUpdateSpy = spy((newRow) => newRow);
+          const processRowUpdateSpy = vi.fn((newRow) => newRow);
           const { user } = render(
             <TestDataGridSelection
               columns={columnsWithParser}
@@ -1564,13 +1564,13 @@ describe('<DataGridPremium /> - Cell selection', () => {
           await simulateFillDrag(handleCell, getCell(1, 2));
 
           await waitFor(() => {
-            expect(pastedValueParserSpy.callCount).to.be.greaterThan(0);
+            expect(pastedValueParserSpy.mock.calls.length).to.be.greaterThan(0);
           });
-          expect(processRowUpdateSpy.callCount).to.equal(1);
+          expect(processRowUpdateSpy.mock.calls.length).to.equal(1);
         });
 
         it('should use valueParser as fallback when pastedValueParser is not defined', async () => {
-          const valueParserSpy = spy((value: string) => Number(value) || 0);
+          const valueParserSpy = vi.fn((value: string) => Number(value) || 0);
           const columnsWithValueParser = [
             { field: 'id', type: 'number' as const },
             { field: 'name', editable: true },
@@ -1582,7 +1582,7 @@ describe('<DataGridPremium /> - Cell selection', () => {
             },
             { field: 'category', editable: true },
           ];
-          const processRowUpdateSpy = spy((newRow) => newRow);
+          const processRowUpdateSpy = vi.fn((newRow) => newRow);
           const { user } = render(
             <TestDataGridSelection
               columns={columnsWithValueParser}
@@ -1601,9 +1601,9 @@ describe('<DataGridPremium /> - Cell selection', () => {
           await simulateFillDrag(handleCell, getCell(1, 2));
 
           await waitFor(() => {
-            expect(valueParserSpy.callCount).to.be.greaterThan(0);
+            expect(valueParserSpy.mock.calls.length).to.be.greaterThan(0);
           });
-          expect(processRowUpdateSpy.callCount).to.equal(1);
+          expect(processRowUpdateSpy.mock.calls.length).to.equal(1);
         });
       });
     });

--- a/packages/x-data-grid-premium/src/tests/exportExcel.DataGridPremium.test.tsx
+++ b/packages/x-data-grid-premium/src/tests/exportExcel.DataGridPremium.test.tsx
@@ -8,11 +8,10 @@ import type {
   GridFormulaFunctionDefinition,
 } from '@mui/x-data-grid-premium';
 import { createRenderer, screen, act } from '@mui/internal-test-utils';
-import { spy } from 'sinon';
-import type { SinonSpy } from 'sinon';
 import Excel from '@mui/x-internal-exceljs-fork';
 import { spyApi } from 'test/utils/helperFn';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { Mock } from 'vitest';
 
 const isJSDOM = /jsdom/.test(window.navigator.userAgent);
 
@@ -699,11 +698,11 @@ describe('<DataGridPremium /> - Export Excel', () => {
   });
 
   describe('web worker', () => {
-    let workerMock: { postMessage: SinonSpy };
+    let workerMock: { postMessage: Mock };
 
     beforeEach(() => {
       workerMock = {
-        postMessage: spy(),
+        postMessage: vi.fn(),
       };
     });
 
@@ -711,13 +710,13 @@ describe('<DataGridPremium /> - Export Excel', () => {
       render(<TestCaseExcelExport />);
       const getDataAsExcelSpy = spyApi(apiRef.current!, 'getDataAsExcel');
       await act(() => apiRef.current?.exportDataAsExcel({ worker: () => workerMock as any }));
-      expect(getDataAsExcelSpy.calledOnce).to.equal(false);
+      expect(getDataAsExcelSpy.mock.calls.length).not.to.equal(1);
     });
 
     it('should post a message to the web worker with the serialized columns', async () => {
       render(<TestCaseExcelExport />);
       await act(() => apiRef.current?.exportDataAsExcel({ worker: () => workerMock as any }));
-      expect(workerMock.postMessage.lastCall.args[0].serializedColumns).to.deep.equal([
+      expect(workerMock.postMessage.mock.lastCall?.[0].serializedColumns).to.deep.equal([
         { key: 'id', headerText: 'id', style: {}, width: 100 / 7.5 },
         { key: 'brand', headerText: 'Brand', style: {}, width: 100 / 7.5 },
       ]);
@@ -726,7 +725,7 @@ describe('<DataGridPremium /> - Export Excel', () => {
     it('should post a message to the web worker with the serialized rows', async () => {
       render(<TestCaseExcelExport />);
       await act(() => apiRef.current?.exportDataAsExcel({ worker: () => workerMock as any }));
-      expect(workerMock.postMessage.lastCall.args[0].serializedRows).to.deep.equal([
+      expect(workerMock.postMessage.mock.lastCall?.[0].serializedRows).to.deep.equal([
         {
           dataValidation: {},
           mergedCells: [],
@@ -774,7 +773,7 @@ describe('<DataGridPremium /> - Export Excel', () => {
           escapeFormulas: false,
         }),
       );
-      const { serializedRows } = workerMock.postMessage.lastCall.args[0];
+      const { serializedRows } = workerMock.postMessage.mock.lastCall?.[0] ?? {};
       expect(serializedRows[0].formulas).to.deep.equal({
         total: { formula: 'A2*B2', result: 20 },
       });

--- a/packages/x-data-grid-premium/src/tests/exportExcel.DataGridPremium.test.tsx
+++ b/packages/x-data-grid-premium/src/tests/exportExcel.DataGridPremium.test.tsx
@@ -710,7 +710,7 @@ describe('<DataGridPremium /> - Export Excel', () => {
       render(<TestCaseExcelExport />);
       const getDataAsExcelSpy = spyApi(apiRef.current!, 'getDataAsExcel');
       await act(() => apiRef.current?.exportDataAsExcel({ worker: () => workerMock as any }));
-      expect(getDataAsExcelSpy.mock.calls.length).not.to.equal(1);
+      expect(getDataAsExcelSpy.mock.calls.length).to.equal(0);
     });
 
     it('should post a message to the web worker with the serialized columns', async () => {
@@ -773,6 +773,7 @@ describe('<DataGridPremium /> - Export Excel', () => {
           escapeFormulas: false,
         }),
       );
+      expect(workerMock.postMessage.mock.calls.length).to.equal(1);
       const { serializedRows } = workerMock.postMessage.mock.lastCall?.[0] ?? {};
       expect(serializedRows[0].formulas).to.deep.equal({
         total: { formula: 'A2*B2', result: 20 },

--- a/packages/x-data-grid-pro/src/tests/cellEditing.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/cellEditing.DataGridPro.test.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
-import { spy } from 'sinon';
 import type { RefObject } from '@mui/x-internals/types';
 import { useGridApiRef, DataGridPro, GridCellModes } from '@mui/x-data-grid-pro';
 import type {
   GridApi,
   DataGridProProps,
   GridRenderEditCellParams,
+  GridRowModel,
   GridValueSetter,
   GridPreProcessEditCellProps,
   GridColDef,
@@ -71,51 +71,51 @@ describe('<DataGridPro /> - Cell editing', () => {
       });
 
       it('should render the component given in renderEditCell', () => {
-        const renderEditCell = spy(defaultRenderEditCell);
+        const renderEditCell = vi.fn(defaultRenderEditCell);
 
         render(<TestCase columnProps={{ renderEditCell }} />);
-        expect(renderEditCell.callCount).to.equal(0);
+        expect(renderEditCell.mock.calls.length).to.equal(0);
         act(() => apiRef.current?.startCellEditMode({ id: 0, field: 'currencyPair' }));
-        expect(renderEditCell.callCount).not.to.equal(0);
+        expect(renderEditCell.mock.calls.length).not.to.equal(0);
       });
 
       it('should pass props to renderEditCell', () => {
-        const renderEditCell = spy(defaultRenderEditCell);
+        const renderEditCell = vi.fn(defaultRenderEditCell);
 
         render(<TestCase columnProps={{ renderEditCell }} />);
 
         act(() => apiRef.current?.startCellEditMode({ id: 0, field: 'currencyPair' }));
-        expect(renderEditCell.lastCall.args[0].value).to.equal('USDGBP');
-        expect(renderEditCell.lastCall.args[0].error).to.equal(false);
-        expect(renderEditCell.lastCall.args[0].isProcessingProps).to.equal(false);
+        expect(renderEditCell.mock.lastCall?.[0].value).to.equal('USDGBP');
+        expect(renderEditCell.mock.lastCall?.[0].error).to.equal(false);
+        expect(renderEditCell.mock.lastCall?.[0].isProcessingProps).to.equal(false);
       });
 
       it('should empty the value if deleteValue is true', () => {
-        const renderEditCell = spy(defaultRenderEditCell);
+        const renderEditCell = vi.fn(defaultRenderEditCell);
 
         render(<TestCase columnProps={{ renderEditCell }} />);
 
         act(() =>
           apiRef.current?.startCellEditMode({ id: 0, field: 'currencyPair', deleteValue: true }),
         );
-        expect(renderEditCell.lastCall.args[0].value).to.equal('');
-        expect(renderEditCell.lastCall.args[0].error).to.equal(false);
-        expect(renderEditCell.lastCall.args[0].isProcessingProps).to.equal(false);
+        expect(renderEditCell.mock.lastCall?.[0].value).to.equal('');
+        expect(renderEditCell.mock.lastCall?.[0].error).to.equal(false);
+        expect(renderEditCell.mock.lastCall?.[0].isProcessingProps).to.equal(false);
       });
     });
 
     describe('setEditCellValue', () => {
       it('should update the value prop given to renderEditCell', async () => {
-        const renderEditCell = spy(defaultRenderEditCell);
+        const renderEditCell = vi.fn(defaultRenderEditCell);
 
         render(<TestCase columnProps={{ renderEditCell }} />);
 
         act(() => apiRef.current?.startCellEditMode({ id: 0, field: 'currencyPair' }));
-        expect(renderEditCell.lastCall.args[0].value).to.equal('USDGBP');
+        expect(renderEditCell.mock.lastCall?.[0].value).to.equal('USDGBP');
         await act(() =>
           apiRef.current?.setEditCellValue({ id: 0, field: 'currencyPair', value: 'usdgbp' }),
         );
-        expect(renderEditCell.lastCall.args[0].value).to.equal('usdgbp');
+        expect(renderEditCell.mock.lastCall?.[0].value).to.equal('usdgbp');
       });
 
       it('should pass to renderEditCell the row with the value updated', async () => {
@@ -124,33 +124,33 @@ describe('<DataGridPro /> - Cell editing', () => {
           currencyPair: value.trim(),
         });
 
-        const renderEditCell = spy(defaultRenderEditCell);
+        const renderEditCell = vi.fn(defaultRenderEditCell);
 
         render(<TestCase columnProps={{ valueSetter, renderEditCell }} />);
         act(() => apiRef.current?.startCellEditMode({ id: 0, field: 'currencyPair' }));
-        expect(renderEditCell.lastCall.args[0].row).to.deep.equal(defaultData.rows[0]);
+        expect(renderEditCell.mock.lastCall?.[0].row).to.deep.equal(defaultData.rows[0]);
         await act(() =>
           apiRef.current?.setEditCellValue({ id: 0, field: 'currencyPair', value: ' usdgbp ' }),
         );
-        expect(renderEditCell.lastCall.args[0].row).to.deep.equal({
+        expect(renderEditCell.mock.lastCall?.[0].row).to.deep.equal({
           ...defaultData.rows[0],
           currencyPair: 'usdgbp',
         });
       });
 
       it('should pass the new value through the value parser if defined', async () => {
-        const valueParser = spy((value) => value.toLowerCase());
-        const renderEditCell = spy(defaultRenderEditCell);
+        const valueParser = vi.fn((value) => value.toLowerCase());
+        const renderEditCell = vi.fn(defaultRenderEditCell);
 
         render(<TestCase columnProps={{ valueParser, renderEditCell }} />);
 
         act(() => apiRef.current?.startCellEditMode({ id: 0, field: 'currencyPair' }));
-        expect(valueParser.callCount).to.equal(0);
+        expect(valueParser.mock.calls.length).to.equal(0);
         await act(() =>
           apiRef.current?.setEditCellValue({ id: 0, field: 'currencyPair', value: 'USD GBP' }),
         );
-        expect(valueParser.callCount).to.equal(1);
-        expect(renderEditCell.lastCall.args[0].value).to.equal('usd gbp');
+        expect(valueParser.mock.calls.length).to.equal(1);
+        expect(renderEditCell.mock.lastCall?.[0].value).to.equal('usd gbp');
       });
 
       it('should return true if no preProcessEditCellProps is defined', async () => {
@@ -164,8 +164,8 @@ describe('<DataGridPro /> - Cell editing', () => {
       });
 
       it('should set isProcessingProps to true before calling preProcessEditCellProps', async () => {
-        const preProcessEditCellProps = spy(({ props }: GridPreProcessEditCellProps) => props);
-        const renderEditCell = spy(defaultRenderEditCell);
+        const preProcessEditCellProps = vi.fn(({ props }: GridPreProcessEditCellProps) => props);
+        const renderEditCell = vi.fn(defaultRenderEditCell);
 
         render(<TestCase columnProps={{ preProcessEditCellProps, renderEditCell }} />);
         act(() => apiRef.current?.startCellEditMode({ id: 0, field: 'currencyPair' }));
@@ -178,12 +178,12 @@ describe('<DataGridPro /> - Cell editing', () => {
             value: 'USD GBP',
           }) as Promise<boolean>;
         });
-        expect(renderEditCell.lastCall.args[0].isProcessingProps).to.equal(true);
+        expect(renderEditCell.mock.lastCall?.[0].isProcessingProps).to.equal(true);
         return act(() => promise);
       });
 
       it('should call preProcessEditCellProps with the correct params', async () => {
-        const preProcessEditCellProps = spy(({ props }: GridPreProcessEditCellProps) => props);
+        const preProcessEditCellProps = vi.fn(({ props }: GridPreProcessEditCellProps) => props);
         render(<TestCase columnProps={{ preProcessEditCellProps }} />);
         act(() => apiRef.current?.startCellEditMode({ id: 0, field: 'currencyPair' }));
         await act(() =>
@@ -193,11 +193,11 @@ describe('<DataGridPro /> - Cell editing', () => {
             value: 'USD GBP',
           }),
         );
-        const args = preProcessEditCellProps.lastCall.args[0];
-        expect(args.id).to.equal(0);
-        expect(args.row).to.deep.equal(defaultData.rows[0]);
-        expect(args.hasChanged).to.equal(true);
-        expect(args.props).to.deep.equal({
+        const args = preProcessEditCellProps.mock.lastCall?.[0];
+        expect(args?.id).to.equal(0);
+        expect(args?.row).to.deep.equal(defaultData.rows[0]);
+        expect(args?.hasChanged).to.equal(true);
+        expect(args?.props).to.deep.equal({
           value: 'USD GBP',
           error: false,
           isProcessingProps: true,
@@ -206,12 +206,12 @@ describe('<DataGridPro /> - Cell editing', () => {
       });
 
       it('should not publish onCellEditStop if field has error', async () => {
-        const preProcessEditCellProps = spy(({ props }: GridPreProcessEditCellProps) => ({
+        const preProcessEditCellProps = vi.fn(({ props }: GridPreProcessEditCellProps) => ({
           ...props,
           error: true,
         }));
 
-        const handleEditCellStop = spy();
+        const handleEditCellStop = vi.fn();
 
         render(
           <TestCase
@@ -232,7 +232,7 @@ describe('<DataGridPro /> - Cell editing', () => {
 
         fireEvent.keyDown(cell, { key: 'Enter' });
 
-        expect(handleEditCellStop.callCount).to.equal(0);
+        expect(handleEditCellStop.mock.calls.length).to.equal(0);
       });
 
       it('should pass to renderEditCell the props returned by preProcessEditCellProps', async () => {
@@ -240,15 +240,15 @@ describe('<DataGridPro /> - Cell editing', () => {
           ...props,
           foo: 'bar',
         });
-        const renderEditCell = spy(defaultRenderEditCell);
+        const renderEditCell = vi.fn(defaultRenderEditCell);
 
         render(<TestCase columnProps={{ preProcessEditCellProps, renderEditCell }} />);
         act(() => apiRef.current?.startCellEditMode({ id: 0, field: 'currencyPair' }));
-        expect(renderEditCell.lastCall.args[0].foo).to.equal(undefined);
+        expect(renderEditCell.mock.lastCall?.[0].foo).to.equal(undefined);
         await act(() =>
           apiRef.current?.setEditCellValue({ id: 0, field: 'currencyPair', value: 'USD GBP' }),
         );
-        expect(renderEditCell.lastCall.args[0].foo).to.equal('bar');
+        expect(renderEditCell.mock.lastCall?.[0].foo).to.equal('bar');
       });
 
       it('should not pass to renderEditCell the value returned by preProcessEditCellProps', async () => {
@@ -256,20 +256,20 @@ describe('<DataGridPro /> - Cell editing', () => {
           ...props,
           value: 'foobar',
         });
-        const renderEditCell = spy(defaultRenderEditCell);
+        const renderEditCell = vi.fn(defaultRenderEditCell);
 
         render(<TestCase columnProps={{ preProcessEditCellProps, renderEditCell }} />);
         act(() => apiRef.current?.startCellEditMode({ id: 0, field: 'currencyPair' }));
-        expect(renderEditCell.lastCall.args[0].value).to.equal('USDGBP');
+        expect(renderEditCell.mock.lastCall?.[0].value).to.equal('USDGBP');
         await act(() =>
           apiRef.current?.setEditCellValue({ id: 0, field: 'currencyPair', value: 'USD GBP' }),
         );
-        expect(renderEditCell.lastCall.args[0].value).to.equal('USD GBP');
+        expect(renderEditCell.mock.lastCall?.[0].value).to.equal('USD GBP');
       });
 
       it('should set isProcessingProps to false after calling preProcessEditCellProps', async () => {
         const preProcessEditCellProps = ({ props }: GridPreProcessEditCellProps) => props;
-        const renderEditCell = spy(defaultRenderEditCell);
+        const renderEditCell = vi.fn(defaultRenderEditCell);
 
         render(<TestCase columnProps={{ preProcessEditCellProps, renderEditCell }} />);
         act(() => apiRef.current?.startCellEditMode({ id: 0, field: 'currencyPair' }));
@@ -282,9 +282,9 @@ describe('<DataGridPro /> - Cell editing', () => {
             value: 'USD GBP',
           }) as Promise<boolean>;
         });
-        expect(renderEditCell.lastCall.args[0].isProcessingProps).to.equal(true);
+        expect(renderEditCell.mock.lastCall?.[0].isProcessingProps).to.equal(true);
         await act(() => promise);
-        expect(renderEditCell.lastCall.args[0].isProcessingProps).to.equal(false);
+        expect(renderEditCell.mock.lastCall?.[0].isProcessingProps).to.equal(false);
       });
 
       it('should return false if preProcessEditCellProps sets an error', async () => {
@@ -338,34 +338,34 @@ describe('<DataGridPro /> - Cell editing', () => {
 
       describe('with debounceMs > 0', () => {
         it('should debounce multiple changes if debounceMs > 0', async () => {
-          const renderEditCell = spy((() => <input />) as (
+          const renderEditCell = vi.fn((() => <input />) as (
             props: GridRenderEditCellParams,
           ) => React.ReactNode);
 
           render(<TestCase columnProps={{ renderEditCell }} />);
           act(() => apiRef.current?.startCellEditMode({ id: 0, field: 'currencyPair' }));
-          expect(renderEditCell.lastCall.args[0].value).to.equal('USDGBP');
-          renderEditCell.resetHistory();
+          expect(renderEditCell.mock.lastCall?.[0].value).to.equal('USDGBP');
+          renderEditCell.mockClear();
           apiRef.current?.setEditCellValue({
             id: 0,
             field: 'currencyPair',
             value: 'USD',
             debounceMs: 100,
           });
-          expect(renderEditCell.callCount).to.equal(0);
+          expect(renderEditCell.mock.calls.length).to.equal(0);
           apiRef.current?.setEditCellValue({
             id: 0,
             field: 'currencyPair',
             value: 'USD GBP',
             debounceMs: 100,
           });
-          expect(renderEditCell.callCount).to.equal(0);
+          expect(renderEditCell.mock.calls.length).to.equal(0);
 
           await waitFor(() => {
-            expect(renderEditCell.callCount).not.to.equal(0);
+            expect(renderEditCell.mock.calls.length).not.to.equal(0);
           });
 
-          expect(renderEditCell.lastCall.args[0].value).to.equal('USD GBP');
+          expect(renderEditCell.mock.lastCall?.[0].value).to.equal('USD GBP');
         });
       });
     });
@@ -460,7 +460,7 @@ describe('<DataGridPro /> - Cell editing', () => {
           ...props,
           error: true,
         });
-        const onCellModesModelChange = spy();
+        const onCellModesModelChange = vi.fn();
         render(
           <TestCase
             onCellModesModelChange={onCellModesModelChange}
@@ -472,7 +472,7 @@ describe('<DataGridPro /> - Cell editing', () => {
           apiRef.current?.setEditCellValue({ id: 0, field: 'currencyPair', value: 'USD GBP' }),
         );
         act(() => apiRef.current?.stopCellEditMode({ id: 0, field: 'currencyPair' }));
-        expect(onCellModesModelChange.lastCall.args[0]).to.deep.equal({
+        expect(onCellModesModelChange.mock.lastCall?.[0]).to.deep.equal({
           0: { currencyPair: { mode: 'edit' } },
         });
       });
@@ -510,7 +510,7 @@ describe('<DataGridPro /> - Cell editing', () => {
       });
 
       it('should call processRowUpdate before updating the row', async () => {
-        const processRowUpdate = spy((row) => ({ ...row, currencyPair: 'USD-GBP' }));
+        const processRowUpdate = vi.fn((row) => ({ ...row, currencyPair: 'USD-GBP' }));
         render(<TestCase processRowUpdate={processRowUpdate} />);
         act(() => apiRef.current?.startCellEditMode({ id: 0, field: 'currencyPair' }));
         await act(() =>
@@ -518,12 +518,12 @@ describe('<DataGridPro /> - Cell editing', () => {
         );
         act(() => apiRef.current?.stopCellEditMode({ id: 0, field: 'currencyPair' }));
         await act(() => Promise.resolve());
-        expect(processRowUpdate.callCount).to.equal(1);
+        expect(processRowUpdate.mock.calls.length).to.equal(1);
         expect(getCell(0, 1).textContent).to.equal('USD-GBP');
       });
 
       it('should call processRowUpdate with the new and old row', async () => {
-        const processRowUpdate = spy((newRow, oldRow) => ({ ...oldRow, ...newRow }));
+        const processRowUpdate = vi.fn((newRow, oldRow) => ({ ...oldRow, ...newRow }));
         render(<TestCase processRowUpdate={processRowUpdate} />);
         act(() => apiRef.current?.startCellEditMode({ id: 0, field: 'currencyPair' }));
         await act(() =>
@@ -531,18 +531,18 @@ describe('<DataGridPro /> - Cell editing', () => {
         );
         act(() => apiRef.current?.stopCellEditMode({ id: 0, field: 'currencyPair' }));
         await act(() => Promise.resolve());
-        expect(processRowUpdate.lastCall.args[0]).to.deep.equal({
+        expect(processRowUpdate.mock.lastCall?.[0]).to.deep.equal({
           ...defaultData.rows[0],
           currencyPair: 'USD GBP',
         });
-        expect(processRowUpdate.lastCall.args[1]).to.deep.equal(defaultData.rows[0]);
+        expect(processRowUpdate.mock.lastCall?.[1]).to.deep.equal(defaultData.rows[0]);
       });
 
       it('should not re-insert a row deleted while processRowUpdate is pending', async () => {
         const testRow = defaultData.rows[0];
         const otherRows = defaultData.rows.slice(1);
         let resolveProcessRowUpdate = () => {};
-        const processRowUpdate = spy(
+        const processRowUpdate = vi.fn(
           (newRow: any) =>
             new Promise<any>((resolve) => {
               resolveProcessRowUpdate = () => resolve(newRow);
@@ -562,7 +562,7 @@ describe('<DataGridPro /> - Cell editing', () => {
 
         // commit the edit; processRowUpdate is now pending
         act(() => apiRef.current?.stopCellEditMode({ id: testRow.id, field: 'currencyPair' }));
-        expect(processRowUpdate.callCount).to.equal(1);
+        expect(processRowUpdate.mock.calls.length).to.equal(1);
 
         // remove the row while processRowUpdate is still pending
         setProps({ rows: otherRows });
@@ -600,7 +600,7 @@ describe('<DataGridPro /> - Cell editing', () => {
         const processRowUpdate = () => {
           throw error;
         };
-        const onProcessRowUpdateError = spy();
+        const onProcessRowUpdateError = vi.fn();
         render(
           <TestCase
             processRowUpdate={processRowUpdate}
@@ -609,7 +609,7 @@ describe('<DataGridPro /> - Cell editing', () => {
         );
         act(() => apiRef.current?.startCellEditMode({ id: 0, field: 'currencyPair' }));
         act(() => apiRef.current?.stopCellEditMode({ id: 0, field: 'currencyPair' }));
-        expect(onProcessRowUpdateError.lastCall.args[0]).to.equal(error);
+        expect(onProcessRowUpdateError.mock.lastCall?.[0]).to.equal(error);
       });
 
       it('should call onProcessRowUpdateError if processRowUpdate rejects', async () => {
@@ -617,7 +617,7 @@ describe('<DataGridPro /> - Cell editing', () => {
         const processRowUpdate = async () => {
           throw error;
         };
-        const onProcessRowUpdateError = spy();
+        const onProcessRowUpdateError = vi.fn();
         render(
           <TestCase
             processRowUpdate={processRowUpdate}
@@ -627,7 +627,7 @@ describe('<DataGridPro /> - Cell editing', () => {
         act(() => apiRef.current?.startCellEditMode({ id: 0, field: 'currencyPair' }));
         act(() => apiRef.current?.stopCellEditMode({ id: 0, field: 'currencyPair' }));
         await act(() => Promise.resolve());
-        expect(onProcessRowUpdateError.lastCall.args[0]).to.equal(error);
+        expect(onProcessRowUpdateError.mock.lastCall?.[0]).to.equal(error);
       });
 
       it('should keep mode=edit if processRowUpdate rejects', async () => {
@@ -635,8 +635,8 @@ describe('<DataGridPro /> - Cell editing', () => {
         const processRowUpdate = () => {
           throw error;
         };
-        const onProcessRowUpdateError = spy();
-        const onCellModesModelChange = spy();
+        const onProcessRowUpdateError = vi.fn();
+        const onCellModesModelChange = vi.fn();
         render(
           <TestCase
             onCellModesModelChange={onCellModesModelChange}
@@ -649,30 +649,30 @@ describe('<DataGridPro /> - Cell editing', () => {
           apiRef.current?.setEditCellValue({ id: 0, field: 'currencyPair', value: 'USD GBP' }),
         );
         act(() => apiRef.current?.stopCellEditMode({ id: 0, field: 'currencyPair' }));
-        expect(onCellModesModelChange.lastCall.args[0]).to.deep.equal({
+        expect(onCellModesModelChange.mock.lastCall?.[0]).to.deep.equal({
           0: { currencyPair: { mode: 'edit' } },
         });
       });
 
       it('should pass the new value through the value setter before calling processRowUpdate', async () => {
-        const valueSetter = spy<GridValueSetter>((value, row) => ({
+        const valueSetter = vi.fn<GridValueSetter>((value, row) => ({
           ...row,
           _currencyPair: value,
         }));
-        const processRowUpdate = spy(() => new Promise(() => {}));
+        const processRowUpdate = vi.fn((_row: GridRowModel) => new Promise(() => {}));
         render(<TestCase processRowUpdate={processRowUpdate} columnProps={{ valueSetter }} />);
         act(() => apiRef.current?.startCellEditMode({ id: 0, field: 'currencyPair' }));
         await act(() =>
           apiRef.current?.setEditCellValue({ id: 0, field: 'currencyPair', value: 'USD GBP' }),
         );
         act(() => apiRef.current?.stopCellEditMode({ id: 0, field: 'currencyPair' }));
-        expect((processRowUpdate.lastCall as any).args[0]).to.deep.equal({
+        expect(processRowUpdate.mock.lastCall?.[0]).to.deep.equal({
           ...defaultData.rows[0],
           currencyPair: 'USDGBP',
           _currencyPair: 'USD GBP',
         });
-        expect(valueSetter.lastCall.args[0]).to.equal('USD GBP');
-        expect(valueSetter.lastCall.args[1]).to.deep.equal(defaultData.rows[0]);
+        expect(valueSetter.mock.lastCall?.[0]).to.equal('USD GBP');
+        expect(valueSetter.mock.lastCall?.[1]).to.deep.equal(defaultData.rows[0]);
       });
 
       it('should move focus to the cell below when cellToFocusAfter=below', async () => {
@@ -750,8 +750,8 @@ describe('<DataGridPro /> - Cell editing', () => {
       });
 
       it('should run all pending value mutations before calling processRowUpdate', async () => {
-        const processRowUpdate = spy(() => new Promise(() => {}));
-        const renderEditCell = spy(defaultRenderEditCell);
+        const processRowUpdate = vi.fn((_row: GridRowModel) => new Promise(() => {}));
+        const renderEditCell = vi.fn(defaultRenderEditCell);
 
         render(<TestCase processRowUpdate={processRowUpdate} columnProps={{ renderEditCell }} />);
         act(() => apiRef.current?.startCellEditMode({ id: 0, field: 'currencyPair' }));
@@ -768,12 +768,12 @@ describe('<DataGridPro /> - Cell editing', () => {
             }),
         );
         act(() => apiRef.current?.stopCellEditMode({ id: 0, field: 'currencyPair' }));
-        expect(renderEditCell.lastCall.args[0].value).to.equal('USD GBP');
-        expect((processRowUpdate.lastCall as any).args[0].currencyPair).to.equal('USD GBP');
+        expect(renderEditCell.mock.lastCall?.[0].value).to.equal('USD GBP');
+        expect(processRowUpdate.mock.lastCall?.[0].currencyPair).to.equal('USD GBP');
       });
 
       it('should keep in edit mode the cells that entered edit mode while processRowUpdate is called', async () => {
-        const onCellModesModelChange = spy();
+        const onCellModesModelChange = vi.fn();
         let resolveCallback: () => void;
         const processRowUpdate = (newRow: any) =>
           new Promise((resolve) => {
@@ -791,19 +791,19 @@ describe('<DataGridPro /> - Cell editing', () => {
           apiRef.current?.setEditCellValue({ id: 0, field: 'currencyPair', value: 'USD GBP' }),
         );
         act(() => apiRef.current?.stopCellEditMode({ id: 0, field: 'currencyPair' }));
-        expect(onCellModesModelChange.lastCall.args[0]).to.deep.equal({
+        expect(onCellModesModelChange.mock.lastCall?.[0]).to.deep.equal({
           0: { currencyPair: { mode: 'view' } },
         });
 
         act(() => apiRef.current?.startCellEditMode({ id: 1, field: 'currencyPair' }));
-        expect(onCellModesModelChange.lastCall.args[0]).to.have.keys('0', '1');
-        expect(onCellModesModelChange.lastCall.args[0][1]).to.deep.equal({
+        expect(onCellModesModelChange.mock.lastCall?.[0]).to.have.keys('0', '1');
+        expect(onCellModesModelChange.mock.lastCall?.[0][1]).to.deep.equal({
           currencyPair: { mode: 'edit' },
         });
 
         resolveCallback!();
         await act(() => Promise.resolve());
-        expect(onCellModesModelChange.lastCall.args[0]).to.deep.equal({
+        expect(onCellModesModelChange.mock.lastCall?.[0]).to.deep.equal({
           1: { currencyPair: { mode: 'edit' } },
         });
       });
@@ -814,20 +814,20 @@ describe('<DataGridPro /> - Cell editing', () => {
     describe('by double-click', () => {
       it(`should publish 'cellEditStart' with reason=cellDoubleClick`, () => {
         render(<TestCase />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('cellEditStart', listener);
         const cell = getCell(0, 1);
         fireEvent.doubleClick(cell);
-        expect(listener.lastCall.args[0].reason).to.equal('cellDoubleClick');
+        expect(listener.mock.lastCall?.[0].reason).to.equal('cellDoubleClick');
       });
 
       it(`should not publish 'cellEditStart' if the cell is not editable`, () => {
         render(<TestCase />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('cellEditStart', listener);
         const cell = getCell(0, 0);
         fireEvent.doubleClick(cell);
-        expect(listener.callCount).to.equal(0);
+        expect(listener.mock.calls.length).to.equal(0);
       });
 
       it('should call startCellEditMode', () => {
@@ -835,63 +835,63 @@ describe('<DataGridPro /> - Cell editing', () => {
         const spiedStartCellEditMode = spyApi(apiRef.current!, 'startCellEditMode');
         const cell = getCell(0, 1);
         fireEvent.doubleClick(cell);
-        expect(spiedStartCellEditMode.callCount).to.equal(1);
+        expect(spiedStartCellEditMode.mock.calls.length).to.equal(1);
       });
     });
 
     describe('by pressing a special character', () => {
       it(`should publish 'cellEditStart' with reason=printableKeyDown`, () => {
         render(<TestCase />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('cellEditStart', listener);
         const cell = getCell(0, 1);
         fireUserEvent.mousePress(cell);
         fireEvent.keyDown(cell, { key: '$' });
-        expect(listener.lastCall.args[0].reason).to.equal('printableKeyDown');
+        expect(listener.mock.lastCall?.[0].reason).to.equal('printableKeyDown');
       });
 
       it(`should not publish 'cellEditStart' if space is pressed`, async () => {
         const { user } = render(<TestCase autoHeight />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('cellEditStart', listener);
         const cell = getCell(0, 1);
         await user.click(cell);
         await user.keyboard('[Space]');
-        expect(listener.callCount).to.equal(0);
+        expect(listener.mock.calls.length).to.equal(0);
       });
     });
 
     describe('by pressing a number', () => {
       it(`should publish 'cellEditStart' with reason=printableKeyDown`, () => {
         render(<TestCase />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('cellEditStart', listener);
         const cell = getCell(0, 1);
         fireUserEvent.mousePress(cell);
         fireEvent.keyDown(cell, { key: '1' });
-        expect(listener.lastCall.args[0].reason).to.equal('printableKeyDown');
+        expect(listener.mock.lastCall?.[0].reason).to.equal('printableKeyDown');
       });
     });
 
     describe('by pressing Enter', () => {
       it(`should publish 'cellEditStart' with reason=enterKeyDown`, () => {
         render(<TestCase />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('cellEditStart', listener);
         const cell = getCell(0, 1);
         fireUserEvent.mousePress(cell);
         fireEvent.keyDown(cell, { key: 'Enter' });
-        expect(listener.lastCall.args[0].reason).to.equal('enterKeyDown');
+        expect(listener.mock.lastCall?.[0].reason).to.equal('enterKeyDown');
       });
 
       it(`should not publish 'cellEditStart' if the cell is not editable`, () => {
         render(<TestCase />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('cellEditStart', listener);
         const cell = getCell(0, 0);
         fireUserEvent.mousePress(cell);
         fireEvent.keyDown(cell, { key: 'Enter' });
-        expect(listener.callCount).to.equal(0);
+        expect(listener.mock.calls.length).to.equal(0);
       });
 
       it('should call startCellEditMode', () => {
@@ -900,11 +900,11 @@ describe('<DataGridPro /> - Cell editing', () => {
         const cell = getCell(0, 1);
         fireUserEvent.mousePress(cell);
         fireEvent.keyDown(cell, { key: 'Enter' });
-        expect(spiedStartCellEditMode.callCount).to.equal(1);
+        expect(spiedStartCellEditMode.mock.calls.length).to.equal(1);
       });
 
       it('should prevent the default behavior to avoid the key affecting the edit component', () => {
-        const handleKeyDown = spy((event: React.KeyboardEvent) => event.defaultPrevented);
+        const handleKeyDown = vi.fn((event: React.KeyboardEvent) => event.defaultPrevented);
         render(
           <div onKeyDown={handleKeyDown}>
             <TestCase />
@@ -913,29 +913,29 @@ describe('<DataGridPro /> - Cell editing', () => {
         const cell = getCell(0, 1);
         fireUserEvent.mousePress(cell);
         fireEvent.keyDown(cell, { key: 'Enter' });
-        expect(handleKeyDown.returnValues).to.deep.equal([true]);
+        expect(handleKeyDown.mock.results.map((result) => result.value)).to.deep.equal([true]);
       });
     });
 
     describe('by pressing Delete', () => {
       it(`should publish 'cellEditStart' with reason=deleteKeyDown`, () => {
         render(<TestCase />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('cellEditStart', listener);
         const cell = getCell(0, 1);
         fireUserEvent.mousePress(cell);
         fireEvent.keyDown(cell, { key: 'Delete' });
-        expect(listener.lastCall.args[0].reason).to.equal('deleteKeyDown');
+        expect(listener.mock.lastCall?.[0].reason).to.equal('deleteKeyDown');
       });
 
       it(`should not publish 'cellEditStart' if the cell is not editable`, () => {
         render(<TestCase />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('cellEditStart', listener);
         const cell = getCell(0, 0);
         fireUserEvent.mousePress(cell);
         fireEvent.keyDown(cell, { key: 'Delete' });
-        expect(listener.callCount).to.equal(0);
+        expect(listener.mock.calls.length).to.equal(0);
       });
 
       it('should call startCellEditMode', () => {
@@ -944,7 +944,7 @@ describe('<DataGridPro /> - Cell editing', () => {
         const cell = getCell(0, 1);
         fireUserEvent.mousePress(cell);
         fireEvent.keyDown(cell, { key: 'Delete' });
-        expect(spiedStartCellEditMode.callCount).to.equal(1);
+        expect(spiedStartCellEditMode.mock.calls.length).to.equal(1);
       });
 
       it('should empty the cell', () => {
@@ -953,8 +953,8 @@ describe('<DataGridPro /> - Cell editing', () => {
         const cell = getCell(0, 1);
         fireUserEvent.mousePress(cell);
         fireEvent.keyDown(cell, { key: 'Delete' });
-        expect(spiedStartCellEditMode.callCount).to.equal(1);
-        expect(spiedStartCellEditMode.lastCall.args[0]).to.deep.equal({
+        expect(spiedStartCellEditMode.mock.calls.length).to.equal(1);
+        expect(spiedStartCellEditMode.mock.lastCall?.[0]).to.deep.equal({
           id: 0,
           field: 'currencyPair',
           deleteValue: true,
@@ -962,16 +962,16 @@ describe('<DataGridPro /> - Cell editing', () => {
       });
 
       it('should call preProcessEditCellProps', async () => {
-        const preProcessEditCellProps = spy(({ props }: GridPreProcessEditCellProps) => props);
+        const preProcessEditCellProps = vi.fn(({ props }: GridPreProcessEditCellProps) => props);
         const { user } = render(<TestCase columnProps={{ preProcessEditCellProps }} />);
 
         const cell = getCell(0, 1);
         await user.click(cell);
         await user.keyboard('{Delete}');
 
-        expect(preProcessEditCellProps.callCount).to.equal(1);
+        expect(preProcessEditCellProps.mock.calls.length).to.equal(1);
 
-        expect(preProcessEditCellProps.lastCall.args[0].props).to.deep.equal({
+        expect(preProcessEditCellProps.mock.lastCall?.[0].props).to.deep.equal({
           value: '',
           error: false,
           isProcessingProps: true,
@@ -986,69 +986,69 @@ describe('<DataGridPro /> - Cell editing', () => {
         const cell = getCell(0, 1);
         fireUserEvent.mousePress(cell);
         fireEvent.keyDown(cell, { key: 'a' }); // A
-        expect(spiedStartCellEditMode.callCount).to.equal(1);
+        expect(spiedStartCellEditMode.mock.calls.length).to.equal(1);
       });
 
       it(`should publish 'cellEditStart' with reason=printableKeyDown`, () => {
         render(<TestCase />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('cellEditStart', listener);
         const cell = getCell(0, 1);
         fireUserEvent.mousePress(cell);
         fireEvent.keyDown(cell, { key: 'a' }); // A
-        expect(listener.lastCall.args[0].reason).to.equal('printableKeyDown');
+        expect(listener.mock.lastCall?.[0].reason).to.equal('printableKeyDown');
       });
 
       it(`should not publish 'cellEditStart' if the cell is not editable`, () => {
         render(<TestCase />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('cellEditStart', listener);
         const cell = getCell(0, 0);
         fireUserEvent.mousePress(cell);
         fireEvent.keyDown(cell, { key: 'a', keyCode: 65 }); // A
-        expect(listener.callCount).to.equal(0);
+        expect(listener.mock.calls.length).to.equal(0);
       });
 
       ['ctrlKey', 'metaKey'].forEach((key) => {
         it(`should not publish 'cellEditStart' if ${key} is pressed`, () => {
           render(<TestCase />);
-          const listener = spy();
+          const listener = vi.fn();
           apiRef.current?.subscribeEvent('cellEditStart', listener);
           const cell = getCell(0, 1);
           fireUserEvent.mousePress(cell);
           fireEvent.keyDown(cell, { key: 'a', keyCode: 65, [key]: true }); // for example Ctrl + A, copy
-          expect(listener.callCount).to.equal(0);
+          expect(listener.mock.calls.length).to.equal(0);
         });
       });
 
       it(`should call startCellEditMode if shiftKey is pressed with a letter`, () => {
         render(<TestCase />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('cellEditStart', listener);
         const cell = getCell(0, 1);
         fireUserEvent.mousePress(cell);
         fireEvent.keyDown(cell, { key: 'a', keyCode: 65, shiftKey: true }); // Print A in uppercase
-        expect(listener.callCount).to.equal(1);
+        expect(listener.mock.calls.length).to.equal(1);
       });
 
       it(`should call startCellEditMode if the paste shortcut is pressed`, () => {
         render(<TestCase />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('cellEditStart', listener);
         const cell = getCell(0, 1);
         fireUserEvent.mousePress(cell);
         fireEvent.keyDown(cell, { key: 'v', keyCode: 86, ctrlKey: true }); // Ctrl+V
-        expect(listener.callCount).to.equal(1);
+        expect(listener.mock.calls.length).to.equal(1);
       });
 
       it(`should call startCellEditMode if a special character on macOS is pressed`, () => {
         render(<TestCase />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('cellEditStart', listener);
         const cell = getCell(0, 1);
         fireUserEvent.mousePress(cell);
         fireEvent.keyDown(cell, { key: 'π', altKey: true }); // ⌥ Option + P
-        expect(listener.callCount).to.equal(1);
+        expect(listener.mock.calls.length).to.equal(1);
       });
 
       it('should empty the cell', () => {
@@ -1057,8 +1057,8 @@ describe('<DataGridPro /> - Cell editing', () => {
         const cell = getCell(0, 1);
         fireUserEvent.mousePress(cell);
         fireEvent.keyDown(cell, { key: 'a' });
-        expect(spiedStartCellEditMode.callCount).to.equal(1);
-        expect(spiedStartCellEditMode.lastCall.args[0]).to.deep.equal({
+        expect(spiedStartCellEditMode.mock.calls.length).to.equal(1);
+        expect(spiedStartCellEditMode.mock.lastCall?.[0]).to.deep.equal({
           id: 0,
           field: 'currencyPair',
           deleteValue: true,
@@ -1067,34 +1067,34 @@ describe('<DataGridPro /> - Cell editing', () => {
 
       it(`should ignore keydown event until the IME is confirmed with a letter`, () => {
         render(<TestCase />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('cellEditStop', listener);
         const cell = getCell(0, 1);
         fireEvent.doubleClick(cell);
         const input = cell.querySelector('input')!;
         fireEvent.change(input, { target: { value: 'あ' } });
         fireEvent.keyDown(cell, { key: 'Enter', keyCode: 229 });
-        expect(listener.callCount).to.equal(0);
+        expect(listener.mock.calls.length).to.equal(0);
         fireEvent.keyDown(cell, { key: 'Enter', keyCode: 13 });
-        expect(listener.callCount).to.equal(1);
+        expect(listener.mock.calls.length).to.equal(1);
         expect(input.value).to.equal('あ');
-        expect(listener.lastCall.args[0].reason).to.equal('enterKeyDown');
+        expect(listener.mock.lastCall?.[0].reason).to.equal('enterKeyDown');
       });
 
       it(`should ignore keydown event until the IME is confirmed with multiple letters`, () => {
         render(<TestCase />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('cellEditStop', listener);
         const cell = getCell(0, 1);
         fireEvent.doubleClick(cell);
         const input = cell.querySelector('input')!;
         fireEvent.change(input, { target: { value: 'ありがとう' } });
         fireEvent.keyDown(cell, { key: 'Enter', keyCode: 229 });
-        expect(listener.callCount).to.equal(0);
+        expect(listener.mock.calls.length).to.equal(0);
         fireEvent.keyDown(cell, { key: 'Enter', keyCode: 13 });
-        expect(listener.callCount).to.equal(1);
+        expect(listener.mock.calls.length).to.equal(1);
         expect(input.value).to.equal('ありがとう');
-        expect(listener.lastCall.args[0].reason).to.equal('enterKeyDown');
+        expect(listener.mock.lastCall?.[0].reason).to.equal('enterKeyDown');
       });
     });
   });
@@ -1103,12 +1103,12 @@ describe('<DataGridPro /> - Cell editing', () => {
     describe('by clicking outside the cell', () => {
       it(`should publish 'cellEditStop' with reason=cellFocusOut`, () => {
         render(<TestCase />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('cellEditStop', listener);
         fireEvent.doubleClick(getCell(0, 1));
-        expect(listener.callCount).to.equal(0);
+        expect(listener.mock.calls.length).to.equal(0);
         fireUserEvent.mousePress(getCell(1, 1));
-        expect(listener.lastCall.args[0].reason).to.equal('cellFocusOut');
+        expect(listener.mock.lastCall?.[0].reason).to.equal('cellFocusOut');
       });
 
       it('should call stopCellEditMode with ignoreModifications=false and cellToFocusAfter=undefined', () => {
@@ -1116,8 +1116,8 @@ describe('<DataGridPro /> - Cell editing', () => {
         const spiedStopCellEditMode = spyApi(apiRef.current!, 'stopCellEditMode');
         fireEvent.doubleClick(getCell(0, 1));
         fireUserEvent.mousePress(getCell(1, 1));
-        expect(spiedStopCellEditMode.callCount).to.equal(1);
-        expect(spiedStopCellEditMode.lastCall.args[0]).to.deep.equal({
+        expect(spiedStopCellEditMode.mock.calls.length).to.equal(1);
+        expect(spiedStopCellEditMode.mock.lastCall?.[0]).to.deep.equal({
           id: 0,
           field: 'currencyPair',
           cellToFocusAfter: undefined,
@@ -1138,22 +1138,22 @@ describe('<DataGridPro /> - Cell editing', () => {
             }),
         );
         fireUserEvent.mousePress(getCell(1, 1));
-        expect(spiedStopCellEditMode.callCount).to.equal(1);
-        expect(spiedStopCellEditMode.lastCall.args[0].ignoreModifications).to.equal(false);
+        expect(spiedStopCellEditMode.mock.calls.length).to.equal(1);
+        expect(spiedStopCellEditMode.mock.lastCall?.[0].ignoreModifications).to.equal(false);
       });
     });
 
     describe('by pressing Escape', () => {
       it(`should publish 'cellEditStop' with reason=escapeKeyDown`, () => {
         render(<TestCase />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('cellEditStop', listener);
         const cell = getCell(0, 1);
         fireUserEvent.mousePress(cell);
         fireEvent.doubleClick(cell);
-        expect(listener.callCount).to.equal(0);
+        expect(listener.mock.calls.length).to.equal(0);
         fireEvent.keyDown(cell, { key: 'Escape' });
-        expect(listener.lastCall.args[0].reason).to.equal('escapeKeyDown');
+        expect(listener.mock.lastCall?.[0].reason).to.equal('escapeKeyDown');
       });
 
       it('should call stopCellEditMode with ignoreModifications=true and cellToFocusAfter=undefined', () => {
@@ -1163,8 +1163,8 @@ describe('<DataGridPro /> - Cell editing', () => {
         fireUserEvent.mousePress(cell);
         fireEvent.doubleClick(cell);
         fireEvent.keyDown(cell, { key: 'Escape' });
-        expect(spiedStopCellEditMode.callCount).to.equal(1);
-        expect(spiedStopCellEditMode.lastCall.args[0]).to.deep.equal({
+        expect(spiedStopCellEditMode.mock.calls.length).to.equal(1);
+        expect(spiedStopCellEditMode.mock.lastCall?.[0]).to.deep.equal({
           id: 0,
           field: 'currencyPair',
           cellToFocusAfter: undefined,
@@ -1176,14 +1176,14 @@ describe('<DataGridPro /> - Cell editing', () => {
     describe('by pressing Enter', () => {
       it(`should publish 'cellEditStop' with reason=enterKeyDown`, () => {
         render(<TestCase />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('cellEditStop', listener);
         const cell = getCell(0, 1);
         fireUserEvent.mousePress(cell);
         fireEvent.doubleClick(cell);
-        expect(listener.callCount).to.equal(0);
+        expect(listener.mock.calls.length).to.equal(0);
         fireEvent.keyDown(cell, { key: 'Enter' });
-        expect(listener.lastCall.args[0].reason).to.equal('enterKeyDown');
+        expect(listener.mock.lastCall?.[0].reason).to.equal('enterKeyDown');
       });
 
       it('should call stopCellEditMode with ignoreModifications=false and cellToFocusAfter=below', () => {
@@ -1193,8 +1193,8 @@ describe('<DataGridPro /> - Cell editing', () => {
         fireUserEvent.mousePress(cell);
         fireEvent.doubleClick(cell);
         fireEvent.keyDown(cell, { key: 'Enter' });
-        expect(spiedStopCellEditMode.callCount).to.equal(1);
-        expect(spiedStopCellEditMode.lastCall.args[0]).to.deep.equal({
+        expect(spiedStopCellEditMode.mock.calls.length).to.equal(1);
+        expect(spiedStopCellEditMode.mock.lastCall?.[0]).to.deep.equal({
           id: 0,
           field: 'currencyPair',
           cellToFocusAfter: 'below',
@@ -1217,22 +1217,22 @@ describe('<DataGridPro /> - Cell editing', () => {
             }),
         );
         fireEvent.keyDown(cell, { key: 'Enter' });
-        expect(spiedStopCellEditMode.callCount).to.equal(1);
-        expect(spiedStopCellEditMode.lastCall.args[0].ignoreModifications).to.equal(false);
+        expect(spiedStopCellEditMode.mock.calls.length).to.equal(1);
+        expect(spiedStopCellEditMode.mock.lastCall?.[0].ignoreModifications).to.equal(false);
       });
     });
 
     describe('by pressing Tab', () => {
       it(`should publish 'cellEditStop' with reason=tabKeyDown`, async () => {
         const { user } = render(<TestCase />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('cellEditStop', listener);
         const cell = getCell(0, 1);
         await user.click(cell);
         await user.dblClick(cell);
-        expect(listener.callCount).to.equal(0);
+        expect(listener.mock.calls.length).to.equal(0);
         await user.keyboard('{Tab}');
-        expect(listener.lastCall.args[0].reason).to.equal('tabKeyDown');
+        expect(listener.mock.lastCall?.[0].reason).to.equal('tabKeyDown');
       });
 
       it('should call stopCellEditMode with ignoreModifications=false and cellToFocusAfter=right', () => {
@@ -1242,8 +1242,8 @@ describe('<DataGridPro /> - Cell editing', () => {
         fireUserEvent.mousePress(cell);
         fireEvent.doubleClick(cell);
         fireEvent.keyDown(cell, { key: 'Tab' });
-        expect(spiedStopCellEditMode.callCount).to.equal(1);
-        expect(spiedStopCellEditMode.lastCall.args[0]).to.deep.equal({
+        expect(spiedStopCellEditMode.mock.calls.length).to.equal(1);
+        expect(spiedStopCellEditMode.mock.lastCall?.[0]).to.deep.equal({
           id: 0,
           field: 'currencyPair',
           cellToFocusAfter: 'right',
@@ -1266,8 +1266,8 @@ describe('<DataGridPro /> - Cell editing', () => {
             }),
         );
         fireEvent.keyDown(cell, { key: 'Tab' });
-        expect(spiedStopCellEditMode.callCount).to.equal(1);
-        expect(spiedStopCellEditMode.lastCall.args[0].ignoreModifications).to.equal(false);
+        expect(spiedStopCellEditMode.mock.calls.length).to.equal(1);
+        expect(spiedStopCellEditMode.mock.lastCall?.[0].ignoreModifications).to.equal(false);
       });
     });
   });
@@ -1325,33 +1325,33 @@ describe('<DataGridPro /> - Cell editing', () => {
 
     it(`should publish 'cellModesModelChange' when the model changes`, () => {
       render(<TestCase />);
-      const listener = spy();
+      const listener = vi.fn();
       apiRef.current?.subscribeEvent('cellModesModelChange', listener);
       const cell = getCell(0, 1);
       fireEvent.doubleClick(cell);
-      expect(listener.lastCall.args[0]).to.deep.equal({
+      expect(listener.mock.lastCall?.[0]).to.deep.equal({
         0: { currencyPair: { mode: 'edit' } },
       });
     });
 
     it(`should publish 'cellModesModelChange' when the prop changes`, () => {
       const { setProps } = render(<TestCase cellModesModel={{}} />);
-      const listener = spy();
-      expect(listener.callCount).to.equal(0);
+      const listener = vi.fn();
+      expect(listener.mock.calls.length).to.equal(0);
       apiRef.current?.subscribeEvent('cellModesModelChange', listener);
       setProps({ cellModesModel: { 0: { currencyPair: { mode: 'edit' } } } });
-      expect(listener.lastCall.args[0]).to.deep.equal({
+      expect(listener.mock.lastCall?.[0]).to.deep.equal({
         0: { currencyPair: { mode: 'edit' } },
       });
     });
 
     it(`should not publish 'cellModesModelChange' when the model changes and cellModesModel is set`, () => {
       render(<TestCase cellModesModel={{}} />);
-      const listener = spy();
+      const listener = vi.fn();
       apiRef.current?.subscribeEvent('cellModesModelChange', listener);
       const cell = getCell(0, 1);
       fireEvent.doubleClick(cell);
-      expect(listener.callCount).to.equal(0);
+      expect(listener.mock.calls.length).to.equal(0);
     });
 
     it('should not mutate the cellModesModel prop if props of any column contains error=true', async () => {
@@ -1377,36 +1377,36 @@ describe('<DataGridPro /> - Cell editing', () => {
 
   describe('prop: onCellModesModelChange', () => {
     it('should call with mode=edit when startEditMode is called', () => {
-      const onCellModesModelChange = spy();
+      const onCellModesModelChange = vi.fn();
       render(<TestCase onCellModesModelChange={onCellModesModelChange} />);
-      expect(onCellModesModelChange.callCount).to.equal(0);
+      expect(onCellModesModelChange.mock.calls.length).to.equal(0);
       act(() => apiRef.current?.startCellEditMode({ id: 0, field: 'currencyPair' }));
-      expect(onCellModesModelChange.callCount).to.equal(1);
-      expect(onCellModesModelChange.lastCall.args[0]).to.deep.equal({
+      expect(onCellModesModelChange.mock.calls.length).to.equal(1);
+      expect(onCellModesModelChange.mock.lastCall?.[0]).to.deep.equal({
         0: { currencyPair: { mode: 'edit' } },
       });
     });
 
     it('should call with mode=view when stopEditMode is called', () => {
-      const onCellModesModelChange = spy();
+      const onCellModesModelChange = vi.fn();
       render(<TestCase onCellModesModelChange={onCellModesModelChange} />);
       act(() => apiRef.current?.startCellEditMode({ id: 0, field: 'currencyPair' }));
-      onCellModesModelChange.resetHistory();
+      onCellModesModelChange.mockClear();
       act(() => apiRef.current?.stopCellEditMode({ id: 0, field: 'currencyPair' }));
-      expect(onCellModesModelChange.args[0][0]).to.deep.equal({
+      expect(onCellModesModelChange.mock.calls[0][0]).to.deep.equal({
         0: { currencyPair: { mode: 'view' } },
       });
-      expect(onCellModesModelChange.args[1][0]).to.deep.equal({});
+      expect(onCellModesModelChange.mock.calls[1][0]).to.deep.equal({});
     });
 
     it(`should not be called when changing the cellModesModel prop`, () => {
-      const onCellModesModelChange = spy();
+      const onCellModesModelChange = vi.fn();
       const { setProps } = render(
         <TestCase cellModesModel={{}} onCellModesModelChange={onCellModesModelChange} />,
       );
-      expect(onCellModesModelChange.callCount).to.equal(0);
+      expect(onCellModesModelChange.mock.calls.length).to.equal(0);
       setProps({ cellModesModel: { 0: { currencyPair: { mode: 'edit' } } } });
-      expect(onCellModesModelChange.callCount).to.equal(0);
+      expect(onCellModesModelChange.mock.calls.length).to.equal(0);
     });
   });
 });

--- a/packages/x-data-grid-pro/src/tests/editComponents.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/editComponents.DataGridPro.test.tsx
@@ -15,9 +15,8 @@ import { unwrapPrivateAPI } from '@mui/x-data-grid-pro/internals';
 import { isJSDOM } from 'test/utils/skipIf';
 import { act, createRenderer, screen, waitFor, within } from '@mui/internal-test-utils';
 import { getCell, getRow, spyApi, sleep } from 'test/utils/helperFn';
-import { spy } from 'sinon';
-import type { SinonSpy } from 'sinon';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { Mock } from 'vitest';
 
 /**
  * Creates a date that is compatible with years before 1901
@@ -75,7 +74,7 @@ describe('<DataGridPro /> - Edit components', () => {
 
       await user.type(input, '[Backspace>4]Puma');
 
-      expect(spiedSetEditCellValue.lastCall.args[0]).to.deep.equal({
+      expect(spiedSetEditCellValue.mock.lastCall?.[0]).to.deep.equal({
         id: 0,
         field: 'brand',
         value: 'Puma',
@@ -129,7 +128,7 @@ describe('<DataGridPro /> - Edit components', () => {
     });
 
     it('should call onValueChange if defined', async () => {
-      const onValueChange = spy();
+      const onValueChange = vi.fn();
 
       defaultData.columns[0].renderEditCell = (params) =>
         renderEditInputCell({ ...params, onValueChange });
@@ -142,8 +141,8 @@ describe('<DataGridPro /> - Edit components', () => {
       const input = within(cell).getByRole<HTMLInputElement>('textbox');
       await user.type(input, '[Backspace>4]Puma');
 
-      expect(onValueChange.callCount).to.equal(8);
-      expect(onValueChange.lastCall.args[1]).to.equal('Puma');
+      expect(onValueChange.mock.calls.length).to.equal(8);
+      expect(onValueChange.mock.lastCall?.[1]).to.equal('Puma');
     });
   });
 
@@ -164,7 +163,7 @@ describe('<DataGridPro /> - Edit components', () => {
       expect(input.value).to.equal('100');
 
       await user.type(input, '[Backspace>2]10');
-      expect(spiedSetEditCellValue.lastCall.args[0]).to.deep.equal({
+      expect(spiedSetEditCellValue.mock.lastCall?.[0]).to.deep.equal({
         id: 0,
         field: 'quantity',
         value: 110,
@@ -187,7 +186,7 @@ describe('<DataGridPro /> - Edit components', () => {
     });
 
     it('should keep values as numbers', async () => {
-      const preProcessEditCellPropsSpy = spy(({ props }) => props);
+      const preProcessEditCellPropsSpy = vi.fn(({ props }) => props);
       defaultData.columns[0].preProcessEditCellProps = preProcessEditCellPropsSpy;
       const { user } = render(<TestCase />);
 
@@ -199,7 +198,7 @@ describe('<DataGridPro /> - Edit components', () => {
 
       await user.type(input, '[Backspace>2]10');
       await waitFor(() =>
-        expect(preProcessEditCellPropsSpy.lastCall.args[0].props.value).to.equal(110),
+        expect(preProcessEditCellPropsSpy.mock.lastCall?.[0].props.value).to.equal(110),
       );
     });
 
@@ -254,10 +253,10 @@ describe('<DataGridPro /> - Edit components', () => {
         initialSelectionEnd: Infinity,
       });
 
-      expect(spiedSetEditCellValue.lastCall.args[0].id).to.equal(0);
-      expect(spiedSetEditCellValue.lastCall.args[0].field).to.equal('createdAt');
-      expect(spiedSetEditCellValue.lastCall.args[0].debounceMs).to.equal(undefined);
-      expect(spiedSetEditCellValue.lastCall.args[0].value?.toISOString()).to.equal(
+      expect(spiedSetEditCellValue.mock.lastCall?.[0].id).to.equal(0);
+      expect(spiedSetEditCellValue.mock.lastCall?.[0].field).to.equal('createdAt');
+      expect(spiedSetEditCellValue.mock.lastCall?.[0].debounceMs).to.equal(undefined);
+      expect(spiedSetEditCellValue.mock.lastCall?.[0].value?.toISOString()).to.equal(
         new Date(2022, 1, 10).toISOString(),
       );
     });
@@ -274,7 +273,7 @@ describe('<DataGridPro /> - Edit components', () => {
         initialSelectionStart: 0,
         initialSelectionEnd: Infinity,
       });
-      expect(spiedSetEditCellValue.lastCall.args[0].value).to.equal(null);
+      expect(spiedSetEditCellValue.mock.lastCall?.[0].value).to.equal(null);
     });
 
     it('should pass the value prop to the input', async () => {
@@ -297,8 +296,8 @@ describe('<DataGridPro /> - Edit components', () => {
 
     it('should handle correctly dates with partial years', async () => {
       const { user } = render(<TestCase />);
-      const spiedSetEditCellValue = spyApi(apiRef.current!, 'setEditCellValue') as SinonSpy<
-        [GridEditCellValueParams & { value: Date }]
+      const spiedSetEditCellValue = spyApi(apiRef.current!, 'setEditCellValue') as Mock<
+        (params: GridEditCellValueParams & { value: Date }) => void
       >;
 
       const cell = getCell(0, 0);
@@ -312,7 +311,7 @@ describe('<DataGridPro /> - Edit components', () => {
         initialSelectionStart: 0,
         initialSelectionEnd: 10,
       });
-      expect(spiedSetEditCellValue.lastCall.args[0].value.getTime()).to.equal(
+      expect(spiedSetEditCellValue.mock.lastCall?.[0].value.getTime()).to.equal(
         generateDate(2021, 0, 5),
       );
 
@@ -321,7 +320,7 @@ describe('<DataGridPro /> - Edit components', () => {
         initialSelectionStart: 8,
         initialSelectionEnd: 10,
       });
-      expect(spiedSetEditCellValue.lastCall.args[0].value.getTime()).to.equal(
+      expect(spiedSetEditCellValue.mock.lastCall?.[0].value.getTime()).to.equal(
         generateDate(2021, 0, 1),
       );
 
@@ -330,7 +329,7 @@ describe('<DataGridPro /> - Edit components', () => {
         initialSelectionStart: 0,
         initialSelectionEnd: 4,
       });
-      expect(spiedSetEditCellValue.lastCall.args[0].value.getTime()).to.equal(
+      expect(spiedSetEditCellValue.mock.lastCall?.[0].value.getTime()).to.equal(
         generateDate(1, 0, 1),
       );
 
@@ -339,7 +338,7 @@ describe('<DataGridPro /> - Edit components', () => {
         initialSelectionStart: 0,
         initialSelectionEnd: 4,
       });
-      expect(spiedSetEditCellValue.lastCall.args[0].value.getTime()).to.equal(
+      expect(spiedSetEditCellValue.mock.lastCall?.[0].value.getTime()).to.equal(
         generateDate(19, 0, 1),
       );
 
@@ -348,7 +347,7 @@ describe('<DataGridPro /> - Edit components', () => {
         initialSelectionStart: 0,
         initialSelectionEnd: 4,
       });
-      expect(spiedSetEditCellValue.lastCall.args[0].value.getTime()).to.equal(
+      expect(spiedSetEditCellValue.mock.lastCall?.[0].value.getTime()).to.equal(
         generateDate(199, 0, 1),
       );
 
@@ -357,13 +356,13 @@ describe('<DataGridPro /> - Edit components', () => {
         initialSelectionStart: 0,
         initialSelectionEnd: 4,
       });
-      expect(spiedSetEditCellValue.lastCall.args[0].value.getTime()).to.equal(
+      expect(spiedSetEditCellValue.mock.lastCall?.[0].value.getTime()).to.equal(
         generateDate(1999, 0, 1),
       );
     });
 
     it('should call onValueChange if defined', async () => {
-      const onValueChange = spy();
+      const onValueChange = vi.fn();
 
       defaultData.columns[0].renderEditCell = (params) =>
         renderEditDateCell({ ...params, onValueChange });
@@ -379,15 +378,15 @@ describe('<DataGridPro /> - Edit components', () => {
         initialSelectionEnd: 10,
       });
 
-      expect(onValueChange.callCount).to.equal(1);
-      expect((onValueChange.lastCall.args[1]! as Date).toISOString()).to.equal(
+      expect(onValueChange.mock.calls.length).to.equal(1);
+      expect((onValueChange.mock.lastCall?.[1]! as Date).toISOString()).to.equal(
         new Date(2022, 1, 10).toISOString(),
       );
     });
 
     // https://github.com/mui/mui-x/issues/23414
     it('should call onValueChange after setEditCellValue', async () => {
-      const onValueChange = spy();
+      const onValueChange = vi.fn();
 
       defaultData.columns[0].renderEditCell = (params) =>
         renderEditDateCell({ ...params, onValueChange });
@@ -404,8 +403,10 @@ describe('<DataGridPro /> - Edit components', () => {
         initialSelectionEnd: 10,
       });
 
-      expect(onValueChange.callCount).to.equal(1);
-      expect(spiedSetEditCellValue.firstCall.calledBefore(onValueChange.firstCall)).to.equal(true);
+      expect(onValueChange.mock.calls.length).to.equal(1);
+      expect(spiedSetEditCellValue.mock.invocationCallOrder[0]).to.be.lessThan(
+        onValueChange.mock.invocationCallOrder[0],
+      );
     });
   });
 
@@ -430,10 +431,10 @@ describe('<DataGridPro /> - Edit components', () => {
         initialSelectionEnd: 16,
       });
 
-      expect(spiedSetEditCellValue.lastCall.args[0].id).to.equal(0);
-      expect(spiedSetEditCellValue.lastCall.args[0].field).to.equal('createdAt');
-      expect(spiedSetEditCellValue.lastCall.args[0].debounceMs).to.equal(undefined);
-      expect((spiedSetEditCellValue.lastCall.args[0].value! as Date).toISOString()).to.equal(
+      expect(spiedSetEditCellValue.mock.lastCall?.[0].id).to.equal(0);
+      expect(spiedSetEditCellValue.mock.lastCall?.[0].field).to.equal('createdAt');
+      expect(spiedSetEditCellValue.mock.lastCall?.[0].debounceMs).to.equal(undefined);
+      expect((spiedSetEditCellValue.mock.lastCall?.[0].value! as Date).toISOString()).to.equal(
         new Date(2022, 1, 10, 15, 30, 0).toISOString(),
       );
     });
@@ -447,7 +448,7 @@ describe('<DataGridPro /> - Edit components', () => {
 
       const input = cell.querySelector('input')!;
       await user.type(input, '[Backspace]');
-      expect(spiedSetEditCellValue.lastCall.args[0].value).to.equal(null);
+      expect(spiedSetEditCellValue.mock.lastCall?.[0].value).to.equal(null);
     });
 
     it('should pass the value prop to the input', async () => {
@@ -470,8 +471,8 @@ describe('<DataGridPro /> - Edit components', () => {
 
     it('should handle correctly dates with partial years', async () => {
       const { user } = render(<TestCase />);
-      const spiedSetEditCellValue = spyApi(apiRef.current!, 'setEditCellValue') as SinonSpy<
-        [GridEditCellValueParams & { value: Date }]
+      const spiedSetEditCellValue = spyApi(apiRef.current!, 'setEditCellValue') as Mock<
+        (params: GridEditCellValueParams & { value: Date }) => void
       >;
 
       const cell = getCell(0, 0);
@@ -485,7 +486,7 @@ describe('<DataGridPro /> - Edit components', () => {
         initialSelectionStart: 0,
         initialSelectionEnd: 10,
       });
-      expect(spiedSetEditCellValue.lastCall.args[0].value.getTime()).to.equal(
+      expect(spiedSetEditCellValue.mock.lastCall?.[0].value.getTime()).to.equal(
         generateDate(2021, 0, 5, 14, 30),
       );
 
@@ -494,7 +495,7 @@ describe('<DataGridPro /> - Edit components', () => {
         initialSelectionStart: 8,
         initialSelectionEnd: 10,
       });
-      expect(spiedSetEditCellValue.lastCall.args[0].value.getTime()).to.equal(
+      expect(spiedSetEditCellValue.mock.lastCall?.[0].value.getTime()).to.equal(
         generateDate(2021, 0, 1, 14, 30),
       );
 
@@ -503,7 +504,7 @@ describe('<DataGridPro /> - Edit components', () => {
         initialSelectionStart: 0,
         initialSelectionEnd: 4,
       });
-      expect(spiedSetEditCellValue.lastCall.args[0].value.getTime()).to.equal(
+      expect(spiedSetEditCellValue.mock.lastCall?.[0].value.getTime()).to.equal(
         generateDate(1, 0, 1, 14, 30),
       );
 
@@ -512,7 +513,7 @@ describe('<DataGridPro /> - Edit components', () => {
         initialSelectionStart: 0,
         initialSelectionEnd: 4,
       });
-      expect(spiedSetEditCellValue.lastCall.args[0].value.getTime()).to.equal(
+      expect(spiedSetEditCellValue.mock.lastCall?.[0].value.getTime()).to.equal(
         generateDate(19, 0, 1, 14, 30),
       );
 
@@ -521,7 +522,7 @@ describe('<DataGridPro /> - Edit components', () => {
         initialSelectionStart: 0,
         initialSelectionEnd: 4,
       });
-      expect(spiedSetEditCellValue.lastCall.args[0].value.getTime()).to.equal(
+      expect(spiedSetEditCellValue.mock.lastCall?.[0].value.getTime()).to.equal(
         generateDate(199, 0, 1, 14, 30),
       );
 
@@ -530,7 +531,7 @@ describe('<DataGridPro /> - Edit components', () => {
         initialSelectionStart: 0,
         initialSelectionEnd: 4,
       });
-      expect(spiedSetEditCellValue.lastCall.args[0].value.getTime()).to.equal(
+      expect(spiedSetEditCellValue.mock.lastCall?.[0].value.getTime()).to.equal(
         generateDate(1999, 0, 1, 14, 30),
       );
 
@@ -539,7 +540,7 @@ describe('<DataGridPro /> - Edit components', () => {
         initialSelectionStart: 11,
         initialSelectionEnd: 16,
       });
-      expect(spiedSetEditCellValue.lastCall.args[0].value.getTime()).to.equal(
+      expect(spiedSetEditCellValue.mock.lastCall?.[0].value.getTime()).to.equal(
         generateDate(1999, 0, 1, 20, 30),
       );
 
@@ -548,7 +549,7 @@ describe('<DataGridPro /> - Edit components', () => {
         initialSelectionStart: 14,
         initialSelectionEnd: 16,
       });
-      expect(spiedSetEditCellValue.lastCall.args[0].value.getTime()).to.equal(
+      expect(spiedSetEditCellValue.mock.lastCall?.[0].value.getTime()).to.equal(
         generateDate(1999, 0, 1, 20, 2),
       );
 
@@ -557,7 +558,7 @@ describe('<DataGridPro /> - Edit components', () => {
         initialSelectionStart: 14,
         initialSelectionEnd: 16,
       });
-      expect(spiedSetEditCellValue.lastCall.args[0].value.getTime()).to.equal(
+      expect(spiedSetEditCellValue.mock.lastCall?.[0].value.getTime()).to.equal(
         generateDate(1999, 0, 1, 20, 25),
       );
     });
@@ -579,7 +580,7 @@ describe('<DataGridPro /> - Edit components', () => {
       await user.dblClick(cell);
       await user.click(screen.queryAllByRole('option')[1]);
 
-      expect(spiedSetEditCellValue.lastCall.args[0]).to.deep.equal({
+      expect(spiedSetEditCellValue.mock.lastCall?.[0]).to.deep.equal({
         id: 0,
         field: 'brand',
         value: 'Adidas',
@@ -606,7 +607,7 @@ describe('<DataGridPro /> - Edit components', () => {
       await user.dblClick(cell);
       await user.click(screen.queryAllByRole('option')[1]);
 
-      expect(spiedSetEditCellValue.lastCall.args[0]).to.deep.equal({
+      expect(spiedSetEditCellValue.mock.lastCall?.[0]).to.deep.equal({
         id: 0,
         field: 'brand',
         value: 1,
@@ -629,7 +630,7 @@ describe('<DataGridPro /> - Edit components', () => {
       await user.dblClick(cell);
       await user.click(screen.queryAllByRole('option')[1]);
 
-      expect(spiedSetEditCellValue.lastCall.args[0]).to.deep.equal({
+      expect(spiedSetEditCellValue.mock.lastCall?.[0]).to.deep.equal({
         id: 0,
         field: 'brand',
         value: 'Adidas',
@@ -650,7 +651,7 @@ describe('<DataGridPro /> - Edit components', () => {
     });
 
     it('should call onValueChange if defined', async () => {
-      const onValueChange = spy();
+      const onValueChange = vi.fn();
 
       defaultData.columns[0].renderEditCell = (params) =>
         renderEditSingleSelectCell({ ...params, onValueChange });
@@ -661,13 +662,13 @@ describe('<DataGridPro /> - Edit components', () => {
       await user.dblClick(cell);
       await user.click(screen.queryAllByRole('option')[1]);
 
-      expect(onValueChange.callCount).to.equal(1);
-      expect(onValueChange.lastCall.args[1]).to.equal('Adidas');
+      expect(onValueChange.mock.calls.length).to.equal(1);
+      expect(onValueChange.mock.lastCall?.[1]).to.equal('Adidas');
     });
 
     // https://github.com/mui/mui-x/issues/23414
     it('should call onValueChange after setEditCellValue', async () => {
-      const onValueChange = spy();
+      const onValueChange = vi.fn();
 
       defaultData.columns[0].renderEditCell = (params) =>
         renderEditSingleSelectCell({ ...params, onValueChange });
@@ -679,12 +680,14 @@ describe('<DataGridPro /> - Edit components', () => {
       await user.dblClick(cell);
       await user.click(screen.queryAllByRole('option')[1]);
 
-      expect(onValueChange.callCount).to.equal(1);
-      expect(spiedSetEditCellValue.firstCall.calledBefore(onValueChange.firstCall)).to.equal(true);
+      expect(onValueChange.mock.calls.length).to.equal(1);
+      expect(spiedSetEditCellValue.mock.invocationCallOrder[0]).to.be.lessThan(
+        onValueChange.mock.invocationCallOrder[0],
+      );
     });
 
     it('should call onCellEditStop', async () => {
-      const onCellEditStop = spy();
+      const onCellEditStop = vi.fn();
 
       const { user } = render(
         <div>
@@ -697,7 +700,7 @@ describe('<DataGridPro /> - Edit components', () => {
       await user.dblClick(cell);
       await user.click(document.getElementById('outside-grid')!);
 
-      expect(onCellEditStop.callCount).to.equal(1);
+      expect(onCellEditStop.mock.calls.length).to.equal(1);
     });
 
     it('should not open the suggestions when Enter is pressed', async () => {
@@ -734,7 +737,7 @@ describe('<DataGridPro /> - Edit components', () => {
       expect(input.checked).to.equal(false);
 
       await user.click(input);
-      expect(spiedSetEditCellValue.lastCall.args[0]).to.deep.equal({
+      expect(spiedSetEditCellValue.mock.lastCall?.[0]).to.deep.equal({
         id: 0,
         field: 'isAdmin',
         value: true,
@@ -742,7 +745,7 @@ describe('<DataGridPro /> - Edit components', () => {
     });
 
     it('should call onValueChange if defined', async () => {
-      const onValueChange = spy();
+      const onValueChange = vi.fn();
 
       defaultData.columns[0].renderEditCell = (params) =>
         renderEditBooleanCell({ ...params, onValueChange });
@@ -755,13 +758,13 @@ describe('<DataGridPro /> - Edit components', () => {
       const input = within(cell).getByRole<HTMLInputElement>('checkbox');
       await user.click(input);
 
-      expect(onValueChange.callCount).to.equal(1);
-      expect(onValueChange.lastCall.args[1]).to.equal(true);
+      expect(onValueChange.mock.calls.length).to.equal(1);
+      expect(onValueChange.mock.lastCall?.[1]).to.equal(true);
     });
 
     // https://github.com/mui/mui-x/issues/23414
     it('should call onValueChange after setEditCellValue', async () => {
-      const onValueChange = spy();
+      const onValueChange = vi.fn();
 
       defaultData.columns[0].renderEditCell = (params) =>
         renderEditBooleanCell({ ...params, onValueChange });
@@ -775,8 +778,10 @@ describe('<DataGridPro /> - Edit components', () => {
       const input = within(cell).getByRole<HTMLInputElement>('checkbox');
       await user.click(input);
 
-      expect(onValueChange.callCount).to.equal(1);
-      expect(spiedSetEditCellValue.firstCall.calledBefore(onValueChange.firstCall)).to.equal(true);
+      expect(onValueChange.mock.calls.length).to.equal(1);
+      expect(spiedSetEditCellValue.mock.invocationCallOrder[0]).to.be.lessThan(
+        onValueChange.mock.invocationCallOrder[0],
+      );
     });
   });
 
@@ -831,7 +836,10 @@ describe('<DataGridPro /> - Edit components', () => {
       const option2 = within(listbox).getByRole('option', { name: 'Option 2' });
       await user.click(option2);
 
-      expect(spiedSetEditCellValue.lastCall.args[0].value).to.deep.equal(['Option 1', 'Option 2']);
+      expect(spiedSetEditCellValue.mock.lastCall?.[0].value).to.deep.equal([
+        'Option 1',
+        'Option 2',
+      ]);
     });
 
     it('should not close dropdown after selecting option (disableCloseOnSelect)', async () => {
@@ -888,11 +896,11 @@ describe('<DataGridPro /> - Edit components', () => {
       const optionTwo = within(listbox).getByRole('option', { name: 'Two' });
       await user.click(optionTwo);
 
-      expect(spiedSetEditCellValue.lastCall.args[0].value).to.deep.equal([1, 2]);
+      expect(spiedSetEditCellValue.mock.lastCall?.[0].value).to.deep.equal([1, 2]);
     });
 
     it('should work with dynamic valueOptions function', async () => {
-      const getValueOptions = spy(() => ['Dynamic 1', 'Dynamic 2']);
+      const getValueOptions = vi.fn(() => ['Dynamic 1', 'Dynamic 2']);
 
       defaultData.columns = [
         {
@@ -917,7 +925,7 @@ describe('<DataGridPro /> - Edit components', () => {
     });
 
     it('should call onValueChange if defined', async () => {
-      const onValueChange = spy();
+      const onValueChange = vi.fn();
 
       defaultData.columns[0].renderEditCell = (params) =>
         renderEditMultiSelectCell({ ...params, onValueChange });
@@ -931,13 +939,13 @@ describe('<DataGridPro /> - Edit components', () => {
       const option2 = within(listbox).getByRole('option', { name: 'Option 2' });
       await user.click(option2);
 
-      expect(onValueChange.callCount).to.be.greaterThan(0);
-      expect(onValueChange.lastCall.args[1]).to.deep.equal(['Option 1', 'Option 2']);
+      expect(onValueChange.mock.calls.length).to.be.greaterThan(0);
+      expect(onValueChange.mock.lastCall?.[1]).to.deep.equal(['Option 1', 'Option 2']);
     });
 
     // https://github.com/mui/mui-x/issues/23414
     it('should call onValueChange after setEditCellValue', async () => {
-      const onValueChange = spy();
+      const onValueChange = vi.fn();
 
       defaultData.columns[0].renderEditCell = (params) =>
         renderEditMultiSelectCell({ ...params, onValueChange });
@@ -952,8 +960,10 @@ describe('<DataGridPro /> - Edit components', () => {
       const option2 = within(listbox).getByRole('option', { name: 'Option 2' });
       await user.click(option2);
 
-      expect(onValueChange.callCount).to.equal(1);
-      expect(spiedSetEditCellValue.firstCall.calledBefore(onValueChange.firstCall)).to.equal(true);
+      expect(onValueChange.mock.calls.length).to.equal(1);
+      expect(spiedSetEditCellValue.mock.invocationCallOrder[0]).to.be.lessThan(
+        onValueChange.mock.invocationCallOrder[0],
+      );
     });
 
     it('should work with null initial value', async () => {
@@ -968,7 +978,7 @@ describe('<DataGridPro /> - Edit components', () => {
       const listbox = await screen.findByRole('listbox');
       await user.click(within(listbox).getByRole('option', { name: 'Option 1' }));
 
-      expect(spiedSetEditCellValue.lastCall.args[0].value).to.deep.equal(['Option 1']);
+      expect(spiedSetEditCellValue.mock.lastCall?.[0].value).to.deep.equal(['Option 1']);
     });
 
     it('should deselect option when clicking selected option', async () => {
@@ -984,11 +994,11 @@ describe('<DataGridPro /> - Edit components', () => {
       const option1 = within(listbox).getByRole('option', { name: 'Option 1' });
       await user.click(option1);
 
-      expect(spiedSetEditCellValue.lastCall.args[0].value).to.deep.equal(['Option 2']);
+      expect(spiedSetEditCellValue.mock.lastCall?.[0].value).to.deep.equal(['Option 2']);
     });
 
     it('should commit value when clicking outside', async () => {
-      const processRowUpdate = spy((newRow: any) => newRow);
+      const processRowUpdate = vi.fn((newRow: any) => newRow);
       const { user } = render(
         <div>
           <TestCase processRowUpdate={processRowUpdate} />
@@ -1007,7 +1017,7 @@ describe('<DataGridPro /> - Edit components', () => {
       await waitFor(() => {
         expect(cell).not.to.have.class('MuiDataGrid-cell--editing');
       });
-      expect(processRowUpdate.lastCall.args[0].tags).to.deep.equal(['Option 1', 'Option 2']);
+      expect(processRowUpdate.mock.lastCall?.[0].tags).to.deep.equal(['Option 1', 'Option 2']);
     });
 
     describe('slotProps.chip as function', () => {

--- a/packages/x-data-grid-pro/src/tests/rowEditing.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/rowEditing.DataGridPro.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { spy } from 'sinon';
 import type { RefObject } from '@mui/x-internals/types';
 import { useGridApiRef, DataGridPro, GridRowModes } from '@mui/x-data-grid-pro';
 import type {
@@ -99,8 +98,8 @@ describe('<DataGridPro /> - Row editing', () => {
       });
 
       it('should render the components given in renderEditCell', () => {
-        const renderEditCell1 = spy(defaultRenderEditCell);
-        const renderEditCell2 = spy(defaultRenderEditCell);
+        const renderEditCell1 = vi.fn(defaultRenderEditCell);
+        const renderEditCell2 = vi.fn(defaultRenderEditCell);
 
         render(
           <TestCase
@@ -108,16 +107,16 @@ describe('<DataGridPro /> - Row editing', () => {
             column2Props={{ renderEditCell: renderEditCell2 }}
           />,
         );
-        expect(renderEditCell1.callCount).to.equal(0);
-        expect(renderEditCell2.callCount).to.equal(0);
+        expect(renderEditCell1.mock.calls.length).to.equal(0);
+        expect(renderEditCell2.mock.calls.length).to.equal(0);
         act(() => apiRef.current?.startRowEditMode({ id: 0 }));
-        expect(renderEditCell1.callCount).not.to.equal(0);
-        expect(renderEditCell2.callCount).not.to.equal(0);
+        expect(renderEditCell1.mock.calls.length).not.to.equal(0);
+        expect(renderEditCell2.mock.calls.length).not.to.equal(0);
       });
 
       it('should pass props to renderEditCell', () => {
-        const renderEditCell1 = spy(defaultRenderEditCell);
-        const renderEditCell2 = spy(defaultRenderEditCell);
+        const renderEditCell1 = vi.fn(defaultRenderEditCell);
+        const renderEditCell2 = vi.fn(defaultRenderEditCell);
 
         render(
           <TestCase
@@ -126,17 +125,17 @@ describe('<DataGridPro /> - Row editing', () => {
           />,
         );
         act(() => apiRef.current?.startRowEditMode({ id: 0 }));
-        expect(renderEditCell1.lastCall.args[0].value).to.equal('USDGBP');
-        expect(renderEditCell1.lastCall.args[0].error).to.equal(false);
-        expect(renderEditCell1.lastCall.args[0].isProcessingProps).to.equal(false);
-        expect(renderEditCell2.lastCall.args[0].value).to.equal(1);
-        expect(renderEditCell2.lastCall.args[0].error).to.equal(false);
-        expect(renderEditCell2.lastCall.args[0].isProcessingProps).to.equal(false);
+        expect(renderEditCell1.mock.lastCall?.[0].value).to.equal('USDGBP');
+        expect(renderEditCell1.mock.lastCall?.[0].error).to.equal(false);
+        expect(renderEditCell1.mock.lastCall?.[0].isProcessingProps).to.equal(false);
+        expect(renderEditCell2.mock.lastCall?.[0].value).to.equal(1);
+        expect(renderEditCell2.mock.lastCall?.[0].error).to.equal(false);
+        expect(renderEditCell2.mock.lastCall?.[0].isProcessingProps).to.equal(false);
       });
 
       it('should empty the value if deleteValue is true', () => {
-        const renderEditCell1 = spy(defaultRenderEditCell);
-        const renderEditCell2 = spy(defaultRenderEditCell);
+        const renderEditCell1 = vi.fn(defaultRenderEditCell);
+        const renderEditCell2 = vi.fn(defaultRenderEditCell);
 
         render(
           <TestCase
@@ -152,15 +151,15 @@ describe('<DataGridPro /> - Row editing', () => {
             deleteValue: true,
           }),
         );
-        expect(renderEditCell1.lastCall.args[0].value).to.equal('');
-        expect(renderEditCell2.lastCall.args[0].value).to.equal(1);
+        expect(renderEditCell1.mock.lastCall?.[0].value).to.equal('');
+        expect(renderEditCell2.mock.lastCall?.[0].value).to.equal(1);
       });
     });
 
     describe('setEditCellValue', () => {
       it('should update the value prop given to renderEditCell', async () => {
-        const renderEditCell1 = spy(defaultRenderEditCell);
-        const renderEditCell2 = spy(defaultRenderEditCell);
+        const renderEditCell1 = vi.fn(defaultRenderEditCell);
+        const renderEditCell2 = vi.fn(defaultRenderEditCell);
 
         render(
           <TestCase
@@ -170,11 +169,11 @@ describe('<DataGridPro /> - Row editing', () => {
         );
 
         act(() => apiRef.current?.startRowEditMode({ id: 0 }));
-        expect(renderEditCell1.lastCall.args[0].value).to.equal('USDGBP');
+        expect(renderEditCell1.mock.lastCall?.[0].value).to.equal('USDGBP');
         await act(() =>
           apiRef.current?.setEditCellValue({ id: 0, field: 'currencyPair', value: 'usdgbp' }),
         );
-        expect(renderEditCell1.lastCall.args[0].value).to.equal('usdgbp');
+        expect(renderEditCell1.mock.lastCall?.[0].value).to.equal('usdgbp');
       });
 
       it('should pass to renderEditCell the row with the values updated', async () => {
@@ -182,8 +181,8 @@ describe('<DataGridPro /> - Row editing', () => {
           ...row,
           currencyPair: value.trim(),
         });
-        const renderEditCell1 = spy(defaultRenderEditCell);
-        const renderEditCell2 = spy(defaultRenderEditCell);
+        const renderEditCell1 = vi.fn(defaultRenderEditCell);
+        const renderEditCell2 = vi.fn(defaultRenderEditCell);
 
         render(
           <TestCase
@@ -192,12 +191,12 @@ describe('<DataGridPro /> - Row editing', () => {
           />,
         );
         act(() => apiRef.current?.startRowEditMode({ id: 0 }));
-        expect(renderEditCell1.lastCall.args[0].row).to.deep.equal(defaultData.rows[0]);
+        expect(renderEditCell1.mock.lastCall?.[0].row).to.deep.equal(defaultData.rows[0]);
         await act(() =>
           apiRef.current?.setEditCellValue({ id: 0, field: 'currencyPair', value: ' usdgbp ' }),
         );
         await act(() => apiRef.current?.setEditCellValue({ id: 0, field: 'price1M', value: 100 }));
-        expect(renderEditCell2.lastCall.args[0].row).to.deep.equal({
+        expect(renderEditCell2.mock.lastCall?.[0].row).to.deep.equal({
           ...defaultData.rows[0],
           currencyPair: 'usdgbp',
           price1M: 100,
@@ -205,17 +204,17 @@ describe('<DataGridPro /> - Row editing', () => {
       });
 
       it('should pass the new value through the value parser if defined', async () => {
-        const valueParser = spy((value) => value.toLowerCase());
-        const renderEditCell = spy(defaultRenderEditCell);
+        const valueParser = vi.fn((value) => value.toLowerCase());
+        const renderEditCell = vi.fn(defaultRenderEditCell);
 
         render(<TestCase column1Props={{ renderEditCell, valueParser }} />);
         act(() => apiRef.current?.startRowEditMode({ id: 0 }));
-        expect(valueParser.callCount).to.equal(0);
+        expect(valueParser.mock.calls.length).to.equal(0);
         await act(() =>
           apiRef.current?.setEditCellValue({ id: 0, field: 'currencyPair', value: 'USD GBP' }),
         );
-        expect(valueParser.callCount).to.equal(1);
-        expect(renderEditCell.lastCall.args[0].value).to.equal('usd gbp');
+        expect(valueParser.mock.calls.length).to.equal(1);
+        expect(renderEditCell.mock.lastCall?.[0].value).to.equal('usd gbp');
       });
 
       it('should return true if no preProcessEditCellProps is defined', async () => {
@@ -230,7 +229,7 @@ describe('<DataGridPro /> - Row editing', () => {
 
       it('should set isProcessingProps to true before calling preProcessEditCellProps', async () => {
         const preProcessEditCellProps = () => new Promise(() => {});
-        const renderEditCell = spy(defaultRenderEditCell);
+        const renderEditCell = vi.fn(defaultRenderEditCell);
         render(<TestCase column1Props={{ preProcessEditCellProps, renderEditCell }} />);
         act(() => apiRef.current?.startRowEditMode({ id: 0 }));
         await act(
@@ -240,12 +239,12 @@ describe('<DataGridPro /> - Row editing', () => {
               resolve();
             }),
         );
-        expect(renderEditCell.lastCall.args[0].isProcessingProps).to.equal(true);
+        expect(renderEditCell.mock.lastCall?.[0].isProcessingProps).to.equal(true);
       });
 
       it('should call all preProcessEditCellProps with the correct params', async () => {
-        const preProcessEditCellProps1 = spy(({ props }: GridPreProcessEditCellProps) => props);
-        const preProcessEditCellProps2 = spy(({ props }: GridPreProcessEditCellProps) => props);
+        const preProcessEditCellProps1 = vi.fn(({ props }: GridPreProcessEditCellProps) => props);
+        const preProcessEditCellProps2 = vi.fn(({ props }: GridPreProcessEditCellProps) => props);
         render(
           <TestCase
             column1Props={{ preProcessEditCellProps: preProcessEditCellProps1 }}
@@ -257,22 +256,22 @@ describe('<DataGridPro /> - Row editing', () => {
           apiRef.current?.setEditCellValue({ id: 0, field: 'currencyPair', value: 'USD GBP' }),
         );
 
-        const args1 = preProcessEditCellProps1.lastCall.args[0];
-        expect(args1.id).to.equal(0);
-        expect(args1.row).to.deep.equal(defaultData.rows[0]);
-        expect(args1.hasChanged).to.equal(true);
-        expect(args1.props).to.deep.equal({
+        const args1 = preProcessEditCellProps1.mock.lastCall?.[0];
+        expect(args1?.id).to.equal(0);
+        expect(args1?.row).to.deep.equal(defaultData.rows[0]);
+        expect(args1?.hasChanged).to.equal(true);
+        expect(args1?.props).to.deep.equal({
           value: 'USD GBP',
           error: false,
           isProcessingProps: true,
           changeReason: 'setEditCellValue',
         });
 
-        const args2 = preProcessEditCellProps2.lastCall.args[0];
-        expect(args2.id).to.equal(0);
-        expect(args2.row).to.deep.equal(defaultData.rows[0]);
-        expect(args2.hasChanged).to.equal(false);
-        expect(args2.props).to.deep.equal({
+        const args2 = preProcessEditCellProps2.mock.lastCall?.[0];
+        expect(args2?.id).to.equal(0);
+        expect(args2?.row).to.deep.equal(defaultData.rows[0]);
+        expect(args2?.hasChanged).to.equal(false);
+        expect(args2?.props).to.deep.equal({
           value: 1,
           error: false,
           isProcessingProps: true,
@@ -280,40 +279,40 @@ describe('<DataGridPro /> - Row editing', () => {
       });
 
       it('should pass to renderEditCell the props returned by preProcessEditCellProps', async () => {
-        const renderEditCell = spy(defaultRenderEditCell);
+        const renderEditCell = vi.fn(defaultRenderEditCell);
         const preProcessEditCellProps = ({ props }: GridPreProcessEditCellProps) => ({
           ...props,
           foo: 'bar',
         });
         render(<TestCase column1Props={{ preProcessEditCellProps, renderEditCell }} />);
         act(() => apiRef.current?.startRowEditMode({ id: 0 }));
-        expect(renderEditCell.lastCall.args[0].foo).to.equal(undefined);
+        expect(renderEditCell.mock.lastCall?.[0].foo).to.equal(undefined);
         await act(() =>
           apiRef.current?.setEditCellValue({ id: 0, field: 'currencyPair', value: 'USD GBP' }),
         );
-        expect(renderEditCell.lastCall.args[0].foo).to.equal('bar');
+        expect(renderEditCell.mock.lastCall?.[0].foo).to.equal('bar');
       });
 
       it('should not pass to renderEditCell the value returned by preProcessEditCellProps', async () => {
-        const renderEditCell = spy(defaultRenderEditCell);
+        const renderEditCell = vi.fn(defaultRenderEditCell);
         const preProcessEditCellProps = ({ props }: GridPreProcessEditCellProps) => ({
           ...props,
           value: 'foobar',
         });
         render(<TestCase column1Props={{ preProcessEditCellProps, renderEditCell }} />);
         act(() => apiRef.current?.startRowEditMode({ id: 0 }));
-        expect(renderEditCell.lastCall.args[0].value).to.equal('USDGBP');
+        expect(renderEditCell.mock.lastCall?.[0].value).to.equal('USDGBP');
         await act(() =>
           apiRef.current?.setEditCellValue({ id: 0, field: 'currencyPair', value: 'USD GBP' }),
         );
-        expect(renderEditCell.lastCall.args[0].value).to.equal('USD GBP');
+        expect(renderEditCell.mock.lastCall?.[0].value).to.equal('USD GBP');
       });
 
       it('should set isProcessingProps to false after calling preProcessEditCellProps', async () => {
         let resolve1: () => void;
         let resolve2: () => void;
-        const renderEditCell1 = spy(defaultRenderEditCell);
-        const renderEditCell2 = spy(defaultRenderEditCell);
+        const renderEditCell1 = vi.fn(defaultRenderEditCell);
+        const renderEditCell2 = vi.fn(defaultRenderEditCell);
 
         const preProcessEditCellProps1 = ({ props }: GridPreProcessEditCellProps) =>
           new Promise((resolve) => {
@@ -349,13 +348,13 @@ describe('<DataGridPro /> - Row editing', () => {
               resolve();
             }),
         );
-        expect(renderEditCell1.lastCall.args[0].isProcessingProps).to.equal(true);
-        expect(renderEditCell2.lastCall.args[0].isProcessingProps).to.equal(true);
+        expect(renderEditCell1.mock.lastCall?.[0].isProcessingProps).to.equal(true);
+        expect(renderEditCell2.mock.lastCall?.[0].isProcessingProps).to.equal(true);
         resolve1!();
         resolve2!();
         await act(() => promise);
-        expect(renderEditCell1.lastCall.args[0].isProcessingProps).to.equal(false);
-        expect(renderEditCell2.lastCall.args[0].isProcessingProps).to.equal(false);
+        expect(renderEditCell1.mock.lastCall?.[0].isProcessingProps).to.equal(false);
+        expect(renderEditCell2.mock.lastCall?.[0].isProcessingProps).to.equal(false);
       });
 
       it('should return false if preProcessEditCellProps sets an error', async () => {
@@ -416,12 +415,12 @@ describe('<DataGridPro /> - Row editing', () => {
         });
 
         it('should debounce multiple changes if debounceMs > 0', async () => {
-          const renderEditCell = spy(defaultRenderEditCell);
+          const renderEditCell = vi.fn(defaultRenderEditCell);
 
           render(<TestCase column1Props={{ renderEditCell }} />);
           await act(async () => apiRef.current?.startRowEditMode({ id: 0 }));
-          expect(renderEditCell.lastCall.args[0].value).to.equal('USDGBP');
-          renderEditCell.resetHistory();
+          expect(renderEditCell.mock.lastCall?.[0].value).to.equal('USDGBP');
+          renderEditCell.mockClear();
           await act(async () => {
             apiRef.current?.setEditCellValue({
               id: 0,
@@ -430,7 +429,7 @@ describe('<DataGridPro /> - Row editing', () => {
               debounceMs: 100,
             });
           });
-          expect(renderEditCell.callCount).to.equal(0);
+          expect(renderEditCell.mock.calls.length).to.equal(0);
           await act(async () => {
             apiRef.current?.setEditCellValue({
               id: 0,
@@ -439,13 +438,13 @@ describe('<DataGridPro /> - Row editing', () => {
               debounceMs: 100,
             });
           });
-          expect(renderEditCell.callCount).to.equal(0);
+          expect(renderEditCell.mock.calls.length).to.equal(0);
 
           await act(async () => {
             await vi.advanceTimersByTimeAsync(100);
           });
-          expect(renderEditCell.callCount).not.to.equal(0);
-          expect(renderEditCell.lastCall.args[0].value).to.equal('USD GBP');
+          expect(renderEditCell.mock.calls.length).not.to.equal(0);
+          expect(renderEditCell.mock.lastCall?.[0].value).to.equal('USD GBP');
         });
       });
     });
@@ -479,7 +478,7 @@ describe('<DataGridPro /> - Row editing', () => {
       });
 
       it('should not call processRowUpdate when ignoreModifications=true, even if the row is not in the grid', async () => {
-        const processRowUpdate = spy((row) => row);
+        const processRowUpdate = vi.fn((row) => row);
         const { setProps } = render(<TestCase processRowUpdate={processRowUpdate} />);
         act(() => apiRef.current?.startRowEditMode({ id: 0 }));
         await act(() =>
@@ -489,7 +488,7 @@ describe('<DataGridPro /> - Row editing', () => {
         setProps({ rows: defaultData.rows.filter((row) => row.id !== 0) });
         act(() => apiRef.current?.stopRowEditMode({ id: 0, ignoreModifications: true }));
         await act(() => Promise.resolve());
-        expect(processRowUpdate.callCount).to.equal(0);
+        expect(processRowUpdate.mock.calls.length).to.equal(0);
       });
 
       it('should do nothing if props are still being processed and ignoreModifications=false', async () => {
@@ -540,7 +539,7 @@ describe('<DataGridPro /> - Row editing', () => {
           ...props,
           error: true,
         });
-        const onRowModesModelChange = spy();
+        const onRowModesModelChange = vi.fn();
         render(
           <TestCase
             onRowModesModelChange={onRowModesModelChange}
@@ -552,7 +551,7 @@ describe('<DataGridPro /> - Row editing', () => {
           apiRef.current?.setEditCellValue({ id: 0, field: 'currencyPair', value: 'USD GBP' }),
         );
         act(() => apiRef.current?.stopRowEditMode({ id: 0 }));
-        expect(onRowModesModelChange.lastCall.args[0]).to.deep.equal({ 0: { mode: 'edit' } });
+        expect(onRowModesModelChange.mock.lastCall?.[0]).to.deep.equal({ 0: { mode: 'edit' } });
       });
 
       it('should allow a 2nd call if the first call was when error=true', async () => {
@@ -588,7 +587,7 @@ describe('<DataGridPro /> - Row editing', () => {
       });
 
       it('should call processRowUpdate before updating the row', async () => {
-        const processRowUpdate = spy((row) => ({ ...row, currencyPair: 'USD-GBP' }));
+        const processRowUpdate = vi.fn((row) => ({ ...row, currencyPair: 'USD-GBP' }));
         render(<TestCase processRowUpdate={processRowUpdate} />);
         act(() => apiRef.current?.startRowEditMode({ id: 0 }));
         await act(() =>
@@ -596,12 +595,12 @@ describe('<DataGridPro /> - Row editing', () => {
         );
         act(() => apiRef.current?.stopRowEditMode({ id: 0 }));
         await act(() => Promise.resolve());
-        expect(processRowUpdate.callCount).to.equal(1);
+        expect(processRowUpdate.mock.calls.length).to.equal(1);
         expect(getCell(0, 1).textContent).to.equal('USD-GBP');
       });
 
       it('should call processRowUpdate with the new and old row', async () => {
-        const processRowUpdate = spy((newRow, oldRow) => ({ ...oldRow, ...newRow }));
+        const processRowUpdate = vi.fn((newRow, oldRow) => ({ ...oldRow, ...newRow }));
         render(<TestCase processRowUpdate={processRowUpdate} />);
         act(() => apiRef.current?.startRowEditMode({ id: 0 }));
         await act(() =>
@@ -609,11 +608,11 @@ describe('<DataGridPro /> - Row editing', () => {
         );
         act(() => apiRef.current?.stopRowEditMode({ id: 0 }));
         await act(() => Promise.resolve());
-        expect(processRowUpdate.lastCall.args[0]).to.deep.equal({
+        expect(processRowUpdate.mock.lastCall?.[0]).to.deep.equal({
           ...defaultData.rows[0],
           currencyPair: 'USD GBP',
         });
-        expect(processRowUpdate.lastCall.args[1]).to.deep.equal(defaultData.rows[0]);
+        expect(processRowUpdate.mock.lastCall?.[1]).to.deep.equal(defaultData.rows[0]);
       });
 
       it('should call processRowUpdate with the old row even if the row is not there anymore', async () => {
@@ -621,7 +620,7 @@ describe('<DataGridPro /> - Row editing', () => {
         const otherRows = defaultData.rows.slice(1);
         const allRows = [testRow, ...otherRows];
         const testValue = 'testing';
-        const processRowUpdate = spy((newRow, oldRow) => ({ ...oldRow, ...newRow }));
+        const processRowUpdate = vi.fn((newRow, oldRow) => ({ ...oldRow, ...newRow }));
         const { setProps } = render(
           <TestCase rows={allRows} processRowUpdate={processRowUpdate} />,
         );
@@ -637,11 +636,11 @@ describe('<DataGridPro /> - Row editing', () => {
         act(() => apiRef.current?.stopRowEditMode({ id: testRow.id }));
         await act(() => Promise.resolve());
         // deleted row data is still passed to `processRowUpdate` as `oldRow` parameter
-        expect(processRowUpdate.lastCall.args[0]).to.deep.equal({
+        expect(processRowUpdate.mock.lastCall?.[0]).to.deep.equal({
           ...defaultData.rows[0],
           currencyPair: testValue,
         });
-        expect(processRowUpdate.lastCall.args[1]).to.deep.equal(testRow);
+        expect(processRowUpdate.mock.lastCall?.[1]).to.deep.equal(testRow);
         // only remaining rows are there after `processRowUpdate` returns deleted row data
         expect(apiRef.current?.getRowsCount()).to.equal(otherRows.length);
       });
@@ -670,7 +669,7 @@ describe('<DataGridPro /> - Row editing', () => {
         const processRowUpdate = () => {
           throw error;
         };
-        const onProcessRowUpdateError = spy();
+        const onProcessRowUpdateError = vi.fn();
         render(
           <TestCase
             processRowUpdate={processRowUpdate}
@@ -679,7 +678,7 @@ describe('<DataGridPro /> - Row editing', () => {
         );
         act(() => apiRef.current?.startRowEditMode({ id: 0 }));
         act(() => apiRef.current?.stopRowEditMode({ id: 0 }));
-        expect(onProcessRowUpdateError.lastCall.args[0]).to.equal(error);
+        expect(onProcessRowUpdateError.mock.lastCall?.[0]).to.equal(error);
       });
 
       it('should call onProcessRowUpdateError if processRowUpdate rejects', async () => {
@@ -687,7 +686,7 @@ describe('<DataGridPro /> - Row editing', () => {
         const processRowUpdate = () => {
           throw error;
         };
-        const onProcessRowUpdateError = spy();
+        const onProcessRowUpdateError = vi.fn();
         render(
           <TestCase
             processRowUpdate={processRowUpdate}
@@ -697,7 +696,7 @@ describe('<DataGridPro /> - Row editing', () => {
         act(() => apiRef.current?.startRowEditMode({ id: 0 }));
         act(() => apiRef.current?.stopRowEditMode({ id: 0 }));
         await Promise.resolve();
-        expect(onProcessRowUpdateError.lastCall.args[0]).to.equal(error);
+        expect(onProcessRowUpdateError.mock.lastCall?.[0]).to.equal(error);
       });
 
       it('should keep mode=edit if processRowUpdate rejects', async () => {
@@ -705,8 +704,8 @@ describe('<DataGridPro /> - Row editing', () => {
         const processRowUpdate = () => {
           throw error;
         };
-        const onProcessRowUpdateError = spy();
-        const onRowModesModelChange = spy();
+        const onProcessRowUpdateError = vi.fn();
+        const onRowModesModelChange = vi.fn();
         render(
           <TestCase
             onRowModesModelChange={onRowModesModelChange}
@@ -719,19 +718,19 @@ describe('<DataGridPro /> - Row editing', () => {
           apiRef.current?.setEditCellValue({ id: 0, field: 'currencyPair', value: 'USD GBP' }),
         );
         act(() => apiRef.current?.stopRowEditMode({ id: 0 }));
-        expect(onRowModesModelChange.lastCall.args[0]).to.deep.equal({ 0: { mode: 'edit' } });
+        expect(onRowModesModelChange.mock.lastCall?.[0]).to.deep.equal({ 0: { mode: 'edit' } });
       });
 
       it('should pass the new value through all value setters before calling processRowUpdate', async () => {
-        const valueSetter1 = spy<GridValueSetter>((value, row) => ({
+        const valueSetter1 = vi.fn<GridValueSetter>((value, row) => ({
           ...row,
           _currencyPair: value,
         }));
-        const valueSetter2 = spy<GridValueSetter>((value, row) => ({
+        const valueSetter2 = vi.fn<GridValueSetter>((value, row) => ({
           ...row,
           _price1M: value,
         }));
-        const processRowUpdate = spy((newRow) => newRow);
+        const processRowUpdate = vi.fn((newRow) => newRow);
         render(
           <TestCase
             processRowUpdate={processRowUpdate}
@@ -745,18 +744,18 @@ describe('<DataGridPro /> - Row editing', () => {
         );
         act(() => apiRef.current?.stopRowEditMode({ id: 0 }));
         await act(() => Promise.resolve());
-        expect(processRowUpdate.lastCall.args[0]).to.deep.equal({
+        expect(processRowUpdate.mock.lastCall?.[0]).to.deep.equal({
           ...defaultData.rows[0],
           currencyPair: 'USDGBP',
           _currencyPair: 'USD GBP',
           price1M: 1,
           _price1M: 1,
         });
-        expect(valueSetter1.lastCall.args[0]).to.equal('USD GBP');
-        expect(valueSetter1.lastCall.args[1]).to.deep.equal(defaultData.rows[0]);
+        expect(valueSetter1.mock.lastCall?.[0]).to.equal('USD GBP');
+        expect(valueSetter1.mock.lastCall?.[1]).to.deep.equal(defaultData.rows[0]);
 
-        expect(valueSetter2.lastCall.args[0]).to.equal(1);
-        expect(valueSetter2.lastCall.args[1]).to.deep.equal({
+        expect(valueSetter2.mock.lastCall?.[0]).to.equal(1);
+        expect(valueSetter2.mock.lastCall?.[1]).to.deep.equal({
           // Ensure that the row contains the values from the previous setter);
           ...defaultData.rows[0],
           currencyPair: 'USDGBP',
@@ -803,7 +802,7 @@ describe('<DataGridPro /> - Row editing', () => {
       });
 
       it('should keep in edit mode the cells that entered edit mode while processRowUpdate is called', async () => {
-        const onRowModesModelChange = spy();
+        const onRowModesModelChange = vi.fn();
         let resolveCallback: () => void;
         const processRowUpdate = (newRow: any) =>
           new Promise((resolve) => {
@@ -821,28 +820,28 @@ describe('<DataGridPro /> - Row editing', () => {
           apiRef.current?.setEditCellValue({ id: 0, field: 'currencyPair', value: 'USD GBP' }),
         );
         act(() => apiRef.current?.stopRowEditMode({ id: 0, field: 'price1M' }));
-        expect(onRowModesModelChange.lastCall.args[0]).to.deep.equal({
+        expect(onRowModesModelChange.mock.lastCall?.[0]).to.deep.equal({
           0: { mode: 'view', field: 'price1M' },
         });
 
         act(() => apiRef.current?.startRowEditMode({ id: 1, fieldToFocus: 'price1M' }));
-        expect(onRowModesModelChange.lastCall.args[0]).to.have.keys('0', '1');
-        expect(onRowModesModelChange.lastCall.args[0][1]).to.deep.equal({
+        expect(onRowModesModelChange.mock.lastCall?.[0]).to.have.keys('0', '1');
+        expect(onRowModesModelChange.mock.lastCall?.[0][1]).to.deep.equal({
           mode: 'edit',
           fieldToFocus: 'price1M',
         });
 
         resolveCallback!();
         await act(() => Promise.resolve());
-        expect(onRowModesModelChange.lastCall.args[0]).to.deep.equal({
+        expect(onRowModesModelChange.mock.lastCall?.[0]).to.deep.equal({
           1: { mode: 'edit', fieldToFocus: 'price1M' },
         });
       });
 
       describe('with pending value mutation', () => {
         it('should run all pending value mutations before calling processRowUpdate', async () => {
-          const processRowUpdate = spy((newRow) => newRow);
-          const renderEditCell = spy(defaultRenderEditCell);
+          const processRowUpdate = vi.fn((newRow) => newRow);
+          const renderEditCell = vi.fn(defaultRenderEditCell);
 
           render(
             <TestCase processRowUpdate={processRowUpdate} column1Props={{ renderEditCell }} />,
@@ -858,8 +857,8 @@ describe('<DataGridPro /> - Row editing', () => {
           });
           act(() => apiRef.current?.stopRowEditMode({ id: 0 }));
           await act(() => Promise.resolve());
-          expect(renderEditCell.lastCall.args[0].value).to.equal('USD GBP');
-          expect(processRowUpdate.lastCall.args[0].currencyPair).to.equal('USD GBP');
+          expect(renderEditCell.mock.lastCall?.[0].value).to.equal('USD GBP');
+          expect(processRowUpdate.mock.lastCall?.[0].currencyPair).to.equal('USD GBP');
         });
       });
     });
@@ -869,20 +868,20 @@ describe('<DataGridPro /> - Row editing', () => {
     describe('by double-click', () => {
       it(`should publish 'rowEditStart' with reason=cellDoubleClick`, () => {
         render(<TestCase />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('rowEditStart', listener);
         const cell = getCell(0, 1);
         fireEvent.doubleClick(cell);
-        expect(listener.lastCall.args[0].reason).to.equal('cellDoubleClick');
+        expect(listener.mock.lastCall?.[0].reason).to.equal('cellDoubleClick');
       });
 
       it(`should not publish 'rowEditStart' if the cell is not editable`, () => {
         render(<TestCase />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('rowEditStart', listener);
         const cell = getCell(0, 0);
         fireEvent.doubleClick(cell);
-        expect(listener.callCount).to.equal(0);
+        expect(listener.mock.calls.length).to.equal(0);
       });
 
       it('should call startRowEditMode', () => {
@@ -890,29 +889,29 @@ describe('<DataGridPro /> - Row editing', () => {
         const spiedStartRowEditMode = spyApi(apiRef.current!, 'startRowEditMode');
         const cell = getCell(0, 1);
         fireEvent.doubleClick(cell);
-        expect(spiedStartRowEditMode.callCount).to.equal(1);
+        expect(spiedStartRowEditMode.mock.calls.length).to.equal(1);
       });
     });
 
     describe('by pressing Enter', () => {
       it(`should publish 'rowEditStart' with reason=enterKeyDown`, () => {
         render(<TestCase />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('rowEditStart', listener);
         const cell = getCell(0, 1);
         fireUserEvent.mousePress(cell);
         fireEvent.keyDown(cell, { key: 'Enter' });
-        expect(listener.lastCall.args[0].reason).to.equal('enterKeyDown');
+        expect(listener.mock.lastCall?.[0].reason).to.equal('enterKeyDown');
       });
 
       it(`should not publish 'rowEditStart' if the cell is not editable`, () => {
         render(<TestCase />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('rowEditStart', listener);
         const cell = getCell(0, 0);
         fireUserEvent.mousePress(cell);
         fireEvent.keyDown(cell, { key: 'Enter' });
-        expect(listener.callCount).to.equal(0);
+        expect(listener.mock.calls.length).to.equal(0);
       });
 
       it('should call startRowEditMode passing fieldToFocus', () => {
@@ -921,8 +920,8 @@ describe('<DataGridPro /> - Row editing', () => {
         const cell = getCell(0, 1);
         fireUserEvent.mousePress(cell);
         fireEvent.keyDown(cell, { key: 'Enter' });
-        expect(spiedStartRowEditMode.callCount).to.equal(1);
-        expect(spiedStartRowEditMode.lastCall.args[0]).to.deep.equal({
+        expect(spiedStartRowEditMode.mock.calls.length).to.equal(1);
+        expect(spiedStartRowEditMode.mock.lastCall?.[0]).to.deep.equal({
           id: 0,
           fieldToFocus: 'currencyPair',
         });
@@ -932,22 +931,22 @@ describe('<DataGridPro /> - Row editing', () => {
     describe('by pressing Delete', () => {
       it(`should publish 'rowEditStart' with reason=deleteKeyDown`, () => {
         render(<TestCase />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('rowEditStart', listener);
         const cell = getCell(0, 1);
         fireUserEvent.mousePress(cell);
         fireEvent.keyDown(cell, { key: 'Delete' });
-        expect(listener.lastCall.args[0].reason).to.equal('deleteKeyDown');
+        expect(listener.mock.lastCall?.[0].reason).to.equal('deleteKeyDown');
       });
 
       it(`should not publish 'rowEditStart' if the cell is not editable`, () => {
         render(<TestCase />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('rowEditStart', listener);
         const cell = getCell(0, 0);
         fireUserEvent.mousePress(cell);
         fireEvent.keyDown(cell, { key: 'Delete' });
-        expect(listener.callCount).to.equal(0);
+        expect(listener.mock.calls.length).to.equal(0);
       });
 
       it('should call startRowEditMode passing fieldToFocus and deleteValue', () => {
@@ -956,8 +955,8 @@ describe('<DataGridPro /> - Row editing', () => {
         const cell = getCell(0, 1);
         fireUserEvent.mousePress(cell);
         fireEvent.keyDown(cell, { key: 'Delete' });
-        expect(spiedStartRowEditMode.callCount).to.equal(1);
-        expect(spiedStartRowEditMode.lastCall.args[0]).to.deep.equal({
+        expect(spiedStartRowEditMode.mock.calls.length).to.equal(1);
+        expect(spiedStartRowEditMode.mock.lastCall?.[0]).to.deep.equal({
           id: 0,
           fieldToFocus: 'currencyPair',
           deleteValue: true,
@@ -965,16 +964,16 @@ describe('<DataGridPro /> - Row editing', () => {
       });
 
       it('should call preProcessEditCellProps', async () => {
-        const preProcessEditCellProps = spy(({ props }: GridPreProcessEditCellProps) => props);
+        const preProcessEditCellProps = vi.fn(({ props }: GridPreProcessEditCellProps) => props);
         const { user } = render(<TestCase column1Props={{ preProcessEditCellProps }} />);
 
         const cell = getCell(0, 1);
         await user.click(cell);
         await user.keyboard('{Delete}');
 
-        expect(preProcessEditCellProps.callCount).to.equal(1);
+        expect(preProcessEditCellProps.mock.calls.length).to.equal(1);
 
-        expect(preProcessEditCellProps.lastCall.args[0].props).to.deep.equal({
+        expect(preProcessEditCellProps.mock.lastCall?.[0].props).to.deep.equal({
           value: '',
           error: false,
           isProcessingProps: true,
@@ -985,27 +984,27 @@ describe('<DataGridPro /> - Row editing', () => {
     describe('by pressing a printable character', () => {
       it(`should publish 'rowEditStart' with reason=printableKeyDown`, () => {
         render(<TestCase />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('rowEditStart', listener);
         const cell = getCell(0, 1);
         fireUserEvent.mousePress(cell);
         fireEvent.keyDown(cell, { key: 'a' });
-        expect(listener.lastCall.args[0].reason).to.equal('printableKeyDown');
+        expect(listener.mock.lastCall?.[0].reason).to.equal('printableKeyDown');
       });
 
       it(`should not publish 'rowEditStart' if the cell is not editable`, () => {
         render(<TestCase />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('rowEditStart', listener);
         const cell = getCell(0, 0);
         fireUserEvent.mousePress(cell);
         fireEvent.keyDown(cell, { key: 'a' });
-        expect(listener.callCount).to.equal(0);
+        expect(listener.mock.calls.length).to.equal(0);
       });
 
       it('should call preProcessEditCellProps for editable columns only', async () => {
-        const preProcessEditCellProps1 = spy(({ props }: GridPreProcessEditCellProps) => props);
-        const preProcessEditCellProps2 = spy(({ props }: GridPreProcessEditCellProps) => props);
+        const preProcessEditCellProps1 = vi.fn(({ props }: GridPreProcessEditCellProps) => props);
+        const preProcessEditCellProps2 = vi.fn(({ props }: GridPreProcessEditCellProps) => props);
         const { user } = render(
           <TestCase
             column1Props={{ preProcessEditCellProps: preProcessEditCellProps1 }}
@@ -1017,50 +1016,50 @@ describe('<DataGridPro /> - Row editing', () => {
         await user.click(cell);
         await user.keyboard('a');
 
-        expect(preProcessEditCellProps1.callCount).to.equal(1);
-        expect(preProcessEditCellProps2.callCount).to.equal(0);
+        expect(preProcessEditCellProps1.mock.calls.length).to.equal(1);
+        expect(preProcessEditCellProps2.mock.calls.length).to.equal(0);
       });
 
       ['ctrlKey', 'metaKey'].forEach((key) => {
         it(`should not publish 'rowEditStart' if ${key} is pressed`, () => {
           render(<TestCase />);
-          const listener = spy();
+          const listener = vi.fn();
           apiRef.current?.subscribeEvent('rowEditStart', listener);
           const cell = getCell(0, 1);
           fireUserEvent.mousePress(cell);
           fireEvent.keyDown(cell, { key: 'a', keyCode: 65, [key]: true });
-          expect(listener.callCount).to.equal(0);
+          expect(listener.mock.calls.length).to.equal(0);
         });
       });
 
       it(`should call startRowEditMode if shiftKey is pressed with a letter`, () => {
         render(<TestCase />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('rowEditStart', listener);
         const cell = getCell(0, 1);
         fireUserEvent.mousePress(cell);
         fireEvent.keyDown(cell, { key: 'a', keyCode: 65, shiftKey: true });
-        expect(listener.callCount).to.equal(1);
+        expect(listener.mock.calls.length).to.equal(1);
       });
 
       it('should not call startRowEditMode if space is pressed', () => {
         render(<TestCase autoHeight />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('rowEditStart', listener);
         const cell = getCell(0, 1);
         fireUserEvent.mousePress(cell);
         fireEvent.keyDown(cell, { key: ' ' });
-        expect(listener.callCount).to.equal(0);
+        expect(listener.mock.calls.length).to.equal(0);
       });
 
       it(`should call startRowEditMode if ctrl+V is pressed`, () => {
         render(<TestCase />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('rowEditStart', listener);
         const cell = getCell(0, 1);
         fireUserEvent.mousePress(cell);
         fireEvent.keyDown(cell, { key: 'v', keyCode: 86, ctrlKey: true });
-        expect(listener.callCount).to.equal(1);
+        expect(listener.mock.calls.length).to.equal(1);
       });
 
       it('should call startRowEditMode passing fieldToFocus and deleteValue', () => {
@@ -1069,8 +1068,8 @@ describe('<DataGridPro /> - Row editing', () => {
         const cell = getCell(0, 1);
         fireUserEvent.mousePress(cell);
         fireEvent.keyDown(cell, { key: 'a' });
-        expect(spiedStartRowEditMode.callCount).to.equal(1);
-        expect(spiedStartRowEditMode.lastCall.args[0]).to.deep.equal({
+        expect(spiedStartRowEditMode.mock.calls.length).to.equal(1);
+        expect(spiedStartRowEditMode.mock.lastCall?.[0]).to.deep.equal({
           id: 0,
           fieldToFocus: 'currencyPair',
           deleteValue: true,
@@ -1079,34 +1078,34 @@ describe('<DataGridPro /> - Row editing', () => {
 
       it(`should ignore keydown event until the IME is confirmed with a letter`, () => {
         render(<TestCase />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('rowEditStop', listener);
         const cell = getCell(0, 1);
         fireEvent.doubleClick(cell);
         const input = cell.querySelector('input')!;
         fireEvent.change(input, { target: { value: 'あ' } });
         fireEvent.keyDown(input, { key: 'Enter', keyCode: 229 });
-        expect(listener.callCount).to.equal(0);
+        expect(listener.mock.calls.length).to.equal(0);
         fireEvent.keyDown(input, { key: 'Enter', keyCode: 13 });
-        expect(listener.callCount).to.equal(1);
+        expect(listener.mock.calls.length).to.equal(1);
         expect(input.value).to.equal('あ');
-        expect(listener.lastCall.args[0].reason).to.equal('enterKeyDown');
+        expect(listener.mock.lastCall?.[0].reason).to.equal('enterKeyDown');
       });
 
       it(`should ignore keydown event until the IME is confirmed with multiple letters`, () => {
         render(<TestCase />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('rowEditStop', listener);
         const cell = getCell(0, 1);
         fireEvent.doubleClick(cell);
         const input = cell.querySelector('input')!;
         fireEvent.change(input, { target: { value: 'ありがとう' } });
         fireEvent.keyDown(input, { key: 'Enter', keyCode: 229 });
-        expect(listener.callCount).to.equal(0);
+        expect(listener.mock.calls.length).to.equal(0);
         fireEvent.keyDown(input, { key: 'Enter', keyCode: 13 });
-        expect(listener.callCount).to.equal(1);
+        expect(listener.mock.calls.length).to.equal(1);
         expect(input.value).to.equal('ありがとう');
-        expect(listener.lastCall.args[0].reason).to.equal('enterKeyDown');
+        expect(listener.mock.lastCall?.[0].reason).to.equal('enterKeyDown');
       });
     });
   });
@@ -1115,14 +1114,14 @@ describe('<DataGridPro /> - Row editing', () => {
     describe('by clicking outside the cell', () => {
       it(`should publish 'rowEditStop' with reason=rowFocusOut`, async () => {
         render(<TestCase />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('rowEditStop', listener);
         fireEvent.doubleClick(getCell(0, 1));
-        expect(listener.callCount).to.equal(0);
+        expect(listener.mock.calls.length).to.equal(0);
         fireUserEvent.mousePress(getCell(1, 1));
 
         await waitFor(() => {
-          expect(listener.lastCall.args[0].reason).to.equal('rowFocusOut');
+          expect(listener.mock.lastCall?.[0].reason).to.equal('rowFocusOut');
         });
       });
 
@@ -1132,18 +1131,18 @@ describe('<DataGridPro /> - Row editing', () => {
           error: true,
         });
         render(<TestCase column1Props={{ preProcessEditCellProps }} />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('rowEditStop', listener);
         const cell = getCell(0, 1);
         fireEvent.doubleClick(cell);
         await act(() =>
           apiRef.current?.setEditCellValue({ id: 0, field: 'currencyPair', value: 'USD GBP' }),
         );
-        expect(listener.callCount).to.equal(0);
+        expect(listener.mock.calls.length).to.equal(0);
 
         fireUserEvent.mousePress(getCell(1, 1));
 
-        expect(listener.callCount).to.equal(0);
+        expect(listener.mock.calls.length).to.equal(0);
       });
 
       it('should call stopRowEditMode with ignoreModifications=false and no cellToFocusAfter', async () => {
@@ -1151,8 +1150,8 @@ describe('<DataGridPro /> - Row editing', () => {
         const spiedStopRowEditMode = spyApi(apiRef.current!, 'stopRowEditMode');
         await user.dblClick(getCell(0, 1));
         await user.click(getCell(1, 1));
-        expect(spiedStopRowEditMode.callCount).to.equal(1);
-        expect(spiedStopRowEditMode.lastCall.args[0]).to.deep.equal({
+        expect(spiedStopRowEditMode.mock.calls.length).to.equal(1);
+        expect(spiedStopRowEditMode.mock.lastCall?.[0]).to.deep.equal({
           id: 0,
           ignoreModifications: false,
           field: 'currencyPair',
@@ -1171,24 +1170,24 @@ describe('<DataGridPro /> - Row editing', () => {
         await user.click(getCell(1, 1));
 
         await waitFor(() => {
-          expect(spiedStopRowEditMode.callCount).to.equal(1);
+          expect(spiedStopRowEditMode.mock.calls.length).to.equal(1);
         });
 
-        expect(spiedStopRowEditMode.lastCall.args[0].ignoreModifications).to.equal(false);
+        expect(spiedStopRowEditMode.mock.lastCall?.[0].ignoreModifications).to.equal(false);
       });
     });
 
     describe('by pressing Escape', () => {
       it(`should publish 'rowEditStop' with reason=escapeKeyDown`, () => {
         render(<TestCase />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('rowEditStop', listener);
         const cell = getCell(0, 1);
         fireUserEvent.mousePress(cell);
         fireEvent.doubleClick(cell);
-        expect(listener.callCount).to.equal(0);
+        expect(listener.mock.calls.length).to.equal(0);
         fireEvent.keyDown(cell.querySelector('input')!, { key: 'Escape' });
-        expect(listener.lastCall.args[0].reason).to.equal('escapeKeyDown');
+        expect(listener.mock.lastCall?.[0].reason).to.equal('escapeKeyDown');
       });
 
       it(`should publish 'rowEditStop' even if field has error`, async () => {
@@ -1197,17 +1196,17 @@ describe('<DataGridPro /> - Row editing', () => {
           error: true,
         });
         render(<TestCase column1Props={{ preProcessEditCellProps }} />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('rowEditStop', listener);
         const cell = getCell(0, 1);
         fireEvent.doubleClick(cell);
         await act(() =>
           apiRef.current?.setEditCellValue({ id: 0, field: 'currencyPair', value: 'USD GBP' }),
         );
-        expect(listener.callCount).to.equal(0);
+        expect(listener.mock.calls.length).to.equal(0);
 
         fireEvent.keyDown(cell.querySelector('input')!, { key: 'Escape' });
-        expect(listener.lastCall.args[0].reason).to.equal('escapeKeyDown');
+        expect(listener.mock.lastCall?.[0].reason).to.equal('escapeKeyDown');
       });
 
       it('should call stopRowEditMode with ignoreModifications=true', () => {
@@ -1217,8 +1216,8 @@ describe('<DataGridPro /> - Row editing', () => {
         fireUserEvent.mousePress(cell);
         fireEvent.doubleClick(cell);
         fireEvent.keyDown(cell.querySelector('input')!, { key: 'Escape' });
-        expect(spiedStopRowEditMode.callCount).to.equal(1);
-        expect(spiedStopRowEditMode.lastCall.args[0]).to.deep.equal({
+        expect(spiedStopRowEditMode.mock.calls.length).to.equal(1);
+        expect(spiedStopRowEditMode.mock.lastCall?.[0]).to.deep.equal({
           id: 0,
           ignoreModifications: true,
           field: 'currencyPair',
@@ -1230,14 +1229,14 @@ describe('<DataGridPro /> - Row editing', () => {
     describe('by pressing Enter', () => {
       it(`should publish 'rowEditStop' with reason=enterKeyDown`, () => {
         render(<TestCase />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('rowEditStop', listener);
         const cell = getCell(0, 1);
         fireUserEvent.mousePress(cell);
         fireEvent.doubleClick(cell);
-        expect(listener.callCount).to.equal(0);
+        expect(listener.mock.calls.length).to.equal(0);
         fireEvent.keyDown(cell.querySelector('input')!, { key: 'Enter' });
-        expect(listener.lastCall.args[0].reason).to.equal('enterKeyDown');
+        expect(listener.mock.lastCall?.[0].reason).to.equal('enterKeyDown');
       });
 
       it(`should not publish 'rowEditStop' if field has error`, async () => {
@@ -1246,17 +1245,17 @@ describe('<DataGridPro /> - Row editing', () => {
           error: true,
         });
         render(<TestCase column1Props={{ preProcessEditCellProps }} />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('rowEditStop', listener);
         const cell = getCell(0, 1);
         fireEvent.doubleClick(cell);
         await act(() =>
           apiRef.current?.setEditCellValue({ id: 0, field: 'currencyPair', value: 'USD GBP' }),
         );
-        expect(listener.callCount).to.equal(0);
+        expect(listener.mock.calls.length).to.equal(0);
 
         fireEvent.keyDown(cell.querySelector('input')!, { key: 'Enter' });
-        expect(listener.callCount).to.equal(0);
+        expect(listener.mock.calls.length).to.equal(0);
       });
 
       it('should call stopRowEditMode with ignoreModifications=false and cellToFocusAfter=below', () => {
@@ -1266,8 +1265,8 @@ describe('<DataGridPro /> - Row editing', () => {
         fireUserEvent.mousePress(cell);
         fireEvent.doubleClick(cell);
         fireEvent.keyDown(cell.querySelector('input')!, { key: 'Enter' });
-        expect(spiedStopRowEditMode.callCount).to.equal(1);
-        expect(spiedStopRowEditMode.lastCall.args[0]).to.deep.equal({
+        expect(spiedStopRowEditMode.mock.calls.length).to.equal(1);
+        expect(spiedStopRowEditMode.mock.lastCall?.[0]).to.deep.equal({
           id: 0,
           ignoreModifications: false,
           field: 'currencyPair',
@@ -1286,34 +1285,34 @@ describe('<DataGridPro /> - Row editing', () => {
           apiRef.current?.setEditCellValue({ id: 0, field: 'currencyPair', value: 'USD GBP' });
         });
         fireEvent.keyDown(cell.querySelector('input')!, { key: 'Enter' });
-        expect(spiedStopRowEditMode.callCount).to.equal(1);
-        expect(spiedStopRowEditMode.lastCall.args[0].ignoreModifications).to.equal(false);
+        expect(spiedStopRowEditMode.mock.calls.length).to.equal(1);
+        expect(spiedStopRowEditMode.mock.lastCall?.[0].ignoreModifications).to.equal(false);
       });
     });
 
     describe('by pressing Tab', () => {
       it(`should publish 'rowEditStop' with reason=tabKeyDown if on the last column`, () => {
         render(<TestCase />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('rowEditStop', listener);
         const cell = getCell(0, 2);
         fireUserEvent.mousePress(cell);
         fireEvent.doubleClick(cell);
-        expect(listener.callCount).to.equal(0);
+        expect(listener.mock.calls.length).to.equal(0);
         fireEvent.keyDown(cell.querySelector('input')!, { key: 'Tab' });
-        expect(listener.lastCall.args[0].reason).to.equal('tabKeyDown');
+        expect(listener.mock.lastCall?.[0].reason).to.equal('tabKeyDown');
       });
 
       it(`should publish 'rowEditStop' with reason=shiftTabKeyDown if on the first column and Shift is pressed`, () => {
         render(<TestCase />);
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('rowEditStop', listener);
         const cell = getCell(0, 1);
         fireUserEvent.mousePress(cell);
         fireEvent.doubleClick(cell);
-        expect(listener.callCount).to.equal(0);
+        expect(listener.mock.calls.length).to.equal(0);
         fireEvent.keyDown(cell.querySelector('input')!, { key: 'Tab', shiftKey: true });
-        expect(listener.lastCall.args[0].reason).to.equal('shiftTabKeyDown');
+        expect(listener.mock.lastCall?.[0].reason).to.equal('shiftTabKeyDown');
       });
 
       it('should call stopRowEditMode with ignoreModifications=false and cellToFocusAfter=right', async () => {
@@ -1323,8 +1322,8 @@ describe('<DataGridPro /> - Row editing', () => {
         await user.click(cell);
         await user.dblClick(cell);
         await user.keyboard('{Tab}');
-        expect(spiedStopRowEditMode.callCount).to.equal(1);
-        expect(spiedStopRowEditMode.lastCall.args[0]).to.deep.equal({
+        expect(spiedStopRowEditMode.mock.calls.length).to.equal(1);
+        expect(spiedStopRowEditMode.mock.lastCall?.[0]).to.deep.equal({
           id: 0,
           ignoreModifications: false,
           field: 'price1M',
@@ -1339,8 +1338,8 @@ describe('<DataGridPro /> - Row editing', () => {
         fireUserEvent.mousePress(cell);
         fireEvent.doubleClick(cell);
         fireEvent.keyDown(cell.querySelector('input')!, { key: 'Tab', shiftKey: true });
-        expect(spiedStopRowEditMode.callCount).to.equal(1);
-        expect(spiedStopRowEditMode.lastCall.args[0]).to.deep.equal({
+        expect(spiedStopRowEditMode.mock.calls.length).to.equal(1);
+        expect(spiedStopRowEditMode.mock.lastCall?.[0]).to.deep.equal({
           id: 0,
           ignoreModifications: false,
           field: 'currencyPair',
@@ -1359,8 +1358,8 @@ describe('<DataGridPro /> - Row editing', () => {
           apiRef.current?.setEditCellValue({ id: 0, field: 'price1M', value: 'USD GBP' });
         });
         fireEvent.keyDown(cell.querySelector('input')!, { key: 'Tab' });
-        expect(spiedStopRowEditMode.callCount).to.equal(1);
-        expect(spiedStopRowEditMode.lastCall.args[0].ignoreModifications).to.equal(false);
+        expect(spiedStopRowEditMode.mock.calls.length).to.equal(1);
+        expect(spiedStopRowEditMode.mock.lastCall?.[0].ignoreModifications).to.equal(false);
       });
 
       it('should keep focus on the first column when editing the first column of the first row of the 2nd page', () => {
@@ -1455,33 +1454,33 @@ describe('<DataGridPro /> - Row editing', () => {
 
     it(`should publish 'rowModesModelChange' when the model changes`, () => {
       render(<TestCase />);
-      const listener = spy();
+      const listener = vi.fn();
       act(() => apiRef.current?.subscribeEvent('rowModesModelChange', listener));
       const cell = getCell(0, 1);
       fireEvent.doubleClick(cell);
-      expect(listener.lastCall.args[0]).to.deep.equal({
+      expect(listener.mock.lastCall?.[0]).to.deep.equal({
         0: { mode: 'edit', fieldToFocus: 'currencyPair' },
       });
     });
 
     it(`should publish 'rowModesModelChange' when the prop changes`, () => {
       const { setProps } = render(<TestCase rowModesModel={{}} />);
-      const listener = spy();
-      expect(listener.callCount).to.equal(0);
+      const listener = vi.fn();
+      expect(listener.mock.calls.length).to.equal(0);
       act(() => apiRef.current?.subscribeEvent('rowModesModelChange', listener));
       setProps({ rowModesModel: { 0: { currencyPair: { mode: 'edit' } } } });
-      expect(listener.lastCall.args[0]).to.deep.equal({
+      expect(listener.mock.lastCall?.[0]).to.deep.equal({
         0: { currencyPair: { mode: 'edit' } },
       });
     });
 
     it(`should not publish 'rowModesModelChange' when the model changes and rowModesModel is set`, () => {
       render(<TestCase rowModesModel={{}} />);
-      const listener = spy();
+      const listener = vi.fn();
       act(() => apiRef.current?.subscribeEvent('rowModesModelChange', listener));
       const cell = getCell(0, 1);
       fireEvent.doubleClick(cell);
-      expect(listener.callCount).to.equal(0);
+      expect(listener.mock.calls.length).to.equal(0);
     });
 
     it('should not mutate the rowModesModel prop if props of any column contains error=true', async () => {
@@ -1507,36 +1506,36 @@ describe('<DataGridPro /> - Row editing', () => {
 
   describe('prop: onRowModesModelChange', () => {
     it('should call with mode=edit when startEditMode is called', () => {
-      const onRowModesModelChange = spy();
+      const onRowModesModelChange = vi.fn();
       render(<TestCase onRowModesModelChange={onRowModesModelChange} />);
-      expect(onRowModesModelChange.callCount).to.equal(0);
+      expect(onRowModesModelChange.mock.calls.length).to.equal(0);
       act(() => apiRef.current?.startRowEditMode({ id: 0, fieldToFocus: 'currencyPair' }));
-      expect(onRowModesModelChange.callCount).to.equal(1);
-      expect(onRowModesModelChange.lastCall.args[0]).to.deep.equal({
+      expect(onRowModesModelChange.mock.calls.length).to.equal(1);
+      expect(onRowModesModelChange.mock.lastCall?.[0]).to.deep.equal({
         0: { mode: 'edit', fieldToFocus: 'currencyPair' },
       });
     });
 
     it('should call with mode=view when stopEditMode is called', () => {
-      const onRowModesModelChange = spy();
+      const onRowModesModelChange = vi.fn();
       render(<TestCase onRowModesModelChange={onRowModesModelChange} />);
       act(() => apiRef.current?.startRowEditMode({ id: 0, fieldToFocus: 'currencyPair' }));
-      onRowModesModelChange.resetHistory();
+      onRowModesModelChange.mockClear();
       act(() => apiRef.current?.stopRowEditMode({ id: 0 }));
-      expect(onRowModesModelChange.args[0][0]).to.deep.equal({
+      expect(onRowModesModelChange.mock.calls[0][0]).to.deep.equal({
         0: { mode: 'view' },
       });
-      expect(onRowModesModelChange.args[1][0]).to.deep.equal({});
+      expect(onRowModesModelChange.mock.calls[1][0]).to.deep.equal({});
     });
 
     it(`should not be called when changing the rowModesModel prop`, () => {
-      const onRowModesModelChange = spy();
+      const onRowModesModelChange = vi.fn();
       const { setProps } = render(
         <TestCase rowModesModel={{}} onRowModesModelChange={onRowModesModelChange} />,
       );
-      expect(onRowModesModelChange.callCount).to.equal(0);
+      expect(onRowModesModelChange.mock.calls.length).to.equal(0);
       setProps({ rowModesModel: { 0: { mode: 'edit' } } });
-      expect(onRowModesModelChange.callCount).to.equal(0);
+      expect(onRowModesModelChange.mock.calls.length).to.equal(0);
     });
   });
 

--- a/packages/x-data-grid/src/tests/editComponents.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/editComponents.DataGrid.test.tsx
@@ -49,7 +49,7 @@ describe('<DataGrid /> - Edit components', () => {
       await user.clear(textarea);
       await user.type(textarea, 'New text');
 
-      expect(spiedSetEditCellValue.lastCall.args[0]).to.deep.equal({
+      expect(spiedSetEditCellValue.mock.lastCall?.[0]).to.deep.equal({
         id: 0,
         field: 'bio',
         value: 'New text',

--- a/packages/x-scheduler-premium/src/event-calendar-premium/tests/EventContextMenu.test.tsx
+++ b/packages/x-scheduler-premium/src/event-calendar-premium/tests/EventContextMenu.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import type { SinonSpy } from 'sinon';
 import { screen, fireEvent } from '@mui/internal-test-utils';
 import { adapter, createSchedulerRenderer, EventBuilder, StoreSpy } from 'test/utils/scheduler';
 import { SchedulerStoreContext } from '@mui/x-scheduler-internals/use-scheduler-store-context';
@@ -12,6 +11,7 @@ import {
   EventContextMenuTrigger,
 } from '@mui/x-scheduler/internals';
 import { describe, it, expect } from 'vitest';
+import type { MockInstance } from 'vitest';
 import { RecurringScopeDialog } from '../../internals/components/recurring-scope-dialog/RecurringScopeDialog';
 
 /**
@@ -34,8 +34,8 @@ describe('EventContextMenu - recurring events (Premium)', () => {
       .recurrent('WEEKLY');
     const occurrence = weeklyEventBuilder.toOccurrence();
 
-    let deleteEventSpy: SinonSpy | undefined;
-    let deleteRecurringEventSpy: SinonSpy | undefined;
+    let deleteEventSpy: MockInstance | undefined;
+    let deleteRecurringEventSpy: MockInstance | undefined;
 
     render(
       <EventCalendarProvider
@@ -71,8 +71,8 @@ describe('EventContextMenu - recurring events (Premium)', () => {
     fireEvent.contextMenu(screen.getByRole('button', { name: 'Weekly sync' }));
     fireEvent.click(screen.getByRole('menuitem', { name: /delete/i }));
 
-    expect(deleteRecurringEventSpy?.calledOnce).to.equal(true);
-    expect(deleteEventSpy?.called).to.equal(false);
+    expect(deleteRecurringEventSpy?.mock.calls.length).to.equal(1);
+    expect(deleteEventSpy?.mock.calls.length).to.equal(0);
     expect(screen.getByText(/Apply this change to:/i)).not.to.equal(null);
   });
 });

--- a/packages/x-scheduler-premium/src/event-calendar-premium/tests/EventDialog.test.tsx
+++ b/packages/x-scheduler-premium/src/event-calendar-premium/tests/EventDialog.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { spy } from 'sinon';
 import { isJSDOM } from 'test/utils/skipIf';
 import type { AnyEventCalendarStore } from 'test/utils/scheduler';
 import {
@@ -33,6 +32,7 @@ import {
   useEventDialogFormField,
 } from '@mui/x-scheduler/event-dialog';
 import { describe, it, expect, vi } from 'vitest';
+import type { Mock, MockInstance } from 'vitest';
 import { PREMIUM_EVENT_DIALOG_OPTIONAL_RENDERERS } from '../../internals/eventDialogOptionalRenderers';
 import { RecurringScopeDialog } from '../../internals/components/recurring-scope-dialog/RecurringScopeDialog';
 
@@ -90,7 +90,7 @@ describe('<EventDialogContent open />', () => {
   const { render } = createSchedulerRenderer();
 
   it('should return to the General tab when the submit fails from the Recurrence tab', async () => {
-    const onEventsChange = spy();
+    const onEventsChange = vi.fn();
     const noResourceEvent = EventBuilder.new()
       .title('Running')
       .singleDay('2025-05-26T07:30:00Z', 45)
@@ -119,14 +119,14 @@ describe('<EventDialogContent open />', () => {
 
     await user.click(screen.getByRole('button', { name: /save/i }));
 
-    expect(onEventsChange.called).to.equal(false);
+    expect(onEventsChange.mock.calls.length).to.equal(0);
     // The failing field lives in the General tab, so the dialog switches back to it.
     expect(generalPanel).not.to.have.attribute('hidden');
     expect(screen.getByText(/a resource is required/i)).not.to.equal(null);
   });
 
   it('should return to the General tab when only a custom validator fails', async () => {
-    const onEventsChange = spy();
+    const onEventsChange = vi.fn();
     function FailingSection() {
       const client = useEventDialogFormField('client', {
         defaultValue: '',
@@ -157,13 +157,13 @@ describe('<EventDialogContent open />', () => {
 
     await user.click(screen.getByRole('button', { name: /save/i }));
 
-    expect(onEventsChange.called).to.equal(false);
+    expect(onEventsChange.mock.calls.length).to.equal(0);
     expect(generalPanel).not.to.have.attribute('hidden');
     expect(screen.getByRole('alert')).to.have.text('Nope');
   });
 
   it('should return to the General tab when a validator throws', async () => {
-    const onEventsChange = spy();
+    const onEventsChange = vi.fn();
     function ThrowingSection() {
       useEventDialogFormField('client', {
         defaultValue: '',
@@ -197,12 +197,12 @@ describe('<EventDialogContent open />', () => {
       'MUI X Scheduler: A form field validator threw or rejected during the submit.',
     ]);
 
-    expect(onEventsChange.called).to.equal(false);
+    expect(onEventsChange.mock.calls.length).to.equal(0);
     expect(generalPanel).not.to.have.attribute('hidden');
   });
 
   it('should return to the General tab when the native validation blocks the submit', async () => {
-    const onEventsChange = spy();
+    const onEventsChange = vi.fn();
     function EndDateClearer() {
       const endDate = useEventDialogFormField('endDate');
       return (
@@ -240,7 +240,7 @@ describe('<EventDialogContent open />', () => {
 
     // The browser refuses the submit over the hidden invalid control; the form
     // must at least bring the failing field back into view.
-    expect(onEventsChange.called).to.equal(false);
+    expect(onEventsChange.mock.calls.length).to.equal(0);
     expect(generalPanel).not.to.have.attribute('hidden');
   });
 
@@ -334,7 +334,7 @@ describe('<EventDialogContent open />', () => {
   });
 
   it('should call "onEventsChange" with updated values on submit', async () => {
-    const onEventsChange = spy();
+    const onEventsChange = vi.fn();
     const { user } = render(
       <EventCalendarProvider
         events={[DEFAULT_EVENT]}
@@ -356,8 +356,8 @@ describe('<EventDialogContent open />', () => {
     await user.click(screen.getByRole('button', { name: /pink/i }));
     await user.click(screen.getByRole('button', { name: /save/i }));
 
-    expect(onEventsChange.calledOnce).to.equal(true);
-    const updated = onEventsChange.firstCall.firstArg[0];
+    expect(onEventsChange.mock.calls.length).to.equal(1);
+    const updated = onEventsChange.mock.calls[0][0][0];
 
     const expectedUpdatedEvent = {
       id: DEFAULT_EVENT.id,
@@ -377,7 +377,7 @@ describe('<EventDialogContent open />', () => {
   }, 10_000);
 
   it('should clear the color when clicking the active color toggle', async () => {
-    const onEventsChange = spy();
+    const onEventsChange = vi.fn();
     const { user } = render(
       <EventCalendarProvider
         events={[DEFAULT_EVENT]}
@@ -395,13 +395,13 @@ describe('<EventDialogContent open />', () => {
     expect(pinkToggle).to.have.attribute('aria-pressed', 'false');
     await user.click(screen.getByRole('button', { name: /save/i }));
 
-    expect(onEventsChange.calledOnce).to.equal(true);
-    expect(onEventsChange.firstCall.firstArg[0].color).to.not.equal('pink');
+    expect(onEventsChange.mock.calls.length).to.equal(1);
+    expect(onEventsChange.mock.calls[0][0][0].color).to.not.equal('pink');
   });
 
   describe('range validation', () => {
     function renderDialog() {
-      const onEventsChange = spy();
+      const onEventsChange = vi.fn();
       const { user } = render(
         <EventCalendarProvider
           events={[DEFAULT_EVENT]}
@@ -438,7 +438,7 @@ describe('<EventDialogContent open />', () => {
       await user.click(screen.getByRole('button', { name: /save/i }));
 
       expect(screen.queryDescriptionOf(screen.getByLabelText(/end date/i))).to.equal(null);
-      expect(onEventsChange.calledOnce).to.equal(true);
+      expect(onEventsChange.mock.calls.length).to.equal(1);
     });
 
     it('should show error on the End time field and block submit if end time is before start time on the same day', async () => {
@@ -449,7 +449,7 @@ describe('<EventDialogContent open />', () => {
       await user.type(screen.getByLabelText(/end time/i), '09:00');
       await user.click(screen.getByRole('button', { name: /save/i }));
 
-      expect(onEventsChange.called).to.equal(false);
+      expect(onEventsChange.mock.calls.length).to.equal(0);
       expect(screen.getDescriptionOf(screen.getByLabelText(/end time/i)).textContent).to.match(
         /end time.*after.*start time/i,
       );
@@ -463,7 +463,7 @@ describe('<EventDialogContent open />', () => {
       await user.type(screen.getByLabelText(/end time/i), '10:00');
       await user.click(screen.getByRole('button', { name: /save/i }));
 
-      expect(onEventsChange.called).to.equal(false);
+      expect(onEventsChange.mock.calls.length).to.equal(0);
       expect(screen.getDescriptionOf(screen.getByLabelText(/end time/i)).textContent).to.match(
         /end time.*after.*start time/i,
       );
@@ -471,7 +471,7 @@ describe('<EventDialogContent open />', () => {
   });
 
   it('should call "onEventsChange" with the updated values when delete button is clicked', async () => {
-    const onEventsChange = spy();
+    const onEventsChange = vi.fn();
     const { user } = render(
       <EventCalendarProvider
         events={[DEFAULT_EVENT]}
@@ -483,8 +483,8 @@ describe('<EventDialogContent open />', () => {
       </EventCalendarProvider>,
     );
     await user.click(screen.getByRole('button', { name: /delete event/i }));
-    expect(onEventsChange.calledOnce).to.equal(true);
-    expect(onEventsChange.firstCall.firstArg).to.deep.equal([]);
+    expect(onEventsChange.mock.calls.length).to.equal(1);
+    expect(onEventsChange.mock.calls[0][0]).to.deep.equal([]);
   });
 
   it('should delete a non-recurring event directly without opening the scope dialog', async () => {
@@ -517,8 +517,8 @@ describe('<EventDialogContent open />', () => {
 
     await user.click(screen.getByRole('button', { name: /delete event/i }));
 
-    expect(deleteEventSpy?.calledOnce).to.equal(true);
-    expect(deleteRecurringEventSpy?.called).to.equal(false);
+    expect(deleteEventSpy?.mock.calls.length).to.equal(1);
+    expect(deleteRecurringEventSpy?.mock.calls.length).to.equal(0);
     expect(screen.queryByText(/Apply this change to:/i)).to.equal(null);
   });
 
@@ -673,7 +673,7 @@ describe('<EventDialogContent open />', () => {
   });
 
   it('should handle a resource without an eventColor (fallback to default)', async () => {
-    const onEventsChange = spy();
+    const onEventsChange = vi.fn();
 
     const noColorResource = ResourceBuilder.new().title('NoColor').build();
     const resourcesNoColor: SchedulerResource[] = [workResource, personalResource, noColorResource];
@@ -773,7 +773,7 @@ describe('<EventDialogContent open />', () => {
   });
 
   it('should fallback to "No resource" with default color when the event has no resource', async () => {
-    const onEventsChange = spy();
+    const onEventsChange = vi.fn();
 
     const eventWithoutResource: SchedulerEvent = {
       ...DEFAULT_EVENT,
@@ -815,8 +815,8 @@ describe('<EventDialogContent open />', () => {
 
     await user.click(screen.getByRole('button', { name: /save/i }));
 
-    expect(onEventsChange.calledOnce).to.equal(true);
-    const updated = onEventsChange.firstCall.firstArg[0];
+    expect(onEventsChange.mock.calls.length).to.equal(1);
+    const updated = onEventsChange.mock.calls[0][0][0];
     // A never-assigned event defaults to an empty resource selection, not `undefined`.
     expect(updated.resource).to.deep.equal([]);
   });
@@ -854,7 +854,7 @@ describe('<EventDialogContent open />', () => {
     });
 
     it('should show "No resource" in the combobox after picking the "No resource" option (single-select mode)', async () => {
-      let updateEventSpy: sinon.SinonSpy | undefined;
+      let updateEventSpy: MockInstance | undefined;
 
       const { user } = render(
         <EventCalendarProvider
@@ -888,12 +888,12 @@ describe('<EventDialogContent open />', () => {
 
       // Single mode writes the plain id, or `undefined` once cleared — never `[]` or `null`,
       // which would silently widen the shape for an app that never opted into arrays.
-      expect(updateEventSpy?.calledOnce).to.equal(true);
-      expect(updateEventSpy?.firstCall.args[0].resource).to.equal(undefined);
+      expect(updateEventSpy?.mock.calls.length).to.equal(1);
+      expect(updateEventSpy?.mock.calls[0][0].resource).to.equal(undefined);
     });
 
     it('should block submit and not call `onEventsChange` when `shouldEventRequireResource={true}` and the event has no resource', async () => {
-      const onEventsChange = spy();
+      const onEventsChange = vi.fn();
 
       const { user } = render(
         <EventCalendarProvider
@@ -921,12 +921,12 @@ describe('<EventDialogContent open />', () => {
 
       await user.click(screen.getByRole('button', { name: /save/i }));
 
-      expect(onEventsChange.called).to.equal(false);
+      expect(onEventsChange.mock.calls.length).to.equal(0);
       expect(screen.getByText(/a resource is required/i)).not.to.equal(null);
     });
 
     it('should unblock submit and clear the error after a resource is selected', async () => {
-      const onEventsChange = spy();
+      const onEventsChange = vi.fn();
 
       const { user } = render(
         <EventCalendarProvider
@@ -945,7 +945,7 @@ describe('<EventDialogContent open />', () => {
       );
 
       await user.click(screen.getByRole('button', { name: /save/i }));
-      expect(onEventsChange.called).to.equal(false);
+      expect(onEventsChange.mock.calls.length).to.equal(0);
       expect(screen.getByText(/a resource is required/i)).not.to.equal(null);
 
       await user.click(screen.getByRole('combobox', { name: /resource/i }));
@@ -957,12 +957,12 @@ describe('<EventDialogContent open />', () => {
 
       await user.click(screen.getByRole('button', { name: /save/i }));
 
-      expect(onEventsChange.calledOnce).to.equal(true);
-      expect(onEventsChange.firstCall.firstArg[0].resource).to.deep.equal([workResource.id]);
+      expect(onEventsChange.mock.calls.length).to.equal(1);
+      expect(onEventsChange.mock.calls[0][0][0].resource).to.deep.equal([workResource.id]);
     });
 
     it('should show the range error and the resource error at the same time', async () => {
-      const onEventsChange = spy();
+      const onEventsChange = vi.fn();
 
       const { user } = render(
         <EventCalendarProvider
@@ -986,7 +986,7 @@ describe('<EventDialogContent open />', () => {
       await user.type(screen.getByLabelText(/end date/i), '2025-05-26');
       await user.click(screen.getByRole('button', { name: /save/i }));
 
-      expect(onEventsChange.called).to.equal(false);
+      expect(onEventsChange.mock.calls.length).to.equal(0);
       expect(screen.getDescriptionOf(screen.getByLabelText(/end date/i)).textContent).to.match(
         /end date.*before.*start date/i,
       );
@@ -1001,7 +1001,7 @@ describe('<EventDialogContent open />', () => {
     });
 
     it('should keep validating the general tab fields when submitting from the recurrence tab', async () => {
-      const onEventsChange = spy();
+      const onEventsChange = vi.fn();
 
       const { user } = render(
         <EventCalendarProvider
@@ -1023,12 +1023,12 @@ describe('<EventDialogContent open />', () => {
       await user.click(screen.getByRole('button', { name: /save/i }));
 
       // The general tab is hidden, not unmounted, so its validators still run and block the submit.
-      expect(onEventsChange.called).to.equal(false);
+      expect(onEventsChange.mock.calls.length).to.equal(0);
       expect(screen.getByText(/a resource is required/i)).not.to.equal(null);
     });
 
     it('should block submit on a Calendar creation placeholder when `shouldEventRequireResource={true}` and no resource is selected', async () => {
-      const onEventsChange = spy();
+      const onEventsChange = vi.fn();
       const start = adapter.date('2025-05-26T07:30:00Z', 'default');
       const end = adapter.date('2025-05-26T08:30:00Z', 'default');
 
@@ -1064,7 +1064,7 @@ describe('<EventDialogContent open />', () => {
 
       await user.click(screen.getByRole('button', { name: /save/i }));
 
-      expect(onEventsChange.called).to.equal(false);
+      expect(onEventsChange.mock.calls.length).to.equal(0);
       expect(screen.getByText(/a resource is required/i)).not.to.equal(null);
     });
   });
@@ -1133,8 +1133,8 @@ describe('<EventDialogContent open />', () => {
       await user.keyboard('{Escape}');
       await user.click(screen.getByRole('button', { name: /save/i }));
 
-      expect(createEventSpy?.calledOnce).to.equal(true);
-      expect(createEventSpy.lastCall.firstArg.resource).to.deep.equal([
+      expect(createEventSpy?.mock.calls.length).to.equal(1);
+      expect(createEventSpy.mock.lastCall?.[0].resource).to.deep.equal([
         workResource.id,
         personalResource.id,
       ]);
@@ -1172,8 +1172,8 @@ describe('<EventDialogContent open />', () => {
       await user.click(await screen.findByRole('option', { name: /work/i }));
       await user.click(screen.getByRole('button', { name: /save/i }));
 
-      expect(createEventSpy?.calledOnce).to.equal(true);
-      expect(createEventSpy.lastCall.firstArg.resource).to.equal(workResource.id);
+      expect(createEventSpy?.mock.calls.length).to.equal(1);
+      expect(createEventSpy.mock.lastCall?.[0].resource).to.equal(workResource.id);
     });
 
     it('should infer a multi-select picker for creation when the first event with a resource in the data has an array', async () => {
@@ -1210,8 +1210,8 @@ describe('<EventDialogContent open />', () => {
       await user.keyboard('{Escape}');
       await user.click(screen.getByRole('button', { name: /save/i }));
 
-      expect(createEventSpy?.calledOnce).to.equal(true);
-      expect(createEventSpy.lastCall.firstArg.resource).to.deep.equal([
+      expect(createEventSpy?.mock.calls.length).to.equal(1);
+      expect(createEventSpy.mock.lastCall?.[0].resource).to.deep.equal([
         workResource.id,
         personalResource.id,
       ]);
@@ -1249,8 +1249,8 @@ describe('<EventDialogContent open />', () => {
       await user.click(await screen.findByRole('option', { name: /work/i }));
       await user.click(screen.getByRole('button', { name: /save/i }));
 
-      expect(createEventSpy?.calledOnce).to.equal(true);
-      expect(createEventSpy.lastCall.firstArg.resource).to.equal(workResource.id);
+      expect(createEventSpy?.mock.calls.length).to.equal(1);
+      expect(createEventSpy.mock.lastCall?.[0].resource).to.equal(workResource.id);
     });
 
     it('should edit an event with an array resource as multi-select even when `canHaveMultipleResources` is false', async () => {
@@ -1287,8 +1287,8 @@ describe('<EventDialogContent open />', () => {
       await user.keyboard('{Escape}');
       await user.click(screen.getByRole('button', { name: /save/i }));
 
-      expect(updateEventSpy?.calledOnce).to.equal(true);
-      expect(updateEventSpy.lastCall.firstArg.resource).to.deep.equal([personalResource.id]);
+      expect(updateEventSpy?.mock.calls.length).to.equal(1);
+      expect(updateEventSpy.mock.lastCall?.[0].resource).to.deep.equal([personalResource.id]);
     });
 
     it('should keep every resource of a multi-resource event when saving without touching the resource picker', async () => {
@@ -1338,8 +1338,8 @@ describe('<EventDialogContent open />', () => {
       await user.type(screen.getByLabelText(/event title/i), ' updated');
       await user.click(screen.getByRole('button', { name: /save/i }));
 
-      expect(updateEventSpy?.calledOnce).to.equal(true);
-      expect(updateEventSpy.lastCall.firstArg.resource).to.deep.equal([
+      expect(updateEventSpy?.mock.calls.length).to.equal(1);
+      expect(updateEventSpy.mock.lastCall?.[0].resource).to.deep.equal([
         personalResource.id,
         workResource.id,
       ]);
@@ -1371,8 +1371,8 @@ describe('<EventDialogContent open />', () => {
       await user.click(await screen.findByRole('option', { name: /work/i }));
       await user.click(screen.getByRole('button', { name: /save/i }));
 
-      expect(updateEventSpy?.calledOnce).to.equal(true);
-      expect(updateEventSpy.lastCall.firstArg.resource).to.equal(workResource.id);
+      expect(updateEventSpy?.mock.calls.length).to.equal(1);
+      expect(updateEventSpy.mock.lastCall?.[0].resource).to.equal(workResource.id);
     });
 
     it('should edit an event with resource: [] as multi-select with nothing selected', async () => {
@@ -1414,8 +1414,8 @@ describe('<EventDialogContent open />', () => {
       await user.keyboard('{Escape}');
       await user.click(screen.getByRole('button', { name: /save/i }));
 
-      expect(updateEventSpy?.calledOnce).to.equal(true);
-      expect(updateEventSpy.lastCall.firstArg.resource).to.deep.equal([
+      expect(updateEventSpy?.mock.calls.length).to.equal(1);
+      expect(updateEventSpy.mock.lastCall?.[0].resource).to.deep.equal([
         workResource.id,
         personalResource.id,
       ]);
@@ -1463,8 +1463,8 @@ describe('<EventDialogContent open />', () => {
       await user.keyboard('{Escape}');
       await user.click(screen.getByRole('button', { name: /save/i }));
 
-      expect(updateEventSpy?.calledOnce).to.equal(true);
-      expect(updateEventSpy.lastCall.firstArg.resource).to.deep.equal([
+      expect(updateEventSpy?.mock.calls.length).to.equal(1);
+      expect(updateEventSpy.mock.lastCall?.[0].resource).to.deep.equal([
         workResource.id,
         personalResource.id,
       ]);
@@ -1511,18 +1511,18 @@ describe('<EventDialogContent open />', () => {
         </EventCalendarProvider>,
       );
 
-      const callCountAfterMount = pushSpy!.callCount;
+      const callCountAfterMount = pushSpy!.mock.calls.length;
 
       await user.type(screen.getByLabelText(/event title/i), 'My event');
       await user.type(screen.getByLabelText(/description/i), 'Some details');
 
-      expect(pushSpy!.callCount).to.equal(callCountAfterMount);
+      expect(pushSpy!.mock.calls.length).to.equal(callCountAfterMount);
     });
 
     it('should change surface of the placeholder to day-grid when all-day is changed to true', async () => {
       const start = adapter.date('2025-05-26T07:30:00Z', 'default');
       const end = adapter.date('2025-05-26T08:30:00Z', 'default');
-      const handleSurfaceChange = spy();
+      const handleSurfaceChange = vi.fn();
 
       const creationOccurrence = EventBuilder.new(adapter)
         .id('tmp')
@@ -1555,17 +1555,17 @@ describe('<EventDialogContent open />', () => {
         </EventCalendarProvider>,
       );
 
-      expect(handleSurfaceChange.lastCall?.firstArg).to.equal('time-grid');
+      expect(handleSurfaceChange.mock.lastCall?.[0]).to.equal('time-grid');
 
       await user.click(screen.getByRole('switch', { name: /all day/i }));
 
-      expect(handleSurfaceChange.lastCall?.firstArg).to.equal('day-grid');
+      expect(handleSurfaceChange.mock.lastCall?.[0]).to.equal('day-grid');
     });
 
     it('should change surface of the placeholder to time-grid when all-day is changed to false', async () => {
       const start = adapter.date('2025-05-26T07:30:00Z', 'default');
       const end = adapter.date('2025-05-26T08:30:00Z', 'default');
-      const handleSurfaceChange = spy();
+      const handleSurfaceChange = vi.fn();
 
       const creationOccurrence = EventBuilder.new(adapter)
         .id('tmp')
@@ -1599,17 +1599,17 @@ describe('<EventDialogContent open />', () => {
         </EventCalendarProvider>,
       );
 
-      expect(handleSurfaceChange.lastCall?.firstArg).to.equal('day-grid');
+      expect(handleSurfaceChange.mock.lastCall?.[0]).to.equal('day-grid');
 
       await user.click(screen.getByRole('switch', { name: /all day/i }));
 
-      expect(handleSurfaceChange.lastCall?.firstArg).to.equal('time-grid');
+      expect(handleSurfaceChange.mock.lastCall?.[0]).to.equal('time-grid');
     });
 
     it('should not change surfaceType when all day changed to true and lockSurfaceType=true', async () => {
       const start = adapter.date('2025-05-26T07:30:00Z', 'default');
       const end = adapter.date('2025-05-26T08:30:00Z', 'default');
-      const handleSurfaceChange = spy();
+      const handleSurfaceChange = vi.fn();
 
       const creationOccurrence = EventBuilder.new(adapter)
         .id('tmp')
@@ -1641,17 +1641,17 @@ describe('<EventDialogContent open />', () => {
           />
         </EventCalendarProvider>,
       );
-      expect(handleSurfaceChange.lastCall?.firstArg).to.equal('time-grid');
+      expect(handleSurfaceChange.mock.lastCall?.[0]).to.equal('time-grid');
 
       await user.click(screen.getByRole('switch', { name: /all day/i }));
 
-      expect(handleSurfaceChange.lastCall?.firstArg).to.equal('time-grid');
+      expect(handleSurfaceChange.mock.lastCall?.[0]).to.equal('time-grid');
     });
 
     it('should write the selected resource into the creation placeholder', async () => {
       const start = adapter.date('2025-05-26T07:30:00Z', 'default');
       const end = adapter.date('2025-05-26T08:30:00Z', 'default');
-      const handleResourceIdChange = spy();
+      const handleResourceIdChange = vi.fn();
 
       const creationOccurrence = EventBuilder.new(adapter)
         .id('tmp')
@@ -1684,12 +1684,12 @@ describe('<EventDialogContent open />', () => {
         </EventCalendarProvider>,
       );
 
-      expect(handleResourceIdChange.lastCall?.firstArg).to.equal(null);
+      expect(handleResourceIdChange.mock.lastCall?.[0]).to.equal(null);
 
       await user.click(screen.getByRole('combobox', { name: /resource/i }));
       await user.click(await screen.findByRole('option', { name: /work/i }));
 
-      expect(handleResourceIdChange.lastCall?.firstArg).to.equal(workResource.id);
+      expect(handleResourceIdChange.mock.lastCall?.[0]).to.equal(workResource.id);
     });
 
     it('should call createEvent with metaChanges + computed start/end on Submit', async () => {
@@ -1711,7 +1711,7 @@ describe('<EventDialogContent open />', () => {
         .description('')
         .toOccurrence();
 
-      const onEventsChange = spy();
+      const onEventsChange = vi.fn();
       let createEventSpy;
 
       const { user } = render(
@@ -1747,8 +1747,8 @@ describe('<EventDialogContent open />', () => {
       await user.click(await screen.findByRole('option', { name: /daily/i }));
       await user.click(screen.getByRole('button', { name: /save/i }));
 
-      expect(createEventSpy?.calledOnce).to.equal(true);
-      const payload = createEventSpy.lastCall.firstArg;
+      expect(createEventSpy?.mock.calls.length).to.equal(1);
+      const payload = createEventSpy.mock.lastCall?.[0];
 
       expect(payload.title).to.equal('New title');
       expect(payload.description).to.equal('Some details');
@@ -1780,7 +1780,7 @@ describe('<EventDialogContent open />', () => {
         .title('')
         .toOccurrence();
 
-      const onEventsChange = spy();
+      const onEventsChange = vi.fn();
       let createEventSpy;
 
       const { user } = render(
@@ -1820,8 +1820,8 @@ describe('<EventDialogContent open />', () => {
 
       await user.click(screen.getByRole('button', { name: /save/i }));
 
-      expect(createEventSpy?.calledOnce).to.equal(true);
-      const payload = createEventSpy.lastCall.firstArg;
+      expect(createEventSpy?.mock.calls.length).to.equal(1);
+      const payload = createEventSpy.mock.lastCall?.[0];
 
       // Form inputs are wall-time values.
       // They must be interpreted in displayTimezone, not in 'default'.
@@ -1897,10 +1897,10 @@ describe('<EventDialogContent open />', () => {
         await user.click(screen.getByText(/All events/i));
         await user.click(screen.getByRole('button', { name: /Cancel/i }));
 
-        expect(updateRecurringEventSpy?.calledOnce).to.equal(true);
-        expect(selectRecurringEventScopeSpy?.called).to.equal(true);
-        expect(selectRecurringEventScopeSpy?.lastCall.firstArg).to.equal(null);
-        expect(updateRecurringEventSpy?.callCount).to.equal(1);
+        expect(updateRecurringEventSpy?.mock.calls.length).to.equal(1);
+        expect(selectRecurringEventScopeSpy?.mock.calls.length).to.be.greaterThan(0);
+        expect(selectRecurringEventScopeSpy?.mock.lastCall?.[0]).to.equal(null);
+        expect(updateRecurringEventSpy?.mock.calls.length).to.equal(1);
       });
 
       it("should call updateRecurringEvent with scope 'all' and not include rrule if not modified on Submit", async () => {
@@ -1952,8 +1952,8 @@ describe('<EventDialogContent open />', () => {
         await user.click(screen.getByText(/All events/i));
         await user.click(screen.getByRole('button', { name: /Confirm/i }));
 
-        expect(updateRecurringEventSpy?.calledOnce).to.equal(true);
-        const openPayload = updateRecurringEventSpy.lastCall.firstArg;
+        expect(updateRecurringEventSpy?.mock.calls.length).to.equal(1);
+        const openPayload = updateRecurringEventSpy.mock.lastCall?.[0];
 
         expect(openPayload.changes.id).to.equal(originalRecurringEvent.id);
         expect(openPayload.changes.title).to.equal('Daily standup');
@@ -1967,8 +1967,8 @@ describe('<EventDialogContent open />', () => {
         );
         expect(openPayload.changes).to.not.have.property('rrule');
 
-        expect(selectRecurringEventScopeSpy?.calledOnce).to.equal(true);
-        expect(selectRecurringEventScopeSpy?.lastCall.firstArg).to.equal('all');
+        expect(selectRecurringEventScopeSpy?.mock.calls.length).to.equal(1);
+        expect(selectRecurringEventScopeSpy?.mock.lastCall?.[0]).to.equal('all');
       });
 
       it("should call updateRecurringEvent with scope 'only-this' and include rrule if modified on Submit", async () => {
@@ -2019,8 +2019,8 @@ describe('<EventDialogContent open />', () => {
         await user.click(screen.getByText(/Only this event/i));
         await user.click(screen.getByRole('button', { name: /Confirm/i }));
 
-        expect(updateRecurringEventSpy?.calledOnce).to.equal(true);
-        const openPayload = updateRecurringEventSpy.lastCall.firstArg;
+        expect(updateRecurringEventSpy?.mock.calls.length).to.equal(1);
+        const openPayload = updateRecurringEventSpy.mock.lastCall?.[0];
 
         expect(openPayload.changes.id).to.equal(originalRecurringEvent.id);
         expect(openPayload.changes.title).to.equal(originalRecurringEventOccurrence.title);
@@ -2033,8 +2033,8 @@ describe('<EventDialogContent open />', () => {
           interval: 1,
           byDay: ['WE'],
         });
-        expect(selectRecurringEventScopeSpy?.calledOnce).to.equal(true);
-        expect(selectRecurringEventScopeSpy?.lastCall.firstArg).to.equal('only-this');
+        expect(selectRecurringEventScopeSpy?.mock.calls.length).to.equal(1);
+        expect(selectRecurringEventScopeSpy?.mock.lastCall?.[0]).to.equal('only-this');
       });
 
       it('should call updateRecurringEvent with scope "this-and-following" and send rrule as undefined when "no repeat" is selected on Submit', async () => {
@@ -2085,14 +2085,14 @@ describe('<EventDialogContent open />', () => {
         await user.click(screen.getByText(/This and following events/i));
         await user.click(screen.getByRole('button', { name: /Confirm/i }));
 
-        expect(updateRecurringEventSpy?.calledOnce).to.equal(true);
-        const openPayload = updateRecurringEventSpy.lastCall.firstArg;
+        expect(updateRecurringEventSpy?.mock.calls.length).to.equal(1);
+        const openPayload = updateRecurringEventSpy.mock.lastCall?.[0];
 
         expect(openPayload.changes.id).to.equal(originalRecurringEvent.id);
         expect(openPayload.changes.rrule).to.equal(undefined);
 
-        expect(selectRecurringEventScopeSpy?.calledOnce).to.equal(true);
-        expect(selectRecurringEventScopeSpy?.lastCall.firstArg).to.equal('this-and-following');
+        expect(selectRecurringEventScopeSpy?.mock.calls.length).to.equal(1);
+        expect(selectRecurringEventScopeSpy?.mock.lastCall?.[0]).to.equal('this-and-following');
       });
 
       describe('Deletion', () => {
@@ -2133,15 +2133,15 @@ describe('<EventDialogContent open />', () => {
           await user.click(screen.getByRole('button', { name: /delete event/i }));
 
           await screen.findByText(/Apply this change to:/i);
-          expect(deleteRecurringEventSpy?.calledOnce).to.equal(true);
-          expect(deleteRecurringEventSpy?.lastCall.firstArg.eventId).to.equal(
+          expect(deleteRecurringEventSpy?.mock.calls.length).to.equal(1);
+          expect(deleteRecurringEventSpy?.mock.lastCall?.[0].eventId).to.equal(
             originalRecurringEvent.id,
           );
-          expect(deleteEventSpy?.called).to.equal(false);
+          expect(deleteEventSpy?.mock.calls.length).to.equal(0);
         });
 
         it('should not delete anything if the user cancels the scope dialog', async () => {
-          const onEventsChange = spy();
+          const onEventsChange = vi.fn();
           let selectRecurringEventScopeSpy;
 
           const { user } = render(
@@ -2174,12 +2174,12 @@ describe('<EventDialogContent open />', () => {
           await user.click(screen.getByText(/All events/i));
           await user.click(screen.getByRole('button', { name: /Cancel/i }));
 
-          expect(selectRecurringEventScopeSpy?.lastCall.firstArg).to.equal(null);
-          expect(onEventsChange.called).to.equal(false);
+          expect(selectRecurringEventScopeSpy?.mock.lastCall?.[0]).to.equal(null);
+          expect(onEventsChange.mock.calls.length).to.equal(0);
         });
 
         it("should delete the whole series with scope 'all' on Confirm", async () => {
-          const onEventsChange = spy();
+          const onEventsChange = vi.fn();
 
           const { user } = render(
             <EventCalendarProvider
@@ -2203,12 +2203,12 @@ describe('<EventDialogContent open />', () => {
           await user.click(screen.getByText(/All events/i));
           await user.click(screen.getByRole('button', { name: /Confirm/i }));
 
-          expect(onEventsChange.calledOnce).to.equal(true);
-          expect(onEventsChange.lastCall.firstArg).to.deep.equal([]);
+          expect(onEventsChange.mock.calls.length).to.equal(1);
+          expect(onEventsChange.mock.lastCall?.[0]).to.deep.equal([]);
         });
 
         it("should delete only the selected occurrence with scope 'only-this' on Confirm", async () => {
-          const onEventsChange = spy();
+          const onEventsChange = vi.fn();
 
           const { user } = render(
             <EventCalendarProvider
@@ -2232,14 +2232,14 @@ describe('<EventDialogContent open />', () => {
           await user.click(screen.getByText(/Only this event/i));
           await user.click(screen.getByRole('button', { name: /Confirm/i }));
 
-          expect(onEventsChange.calledOnce).to.equal(true);
-          const updatedEvents = onEventsChange.lastCall.firstArg;
+          expect(onEventsChange.mock.calls.length).to.equal(1);
+          const updatedEvents = onEventsChange.mock.lastCall?.[0];
           expect(updatedEvents).to.have.length(1);
           expect(updatedEvents[0].exDates).to.have.length(1);
         });
 
         it("should truncate the series with scope 'this-and-following' on Confirm", async () => {
-          const onEventsChange = spy();
+          const onEventsChange = vi.fn();
           const laterOccurrence = EventBuilder.new(adapter)
             .id(originalRecurringEvent.id)
             .title(originalRecurringEvent.title)
@@ -2266,8 +2266,8 @@ describe('<EventDialogContent open />', () => {
           await user.click(screen.getByText(/This and following events/i));
           await user.click(screen.getByRole('button', { name: /Confirm/i }));
 
-          expect(onEventsChange.calledOnce).to.equal(true);
-          const updatedEvents = onEventsChange.lastCall.firstArg;
+          expect(onEventsChange.mock.calls.length).to.equal(1);
+          const updatedEvents = onEventsChange.mock.lastCall?.[0];
           expect(updatedEvents).to.have.length(1);
           expect(updatedEvents[0].rrule.until).not.to.equal(undefined);
         });
@@ -2379,7 +2379,7 @@ describe('<EventDialogContent open />', () => {
         });
 
         it('should submit custom recurrence with Ends: after', async () => {
-          const onEventsChange = spy();
+          const onEventsChange = vi.fn();
 
           const { user } = render(
             <EventCalendarProvider
@@ -2419,8 +2419,8 @@ describe('<EventDialogContent open />', () => {
 
           await user.click(screen.getByRole('button', { name: /save/i }));
 
-          expect(onEventsChange.calledOnce).to.equal(true);
-          const updated = onEventsChange.firstCall.firstArg[0];
+          expect(onEventsChange.mock.calls.length).to.equal(1);
+          const updated = onEventsChange.mock.calls[0][0][0];
 
           expect(updated.rrule).to.deep.equal({
             freq: 'WEEKLY',
@@ -2433,7 +2433,7 @@ describe('<EventDialogContent open />', () => {
         });
 
         it('should submit custom recurrence with Ends: never', async () => {
-          const onEventsChange = spy();
+          const onEventsChange = vi.fn();
 
           const { user } = render(
             <EventCalendarProvider
@@ -2470,8 +2470,8 @@ describe('<EventDialogContent open />', () => {
 
           await user.click(screen.getByRole('button', { name: /save/i }));
 
-          expect(onEventsChange.calledOnce).to.equal(true);
-          const updated = onEventsChange.firstCall.firstArg[0];
+          expect(onEventsChange.mock.calls.length).to.equal(1);
+          const updated = onEventsChange.mock.calls[0][0][0];
 
           // DEFAULT_EVENT is 2025-05-26, so byMonthDay defaults to [26]
           expect(updated.rrule).to.deep.equal({
@@ -2483,7 +2483,7 @@ describe('<EventDialogContent open />', () => {
         });
 
         it('should submit custom recurrence with Ends: until and selected date', async () => {
-          const onEventsChange = spy();
+          const onEventsChange = vi.fn();
 
           const { user } = render(
             <EventCalendarProvider
@@ -2522,8 +2522,8 @@ describe('<EventDialogContent open />', () => {
 
           await user.click(screen.getByRole('button', { name: /save/i }));
 
-          expect(onEventsChange.calledOnce).to.equal(true);
-          const updated = onEventsChange.firstCall.firstArg[0];
+          expect(onEventsChange.mock.calls.length).to.equal(1);
+          const updated = onEventsChange.mock.calls[0][0][0];
 
           expect(updated.rrule).to.deep.include({ freq: 'YEARLY', interval: 3 });
           expect(updated.rrule?.count ?? undefined).to.equal(undefined);
@@ -2531,7 +2531,7 @@ describe('<EventDialogContent open />', () => {
         });
 
         it('should block saving a custom recurrence with Ends: until and no date', async () => {
-          const onEventsChange = spy();
+          const onEventsChange = vi.fn();
 
           const { user } = render(
             <EventCalendarProvider
@@ -2555,7 +2555,7 @@ describe('<EventDialogContent open />', () => {
 
           await user.click(screen.getByRole('button', { name: /save/i }));
 
-          expect(onEventsChange.called).to.equal(false);
+          expect(onEventsChange.mock.calls.length).to.equal(0);
           // The failing field lives in the Recurrence tab, so it must stay visible.
           expect(screen.getByRole('tabpanel', { name: /recurrence/i })).not.to.have.attribute(
             'hidden',
@@ -2563,7 +2563,7 @@ describe('<EventDialogContent open />', () => {
         });
 
         it('should block a programmatic submit when the Ends until date is invalid', async () => {
-          const onEventsChange = spy();
+          const onEventsChange = vi.fn();
 
           const { user } = render(
             <EventCalendarProvider
@@ -2589,14 +2589,14 @@ describe('<EventDialogContent open />', () => {
           fireEvent.submit(screen.getByRole('button', { name: /save/i }).closest('form')!);
           await waitFor(() => expect(dateInput).to.have.attribute('aria-invalid', 'true'));
 
-          expect(onEventsChange.called).to.equal(false);
+          expect(onEventsChange.mock.calls.length).to.equal(0);
           expect(screen.getByRole('tabpanel', { name: /recurrence/i })).not.to.have.attribute(
             'hidden',
           );
         });
 
         it('should keep the Recurrence tab visible when a recurrence control is natively invalid', async () => {
-          const onEventsChange = spy();
+          const onEventsChange = vi.fn();
 
           const { user } = render(
             <EventCalendarProvider
@@ -2621,14 +2621,14 @@ describe('<EventDialogContent open />', () => {
 
           await user.click(screen.getByRole('button', { name: /save/i }));
 
-          expect(onEventsChange.called).to.equal(false);
+          expect(onEventsChange.mock.calls.length).to.equal(0);
           expect(screen.getByRole('tabpanel', { name: /recurrence/i })).not.to.have.attribute(
             'hidden',
           );
         });
 
         it('should submit custom weekly with selected weekdays', async () => {
-          const onEventsChange = spy();
+          const onEventsChange = vi.fn();
 
           const { user } = render(
             <EventCalendarProvider
@@ -2656,8 +2656,8 @@ describe('<EventDialogContent open />', () => {
 
           await user.click(screen.getByRole('button', { name: /save/i }));
 
-          expect(onEventsChange.calledOnce).to.equal(true);
-          const updated = onEventsChange.firstCall.firstArg[0];
+          expect(onEventsChange.mock.calls.length).to.equal(1);
+          const updated = onEventsChange.mock.calls[0][0][0];
 
           expect(updated.rrule).to.deep.equal({
             freq: 'WEEKLY',
@@ -2668,7 +2668,7 @@ describe('<EventDialogContent open />', () => {
         });
 
         it('should submit custom monthly with "day of month" option', async () => {
-          const onEventsChange = spy();
+          const onEventsChange = vi.fn();
 
           const { user } = render(
             <EventCalendarProvider
@@ -2697,8 +2697,8 @@ describe('<EventDialogContent open />', () => {
 
           await user.click(screen.getByRole('button', { name: /save/i }));
 
-          expect(onEventsChange.calledOnce).to.equal(true);
-          const updated = onEventsChange.firstCall.firstArg[0];
+          expect(onEventsChange.mock.calls.length).to.equal(1);
+          const updated = onEventsChange.mock.calls[0][0][0];
 
           expect(updated.rrule).to.deep.equal({
             freq: 'MONTHLY',
@@ -2709,7 +2709,7 @@ describe('<EventDialogContent open />', () => {
         });
 
         it('should submit custom monthly with "ordinal weekday" option', async () => {
-          const onEventsChange = spy();
+          const onEventsChange = vi.fn();
 
           const { user } = render(
             <EventCalendarProvider
@@ -2736,8 +2736,8 @@ describe('<EventDialogContent open />', () => {
 
           await user.click(screen.getByRole('button', { name: /save/i }));
 
-          expect(onEventsChange.calledOnce).to.equal(true);
-          const updated = onEventsChange.firstCall.firstArg[0];
+          expect(onEventsChange.mock.calls.length).to.equal(1);
+          const updated = onEventsChange.mock.calls[0][0][0];
 
           expect(updated.rrule).to.deep.equal({
             freq: 'MONTHLY',
@@ -2773,7 +2773,7 @@ describe('<EventDialogContent open />', () => {
         });
 
         it('should pre-fill WEEKLY preset with the event weekday code', async () => {
-          const onEventsChange = spy();
+          const onEventsChange = vi.fn();
 
           // DEFAULT_EVENT falls on Monday 2025-05-26
           const { user } = render(
@@ -2792,15 +2792,15 @@ describe('<EventDialogContent open />', () => {
           await user.click(await screen.findByRole('option', { name: /repeats weekly/i }));
           await user.click(screen.getByRole('button', { name: /save/i }));
 
-          expect(onEventsChange.calledOnce).to.equal(true);
-          const updated = onEventsChange.firstCall.firstArg[0];
+          expect(onEventsChange.mock.calls.length).to.equal(1);
+          const updated = onEventsChange.mock.calls[0][0][0];
 
           // WEEKLY preset must pre-fill byDay with the event's weekday (Monday → 'MO')
           expect(updated.rrule).to.deep.equal({ freq: 'WEEKLY', interval: 1, byDay: ['MO'] });
         });
 
         it('should pre-fill MONTHLY preset with the event day-of-month', async () => {
-          const onEventsChange = spy();
+          const onEventsChange = vi.fn();
 
           // DEFAULT_EVENT is on the 26th → byMonthDay should be [26]
           const { user } = render(
@@ -2819,8 +2819,8 @@ describe('<EventDialogContent open />', () => {
           await user.click(await screen.findByRole('option', { name: /repeats monthly/i }));
           await user.click(screen.getByRole('button', { name: /save/i }));
 
-          expect(onEventsChange.calledOnce).to.equal(true);
-          const updated = onEventsChange.firstCall.firstArg[0];
+          expect(onEventsChange.mock.calls.length).to.equal(1);
+          const updated = onEventsChange.mock.calls[0][0][0];
 
           // MONTHLY preset must never produce an empty byMonthDay array
           expect(updated.rrule).to.deep.equal({
@@ -2875,7 +2875,7 @@ describe('<EventDialogContent open />', () => {
         });
 
         it('should not allow unchecking the last selected weekday in WEEKLY mode', async () => {
-          const onEventsChange = spy();
+          const onEventsChange = vi.fn();
 
           const { user } = render(
             <EventCalendarProvider
@@ -2904,13 +2904,13 @@ describe('<EventDialogContent open />', () => {
 
           await user.click(screen.getByRole('button', { name: /save/i }));
 
-          expect(onEventsChange.calledOnce).to.equal(true);
-          const updated = onEventsChange.firstCall.firstArg[0];
+          expect(onEventsChange.mock.calls.length).to.equal(1);
+          const updated = onEventsChange.mock.calls[0][0][0];
           expect(updated.rrule.byDay).to.deep.equal(['MO']);
         });
 
         it('should pre-fill byDay with the event weekday when switching frequency to WEEKLY', async () => {
-          const onEventsChange = spy();
+          const onEventsChange = vi.fn();
 
           const { user } = render(
             <EventCalendarProvider
@@ -2940,8 +2940,8 @@ describe('<EventDialogContent open />', () => {
 
           await user.click(screen.getByRole('button', { name: /save/i }));
 
-          expect(onEventsChange.calledOnce).to.equal(true);
-          const updated = onEventsChange.firstCall.firstArg[0];
+          expect(onEventsChange.mock.calls.length).to.equal(1);
+          const updated = onEventsChange.mock.calls[0][0][0];
           // byDay must be pre-filled with the event's weekday (Monday → 'MO'), not left empty
           expect(updated.rrule.byDay).to.deep.equal(['MO']);
         });
@@ -2995,8 +2995,8 @@ describe('<EventDialogContent open />', () => {
         await user.keyboard('{Escape}');
         await user.click(screen.getByRole('button', { name: /save/i }));
 
-        expect(updateEventSpy?.calledOnce).to.equal(true);
-        const payload = updateEventSpy.lastCall.firstArg;
+        expect(updateEventSpy?.mock.calls.length).to.equal(1);
+        const payload = updateEventSpy.mock.lastCall?.[0];
 
         expect(payload.id).to.equal(nonRecurringEvent.id);
         expect(payload.title).to.equal('Task updated');
@@ -3038,8 +3038,8 @@ describe('<EventDialogContent open />', () => {
         await user.click(await screen.findByRole('option', { name: /repeats daily/i }));
         await user.click(screen.getByRole('button', { name: /save/i }));
 
-        expect(updateEventSpy?.calledOnce).to.equal(true);
-        const payload = updateEventSpy.lastCall.firstArg;
+        expect(updateEventSpy?.mock.calls.length).to.equal(1);
+        const payload = updateEventSpy.mock.lastCall?.[0];
 
         expect(payload.id).to.equal(nonRecurringEvent.id);
         expect(payload.rrule).to.deep.equal({
@@ -3085,7 +3085,7 @@ describe('<EventDialogContent open />', () => {
         .toOccurrence();
 
       it('should preserve custom data when editing a non-recurring event', async () => {
-        const onEventsChange = spy();
+        const onEventsChange = vi.fn();
         const { user } = render(
           <EventCalendarProvider
             events={[nonRecurringEventWithCustomData]}
@@ -3103,8 +3103,8 @@ describe('<EventDialogContent open />', () => {
         await user.type(screen.getByLabelText(/event title/i), ' updated');
         await user.click(screen.getByRole('button', { name: /save/i }));
 
-        expect(onEventsChange.calledOnce).to.equal(true);
-        const updated = onEventsChange.lastCall.firstArg.find(
+        expect(onEventsChange.mock.calls.length).to.equal(1);
+        const updated = onEventsChange.mock.lastCall?.[0].find(
           (event) => event.id === nonRecurringEventWithCustomData.id,
         );
         expect(updated.title).to.equal('Task updated');
@@ -3112,7 +3112,7 @@ describe('<EventDialogContent open />', () => {
       });
 
       it("should preserve custom data when editing a recurring event with scope 'all'", async () => {
-        const onEventsChange = spy();
+        const onEventsChange = vi.fn();
         const { user } = render(
           <EventCalendarProvider
             events={[recurringEventWithCustomData]}
@@ -3136,14 +3136,14 @@ describe('<EventDialogContent open />', () => {
         await user.click(screen.getByText(/All events/i));
         await user.click(screen.getByRole('button', { name: /Confirm/i }));
 
-        const updated = onEventsChange.lastCall.firstArg.find(
+        const updated = onEventsChange.mock.lastCall?.[0].find(
           (event) => event.id === recurringEventWithCustomData.id,
         );
         expect(updated.customField).to.equal('preserve-me');
       });
 
       it("should preserve custom data on the new event with scope 'only-this'", async () => {
-        const onEventsChange = spy();
+        const onEventsChange = vi.fn();
         const { user } = render(
           <EventCalendarProvider
             events={[recurringEventWithCustomData]}
@@ -3167,7 +3167,7 @@ describe('<EventDialogContent open />', () => {
         await user.click(screen.getByText(/Only this event/i));
         await user.click(screen.getByRole('button', { name: /Confirm/i }));
 
-        const created = onEventsChange.lastCall.firstArg.find(
+        const created = onEventsChange.mock.lastCall?.[0].find(
           (event) => event.extractedFromId === recurringEventWithCustomData.id,
         );
         expect(created).to.not.equal(undefined);
@@ -3175,7 +3175,7 @@ describe('<EventDialogContent open />', () => {
       });
 
       it("should preserve custom data on the new event with scope 'this-and-following'", async () => {
-        const onEventsChange = spy();
+        const onEventsChange = vi.fn();
         const { user } = render(
           <EventCalendarProvider
             events={[recurringEventWithCustomData]}
@@ -3199,7 +3199,7 @@ describe('<EventDialogContent open />', () => {
         await user.click(screen.getByText(/This and following events/i));
         await user.click(screen.getByRole('button', { name: /Confirm/i }));
 
-        const created = onEventsChange.lastCall.firstArg.find(
+        const created = onEventsChange.mock.lastCall?.[0].find(
           (event) => event.extractedFromId === recurringEventWithCustomData.id,
         );
         expect(created).to.not.equal(undefined);
@@ -3249,7 +3249,7 @@ describe('<EventDialogContent open />', () => {
         function renderWithCustomFieldSlot(
           event: SchedulerEvent,
           occurrence: ReturnType<typeof EventBuilder.prototype.toOccurrence>,
-          onEventsChange: ReturnType<typeof spy>,
+          onEventsChange: Mock,
           onSpyReady: (sp: any) => void,
           // Recurring saves go through `updateRecurringEvent`, non-recurring through `updateEvent`.
           method: 'updateEvent' | 'updateRecurringEvent' = 'updateEvent',
@@ -3280,7 +3280,7 @@ describe('<EventDialogContent open />', () => {
         }
 
         it('should save a custom field edited through useEventDialogFormField', async () => {
-          const onEventsChange = spy();
+          const onEventsChange = vi.fn();
           let updateEventSpy;
           const { user } = renderWithCustomFieldSlot(
             nonRecurringEventWithCustomData,
@@ -3296,15 +3296,15 @@ describe('<EventDialogContent open />', () => {
 
           await editCustomFieldAndSave(user);
 
-          expect(onEventsChange.calledOnce).to.equal(true);
-          const updated = onEventsChange.lastCall.firstArg.find(
+          expect(onEventsChange.mock.calls.length).to.equal(1);
+          const updated = onEventsChange.mock.lastCall?.[0].find(
             (event) => event.id === nonRecurringEventWithCustomData.id,
           );
           expect(updated.customField).to.equal('edited');
 
           // Only the edited custom field enters the changes payload — an untouched
           // seeded field keeps resolving against the live model instead.
-          const changes = updateEventSpy!.lastCall.firstArg;
+          const changes = updateEventSpy!.mock.lastCall?.[0];
           expect(changes.customField).to.equal('edited');
           expect(changes).not.to.have.property('untouchedField');
           expect(updated.untouchedField).to.equal('keep-me');
@@ -3335,7 +3335,7 @@ describe('<EventDialogContent open />', () => {
 
         scopeScenarios.forEach(({ scope, optionText, findSavedEvent }) => {
           it(`should save a custom field edited through the slot with scope '${scope}'`, async () => {
-            const onEventsChange = spy();
+            const onEventsChange = vi.fn();
             let updateEventSpy;
             const { user } = renderWithCustomFieldSlot(
               recurringEventWithUntouchedData,
@@ -3353,11 +3353,11 @@ describe('<EventDialogContent open />', () => {
             await user.click(screen.getByText(optionText));
             await user.click(screen.getByRole('button', { name: /Confirm/i }));
 
-            const saved = findSavedEvent(onEventsChange.lastCall.firstArg);
+            const saved = findSavedEvent(onEventsChange.mock.lastCall?.[0]);
             expect(saved).to.not.equal(undefined);
             expect(saved.customField).to.equal('edited');
             expect(saved.untouchedField).to.equal('keep-me');
-            const { changes } = updateEventSpy!.lastCall.firstArg;
+            const { changes } = updateEventSpy?.mock.lastCall?.[0] ?? {};
             expect(changes.customField).to.equal('edited');
             expect(changes).not.to.have.property('untouchedField');
           });
@@ -3365,7 +3365,7 @@ describe('<EventDialogContent open />', () => {
       });
 
       it('should use the latest custom data when it changes while the scope dialog is open', async () => {
-        const onEventsChange = spy();
+        const onEventsChange = vi.fn();
         const eventBefore = {
           ...recurringEventWithCustomData,
           customField: 'before',
@@ -3404,14 +3404,14 @@ describe('<EventDialogContent open />', () => {
         await user.click(screen.getByText(/All events/i));
         await user.click(screen.getByRole('button', { name: /Confirm/i }));
 
-        const updated = onEventsChange.lastCall.firstArg.find(
+        const updated = onEventsChange.mock.lastCall?.[0].find(
           (event) => event.id === recurringEventWithCustomData.id,
         );
         expect(updated.customField).to.equal('after');
       });
 
       it('should carry the latest custom data onto the new event when it changes while the scope dialog is open', async () => {
-        const onEventsChange = spy();
+        const onEventsChange = vi.fn();
         const eventBefore = {
           ...recurringEventWithCustomData,
           customField: 'before',
@@ -3450,7 +3450,7 @@ describe('<EventDialogContent open />', () => {
         await user.click(screen.getByText(/Only this event/i));
         await user.click(screen.getByRole('button', { name: /Confirm/i }));
 
-        const created = onEventsChange.lastCall.firstArg.find(
+        const created = onEventsChange.mock.lastCall?.[0].find(
           (event) => event.extractedFromId === recurringEventWithCustomData.id,
         );
         expect(created.customField).to.equal('after');
@@ -3520,7 +3520,7 @@ describe('<EventDialogContent open />', () => {
 
   describe('editingOccurrence state', () => {
     it('should leave editingOccurrence null when the content is rendered directly', () => {
-      const handleEditingChange = spy();
+      const handleEditingChange = vi.fn();
 
       render(
         <EventCalendarProvider events={[DEFAULT_EVENT]} resources={resources}>
@@ -3534,11 +3534,11 @@ describe('<EventDialogContent open />', () => {
       );
 
       // `onOpen` sets editingOccurrence; rendering content directly (no trigger flow) leaves it null.
-      expect(handleEditingChange.lastCall?.firstArg).to.equal(null);
+      expect(handleEditingChange.mock.lastCall?.[0]).to.equal(null);
     });
 
     it('should reflect the edited occurrence id while an event is being edited', async () => {
-      const handleEditingChange = spy();
+      const handleEditingChange = vi.fn();
 
       render(
         <EventCalendarProvider events={[DEFAULT_EVENT]} resources={resources}>
@@ -3556,7 +3556,7 @@ describe('<EventDialogContent open />', () => {
       );
 
       // After `startEditing`, it should be the event ID.
-      expect(handleEditingChange.lastCall?.firstArg).to.equal(DEFAULT_EVENT.id);
+      expect(handleEditingChange.mock.lastCall?.[0]).to.equal(DEFAULT_EVENT.id);
     });
 
     it('should expose startEditing on the store', () => {

--- a/packages/x-scheduler-premium/src/event-calendar-premium/tests/EventDialog.test.tsx
+++ b/packages/x-scheduler-premium/src/event-calendar-premium/tests/EventDialog.test.tsx
@@ -1900,7 +1900,6 @@ describe('<EventDialogContent open />', () => {
         expect(updateRecurringEventSpy?.mock.calls.length).to.equal(1);
         expect(selectRecurringEventScopeSpy?.mock.calls.length).to.be.greaterThan(0);
         expect(selectRecurringEventScopeSpy?.mock.lastCall?.[0]).to.equal(null);
-        expect(updateRecurringEventSpy?.mock.calls.length).to.equal(1);
       });
 
       it("should call updateRecurringEvent with scope 'all' and not include rrule if not modified on Submit", async () => {
@@ -3357,6 +3356,7 @@ describe('<EventDialogContent open />', () => {
             expect(saved).to.not.equal(undefined);
             expect(saved.customField).to.equal('edited');
             expect(saved.untouchedField).to.equal('keep-me');
+            expect(updateEventSpy?.mock.calls.length).to.equal(1);
             const { changes } = updateEventSpy?.mock.lastCall?.[0] ?? {};
             expect(changes.customField).to.equal('edited');
             expect(changes).not.to.have.property('untouchedField');

--- a/packages/x-scheduler-premium/src/event-timeline-premium/tests/EventDialog.test.tsx
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/tests/EventDialog.test.tsx
@@ -22,6 +22,7 @@ import {
 } from '@mui/x-scheduler/internals';
 import { eventTimelinePremiumClasses } from '@mui/x-scheduler-premium/event-timeline-premium';
 import { describe, it, expect } from 'vitest';
+import type { MockInstance } from 'vitest';
 import { PREMIUM_EVENT_DIALOG_OPTIONAL_RENDERERS } from '../../internals/eventDialogOptionalRenderers';
 
 const editingStyledContextValue = {
@@ -71,7 +72,7 @@ describe('<EventDialogContent /> — Event Timeline Premium creation', () => {
   function renderCreationDialog(options: {
     rowResource: SchedulerResource;
     eventCreation?: Partial<SchedulerEventCreationConfig> | boolean;
-    onCreateEventSpyReady: (spy: sinon.SinonSpy) => void;
+    onCreateEventSpyReady: (spy: MockInstance) => void;
   }) {
     const { rowResource, eventCreation, onCreateEventSpyReady } = options;
 
@@ -125,7 +126,7 @@ describe('<EventDialogContent /> — Event Timeline Premium creation', () => {
   }
 
   it("should seed the picker as multi-select with the row's resource when `canHaveMultipleResources` is true, and let a second resource be added", async () => {
-    let createEventSpy: sinon.SinonSpy | undefined;
+    let createEventSpy: MockInstance | undefined;
     const { user, currentDialog } = renderCreationDialog({
       rowResource: engineering,
       eventCreation: { canHaveMultipleResources: true },
@@ -144,12 +145,12 @@ describe('<EventDialogContent /> — Event Timeline Premium creation', () => {
     await user.keyboard('{Escape}');
     await user.click(currentDialog.getByRole('button', { name: /save/i }));
 
-    expect(createEventSpy?.calledOnce).to.equal(true);
-    expect(createEventSpy?.firstCall.args[0].resource).to.deep.equal([engineering.id, design.id]);
+    expect(createEventSpy?.mock.calls.length).to.equal(1);
+    expect(createEventSpy?.mock.calls[0][0].resource).to.deep.equal([engineering.id, design.id]);
   });
 
   it("should seed the picker as single-select with the row's resource when `canHaveMultipleResources` is false, and picking another resource replaces it", async () => {
-    let createEventSpy: sinon.SinonSpy | undefined;
+    let createEventSpy: MockInstance | undefined;
     const { user, currentDialog } = renderCreationDialog({
       rowResource: engineering,
       eventCreation: { canHaveMultipleResources: false },
@@ -167,7 +168,7 @@ describe('<EventDialogContent /> — Event Timeline Premium creation', () => {
     await user.click(await screen.findByRole('option', { name: /design/i }));
     await user.click(currentDialog.getByRole('button', { name: /save/i }));
 
-    expect(createEventSpy?.calledOnce).to.equal(true);
-    expect(createEventSpy?.firstCall.args[0].resource).to.equal(design.id);
+    expect(createEventSpy?.mock.calls.length).to.equal(1);
+    expect(createEventSpy?.mock.calls[0][0].resource).to.equal(design.id);
   });
 });

--- a/test/utils/helperFn.ts
+++ b/test/utils/helperFn.ts
@@ -1,4 +1,4 @@
-import { spy } from 'sinon';
+import { vi } from 'vitest';
 import { act, screen, waitFor } from '@mui/internal-test-utils';
 import { gridClasses, GridRowId } from '@mui/x-data-grid';
 import { unwrapPrivateAPI } from '@mui/x-data-grid/internals';
@@ -62,7 +62,7 @@ export function spyApi(api: GridApiCommon, methodName: string) {
   const privateApi = unwrapPrivateAPI(api);
   const method = privateApi[methodKey];
 
-  const spyFn = spy((...args: any[]) => {
+  const spyFn = vi.fn((...args: any[]) => {
     return spyFn.target(...args);
   }) as any;
   spyFn.spying = true;

--- a/test/utils/helperFn.ts
+++ b/test/utils/helperFn.ts
@@ -1,4 +1,5 @@
 import { vi } from 'vitest';
+import type { Mock } from 'vitest';
 import { act, screen, waitFor } from '@mui/internal-test-utils';
 import { gridClasses, GridRowId } from '@mui/x-data-grid';
 import { unwrapPrivateAPI } from '@mui/x-data-grid/internals';
@@ -57,19 +58,25 @@ export async function actSleep(duration: number) {
   });
 }
 
-export function spyApi(api: GridApiCommon, methodName: string) {
+type ApiMethod = (...args: any[]) => any;
+
+/** The recording wrapper `spyApi` swaps onto the API, plus the fields the grid reads back. */
+export type SpiedApiMethod = Mock<ApiMethod> & { spying: boolean; target: ApiMethod };
+
+export function spyApi(api: GridApiCommon, methodName: string): SpiedApiMethod {
   const methodKey = methodName as keyof GridApiCommon;
   const privateApi = unwrapPrivateAPI(api);
-  const method = privateApi[methodKey];
+  const method = privateApi[methodKey] as ApiMethod;
 
-  const spyFn = vi.fn((...args: any[]) => {
-    return spyFn.target(...args);
-  }) as any;
-  spyFn.spying = true;
-  spyFn.target = method;
+  const spyFn: SpiedApiMethod = Object.assign(
+    vi.fn((...args: any[]) => spyFn.target(...args)),
+    { spying: true, target: method },
+  );
 
-  api[methodKey] = spyFn;
-  privateApi[methodKey] = spyFn;
+  // Indexing with `keyof GridApiCommon` collapses to an intersection of every method
+  // signature, so the write itself needs the escape hatch, not the spy.
+  Object.assign(api, { [methodKey]: spyFn });
+  Object.assign(privateApi, { [methodKey]: spyFn });
 
   return spyFn;
 }

--- a/test/utils/scheduler/StoreSpy.tsx
+++ b/test/utils/scheduler/StoreSpy.tsx
@@ -27,6 +27,8 @@ export function StoreSpy<T>({
     spyRef.current = sp;
     onSpyReady(sp);
 
+    // `mockRestore` also clears the recorded calls, unlike Sinon's `restore`, so a spy
+    // must stay mounted for as long as anything asserts on it.
     return () => spyRef.current?.mockRestore();
   }, [store, method, onSpyReady]);
 

--- a/test/utils/scheduler/StoreSpy.tsx
+++ b/test/utils/scheduler/StoreSpy.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { spy as sinonSpy, SinonSpy } from 'sinon';
+import { vi } from 'vitest';
+import type { MockInstance } from 'vitest';
 
 export function StoreSpy<T>({
   Context,
@@ -8,25 +9,25 @@ export function StoreSpy<T>({
 }: {
   Context: React.Context<T | null>;
   method: Extract<keyof T, string>;
-  onSpyReady: (sp: SinonSpy) => void;
+  onSpyReady: (sp: MockInstance) => void;
 }) {
   const store = React.useContext(Context);
   if (!store) {
     throw new Error('StoreSpy must be used inside the matching Provider');
   }
 
-  const spyRef = React.useRef<SinonSpy | null>(null);
+  const spyRef = React.useRef<MockInstance | null>(null);
 
   React.useEffect(() => {
     const fn = (store as any)[method];
     if (typeof fn !== 'function') {
       throw new Error(`Method "${String(method)}" not found or is not a function on store`);
     }
-    const sp = sinonSpy(store as any, method as any);
+    const sp = vi.spyOn(store as any, method as any);
     spyRef.current = sp;
     onSpyReady(sp);
 
-    return () => spyRef.current?.restore?.();
+    return () => spyRef.current?.mockRestore?.();
   }, [store, method, onSpyReady]);
 
   return null;

--- a/test/utils/scheduler/StoreSpy.tsx
+++ b/test/utils/scheduler/StoreSpy.tsx
@@ -27,7 +27,7 @@ export function StoreSpy<T>({
     spyRef.current = sp;
     onSpyReady(sp);
 
-    return () => spyRef.current?.mockRestore?.();
+    return () => spyRef.current?.mockRestore();
   }, [store, method, onSpyReady]);
 
   return null;


### PR DESCRIPTION
Fourth step away from Sinon, following #23443, #23460 and #23464.

The previous steps took the spies each test file owns. This one takes the two shared helpers, and every call site that reads what they return. Those had to move together: a helper cannot change its return type without every consumer changing its accessors in the same commit.

Sinon goes from 37 files to 29. It stays a dependency, and `test/setupVitest.ts` keeps calling `sinon.restore()`.

## The two helpers

**`spyApi`** (`test/utils/helperFn.ts`) wraps a Grid API method with a recording function and swaps it onto the api object. It never used the spy-on-object form, so it maps straight to `vi.fn`.

**`StoreSpy`** (`test/utils/scheduler/StoreSpy.tsx`) is the first real spy-on-object in this series:

```diff
-const sp = sinonSpy(store as any, method as any);
+const sp = vi.spyOn(store as any, method as any);
 ...
-return () => spyRef.current?.restore?.();
+return () => spyRef.current?.mockRestore?.();
```

Worth noting for the `vi.spyOn` step that follows: this helper has always restored its own spy in its effect cleanup, so it needs nothing from the shared teardown. No `vi.restoreAllMocks()` is required here.

Their spies are typed accordingly, `Mock` for `spyApi` and `MockInstance` for `StoreSpy`.

## `calledBefore`

The one accessor with no equivalent. Sinon compares call objects; Vitest exposes a global ordering counter instead:

```diff
-expect(spiedSetEditCellValue.firstCall.calledBefore(onValueChange.firstCall)).to.equal(true);
+expect(spiedSetEditCellValue.mock.invocationCallOrder[0]).to.be.lessThan(
+  onValueChange.mock.invocationCallOrder[0],
+);
```

## Types that needed a real signature

`vi.fn(() => new Promise(() => {}))` declares no parameters, so `mock.lastCall` types as an empty tuple even though the Grid calls it with a row. Two `processRowUpdate` mocks now declare the parameter their assertions read, the same fix #23464 needed for a getter mock.

## Still on Sinon here

One file keeps its Sinon import for a reason outside this step: `cellSelection.DataGridPremium` uses `stub` for `requestAnimationFrame`. It now reads its helper-derived spies through the Vitest API while that waits for a later step.

## Status

`typescript` and `eslint` are clean, and the browser suite is fully green: **761 files passed, 4 skipped, 0 failures**.

The jsdom suite shows the usual intermittent failures in `x-telemetry/src/postinstall/get-project-id.test.ts` on my machine. That file is untouched here, it passes when its package runs alone, and `test_unit` has been green on it in CI, so it is local environment noise.
