### PR TITLE
[code-infra] Replace the sinon stubs with Vitest mocks

### DIFF
--- a/packages/x-data-grid-premium/src/tests/aiAssistant.DataGridPremium.test.tsx
+++ b/packages/x-data-grid-premium/src/tests/aiAssistant.DataGridPremium.test.tsx
@@ -40,7 +40,7 @@ describe('<DataGridPremium /> - AI Assistant', () => {
   const { render } = createRenderer();
 
   let apiRef: RefObject<GridApi | null>;
-  const promptSpy = vi.fn().mockResolvedValue({});
+  const promptSpy = vi.fn();
 
   function Test(props: Partial<DataGridPremiumProps & { allowAiAssistantDataSampling: boolean }>) {
     apiRef = useGridApiRef();

--- a/packages/x-data-grid-premium/src/tests/aiAssistant.DataGridPremium.test.tsx
+++ b/packages/x-data-grid-premium/src/tests/aiAssistant.DataGridPremium.test.tsx
@@ -1,10 +1,9 @@
 import type { RefObject } from '@mui/x-internals/types';
 import { act, createRenderer, screen } from '@mui/internal-test-utils';
-import { spy, stub } from 'sinon';
 import { DataGridPremium, GridAiAssistantPanel, useGridApiRef } from '@mui/x-data-grid-premium';
 import type { DataGridPremiumProps, GridApi, GridRowsProp } from '@mui/x-data-grid-premium';
 import { isJSDOM } from 'test/utils/skipIf';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
 
 interface BaselineProps extends DataGridPremiumProps {
   rows: GridRowsProp;
@@ -41,7 +40,7 @@ describe('<DataGridPremium /> - AI Assistant', () => {
   const { render } = createRenderer();
 
   let apiRef: RefObject<GridApi | null>;
-  const promptSpy = stub().resolves({});
+  const promptSpy = vi.fn().mockResolvedValue({});
 
   function Test(props: Partial<DataGridPremiumProps & { allowAiAssistantDataSampling: boolean }>) {
     apiRef = useGridApiRef();
@@ -64,7 +63,7 @@ describe('<DataGridPremium /> - AI Assistant', () => {
   }
 
   beforeEach(() => {
-    promptSpy.reset();
+    promptSpy.mockReset();
   });
 
   describe.skipIf(isJSDOM)('data sampling', () => {
@@ -83,9 +82,9 @@ describe('<DataGridPremium /> - AI Assistant', () => {
       await user.type(input, 'Do something with the data');
       await user.keyboard('{Enter}');
 
-      expect(promptSpy.callCount).to.equal(1);
-      expect(promptSpy.firstCall.args[1]).contains('Example1');
-      expect(promptSpy.firstCall.args[1]).not.contains('CatA');
+      expect(promptSpy.mock.calls.length).to.equal(1);
+      expect(promptSpy.mock.calls[0][1]).contains('Example1');
+      expect(promptSpy.mock.calls[0][1]).not.contains('CatA');
     });
 
     it('should sample rows to generate the prompt context', async () => {
@@ -98,17 +97,17 @@ describe('<DataGridPremium /> - AI Assistant', () => {
       await user.type(input, 'Do something with the data');
       await user.keyboard('{Enter}');
 
-      expect(promptSpy.callCount).to.equal(1);
-      expect(promptSpy.firstCall.args[1]).not.contains('Example1');
-      expect(promptSpy.firstCall.args[1]).contains('CatA');
+      expect(promptSpy.mock.calls.length).to.equal(1);
+      expect(promptSpy.mock.calls[0][1]).not.contains('Example1');
+      expect(promptSpy.mock.calls[0][1]).contains('CatA');
     });
   });
 
   describe('API', () => {
     it('should not do anything if the feature is disabled', async () => {
-      const sortChangeSpy = spy();
+      const sortChangeSpy = vi.fn();
 
-      promptSpy.resolves({
+      promptSpy.mockResolvedValue({
         select: -1,
         filters: [],
         aggregation: {},
@@ -126,17 +125,17 @@ describe('<DataGridPremium /> - AI Assistant', () => {
 
       await act(() => apiRef.current?.aiAssistant.processPrompt('Do something with the data'));
 
-      expect(sortChangeSpy.callCount).to.equal(0);
+      expect(sortChangeSpy.mock.calls.length).to.equal(0);
     });
 
     it('should apply the prompt result', async () => {
-      const sortChangeSpy = spy();
-      const filterChangeSpy = spy();
-      const aggregationChangeSpy = spy();
-      const rowSelectionChangeSpy = spy();
-      const rowGroupingChangeSpy = spy();
+      const sortChangeSpy = vi.fn();
+      const filterChangeSpy = vi.fn();
+      const aggregationChangeSpy = vi.fn();
+      const rowSelectionChangeSpy = vi.fn();
+      const rowGroupingChangeSpy = vi.fn();
 
-      promptSpy.resolves({
+      promptSpy.mockResolvedValue({
         select: 1,
         filters: [
           {
@@ -174,16 +173,16 @@ describe('<DataGridPremium /> - AI Assistant', () => {
 
       await act(() => apiRef.current?.aiAssistant.processPrompt('Do something with the data'));
 
-      expect(sortChangeSpy.callCount).to.equal(1);
-      expect(filterChangeSpy.callCount).to.equal(1);
-      expect(aggregationChangeSpy.callCount).to.equal(1);
-      expect(rowSelectionChangeSpy.callCount).to.equal(1);
-      expect(rowGroupingChangeSpy.callCount).to.equal(1);
+      expect(sortChangeSpy.mock.calls.length).to.equal(1);
+      expect(filterChangeSpy.mock.calls.length).to.equal(1);
+      expect(aggregationChangeSpy.mock.calls.length).to.equal(1);
+      expect(rowSelectionChangeSpy.mock.calls.length).to.equal(1);
+      expect(rowGroupingChangeSpy.mock.calls.length).to.equal(1);
     });
 
     it('should return the prompt processing error', async () => {
       const errorMsg = 'Prompt processing error';
-      promptSpy.rejects(new Error(errorMsg));
+      promptSpy.mockRejectedValue(new Error(errorMsg));
 
       render(<Test />);
       const response = (await act(() =>

--- a/packages/x-data-grid-premium/src/tests/cellSelection.DataGridPremium.test.tsx
+++ b/packages/x-data-grid-premium/src/tests/cellSelection.DataGridPremium.test.tsx
@@ -1,6 +1,4 @@
 import * as React from 'react';
-import { stub } from 'sinon';
-import type { SinonStub } from 'sinon';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import type { RefObject } from '@mui/x-internals/types';
 import { spyApi, getCell, grid } from 'test/utils/helperFn';
@@ -10,6 +8,7 @@ import type { DataGridPremiumProps, GridApi, GridColDef } from '@mui/x-data-grid
 import { getBasicGridData } from '@mui/x-data-grid-generator';
 import { isJSDOM, isOSX } from 'test/utils/skipIf';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { MockInstance } from 'vitest';
 
 describe('<DataGridPremium /> - Cell selection', () => {
   const { render } = createRenderer();
@@ -607,12 +606,14 @@ describe('<DataGridPremium /> - Cell selection', () => {
 
   // JSDOM doesn't support scroll events
   describe.skipIf(isJSDOM)('Auto-scroll', () => {
+    let requestAnimationFrame: MockInstance;
+
     beforeEach(() => {
-      stub(window, 'requestAnimationFrame').callsFake(() => 0);
+      requestAnimationFrame = vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 0);
     });
 
     afterEach(() => {
-      (window.requestAnimationFrame as SinonStub).restore();
+      requestAnimationFrame.mockRestore();
     });
 
     it('should auto-scroll when the mouse approaches the bottom edge', async () => {

--- a/packages/x-data-grid-premium/src/tests/cellSelection.DataGridPremium.test.tsx
+++ b/packages/x-data-grid-premium/src/tests/cellSelection.DataGridPremium.test.tsx
@@ -606,14 +606,14 @@ describe('<DataGridPremium /> - Cell selection', () => {
 
   // JSDOM doesn't support scroll events
   describe.skipIf(isJSDOM)('Auto-scroll', () => {
-    let requestAnimationFrame: MockInstance;
+    let rafStub: MockInstance;
 
     beforeEach(() => {
-      requestAnimationFrame = vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 0);
+      rafStub = vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 0);
     });
 
     afterEach(() => {
-      requestAnimationFrame.mockRestore();
+      rafStub.mockRestore();
     });
 
     it('should auto-scroll when the mouse approaches the bottom edge', async () => {

--- a/packages/x-data-grid-premium/src/tests/clipboard.DataGridPremium.test.tsx
+++ b/packages/x-data-grid-premium/src/tests/clipboard.DataGridPremium.test.tsx
@@ -3,13 +3,12 @@ import type { RefObject } from '@mui/x-internals/types';
 import { useGridApiRef, DataGridPremium } from '@mui/x-data-grid-premium';
 import type { GridApi, DataGridPremiumProps, GridColDef } from '@mui/x-data-grid-premium';
 import { act, createRenderer, fireEvent, waitFor } from '@mui/internal-test-utils';
-import { spy, stub } from 'sinon';
-import type { SinonSpy, SinonStub } from 'sinon';
 import { getCell, getColumnValues, includeRowSelection, sleep } from 'test/utils/helperFn';
 import Portal from '@mui/material/Portal';
 import { getBasicGridData } from '@mui/x-data-grid-generator';
 import { isJSDOM } from 'test/utils/skipIf';
-import { describe, it, expect, afterEach } from 'vitest';
+import { vi, describe, it, expect, afterEach } from 'vitest';
+import type { MockInstance } from 'vitest';
 
 describe('<DataGridPremium /> - Clipboard', () => {
   const { render } = createRenderer();
@@ -57,17 +56,17 @@ describe('<DataGridPremium /> - Clipboard', () => {
   }
 
   describe('copy', () => {
-    let writeText: SinonSpy | undefined;
+    let writeText: MockInstance | undefined;
 
     afterEach(function afterEachHook() {
-      writeText?.restore();
+      writeText?.mockRestore();
     });
 
     ['ctrlKey', 'metaKey'].forEach((key) => {
       it(`should copy the selected cells to the clipboard when ${key} + C is pressed`, async () => {
         const { user } = render(<Test />);
 
-        writeText = spy(navigator.clipboard, 'writeText');
+        writeText = vi.spyOn(navigator.clipboard, 'writeText');
 
         const cell = getCell(0, 0);
         await act(() => cell.focus());
@@ -77,7 +76,7 @@ describe('<DataGridPremium /> - Clipboard', () => {
         fireEvent.click(getCell(2, 2), { shiftKey: true });
 
         fireEvent.keyDown(cell, { key: 'c', keyCode: 67, [key]: true });
-        expect(writeText.firstCall.args[0]).to.equal(
+        expect(writeText.mock.calls[0][0]).to.equal(
           [
             ['0', 'USDGBP', '1'].join('\t'),
             ['1', 'USDEUR', '11'].join('\t'),
@@ -90,7 +89,7 @@ describe('<DataGridPremium /> - Clipboard', () => {
     it(`should copy cells range selected in one row`, async () => {
       const { user } = render(<Test />);
 
-      writeText = spy(navigator.clipboard, 'writeText');
+      writeText = vi.spyOn(navigator.clipboard, 'writeText');
 
       const cell = getCell(0, 0);
       await act(() => cell.focus());
@@ -100,7 +99,7 @@ describe('<DataGridPremium /> - Clipboard', () => {
       fireEvent.click(getCell(0, 2), { shiftKey: true });
 
       fireEvent.keyDown(cell, { key: 'c', keyCode: 67, ctrlKey: true });
-      expect(writeText.firstCall.args[0]).to.equal([['0', 'USDGBP', '1'].join('\t')].join('\r\n'));
+      expect(writeText.mock.calls[0][0]).to.equal([['0', 'USDGBP', '1'].join('\t')].join('\r\n'));
     });
 
     it(`should copy cells range selected based on their sorted order`, async () => {
@@ -121,7 +120,7 @@ describe('<DataGridPremium /> - Clipboard', () => {
         </div>,
       );
 
-      writeText = spy(navigator.clipboard, 'writeText');
+      writeText = vi.spyOn(navigator.clipboard, 'writeText');
 
       const cell = getCell(0, 0);
       await act(() => cell.focus());
@@ -134,7 +133,7 @@ describe('<DataGridPremium /> - Clipboard', () => {
       fireEvent.click(getCell(2, 0), { ctrlKey: true });
 
       fireEvent.keyDown(cell, { key: 'c', keyCode: 67, ctrlKey: true });
-      expect(writeText.lastCall.firstArg).to.equal(['Adidas', 'Nike', 'Puma'].join('\r\n'));
+      expect(writeText.mock.lastCall?.[0]).to.equal(['Adidas', 'Nike', 'Puma'].join('\r\n'));
     });
 
     it('should not escape double quotes when copying multiple cells to clipboard', async () => {
@@ -152,7 +151,7 @@ describe('<DataGridPremium /> - Clipboard', () => {
         </div>,
       );
 
-      writeText = spy(navigator.clipboard, 'writeText');
+      writeText = vi.spyOn(navigator.clipboard, 'writeText');
 
       const cell = getCell(0, 0);
       await act(() => cell.focus());
@@ -162,7 +161,7 @@ describe('<DataGridPremium /> - Clipboard', () => {
       fireEvent.click(getCell(1, 0), { ctrlKey: true });
 
       fireEvent.keyDown(cell, { key: 'c', keyCode: 67, ctrlKey: true });
-      expect(writeText.lastCall.firstArg).to.equal(['1 " 1', '2'].join('\r\n'));
+      expect(writeText.mock.lastCall?.[0]).to.equal(['1 " 1', '2'].join('\r\n'));
     });
 
     it('should copy aggregation cell value to clipboard', async () => {
@@ -177,7 +176,7 @@ describe('<DataGridPremium /> - Clipboard', () => {
       // set aggregation model through API to avoid act error
       await act(async () => apiRef.current?.setAggregationModel({ value: 'sum' }));
 
-      writeText = spy(navigator.clipboard, 'writeText');
+      writeText = vi.spyOn(navigator.clipboard, 'writeText');
 
       // Because of the row grouping, the value column only displays the aggregation cells initially
       const aggregationCell = getCell(0, 2);
@@ -187,7 +186,7 @@ describe('<DataGridPremium /> - Clipboard', () => {
       await user.click(aggregationCell);
       fireEvent.keyDown(aggregationCell, { key: 'c', keyCode: 67, ctrlKey: true });
 
-      expect(writeText.firstCall.args[0]).to.equal('30');
+      expect(writeText.mock.calls[0][0]).to.equal('30');
     });
   });
 
@@ -208,12 +207,12 @@ describe('<DataGridPremium /> - Clipboard', () => {
       it(`should not enter cell edit mode when ${key} + V is pressed`, async () => {
         const { user } = render(<Test />);
 
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('cellEditStart', listener);
         const cell = getCell(0, 1);
         await user.click(cell);
         fireEvent.keyDown(cell, { key: 'v', keyCode: 86, [key]: true }); // Ctrl+V
-        expect(listener.callCount).to.equal(0);
+        expect(listener.mock.calls.length).to.equal(0);
       });
     });
 
@@ -221,12 +220,12 @@ describe('<DataGridPremium /> - Clipboard', () => {
       it(`should not enter row edit mode when ${key} + V is pressed`, async () => {
         const { user } = render(<Test editMode="row" />);
 
-        const listener = spy();
+        const listener = vi.fn();
         apiRef.current?.subscribeEvent('rowEditStart', listener);
         const cell = getCell(0, 1);
         await user.click(cell);
         fireEvent.keyDown(cell, { key: 'v', keyCode: 86, [key]: true }); // Ctrl+V
-        expect(listener.callCount).to.equal(0);
+        expect(listener.mock.calls.length).to.equal(0);
       });
     });
 
@@ -584,7 +583,7 @@ describe('<DataGridPremium /> - Clipboard', () => {
     });
 
     it('should use valueSetter if the column has one', async () => {
-      const processRowUpdateSpy = spy((newRow) => newRow);
+      const processRowUpdateSpy = vi.fn((newRow) => newRow);
 
       const columns: GridColDef<(typeof rows)[number]>[] = [
         { field: 'firstName' },
@@ -627,8 +626,8 @@ describe('<DataGridPremium /> - Clipboard', () => {
       paste(cell, 'John Doe');
 
       await waitFor(() => expect(getColumnValues(0)).to.deep.equal(['Jon', 'John']));
-      expect(processRowUpdateSpy.callCount).to.equal(1);
-      expect(processRowUpdateSpy.args[0]).to.deep.equal([
+      expect(processRowUpdateSpy.mock.calls.length).to.equal(1);
+      expect(processRowUpdateSpy.mock.calls[0]).to.deep.equal([
         { id: 1, firstName: 'John', lastName: 'Doe' },
         { id: 1, firstName: 'Cersei', lastName: 'Lannister' },
         { rowId: 1 },
@@ -775,7 +774,7 @@ describe('<DataGridPremium /> - Clipboard', () => {
     });
 
     it('should call `processRowUpdate` with each row impacted by the paste', async () => {
-      const processRowUpdateSpy = spy((newRow) => {
+      const processRowUpdateSpy = vi.fn((newRow) => {
         return newRow;
       });
       const { user } = render(<Test processRowUpdate={processRowUpdateSpy} />);
@@ -793,8 +792,8 @@ describe('<DataGridPremium /> - Clipboard', () => {
         expect(getCell(2, 2).textContent).to.equal('12');
       });
 
-      expect(processRowUpdateSpy.callCount).to.equal(3);
-      expect(processRowUpdateSpy.args).to.deep.equal([
+      expect(processRowUpdateSpy.mock.calls.length).to.equal(3);
+      expect(processRowUpdateSpy.mock.calls).to.deep.equal([
         [
           { id: 0, currencyPair: '12', price1M: '12' }, // new row
           { id: 0, currencyPair: 'USDGBP', price1M: 1 }, // old row
@@ -892,7 +891,7 @@ describe('<DataGridPremium /> - Clipboard', () => {
     });
 
     it('should call `onProcessRowUpdateError()` if `processRowUpdate()` fails', async () => {
-      const onProcessRowUpdateError = spy();
+      const onProcessRowUpdateError = vi.fn();
       const error = new Error('Something went wrong');
       const { user } = render(
         <Test
@@ -914,20 +913,20 @@ describe('<DataGridPremium /> - Clipboard', () => {
       paste(cell, '12');
 
       await waitFor(() => {
-        expect(onProcessRowUpdateError.callCount).to.equal(1);
+        expect(onProcessRowUpdateError.mock.calls.length).to.equal(1);
       });
-      expect(onProcessRowUpdateError.args[0][0]).to.equal(error);
+      expect(onProcessRowUpdateError.mock.calls[0][0]).to.equal(error);
     });
 
     it('should emit clipboard paste events', async () => {
       const calls: string[] = [];
-      const onClipboardPasteStartSpy = spy(() => {
+      const onClipboardPasteStartSpy = vi.fn(() => {
         calls.push('onClipboardPasteStart');
       });
-      const onClipboardPasteEndSpy = spy(() => {
+      const onClipboardPasteEndSpy = vi.fn(() => {
         calls.push('onClipboardPasteEnd');
       });
-      const processRowUpdateSpy = spy((newRow) => {
+      const processRowUpdateSpy = vi.fn((newRow) => {
         calls.push('processRowUpdate');
         return newRow;
       });
@@ -972,7 +971,7 @@ describe('<DataGridPremium /> - Clipboard', () => {
       }
 
       let replacement: CurrencyRow | undefined;
-      const onClipboardPasteEnd = spy();
+      const onClipboardPasteEnd = vi.fn();
       const { user } = render(
         <Test
           onClipboardPasteEnd={onClipboardPasteEnd}
@@ -995,7 +994,7 @@ describe('<DataGridPremium /> - Clipboard', () => {
       // The instance returned in the envelope is stored verbatim.
       expect(apiRef.current?.getRow(0)).to.equal(replacement);
       // The `clipboardPasteEnd` event exposes the stored row, not the envelope.
-      expect(onClipboardPasteEnd.lastCall.args[0].newRows.get(0)).to.equal(replacement);
+      expect(onClipboardPasteEnd.mock.lastCall?.[0].newRows.get(0)).to.equal(replacement);
     });
 
     describe('should copy and paste cell value', () => {
@@ -1004,14 +1003,14 @@ describe('<DataGridPremium /> - Clipboard', () => {
         clipboardData = data;
         return Promise.resolve();
       };
-      let writeTextStub: SinonStub;
+      let writeTextStub: MockInstance;
 
       const stubClipboard = () => {
-        writeTextStub = stub(navigator.clipboard, 'writeText').callsFake(writeText);
+        writeTextStub = vi.spyOn(navigator.clipboard, 'writeText').mockImplementation(writeText);
       };
 
       afterEach(function afterEachHook() {
-        writeTextStub.restore();
+        writeTextStub.mockRestore();
         clipboardData = '';
       });
 

--- a/packages/x-data-grid/src/tests/layout.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/layout.DataGrid.test.tsx
@@ -8,7 +8,6 @@ import {
   reactMajor,
   act,
 } from '@mui/internal-test-utils';
-import { stub, spy } from 'sinon';
 import { DataGrid, gridClasses, useGridApiRef } from '@mui/x-data-grid';
 import type { DataGridProps, GridColDef, GridApi } from '@mui/x-data-grid';
 import { ptBR } from '@mui/x-data-grid/locales';
@@ -25,7 +24,8 @@ import {
   sleep,
 } from 'test/utils/helperFn';
 import { isJSDOM, isOSX } from 'test/utils/skipIf';
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { MockInstance } from 'vitest';
 
 const getVariable = (name: string) => $('.MuiDataGrid-root')!.style.getPropertyValue(name);
 
@@ -247,13 +247,14 @@ describe('<DataGrid /> - Layout & warnings', () => {
     });
 
     describe('swallow warnings', () => {
+      let consoleError: MockInstance;
+
       beforeEach(() => {
-        stub(console, 'error');
+        consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
       });
 
       afterEach(() => {
-        // @ts-expect-error beforeEach side effect
-        console.error.restore();
+        consoleError.mockRestore();
       });
 
       it('should have a stable height if the parent container has no intrinsic height', () => {
@@ -1175,7 +1176,7 @@ describe('<DataGrid /> - Layout & warnings', () => {
   });
 
   it('should not render the "no rows" overlay when transitioning the loading prop from false to true', () => {
-    const NoRowsOverlay = spy(() => null);
+    const NoRowsOverlay = vi.fn(() => null);
     function TestCase(props: Partial<DataGridProps>) {
       return (
         <div style={{ width: 300, height: 500 }}>
@@ -1184,13 +1185,13 @@ describe('<DataGrid /> - Layout & warnings', () => {
       );
     }
     const { setProps } = render(<TestCase rows={[]} loading />);
-    expect(NoRowsOverlay.callCount).to.equal(0);
+    expect(NoRowsOverlay.mock.calls.length).to.equal(0);
     setProps({ loading: false, rows: [{ id: 1 }] });
-    expect(NoRowsOverlay.callCount).to.equal(0);
+    expect(NoRowsOverlay.mock.calls.length).to.equal(0);
   });
 
   it('should render the "no rows" overlay when changing the loading to false but not changing the rows prop', () => {
-    const NoRowsOverlay = spy(() => null);
+    const NoRowsOverlay = vi.fn(() => null);
     function TestCase(props: Partial<DataGridProps>) {
       return (
         <div style={{ width: 300, height: 500 }}>
@@ -1200,9 +1201,9 @@ describe('<DataGrid /> - Layout & warnings', () => {
     }
     const rows: DataGridProps['rows'] = [];
     const { setProps } = render(<TestCase rows={rows} loading />);
-    expect(NoRowsOverlay.callCount).to.equal(0);
+    expect(NoRowsOverlay.mock.calls.length).to.equal(0);
     setProps({ loading: false });
-    expect(NoRowsOverlay.callCount).not.to.equal(0);
+    expect(NoRowsOverlay.mock.calls.length).not.to.equal(0);
   });
 
   // Doesn't work with mocked window.getComputedStyle
@@ -1405,7 +1406,7 @@ describe('<DataGrid /> - Layout & warnings', () => {
     async () => {
       // Stub performance.now to drive the oscillation detector's elapsed-time check.
       let mockTime = 1000;
-      const performanceNowStub = stub(performance, 'now').callsFake(() => mockTime);
+      const performanceNowStub = vi.spyOn(performance, 'now').mockImplementation(() => mockTime);
       try {
         function TestCase({ height }: { height: number }) {
           return (
@@ -1435,7 +1436,7 @@ describe('<DataGrid /> - Layout & warnings', () => {
           expect(getVariable('--DataGrid-hasScrollY')).to.equal('0');
         });
       } finally {
-        performanceNowStub.restore();
+        performanceNowStub.mockRestore();
       }
     },
   );

--- a/packages/x-data-grid/src/tests/rows.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/rows.DataGrid.test.tsx
@@ -10,7 +10,6 @@ import {
   fireEvent,
 } from '@mui/internal-test-utils';
 import clsx from 'clsx';
-import { spy, stub } from 'sinon';
 import { iconButtonClasses } from '@mui/material/IconButton';
 import Portal from '@mui/material/Portal';
 import SvgIcon, { svgIconClasses } from '@mui/material/SvgIcon';
@@ -42,7 +41,7 @@ import {
 import Dialog from '@mui/material/Dialog';
 import { isJSDOM } from 'test/utils/skipIf';
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { COMPACT_DENSITY_FACTOR } from '../hooks/features/density/densitySelector';
 import type { GridApiCommunity } from '../models/api/gridApiCommunity';
 
@@ -105,7 +104,7 @@ describe('<DataGrid /> - Rows', () => {
   });
 
   it('should ignore events coming from a portal in the cell', async () => {
-    const handleRowClick = spy();
+    const handleRowClick = vi.fn();
     function InputCell() {
       return <input type="text" name="input" />;
     }
@@ -136,9 +135,9 @@ describe('<DataGrid /> - Rows', () => {
       </div>,
     );
     await user.click(document.querySelector('input[name="portal-input"]')!);
-    expect(handleRowClick.callCount).to.equal(0);
+    expect(handleRowClick.mock.calls.length).to.equal(0);
     await user.click(document.querySelector('input[name="input"]')!);
-    expect(handleRowClick.callCount).to.equal(1);
+    expect(handleRowClick.mock.calls.length).to.equal(1);
   });
 
   // https://github.com/mui/mui-x/issues/21063
@@ -303,10 +302,10 @@ describe('<DataGrid /> - Rows', () => {
       });
 
       it('should call getActions with the row params', () => {
-        const getActions = stub().returns([]);
+        const getActions = vi.fn().mockReturnValue([]);
         render(<TestCase getActions={getActions} />);
-        expect(getActions.args[0][0].id).to.equal(1);
-        expect(getActions.args[0][0].row).to.deep.equal({ id: 1 });
+        expect(getActions.mock.calls[0][0].id).to.equal(1);
+        expect(getActions.mock.calls[0][0].row).to.deep.equal({ id: 1 });
       });
 
       it('should always show the actions not marked as showInMenu', () => {
@@ -1395,7 +1394,7 @@ describe('<DataGrid /> - Rows', () => {
     }
 
     it('should be called with the correct params', async () => {
-      const getRowSpacing = stub().returns({});
+      const getRowSpacing = vi.fn().mockReturnValue({});
       const { user } = render(
         <TestCase
           getRowSpacing={getRowSpacing}
@@ -1403,14 +1402,14 @@ describe('<DataGrid /> - Rows', () => {
           pageSizeOptions={[2]}
         />,
       );
-      expect(getRowSpacing.args[0][0]).to.deep.equal({
+      expect(getRowSpacing.mock.calls[0][0]).to.deep.equal({
         isFirstVisible: true,
         isLastVisible: false,
         indexRelativeToCurrentPage: 0,
         id: 0,
         model: rows[0],
       });
-      expect(getRowSpacing.args[1][0]).to.deep.equal({
+      expect(getRowSpacing.mock.calls[1][0]).to.deep.equal({
         isFirstVisible: false,
         isLastVisible: true,
         indexRelativeToCurrentPage: 1,
@@ -1418,17 +1417,17 @@ describe('<DataGrid /> - Rows', () => {
         model: rows[1],
       });
 
-      getRowSpacing.resetHistory();
+      getRowSpacing.mockClear();
       await user.click(screen.getByRole('button', { name: /next page/i }));
 
-      expect(getRowSpacing.args[0][0]).to.deep.equal({
+      expect(getRowSpacing.mock.calls[0][0]).to.deep.equal({
         isFirstVisible: true,
         isLastVisible: false,
         indexRelativeToCurrentPage: 0,
         id: 2,
         model: rows[2],
       });
-      expect(getRowSpacing.args[1][0]).to.deep.equal({
+      expect(getRowSpacing.mock.calls[1][0]).to.deep.equal({
         isFirstVisible: false,
         isLastVisible: true,
         indexRelativeToCurrentPage: 1,

--- a/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.test.tsx
+++ b/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.test.tsx
@@ -1,6 +1,5 @@
 import type { Dayjs } from 'dayjs';
 import dayjs from 'dayjs';
-import { stub } from 'sinon';
 import { DateTimeField } from '@mui/x-date-pickers/DateTimeField';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import type { AdapterFormats, PickerValidDate } from '@mui/x-date-pickers/models';
@@ -16,7 +15,7 @@ import 'dayjs/locale/de';
 // We import the plugins here just to have the typing
 import 'dayjs/plugin/utc';
 import 'dayjs/plugin/timezone';
-import { describe, it, expect } from 'vitest';
+import { vi, onTestFinished, describe, it, expect } from 'vitest';
 
 describe('<AdapterDayjs />', () => {
   const commonParams = {
@@ -59,10 +58,9 @@ describe('<AdapterDayjs />', () => {
       // comparisons against plain `dayjs()` dates (for which `getTimezone()`
       // returns `'system'`) went through an unnecessary `setTimezone` conversion
       // that could shift the day across midnight. CI runs in UTC, so the non-UTC
-      // branch is only reachable by stubbing `dayjs.tz.guess()`. The Sinon
-      // default sandbox is restored by the global `afterEach` in
-      // `test/setupVitest.ts`, so no manual cleanup is needed.
-      stub(dayjs.tz, 'guess').returns('America/New_York');
+      // branch is only reachable by stubbing `dayjs.tz.guess()`.
+      const guess = vi.spyOn(dayjs.tz, 'guess').mockReturnValue('America/New_York');
+      onTestFinished(() => guess.mockRestore());
 
       const adapter = new AdapterDayjs();
       const resolvedDate = adapter.date(TEST_DATE_ISO_STRING, 'system') as Dayjs;

--- a/test/utils/pickers/misc.ts
+++ b/test/utils/pickers/misc.ts
@@ -1,12 +1,11 @@
-import sinon from 'sinon';
 import { MuiPickersAdapter, PickerValidDate } from '@mui/x-date-pickers/models';
-import { onTestFinished } from 'vitest';
+import { onTestFinished, vi } from 'vitest';
 import { PickerComponentFamily } from './describe.types';
 import { OpenPickerParams } from './openPicker';
 
 export const stubMatchMedia = (matches = true) => {
   const original = window.matchMedia;
-  window.matchMedia = sinon.stub().returns({
+  window.matchMedia = vi.fn().mockReturnValue({
     matches,
     addListener: () => {},
     addEventListener: () => {},


### PR DESCRIPTION
Fifth step away from Sinon, following #23443, #23460, #23464 and #23466. Sinon goes from 29 files to 22.

## Bare `stub()`

A standalone stub is a `vi.fn()`, with its configuration methods renamed:

```
stub()            -> vi.fn()
.returns(value)   -> .mockReturnValue(value)
.resolves(value)  -> .mockResolvedValue(value)
.rejects(error)   -> .mockRejectedValue(error)
.reset()          -> .mockReset()
.restore()        -> .mockRestore()
```

## `stub(obj, 'method')` is not a plain `vi.spyOn`

This is the part worth reviewing. Sinon replaces the method with a no-op that returns `undefined`; `vi.spyOn` wraps the method but keeps calling the original. So the replacement has to be spelled out:

```diff
-stub(console, 'error');
+vi.spyOn(console, 'error').mockImplementation(() => {});
```

That one is load-bearing: it backs the `swallow warnings` suite in `layout.DataGrid.test.tsx`, and a bare `vi.spyOn` there would stop swallowing and let the suite fail on the warnings it exists to absorb. The same applies to the `performance.now`, `navigator.clipboard.writeText` and `requestAnimationFrame` stubs, which all carried a `callsFake` and now carry a `mockImplementation`.

## Restoring

Four of the five spy-on-object sites already restored explicitly, in an `afterEach` or a `try`/`finally`, so they only needed the method renamed.

`AdapterDayjs.test.tsx` was the one relying on the shared `sinon.restore()`, and said so in a comment. It now restores through `onTestFinished`. So this step still needs no `vi.restoreAllMocks()` in the shared teardown.

## Files that come along

Four files were held back from the earlier steps only by their `stub` usage, so their remaining `spy()` calls and accessors migrate here too, leaving them fully Sinon-free: `aiAssistant`, `layout`, `rows` and `clipboard`.

## Status

`typescript` and `eslint` are clean, and the changed test files pass in the browser.

Two things this step caught that are worth knowing for the remaining migrations:

- A blanket `spy(` to `vi.fn(` rewrite silently produces `vi.fn(obj, 'method')` where the source was a spy-on-object. TypeScript catches it on arity, but only because `vi.fn` takes at most one argument. There are no remaining occurrences anywhere in the repo.
- Renaming `stub()` to `vi.fn()` does not update the accessors on that variable, and `.args` on a `Mock` is `any`, so both `tsc` and `eslint` stay green while the test is broken. Only running the suite surfaced it.
