### PR TITLE
[code-infra] Replace the sinon spy-on-object calls with `vi.spyOn`

### DIFF
--- a/packages/x-data-grid-premium/src/tests/dataSourceAggregation.DataGridPremium.test.tsx
+++ b/packages/x-data-grid-premium/src/tests/dataSourceAggregation.DataGridPremium.test.tsx
@@ -16,7 +16,7 @@ import type {
   GridGetRowsResponse,
 } from '@mui/x-data-grid-premium';
 import { getColumnHeaderCell, getCell } from 'test/utils/helperFn';
-import { vi, describe, it, expect } from 'vitest';
+import { vi, onTestFinished, describe, it, expect } from 'vitest';
 
 describe('<DataGridPremium /> - Data source aggregation', () => {
   const { render } = createRenderer();
@@ -266,6 +266,7 @@ describe('<DataGridPremium /> - Data source aggregation', () => {
     });
 
     const setChildrenLoadingSpy = vi.spyOn(apiRef.current!.dataSource, 'setChildrenLoading');
+    onTestFinished(() => setChildrenLoadingSpy.mockRestore());
 
     fetchRowsSpy.mockClear();
     setChildrenLoadingSpy.mockClear();
@@ -281,7 +282,6 @@ describe('<DataGridPremium /> - Data source aggregation', () => {
     const hasLoadingTrueCall = setChildrenLoadingSpy.mock.calls.some(
       (call) => call[0] === expandedRowId && call[1] === true,
     );
-    setChildrenLoadingSpy.mockRestore();
     expect(hasLoadingTrueCall).to.equal(false);
   });
 

--- a/packages/x-data-grid-premium/src/tests/dataSourceAggregation.DataGridPremium.test.tsx
+++ b/packages/x-data-grid-premium/src/tests/dataSourceAggregation.DataGridPremium.test.tsx
@@ -15,21 +15,20 @@ import type {
   GridGroupNode,
   GridGetRowsResponse,
 } from '@mui/x-data-grid-premium';
-import { spy } from 'sinon';
 import { getColumnHeaderCell, getCell } from 'test/utils/helperFn';
-import { describe, it, expect } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 
 describe('<DataGridPremium /> - Data source aggregation', () => {
   const { render } = createRenderer();
 
   let apiRef: RefObject<GridApi | null>;
-  const fetchRowsSpy = spy();
-  const editRowSpy = spy();
+  const fetchRowsSpy = vi.fn();
+  const editRowSpy = vi.fn();
 
   // TODO: Resets strictmode calls, need to find a better fix for this, maybe an AbortController?
   function Reset() {
     React.useLayoutEffect(() => {
-      fetchRowsSpy.resetHistory();
+      fetchRowsSpy.mockClear();
     }, []);
     return null;
   }
@@ -136,7 +135,7 @@ describe('<DataGridPremium /> - Data source aggregation', () => {
       <TestDataSourceAggregation dataSource={dataSource} columns={[{ field: 'id' }]} />,
     );
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.be.greaterThan(0);
+      expect(fetchRowsSpy.mock.calls.length).to.be.greaterThan(0);
     });
     await user.click(within(getColumnHeaderCell(0)).getByLabelText('id column menu'));
     // wait for the column menu to be open first
@@ -147,7 +146,7 @@ describe('<DataGridPremium /> - Data source aggregation', () => {
   it('should not show aggregation option in the column menu when no aggregation function is defined', async () => {
     const { user } = render(<TestDataSourceAggregation aggregationFunctions={{}} />);
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.be.greaterThan(0);
+      expect(fetchRowsSpy.mock.calls.length).to.be.greaterThan(0);
     });
     await user.click(within(getColumnHeaderCell(0)).getByLabelText('id column menu'));
     expect(screen.queryByLabelText('Aggregation')).to.equal(null);
@@ -162,10 +161,10 @@ describe('<DataGridPremium /> - Data source aggregation', () => {
       />,
     );
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.be.greaterThan(0);
+      expect(fetchRowsSpy.mock.calls.length).to.be.greaterThan(0);
     });
 
-    expect(fetchRowsSpy.lastCall.args[0].aggregationModel).to.deep.equal({ id: 'size' });
+    expect(fetchRowsSpy.mock.lastCall?.[0].aggregationModel).to.deep.equal({ id: 'size' });
   });
 
   it('should show the aggregation footer row when aggregation is enabled', async () => {
@@ -224,13 +223,13 @@ describe('<DataGridPremium /> - Data source aggregation', () => {
       />,
     );
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.be.greaterThan(0);
+      expect(fetchRowsSpy.mock.calls.length).to.be.greaterThan(0);
     });
 
-    fetchRowsSpy.resetHistory();
+    fetchRowsSpy.mockClear();
 
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.be.greaterThan(1);
+      expect(fetchRowsSpy.mock.calls.length).to.be.greaterThan(1);
     });
   });
 
@@ -251,7 +250,7 @@ describe('<DataGridPremium /> - Data source aggregation', () => {
     );
 
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.equal(1);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(1);
     });
     await waitFor(() => {
       expect(Object.keys(apiRef.current!.state.rows.tree).length).to.be.greaterThan(1);
@@ -263,26 +262,26 @@ describe('<DataGridPremium /> - Data source aggregation', () => {
     await user.click(within(cell11).getByRole('button'));
 
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.be.greaterThan(1);
+      expect(fetchRowsSpy.mock.calls.length).to.be.greaterThan(1);
     });
 
-    const setChildrenLoadingSpy = spy(apiRef.current!.dataSource, 'setChildrenLoading');
+    const setChildrenLoadingSpy = vi.spyOn(apiRef.current!.dataSource, 'setChildrenLoading');
 
-    fetchRowsSpy.resetHistory();
-    setChildrenLoadingSpy.resetHistory();
+    fetchRowsSpy.mockClear();
+    setChildrenLoadingSpy.mockClear();
 
     await waitFor(() => {
-      const hasNestedGroupRequest = fetchRowsSpy.getCalls().some((call) => {
-        const groupKeys = call.args[0].groupKeys || [];
+      const hasNestedGroupRequest = fetchRowsSpy.mock.calls.some((call) => {
+        const groupKeys = call[0].groupKeys || [];
         return groupKeys.length > 0;
       });
       expect(hasNestedGroupRequest).to.equal(true);
     });
 
-    const hasLoadingTrueCall = setChildrenLoadingSpy
-      .getCalls()
-      .some((call) => call.args[0] === expandedRowId && call.args[1] === true);
-    setChildrenLoadingSpy.restore();
+    const hasLoadingTrueCall = setChildrenLoadingSpy.mock.calls.some(
+      (call) => call[0] === expandedRowId && call[1] === true,
+    );
+    setChildrenLoadingSpy.mockRestore();
     expect(hasLoadingTrueCall).to.equal(false);
   });
 
@@ -303,7 +302,7 @@ describe('<DataGridPremium /> - Data source aggregation', () => {
       />,
     );
 
-    expect(fetchRowsSpy.callCount).to.equal(1);
+    expect(fetchRowsSpy.mock.calls.length).to.equal(1);
     await waitFor(() => {
       expect(Object.keys(apiRef.current!.state.rows.tree).length).to.be.greaterThan(1);
     });
@@ -312,7 +311,7 @@ describe('<DataGridPremium /> - Data source aggregation', () => {
     await user.click(within(cell11).getByRole('button'));
 
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.equal(2);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(2);
     });
 
     const cell = getCell(1, apiRef.current!.state.columns.orderedFields.indexOf('gross'));
@@ -321,10 +320,10 @@ describe('<DataGridPremium /> - Data source aggregation', () => {
 
     await user.keyboard('{Enter}{Delete}1{Enter}');
 
-    expect(editRowSpy.callCount).to.equal(1);
+    expect(editRowSpy.mock.calls.length).to.equal(1);
     // Two additional calls should be made
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.equal(4);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(4);
     });
   });
 });

--- a/packages/x-data-grid-premium/src/tests/formula.integration.DataGridPremium.test.tsx
+++ b/packages/x-data-grid-premium/src/tests/formula.integration.DataGridPremium.test.tsx
@@ -104,7 +104,7 @@ describe('<DataGridPremium /> - Formulas feature integration', () => {
   });
 
   describe('clipboard', () => {
-    let writeText: MockInstance | undefined;
+    let writeText: MockInstance<typeof navigator.clipboard.writeText> | undefined;
 
     afterEach(function afterEachHook() {
       writeText?.mockRestore();

--- a/packages/x-data-grid-premium/src/tests/formula.integration.DataGridPremium.test.tsx
+++ b/packages/x-data-grid-premium/src/tests/formula.integration.DataGridPremium.test.tsx
@@ -2,14 +2,13 @@ import * as React from 'react';
 import type { RefObject } from '@mui/x-internals/types';
 import { createRenderer, fireEvent, act, waitFor } from '@mui/internal-test-utils';
 import { getCell, getColumnValues, microtasks } from 'test/utils/helperFn';
-import { spy } from 'sinon';
-import type { SinonSpy } from 'sinon';
+import type { MockInstance } from 'vitest';
 import { DataGridPremium, useGridApiRef } from '@mui/x-data-grid-premium';
 import { formulaFeature } from '@mui/x-data-grid-premium/formula';
 import type { DataGridPremiumProps, GridApi } from '@mui/x-data-grid-premium';
 import { unwrapPrivateAPI } from '@mui/x-data-grid/internals';
 import { isJSDOM } from 'test/utils/skipIf';
-import { describe, it, expect, afterEach } from 'vitest';
+import { vi, describe, it, expect, afterEach } from 'vitest';
 import type { GridPrivateApiPremium } from '../models/gridApiPremium';
 import type { GridFormulaPrivateApi } from '../hooks/features/formula/gridFormulaInterfaces';
 
@@ -105,22 +104,22 @@ describe('<DataGridPremium /> - Formulas feature integration', () => {
   });
 
   describe('clipboard', () => {
-    let writeText: SinonSpy | undefined;
+    let writeText: MockInstance | undefined;
 
     afterEach(function afterEachHook() {
-      writeText?.restore();
+      writeText?.mockRestore();
       writeText = undefined;
     });
 
     it('should copy the evaluated value, not the formula source', async () => {
       const { user } = await render(<Test cellSelection disableRowSelectionOnClick />);
-      writeText = spy(navigator.clipboard, 'writeText');
+      writeText = vi.spyOn(navigator.clipboard, 'writeText');
 
       const cell = getCell(0, 3);
       await user.click(cell);
       fireEvent.keyDown(cell, { key: 'c', keyCode: 67, ctrlKey: true });
 
-      expect(writeText.lastCall.args[0]).to.equal('6');
+      expect(writeText.mock.lastCall?.[0]).to.equal('6');
     });
 
     it('should paste `=` strings as formulas', async () => {

--- a/packages/x-data-grid-pro/src/tests/clipboard.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/clipboard.DataGridPro.test.tsx
@@ -41,7 +41,7 @@ describe('<DataGridPro /> - Clipboard', () => {
   }
 
   describe('copy to clipboard', () => {
-    let writeText: MockInstance | undefined;
+    let writeText: MockInstance<typeof navigator.clipboard.writeText> | undefined;
 
     afterEach(function afterEachHook() {
       writeText?.mockRestore();

--- a/packages/x-data-grid-pro/src/tests/clipboard.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/clipboard.DataGridPro.test.tsx
@@ -2,11 +2,10 @@ import type { RefObject } from '@mui/x-internals/types';
 import { useGridApiRef, DataGridPro } from '@mui/x-data-grid-pro';
 import type { GridApi, DataGridProProps } from '@mui/x-data-grid-pro';
 import { createRenderer, fireEvent, act } from '@mui/internal-test-utils';
-import { spy } from 'sinon';
-import type { SinonSpy } from 'sinon';
+import type { MockInstance } from 'vitest';
 import { getCell } from 'test/utils/helperFn';
 import { fireUserEvent } from 'test/utils/fireUserEvent';
-import { describe, it, expect, afterEach } from 'vitest';
+import { vi, describe, it, expect, afterEach } from 'vitest';
 
 const isJSDOM = /jsdom/.test(window.navigator.userAgent);
 
@@ -42,23 +41,23 @@ describe('<DataGridPro /> - Clipboard', () => {
   }
 
   describe('copy to clipboard', () => {
-    let writeText: SinonSpy | undefined;
+    let writeText: MockInstance | undefined;
 
     afterEach(function afterEachHook() {
-      writeText?.restore();
+      writeText?.mockRestore();
     });
 
     ['ctrlKey', 'metaKey'].forEach((key) => {
       it(`should copy the selected rows to the clipboard when ${key} + C is pressed`, () => {
         render(<Test disableRowSelectionOnClick />);
 
-        writeText = spy(navigator.clipboard, 'writeText');
+        writeText = vi.spyOn(navigator.clipboard, 'writeText');
 
         act(() => apiRef.current?.selectRows([0, 1]));
         const cell = getCell(0, 0);
         fireUserEvent.mousePress(cell);
         fireEvent.keyDown(cell, { key: 'c', keyCode: 67, [key]: true });
-        expect(writeText.firstCall.args[0]).to.equal(['0\tNike', '1\tAdidas'].join('\r\n'));
+        expect(writeText.mock.calls[0][0]).to.equal(['0\tNike', '1\tAdidas'].join('\r\n'));
       });
     });
 
@@ -71,14 +70,14 @@ describe('<DataGridPro /> - Clipboard', () => {
         />,
       );
 
-      writeText = spy(navigator.clipboard, 'writeText');
+      writeText = vi.spyOn(navigator.clipboard, 'writeText');
 
       const cell = getCell(0, 0);
       cell.focus();
       fireUserEvent.mousePress(cell);
 
       fireEvent.keyDown(cell, { key: 'c', keyCode: 67, ctrlKey: true });
-      expect(writeText.lastCall.firstArg).to.equal('1 " 1');
+      expect(writeText.mock.lastCall?.[0]).to.equal('1 " 1');
     });
 
     it('should not escape double quotes when copying rows to clipboard', () => {
@@ -93,13 +92,13 @@ describe('<DataGridPro /> - Clipboard', () => {
         />,
       );
 
-      writeText = spy(navigator.clipboard, 'writeText');
+      writeText = vi.spyOn(navigator.clipboard, 'writeText');
 
       act(() => apiRef.current?.selectRows([0, 1]));
       const cell = getCell(0, 0);
       fireUserEvent.mousePress(cell);
       fireEvent.keyDown(cell, { key: 'c', keyCode: 67, ctrlKey: true });
-      expect(writeText.firstCall.args[0]).to.equal(['1 " 1', '2'].join('\r\n'));
+      expect(writeText.mock.calls[0][0]).to.equal(['1 " 1', '2'].join('\r\n'));
     });
   });
 });

--- a/packages/x-data-grid-pro/src/tests/dataSourceLazyLoader.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/dataSourceLazyLoader.DataGridPro.test.tsx
@@ -850,6 +850,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
       await waitFor(() => expect(apiRef.current!.getRow('A-0')).not.to.equal(null));
 
       const setChildrenLoadingSpy = vi.spyOn(apiRef.current!.dataSource, 'setChildrenLoading');
+      onTestFinished(() => setChildrenLoadingSpy.mockRestore());
       localFetchRowsSpy.mockClear();
       setChildrenLoadingSpy.mockClear();
 
@@ -864,7 +865,6 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
       const hasLoadingTrueCall = setChildrenLoadingSpy.mock.calls.some(
         (call) => call[0] === 'A' && call[1] === true,
       );
-      setChildrenLoadingSpy.mockRestore();
       expect(hasLoadingTrueCall).to.equal(false);
     });
 

--- a/packages/x-data-grid-pro/src/tests/dataSourceLazyLoader.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/dataSourceLazyLoader.DataGridPro.test.tsx
@@ -15,16 +15,15 @@ import type {
   GridGroupNode,
   GridRowSelectionModel,
 } from '@mui/x-data-grid-pro';
-import { spy } from 'sinon';
 import { isJSDOM } from 'test/utils/skipIf';
 import { TestCache } from '@mui/x-data-grid/internals';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, onTestFinished, beforeEach } from 'vitest';
 
 // Needs layout
 describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
   const { render } = createRenderer();
   const defaultTransformGetRowsResponse = (response: GridGetRowsResponse) => response;
-  const fetchRowsSpy = spy();
+  const fetchRowsSpy = vi.fn();
 
   let transformGetRowsResponse: (response: GridGetRowsResponse) => GridGetRowsResponse;
   let apiRef: RefObject<GridApi | null>;
@@ -42,7 +41,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
   // TODO: Resets strictmode calls, need to find a better fix for this, maybe an AbortController?
   function Reset() {
     React.useLayoutEffect(() => {
-      fetchRowsSpy.resetHistory();
+      fetchRowsSpy.mockClear();
     }, []);
     return null;
   }
@@ -117,14 +116,14 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
   it('should load the first page initially', async () => {
     render(<TestDataSourceLazyLoader />);
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.equal(1);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(1);
     });
   });
 
   it('should re-fetch the data once if multiple models have changed', async () => {
     const { setProps } = render(<TestDataSourceLazyLoader />);
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.equal(1);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(1);
     });
 
     setProps({
@@ -133,7 +132,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
     });
 
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.equal(2);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(2);
     });
   });
 
@@ -148,33 +147,33 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
     it('should not send a filter item without a value to the data source', async () => {
       render(<TestDataSourceLazyLoader dataSourceCache={null} />);
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(1);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(1);
       });
 
       await upsertFilterItem({ id: 1, field: 'id', operator: 'contains', value: '1' });
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(2);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(2);
       });
 
       await upsertFilterItem({ id: 1, field: 'id', operator: 'contains' });
 
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(3);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(3);
       });
-      const url = new URL(fetchRowsSpy.lastCall.args[0]);
+      const url = new URL(fetchRowsSpy.mock.lastCall?.[0]);
       expect(JSON.parse(url.searchParams.get('filterModel')!).items).to.deep.equal([]);
     });
 
     it('should not re-fetch when the change only adds an incomplete item', async () => {
       render(<TestDataSourceLazyLoader dataSourceCache={null} />);
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(1);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(1);
       });
 
       await upsertFilterItem({ id: 1, field: 'id', operator: 'contains' });
       await actSleep(50);
 
-      expect(fetchRowsSpy.callCount).to.equal(1);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(1);
     });
   });
 
@@ -231,12 +230,12 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
       await waitFor(() => expect(getRow(0)).not.to.be.undefined);
 
       // reset the spy call count
-      fetchRowsSpy.resetHistory();
+      fetchRowsSpy.mockClear();
 
       await act(async () => apiRef.current?.scrollToIndexes({ rowIndex: 10 }));
 
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(1);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(1);
       });
     });
 
@@ -245,25 +244,25 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
       // wait until the rows are rendered
       await waitFor(() => expect(getRow(0)).not.to.be.undefined);
 
-      const initialSearchParams = new URL(fetchRowsSpy.lastCall.args[0]).searchParams;
+      const initialSearchParams = new URL(fetchRowsSpy.mock.lastCall?.[0]).searchParams;
       expect(initialSearchParams.get('end')).to.equal('9');
 
       await act(async () => apiRef.current?.scrollToIndexes({ rowIndex: 10 }));
 
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(2);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(2);
       });
 
-      const beforeSortSearchParams = new URL(fetchRowsSpy.lastCall.args[0]).searchParams;
+      const beforeSortSearchParams = new URL(fetchRowsSpy.mock.lastCall?.[0]).searchParams;
       expect(beforeSortSearchParams.get('end')).not.to.equal('9');
 
       await act(async () => apiRef.current?.sortColumn(mockServer.columns[0].field, 'asc'));
 
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(3);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(3);
       });
 
-      const afterSortSearchParams = new URL(fetchRowsSpy.lastCall.args[0]).searchParams;
+      const afterSortSearchParams = new URL(fetchRowsSpy.mock.lastCall?.[0]).searchParams;
       expect(afterSortSearchParams.get('end')).to.equal('9');
     });
 
@@ -275,9 +274,9 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
       await act(async () => apiRef.current?.scrollToIndexes({ rowIndex: 10 }));
 
       // wait until the rows are rendered
-      await waitFor(() => expect(fetchRowsSpy.callCount).to.equal(2));
+      await waitFor(() => expect(fetchRowsSpy.mock.calls.length).to.equal(2));
 
-      const beforeFilteringSearchParams = new URL(fetchRowsSpy.lastCall.args[0]).searchParams;
+      const beforeFilteringSearchParams = new URL(fetchRowsSpy.mock.lastCall?.[0]).searchParams;
       // first row is not the first page anymore
       expect(beforeFilteringSearchParams.get('start')).to.equal('10');
 
@@ -294,10 +293,10 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
       });
 
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(3);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(3);
       });
 
-      const afterFilteringSearchParams = new URL(fetchRowsSpy.lastCall.args[0]).searchParams;
+      const afterFilteringSearchParams = new URL(fetchRowsSpy.mock.lastCall?.[0]).searchParams;
       // first row is the start of the first page
       expect(afterFilteringSearchParams.get('start')).to.equal('0');
     });
@@ -307,7 +306,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
       await waitFor(() => expect(getRow(0)).not.to.be.undefined);
 
       vi.useFakeTimers();
-      fetchRowsSpy.resetHistory();
+      fetchRowsSpy.mockClear();
 
       await act(async () => {
         apiRef.current?.publishEvent('renderedRowsIntervalChange', {
@@ -319,12 +318,12 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
         await vi.advanceTimersByTimeAsync(700);
       });
 
-      expect(fetchRowsSpy.callCount).to.equal(0);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(0);
       vi.useRealTimers();
     });
 
     it('should not refetch during polling when cache entry is still valid', async () => {
-      const localFetchRowsSpy = spy();
+      const localFetchRowsSpy = vi.fn();
       render(
         <TestDataSourceLazyLoader
           mockServerRowCount={20}
@@ -336,7 +335,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
       await waitFor(() => expect(getRow(0)).not.to.be.undefined);
 
       vi.useFakeTimers();
-      localFetchRowsSpy.resetHistory();
+      localFetchRowsSpy.mockClear();
 
       await act(async () => {
         apiRef.current?.publishEvent('renderedRowsIntervalChange', {
@@ -348,7 +347,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
         await vi.advanceTimersByTimeAsync(50);
       });
 
-      expect(localFetchRowsSpy.callCount).to.equal(0);
+      expect(localFetchRowsSpy.mock.calls.length).to.equal(0);
       vi.useRealTimers();
     });
 
@@ -362,7 +361,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
 
       // Wait for the scroll-triggered fetches to complete
       await waitFor(() => {
-        const lastUrl = fetchRowsSpy.lastCall?.args[0];
+        const lastUrl = fetchRowsSpy.mock.lastCall?.[0];
         if (!lastUrl) {
           return;
         }
@@ -370,7 +369,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
         expect(Number(params.get('start'))).to.be.greaterThan(0);
       });
 
-      fetchRowsSpy.resetHistory();
+      fetchRowsSpy.mockClear();
 
       // Call fetchRows without explicit params
       act(() => {
@@ -378,17 +377,17 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
       });
 
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(1);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(1);
       });
 
       // The request should use viewport-based start, not the default page 0
-      const searchParams = new URL(fetchRowsSpy.lastCall.args[0]).searchParams;
+      const searchParams = new URL(fetchRowsSpy.mock.lastCall?.[0]).searchParams;
       const start = Number(searchParams.get('start'));
       expect(start).to.be.greaterThan(0);
     });
 
     it('should periodically revalidate the current range when dataSourceRevalidateMs is set', async () => {
-      const localFetchRowsSpy = spy();
+      const localFetchRowsSpy = vi.fn();
       render(
         <TestDataSourceLazyLoader
           mockServerRowCount={20}
@@ -402,10 +401,10 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
       await act(async () => apiRef.current?.scrollToIndexes({ rowIndex: 10 }));
       await waitFor(() => expect(getRow(19)).not.to.be.undefined);
 
-      localFetchRowsSpy.resetHistory();
+      localFetchRowsSpy.mockClear();
 
       await waitFor(() => {
-        expect(localFetchRowsSpy.callCount).to.be.greaterThan(1);
+        expect(localFetchRowsSpy.mock.calls.length).to.be.greaterThan(1);
       });
     });
 
@@ -425,7 +424,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
           mockServerRowCount={12}
           dataSourceCache={null}
           dataSourceRevalidateMs={1}
-          onFetchRows={spy()}
+          onFetchRows={vi.fn()}
         />,
       );
       await waitFor(() => expect(getRow(0)).not.to.be.undefined);
@@ -678,7 +677,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
     });
 
     it('should periodically revalidate root rows when dataSourceRevalidateMs is set', async () => {
-      const localFetchRowsSpy = spy();
+      const localFetchRowsSpy = vi.fn();
       render(
         <TestNestedDataSourceLazyLoader
           dataSourceCache={null}
@@ -689,22 +688,22 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
 
       await waitFor(() => expect(getRow(0)).not.to.be.undefined);
 
-      localFetchRowsSpy.resetHistory();
+      localFetchRowsSpy.mockClear();
 
       await waitFor(() => {
-        expect(localFetchRowsSpy.callCount).to.be.greaterThan(1);
+        expect(localFetchRowsSpy.mock.calls.length).to.be.greaterThan(1);
       });
-      const rootRequest = localFetchRowsSpy.getCalls().find((call) => {
-        const params = call.firstArg as GridGetRowsParams;
+      const rootRequest = localFetchRowsSpy.mock.calls.find((call) => {
+        const params = call[0] as GridGetRowsParams;
         return params.groupKeys?.length === 0;
-      })?.firstArg as GridGetRowsParams | undefined;
+      })?.[0] as GridGetRowsParams | undefined;
       expect(rootRequest).not.to.equal(undefined);
       expect(rootRequest?.start).to.equal(0);
       expect(rootRequest?.end).to.equal(9);
     });
 
     it('should lazy load children for default-expanded tree data groups', async () => {
-      const localFetchRowsSpy = spy();
+      const localFetchRowsSpy = vi.fn();
       render(
         <TestNestedDataSourceLazyLoader
           defaultGroupingExpansionDepth={1}
@@ -719,15 +718,15 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
       const parentNode = apiRef.current!.getRowNode<GridGroupNode>('A')!;
       expect(parentNode.childrenExpanded).to.equal(true);
 
-      const nestedRequest = localFetchRowsSpy.getCalls().find((call) => {
-        const params = call.firstArg as GridGetRowsParams;
+      const nestedRequest = localFetchRowsSpy.mock.calls.find((call) => {
+        const params = call[0] as GridGetRowsParams;
         return JSON.stringify(params.groupKeys) === JSON.stringify(['A']);
-      })?.firstArg as GridGetRowsParams | undefined;
+      })?.[0] as GridGetRowsParams | undefined;
       expect(nestedRequest).not.to.equal(undefined);
     });
 
     it('should apply default expansion to tree data groups loaded while scrolling', async () => {
-      const localFetchRowsSpy = spy();
+      const localFetchRowsSpy = vi.fn();
       render(
         <TestNestedDataSourceLazyLoader
           defaultGroupingExpansionDepth={1}
@@ -745,16 +744,16 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
       const scrolledParentNode = apiRef.current!.getRowNode<GridGroupNode>('K')!;
       expect(scrolledParentNode.childrenExpanded).to.equal(true);
 
-      const scrolledNestedRequest = localFetchRowsSpy.getCalls().find((call) => {
-        const params = call.firstArg as GridGetRowsParams;
+      const scrolledNestedRequest = localFetchRowsSpy.mock.calls.find((call) => {
+        const params = call[0] as GridGetRowsParams;
         return JSON.stringify(params.groupKeys) === JSON.stringify(['K']);
-      })?.firstArg as GridGetRowsParams | undefined;
+      })?.[0] as GridGetRowsParams | undefined;
       expect(scrolledNestedRequest).not.to.equal(undefined);
     });
 
     it('should use isGroupExpandedByDefault for lazy-loaded tree data groups', async () => {
-      const localFetchRowsSpy = spy();
-      const isGroupExpandedByDefault = spy((node: GridGroupNode) => node.id === 'K');
+      const localFetchRowsSpy = vi.fn();
+      const isGroupExpandedByDefault = vi.fn((node: GridGroupNode) => node.id === 'K');
       render(
         <TestNestedDataSourceLazyLoader
           defaultGroupingExpansionDepth={-1}
@@ -777,7 +776,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
 
       const scrolledParentNode = apiRef.current!.getRowNode<GridGroupNode>('K')!;
       expect(scrolledParentNode.childrenExpanded).to.equal(true);
-      expect(isGroupExpandedByDefault.called).to.equal(true);
+      expect(isGroupExpandedByDefault.mock.calls.length).to.be.greaterThan(0);
     });
 
     [
@@ -799,7 +798,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
       },
     ].forEach(({ label, updateModel, isMatchingRequest }) => {
       it(`should preserve expanded tree data groups and fetch children after ${label}`, async () => {
-        const localFetchRowsSpy = spy();
+        const localFetchRowsSpy = vi.fn();
         const { user } = render(
           <TestNestedDataSourceLazyLoader dataSourceCache={null} onFetchRows={localFetchRowsSpy} />,
         );
@@ -809,13 +808,13 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
         await waitFor(() => expect(apiRef.current!.getRow('A-0')).not.to.equal(null));
 
         const initialChildValue = apiRef.current!.getRow<TreeRow>('A-0')!.value;
-        localFetchRowsSpy.resetHistory();
+        localFetchRowsSpy.mockClear();
 
         act(() => updateModel());
 
         await waitFor(() => {
-          const nestedRequest = localFetchRowsSpy.getCalls().find((call) => {
-            const params = call.firstArg as GridGetRowsParams;
+          const nestedRequest = localFetchRowsSpy.mock.calls.find((call) => {
+            const params = call[0] as GridGetRowsParams;
             return (
               JSON.stringify(params.groupKeys) === JSON.stringify(['A']) &&
               isMatchingRequest(params)
@@ -837,7 +836,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
     });
 
     it('should periodically revalidate expanded nested rows without setting children loading', async () => {
-      const localFetchRowsSpy = spy();
+      const localFetchRowsSpy = vi.fn();
       const { user } = render(
         <TestNestedDataSourceLazyLoader
           dataSourceCache={null}
@@ -850,27 +849,27 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
       await user.click(within(getCell(0, 0)).getByRole('button'));
       await waitFor(() => expect(apiRef.current!.getRow('A-0')).not.to.equal(null));
 
-      const setChildrenLoadingSpy = spy(apiRef.current!.dataSource, 'setChildrenLoading');
-      localFetchRowsSpy.resetHistory();
-      setChildrenLoadingSpy.resetHistory();
+      const setChildrenLoadingSpy = vi.spyOn(apiRef.current!.dataSource, 'setChildrenLoading');
+      localFetchRowsSpy.mockClear();
+      setChildrenLoadingSpy.mockClear();
 
       await waitFor(() => {
-        const hasNestedRequest = localFetchRowsSpy.getCalls().some((call) => {
-          const params = call.firstArg as GridGetRowsParams;
+        const hasNestedRequest = localFetchRowsSpy.mock.calls.some((call) => {
+          const params = call[0] as GridGetRowsParams;
           return (params.groupKeys?.length ?? 0) > 0;
         });
         expect(hasNestedRequest).to.equal(true);
       });
 
-      const hasLoadingTrueCall = setChildrenLoadingSpy
-        .getCalls()
-        .some((call) => call.args[0] === 'A' && call.args[1] === true);
-      setChildrenLoadingSpy.restore();
+      const hasLoadingTrueCall = setChildrenLoadingSpy.mock.calls.some(
+        (call) => call[0] === 'A' && call[1] === true,
+      );
+      setChildrenLoadingSpy.mockRestore();
       expect(hasLoadingTrueCall).to.equal(false);
     });
 
     it('should not call getRows during polling when the cache entry is still valid', async () => {
-      const localFetchRowsSpy = spy();
+      const localFetchRowsSpy = vi.fn();
       render(
         <TestNestedDataSourceLazyLoader
           dataSourceRevalidateMs={1}
@@ -881,7 +880,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
       await waitFor(() => expect(getRow(0)).not.to.be.undefined);
 
       vi.useFakeTimers();
-      localFetchRowsSpy.resetHistory();
+      localFetchRowsSpy.mockClear();
 
       act(() => {
         apiRef.current?.publishEvent('renderedRowsIntervalChange', {
@@ -896,13 +895,13 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
         await vi.advanceTimersByTimeAsync(20);
       });
 
-      expect(localFetchRowsSpy.callCount).to.equal(0);
+      expect(localFetchRowsSpy.mock.calls.length).to.equal(0);
 
       vi.useRealTimers();
     });
 
     it('should update same-id rows without losing nested selection', async () => {
-      const localFetchRowsSpy = spy();
+      const localFetchRowsSpy = vi.fn();
       const { user } = render(
         <TestNestedDataSourceLazyLoader
           dataSourceCache={null}
@@ -920,7 +919,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
       });
       const initialValue = apiRef.current!.getRow<TreeRow>('A-0')!.value;
 
-      localFetchRowsSpy.resetHistory();
+      localFetchRowsSpy.mockClear();
 
       await waitFor(() => {
         expect(apiRef.current!.getRow<TreeRow>('A-0')!.value).to.be.greaterThan(initialValue);
@@ -929,7 +928,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
     });
 
     it('should collapse expanded nested rows without deleting skeleton rows through row updates', async () => {
-      const localFetchRowsSpy = spy();
+      const localFetchRowsSpy = vi.fn();
       const { user } = render(
         <TestNestedDataSourceLazyLoader
           dataSourceCache={null}
@@ -950,7 +949,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
     });
 
     it('should replace different-id rows under the correct parent', async () => {
-      const localFetchRowsSpy = spy();
+      const localFetchRowsSpy = vi.fn();
       const transformRows = (rows: TreeRow[], params: GridGetRowsParams, requestCount: number) => {
         if ((params.groupKeys?.length ?? 0) === 1 && requestCount > 2) {
           return rows.map((row, index) =>
@@ -972,7 +971,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
       await user.click(within(getCell(0, 0)).getByRole('button'));
       await waitFor(() => expect(apiRef.current!.getRow('A-0')).not.to.equal(null));
 
-      localFetchRowsSpy.resetHistory();
+      localFetchRowsSpy.mockClear();
 
       await waitFor(() => {
         expect(apiRef.current!.getRow('A-0-updated')).not.to.equal(null);
@@ -994,7 +993,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
         <TestNestedDataSourceLazyLoader
           dataSourceCache={null}
           dataSourceRevalidateMs={1}
-          onFetchRows={spy()}
+          onFetchRows={vi.fn()}
           transformRows={transformRows}
         />,
       );
@@ -1020,7 +1019,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
         <TestNestedDataSourceLazyLoader
           dataSourceCache={null}
           dataSourceRevalidateMs={1}
-          onFetchRows={spy()}
+          onFetchRows={vi.fn()}
           transformRows={transformRows}
         />,
       );
@@ -1060,7 +1059,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
         <TestNestedDataSourceLazyLoader
           dataSourceCache={null}
           dataSourceRevalidateMs={1}
-          onFetchRows={spy()}
+          onFetchRows={vi.fn()}
           transformRows={transformRows}
         />,
       );
@@ -1086,7 +1085,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
         <TestNestedDataSourceLazyLoader
           dataSourceCache={null}
           dataSourceRevalidateMs={1}
-          onFetchRows={spy()}
+          onFetchRows={vi.fn()}
           transformRows={transformRows}
         />,
       );
@@ -1184,7 +1183,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
     });
 
     it('should not periodically revalidate when dataSourceRevalidateMs is zero', async () => {
-      const localFetchRowsSpy = spy();
+      const localFetchRowsSpy = vi.fn();
       render(
         <TestNestedDataSourceLazyLoader
           dataSourceCache={null}
@@ -1196,13 +1195,13 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
       await waitFor(() => expect(getRow(0)).not.to.be.undefined);
 
       vi.useFakeTimers();
-      localFetchRowsSpy.resetHistory();
+      localFetchRowsSpy.mockClear();
 
       await act(async () => {
         await vi.advanceTimersByTimeAsync(20);
       });
 
-      expect(localFetchRowsSpy.callCount).to.equal(0);
+      expect(localFetchRowsSpy.mock.calls.length).to.equal(0);
 
       vi.useRealTimers();
     });
@@ -1229,7 +1228,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
       await waitFor(() => expect(getRow(0)).not.to.be.undefined);
 
       // reset the spy call count
-      fetchRowsSpy.resetHistory();
+      fetchRowsSpy.mockClear();
 
       // make one small and one big scroll that makes sure that the bottom of the grid window is reached
       await act(async () => {
@@ -1241,7 +1240,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
 
       // Only one additional fetch should have been made
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(1);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(1);
       });
     });
 
@@ -1259,7 +1258,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
       expect(apiRef.current?.getRow(firstRowId)).to.equal(replacement);
 
       // reset the spy call count
-      fetchRowsSpy.resetHistory();
+      fetchRowsSpy.mockClear();
 
       // make one small and one big scroll that makes sure that the bottom of the grid window is reached
       await act(async () => {
@@ -1270,7 +1269,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
       });
 
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(1);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(1);
       });
       await waitFor(() => expect(getRow(10)).not.to.be.undefined);
 
@@ -1288,9 +1287,9 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
       );
 
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(3); // grid is 4 rows high and the threshold is 60px, so 3 pages are loaded
+        expect(fetchRowsSpy.mock.calls.length).to.equal(3); // grid is 4 rows high and the threshold is 60px, so 3 pages are loaded
       });
-      const lastSearchParams = new URL(fetchRowsSpy.lastCall.args[0]).searchParams;
+      const lastSearchParams = new URL(fetchRowsSpy.mock.lastCall?.[0]).searchParams;
       expect(lastSearchParams.get('end')).to.equal('5'); // 6th row
     });
 
@@ -1304,9 +1303,9 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
         />,
       );
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(2);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(2);
       });
-      const lastSearchParams = new URL(fetchRowsSpy.lastCall.args[0]).searchParams;
+      const lastSearchParams = new URL(fetchRowsSpy.mock.lastCall?.[0]).searchParams;
       // 3rd and 4th row were requested but not added
       expect(lastSearchParams.get('start')).to.equal('2');
       expect(lastSearchParams.get('end')).to.equal('3');
@@ -1322,13 +1321,13 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
       // wait until the rows are rendered
       await waitFor(() => expect(getRow(10)).not.to.be.undefined);
 
-      const beforeSortingSearchParams = new URL(fetchRowsSpy.lastCall.args[0]).searchParams;
+      const beforeSortingSearchParams = new URL(fetchRowsSpy.mock.lastCall?.[0]).searchParams;
       // last row is not the first page anymore
       expect(beforeSortingSearchParams.get('end')).not.to.equal('9');
 
       await act(async () => apiRef.current?.sortColumn(mockServer.columns[0].field, 'asc'));
 
-      const afterSortingSearchParams = new URL(fetchRowsSpy.lastCall.args[0]).searchParams;
+      const afterSortingSearchParams = new URL(fetchRowsSpy.mock.lastCall?.[0]).searchParams;
       // last row is the end of the first page
       expect(afterSortingSearchParams.get('end')).to.equal('9');
     });
@@ -1343,7 +1342,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
       // wait until the rows are rendered
       await waitFor(() => expect(getRow(10)).not.to.be.undefined);
 
-      const beforeFilteringSearchParams = new URL(fetchRowsSpy.lastCall.args[0]).searchParams;
+      const beforeFilteringSearchParams = new URL(fetchRowsSpy.mock.lastCall?.[0]).searchParams;
       // last row is not the first page anymore
       expect(beforeFilteringSearchParams.get('end')).not.to.equal('9');
 
@@ -1359,7 +1358,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
         });
       });
 
-      const afterFilteringSearchParams = new URL(fetchRowsSpy.lastCall.args[0]).searchParams;
+      const afterFilteringSearchParams = new URL(fetchRowsSpy.mock.lastCall?.[0]).searchParams;
       // last row is the end of the first page
       expect(afterFilteringSearchParams.get('end')).to.equal('9');
     });
@@ -1396,7 +1395,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
       });
 
       // only the initial page was fetched; the wasted second request was suppressed
-      expect(fetchRowsSpy.callCount).to.equal(1);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(1);
     });
 
     it('should resume fetching after a query change once hasNextPage is true again', async () => {
@@ -1415,20 +1414,20 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
 
       // subsequent responses now report that more pages are available
       isFirstResponse = false;
-      fetchRowsSpy.resetHistory();
+      fetchRowsSpy.mockClear();
 
       // a new query (sorting) re-queries the first page
       await act(async () => {
         apiRef.current?.sortColumn(mockServer.columns[0].field, 'asc');
       });
-      await waitFor(() => expect(fetchRowsSpy.callCount).to.be.at.least(1));
+      await waitFor(() => expect(fetchRowsSpy.mock.calls.length).to.be.at.least(1));
 
       // scrolling to the bottom fetches the next page again
-      fetchRowsSpy.resetHistory();
+      fetchRowsSpy.mockClear();
       await act(async () => {
         apiRef.current?.scrollToIndexes({ rowIndex: 9 });
       });
-      await waitFor(() => expect(fetchRowsSpy.callCount).to.be.at.least(1));
+      await waitFor(() => expect(fetchRowsSpy.mock.calls.length).to.be.at.least(1));
     });
 
     it('should handle an empty result set with hasNextPage: false without extra fetches', async () => {
@@ -1444,7 +1443,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
       // Only the initial request is made. An empty result set produces no rows and no
       // skeleton rows, so there is no last row to attach the scroll-end trigger to and
       // therefore no further request — and no crash.
-      await waitFor(() => expect(fetchRowsSpy.callCount).to.equal(1));
+      await waitFor(() => expect(fetchRowsSpy.mock.calls.length).to.equal(1));
       expect(() => getRow(0)).to.throw();
     });
 
@@ -1474,7 +1473,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
       });
 
       // only the initial page was fetched; the wasted second request was suppressed
-      expect(fetchRowsSpy.callCount).to.equal(1);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(1);
     });
 
     it('should let a controlled paginationMeta.hasNextPage: true override a false response', async () => {
@@ -1495,13 +1494,13 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
 
       // wait until the first page is rendered
       await waitFor(() => expect(getRow(0)).not.to.be.undefined);
-      fetchRowsSpy.resetHistory();
+      fetchRowsSpy.mockClear();
 
       // scrolling to the bottom still fetches the next page despite the false response
       await act(async () => {
         apiRef.current?.scrollToIndexes({ rowIndex: 9 });
       });
-      await waitFor(() => expect(fetchRowsSpy.callCount).to.be.at.least(1));
+      await waitFor(() => expect(fetchRowsSpy.mock.calls.length).to.be.at.least(1));
     });
 
     it('should honor initialState pagination meta hasNextPage: false', async () => {
@@ -1533,7 +1532,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
       });
 
       // only the initial page was fetched; initialState suppressed the wasted request
-      expect(fetchRowsSpy.callCount).to.equal(1);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(1);
     });
 
     it('should re-evaluate hasNextPage when the dataSource reference changes', async () => {
@@ -1556,8 +1555,8 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
         },
       });
 
-      const exhaustedFetchSpy = spy();
-      const silentFetchSpy = spy();
+      const exhaustedFetchSpy = vi.fn();
+      const silentFetchSpy = vi.fn();
       const exhaustedDataSource = createStaticDataSource(exhaustedFetchSpy, {
         hasNextPage: false,
       });
@@ -1567,16 +1566,16 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
       await waitFor(() => expect(getRow(0)).not.to.be.undefined);
 
       setProps({ dataSource: silentDataSource });
-      await waitFor(() => expect(silentFetchSpy.callCount).to.be.at.least(1));
+      await waitFor(() => expect(silentFetchSpy.mock.calls.length).to.be.at.least(1));
       await waitFor(() => expect(getRow(0)).not.to.be.undefined);
-      silentFetchSpy.resetHistory();
+      silentFetchSpy.mockClear();
 
       // scrolling to the bottom must fetch again: the stale `false` from the previous
       // data source must not survive the restart
       await act(async () => {
         apiRef.current?.scrollToIndexes({ rowIndex: 9 });
       });
-      await waitFor(() => expect(silentFetchSpy.callCount).to.be.at.least(1));
+      await waitFor(() => expect(silentFetchSpy.mock.calls.length).to.be.at.least(1));
     });
 
     it('should honor a pagination meta update made through the API', async () => {
@@ -1594,12 +1593,12 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
       await act(async () => {
         apiRef.current?.setPaginationMeta({ hasNextPage: true });
       });
-      fetchRowsSpy.resetHistory();
+      fetchRowsSpy.mockClear();
 
       await act(async () => {
         apiRef.current?.scrollToIndexes({ rowIndex: 9 });
       });
-      await waitFor(() => expect(fetchRowsSpy.callCount).to.be.at.least(1));
+      await waitFor(() => expect(fetchRowsSpy.mock.calls.length).to.be.at.least(1));
     });
   });
 
@@ -1650,19 +1649,19 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
       await waitFor(() => expect(getRow(0)).not.to.be.undefined);
 
       // reset the spy call count
-      fetchRowsSpy.resetHistory();
+      fetchRowsSpy.mockClear();
 
       // reduce the rowCount to be more than the number of rows
       await act(async () => {
         apiRef.current?.setRowCount(80);
       });
-      expect(fetchRowsSpy.callCount).to.equal(0);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(0);
 
       // reduce the rowCount once more, but now to be less than the number of rows
       await act(async () => {
         apiRef.current?.setRowCount(20);
       });
-      await waitFor(() => expect(fetchRowsSpy.callCount).to.equal(1));
+      await waitFor(() => expect(fetchRowsSpy.mock.calls.length).to.equal(1));
     });
 
     it('should allow setting the row count via API', async () => {
@@ -1688,15 +1687,16 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
   describe('Cache', () => {
     it('should combine cache chunks when possible to reduce the number of requests', async () => {
       const testCache = new TestCache();
-      const cacheGetSpy = spy(testCache, 'get');
+      const cacheGetSpy = vi.spyOn(testCache, 'get');
+      onTestFinished(() => cacheGetSpy.mockRestore());
       render(<TestDataSourceLazyLoader dataSourceCache={testCache} />);
 
       await waitFor(() => {
-        expect(cacheGetSpy.called).to.equal(true);
+        expect(cacheGetSpy.mock.calls.length).to.be.greaterThan(0);
       });
 
-      cacheGetSpy.resetHistory();
-      fetchRowsSpy.resetHistory();
+      cacheGetSpy.mockClear();
+      fetchRowsSpy.mockClear();
 
       act(() => {
         apiRef.current?.dataSource.fetchRows(GRID_ROOT_GROUP_ID, {
@@ -1706,9 +1706,9 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
       });
 
       await waitFor(() => {
-        expect(cacheGetSpy.callCount).to.equal(3);
+        expect(cacheGetSpy.mock.calls.length).to.equal(3);
       });
-      expect(fetchRowsSpy.callCount).to.equal(1);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(1);
 
       act(() => {
         apiRef.current?.dataSource.fetchRows(GRID_ROOT_GROUP_ID, {
@@ -1718,9 +1718,9 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
       });
 
       await waitFor(() => {
-        expect(cacheGetSpy.callCount).to.equal(4);
+        expect(cacheGetSpy.mock.calls.length).to.equal(4);
       });
-      expect(fetchRowsSpy.callCount).to.equal(1);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(1);
     });
   });
 });

--- a/packages/x-data-grid-pro/src/tests/dataSourceTreeData.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/dataSourceTreeData.DataGridPro.test.tsx
@@ -13,7 +13,7 @@ import type {
 } from '@mui/x-data-grid-pro';
 import { actSleep, getCell, getRow } from 'test/utils/helperFn';
 import { isJSDOM } from 'test/utils/skipIf';
-import { vi, describe, it, expect } from 'vitest';
+import { vi, onTestFinished, describe, it, expect } from 'vitest';
 
 const dataSetOptions = {
   dataSet: 'Employee' as const,
@@ -348,6 +348,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
     });
 
     const setChildrenLoadingSpy = vi.spyOn(apiRef.current!.dataSource, 'setChildrenLoading');
+    onTestFinished(() => setChildrenLoadingSpy.mockRestore());
 
     localFetchRowsSpy.mockClear();
     setChildrenLoadingSpy.mockClear();
@@ -366,7 +367,6 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
     const hasLoadingTrueCall = setChildrenLoadingSpy.mock.calls.some(
       (call) => call[0] === expandedRowId && call[1] === true,
     );
-    setChildrenLoadingSpy.mockRestore();
     expect(hasLoadingTrueCall).to.equal(false);
 
     // Stop revalidation so an in-flight fetch can't re-arm the 1ms interval

--- a/packages/x-data-grid-pro/src/tests/dataSourceTreeData.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/dataSourceTreeData.DataGridPro.test.tsx
@@ -11,10 +11,9 @@ import type {
   GridGetRowsResponse,
   GridGroupNode,
 } from '@mui/x-data-grid-pro';
-import { spy } from 'sinon';
 import { actSleep, getCell, getRow } from 'test/utils/helperFn';
 import { isJSDOM } from 'test/utils/skipIf';
-import { describe, it, expect } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 
 const dataSetOptions = {
   dataSet: 'Employee' as const,
@@ -31,7 +30,7 @@ const SUPPORTS_ACTIVITY = 'Activity' in React;
 // Needs layout
 describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
   const { render } = createRenderer();
-  const fetchRowsSpy = spy();
+  const fetchRowsSpy = vi.fn();
 
   let apiRef: RefObject<GridApi | null>;
   let mockServer: ReturnType<typeof useMockServer>;
@@ -53,7 +52,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
   // TODO: Resets strictmode calls, need to find a better fix for this, maybe an AbortController?
   function Reset() {
     React.useLayoutEffect(() => {
-      fetchRowsSpy.resetHistory();
+      fetchRowsSpy.mockClear();
     }, []);
     return null;
   }
@@ -129,18 +128,18 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
   it('should fetch the data on initial render', async () => {
     render(<TestDataSource />);
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.equal(1);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(1);
     });
   });
 
   it('should re-fetch the data on filter change', async () => {
     const { setProps } = render(<TestDataSource />);
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.equal(1);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(1);
     });
     setProps({ filterModel: { items: [{ field: 'name', value: 'John', operator: 'contains' }] } });
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.equal(2);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(2);
     });
   });
 
@@ -148,7 +147,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
     it('should not send a filter item without a value to the data source', async () => {
       render(<TestDataSource dataSourceCache={null} />);
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(1);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(1);
       });
 
       await act(async () => {
@@ -160,7 +159,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
         });
       });
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(2);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(2);
       });
 
       await act(async () => {
@@ -168,16 +167,16 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
       });
 
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(3);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(3);
       });
-      const url = new URL(fetchRowsSpy.lastCall.args[0]);
+      const url = new URL(fetchRowsSpy.mock.lastCall?.[0]);
       expect(JSON.parse(url.searchParams.get('filterModel')!).items).to.deep.equal([]);
     });
 
     it('should not re-fetch when the change only adds an incomplete item', async () => {
       render(<TestDataSource dataSourceCache={null} />);
       await waitFor(() => {
-        expect(fetchRowsSpy.callCount).to.equal(1);
+        expect(fetchRowsSpy.mock.calls.length).to.equal(1);
       });
 
       await act(async () => {
@@ -185,34 +184,34 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
       });
       await actSleep(50);
 
-      expect(fetchRowsSpy.callCount).to.equal(1);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(1);
     });
   });
 
   it('should re-fetch the data on sort change', async () => {
     const { setProps } = render(<TestDataSource />);
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.equal(1);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(1);
     });
     setProps({ sortModel: [{ field: 'name', sort: 'asc' }] });
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.equal(2);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(2);
     });
   });
 
   it('should re-fetch the data on pagination change', async () => {
     const { setProps } = render(<TestDataSource />);
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.equal(1);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(1);
     });
     setProps({ paginationModel: { page: 1, pageSize: 10 } });
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.equal(2);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(2);
     });
   });
 
   it('should periodically revalidate root rows when dataSourceRevalidateMs is set', async () => {
-    const localFetchRowsSpy = spy();
+    const localFetchRowsSpy = vi.fn();
     const { setProps, unmount } = render(
       <TestDataSource
         dataSourceCache={null}
@@ -222,15 +221,15 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
     );
 
     await waitFor(() => {
-      expect(localFetchRowsSpy.callCount).to.be.greaterThan(0);
+      expect(localFetchRowsSpy.mock.calls.length).to.be.greaterThan(0);
     });
 
-    const callCountAfterFirstFetch = localFetchRowsSpy.callCount;
+    const callCountAfterFirstFetch = localFetchRowsSpy.mock.calls.length;
 
     // With `dataSourceRevalidateMs` set, the grid refetches on an interval, so
     // the call count keeps growing on its own without any further prop change.
     await waitFor(() => {
-      expect(localFetchRowsSpy.callCount).to.be.greaterThan(callCountAfterFirstFetch);
+      expect(localFetchRowsSpy.mock.calls.length).to.be.greaterThan(callCountAfterFirstFetch);
     });
 
     // Stop revalidation so an in-flight fetch can't re-arm the 1ms interval
@@ -240,7 +239,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
   });
 
   it('should periodically revalidate expanded nested rows when dataSourceRevalidateMs is set', async () => {
-    const localFetchRowsSpy = spy();
+    const localFetchRowsSpy = vi.fn();
     const { setProps, user, unmount } = render(
       <TestDataSource
         dataSourceCache={null}
@@ -250,7 +249,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
     );
 
     await waitFor(() => {
-      expect(localFetchRowsSpy.callCount).to.equal(1);
+      expect(localFetchRowsSpy.mock.calls.length).to.equal(1);
     });
 
     await waitFor(() => expect(getRow(0)).not.to.be.undefined);
@@ -258,16 +257,16 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
     await user.click(within(cell11).getByRole('button'));
 
     await waitFor(() => {
-      expect(localFetchRowsSpy.callCount).to.be.greaterThan(1);
+      expect(localFetchRowsSpy.mock.calls.length).to.be.greaterThan(1);
     });
 
-    localFetchRowsSpy.resetHistory();
+    localFetchRowsSpy.mockClear();
 
     // The expanded group is revalidated on the interval; wait for one of those
     // background nested requests (a call carrying `groupKeys`) to be issued.
     await waitFor(() => {
-      const hasNestedGroupRequest = localFetchRowsSpy.getCalls().some((call) => {
-        const url = new URL(call.firstArg as string);
+      const hasNestedGroupRequest = localFetchRowsSpy.mock.calls.some((call) => {
+        const url = new URL(call[0] as string);
         const groupKeys = JSON.parse(url.searchParams.get('groupKeys') || '[]');
         return groupKeys.length > 0;
       });
@@ -286,7 +285,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
     );
 
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.equal(1);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(1);
     });
 
     await waitFor(() => expect(getRow(0)).not.to.be.undefined);
@@ -294,7 +293,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
     await user.click(within(cell11).getByRole('button'));
 
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.be.greaterThan(1);
+      expect(fetchRowsSpy.mock.calls.length).to.be.greaterThan(1);
       const expandedNode = apiRef.current!.state.rows.tree[expandedRowId] as GridGroupNode;
       expect(expandedNode.children.length).to.be.greaterThan(0);
     });
@@ -306,12 +305,12 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
     });
     expect(apiRef.current!.isRowSelected(firstChildId)).to.equal(true);
 
-    fetchRowsSpy.resetHistory();
+    fetchRowsSpy.mockClear();
 
     // Wait for a background nested revalidation (a call carrying `groupKeys`).
     await waitFor(() => {
-      const hasNestedGroupRequest = fetchRowsSpy.getCalls().some((call) => {
-        const url = new URL(call.firstArg as string);
+      const hasNestedGroupRequest = fetchRowsSpy.mock.calls.some((call) => {
+        const url = new URL(call[0] as string);
         const groupKeys = JSON.parse(url.searchParams.get('groupKeys') || '[]');
         return groupKeys.length > 0;
       });
@@ -327,7 +326,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
   });
 
   it('should not set children loading state during background nested revalidation', async () => {
-    const localFetchRowsSpy = spy();
+    const localFetchRowsSpy = vi.fn();
     const { setProps, user, unmount } = render(
       <TestDataSource
         dataSourceCache={null}
@@ -337,7 +336,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
     );
 
     await waitFor(() => {
-      expect(localFetchRowsSpy.callCount).to.equal(1);
+      expect(localFetchRowsSpy.mock.calls.length).to.equal(1);
     });
 
     await waitFor(() => expect(getRow(0)).not.to.be.undefined);
@@ -345,18 +344,18 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
     await user.click(within(cell11).getByRole('button'));
 
     await waitFor(() => {
-      expect(localFetchRowsSpy.callCount).to.be.greaterThan(1);
+      expect(localFetchRowsSpy.mock.calls.length).to.be.greaterThan(1);
     });
 
-    const setChildrenLoadingSpy = spy(apiRef.current!.dataSource, 'setChildrenLoading');
+    const setChildrenLoadingSpy = vi.spyOn(apiRef.current!.dataSource, 'setChildrenLoading');
 
-    localFetchRowsSpy.resetHistory();
-    setChildrenLoadingSpy.resetHistory();
+    localFetchRowsSpy.mockClear();
+    setChildrenLoadingSpy.mockClear();
 
     // Wait for a background nested revalidation (a call carrying `groupKeys`)...
     await waitFor(() => {
-      const hasNestedGroupRequest = localFetchRowsSpy.getCalls().some((call) => {
-        const url = new URL(call.firstArg as string);
+      const hasNestedGroupRequest = localFetchRowsSpy.mock.calls.some((call) => {
+        const url = new URL(call[0] as string);
         const groupKeys = JSON.parse(url.searchParams.get('groupKeys') || '[]');
         return groupKeys.length > 0;
       });
@@ -364,10 +363,10 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
     });
 
     // ...and confirm it never put the expanded group into a loading state.
-    const hasLoadingTrueCall = setChildrenLoadingSpy
-      .getCalls()
-      .some((call) => call.args[0] === expandedRowId && call.args[1] === true);
-    setChildrenLoadingSpy.restore();
+    const hasLoadingTrueCall = setChildrenLoadingSpy.mock.calls.some(
+      (call) => call[0] === expandedRowId && call[1] === true,
+    );
+    setChildrenLoadingSpy.mockRestore();
     expect(hasLoadingTrueCall).to.equal(false);
 
     // Stop revalidation so an in-flight fetch can't re-arm the 1ms interval
@@ -400,7 +399,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
     );
 
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.equal(1);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(1);
     });
 
     await waitFor(() => expect(getRow(0)).not.to.be.undefined);
@@ -409,7 +408,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
     await user.click(within(cell11).getByRole('button'));
 
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.equal(2);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(2);
       expect(apiRef.current!.state.rows.tree[testRowId]).not.to.equal(undefined);
     });
 
@@ -418,7 +417,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
     });
 
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.equal(3);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(3);
       expect(apiRef.current!.state.rows.tree[testRowId]).to.equal(undefined);
     });
   });
@@ -430,7 +429,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
       throw new Error('apiRef.current.state is not defined');
     }
 
-    expect(fetchRowsSpy.callCount).to.equal(1);
+    expect(fetchRowsSpy.mock.calls.length).to.equal(1);
     await waitFor(() => {
       expect(Object.keys(apiRef.current!.state.rows.tree).length).to.equal(10 + 1);
     });
@@ -439,7 +438,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
     await user.click(within(cell11).getByRole('button'));
 
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.equal(2);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(2);
     });
 
     const cell11ChildrenCount = Number(cell11.innerText.split('(')[1].split(')')[0]);
@@ -471,7 +470,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
     );
 
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.equal(1);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(1);
     });
 
     await waitFor(() => {
@@ -486,7 +485,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
     await user.click(within(cell11).getByRole('button'));
 
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.equal(2);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(2);
     });
 
     // children are part of the tree
@@ -505,7 +504,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
     });
 
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.equal(3);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(3);
     });
 
     // children are still part of the tree, and the stale test row has been
@@ -521,7 +520,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
   it('should collapse the nested data if refetching the root level with `keepChildrenExpanded` set to `false`', async () => {
     const { user } = render(<TestDataSource dataSourceCache={null} />);
 
-    expect(fetchRowsSpy.callCount).to.equal(1);
+    expect(fetchRowsSpy.mock.calls.length).to.equal(1);
     await waitFor(() => {
       expect(Object.keys(apiRef.current!.state.rows.tree).length).to.equal(10 + 1);
     });
@@ -530,7 +529,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
     await user.click(within(cell11).getByRole('button'));
 
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.be.greaterThan(1);
+      expect(fetchRowsSpy.mock.calls.length).to.be.greaterThan(1);
     });
 
     const cell11ChildrenCount = Number(cell11.innerText.split('(')[1].split(')')[0]);
@@ -542,14 +541,14 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
       );
     });
 
-    fetchRowsSpy.resetHistory();
+    fetchRowsSpy.mockClear();
 
     act(() => {
       apiRef.current?.dataSource.fetchRows(undefined, { keepChildrenExpanded: false });
     });
 
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.equal(1);
+      expect(fetchRowsSpy.mock.calls.length).to.equal(1);
     });
 
     // Children collapse once the re-fetch settles, leaving only the root rows.
@@ -719,7 +718,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
       throw new Error('apiRef.current.state is not defined');
     }
 
-    expect(fetchRowsSpy.callCount).to.equal(1);
+    expect(fetchRowsSpy.mock.calls.length).to.equal(1);
 
     await waitFor(() => {
       expect(Object.keys(apiRef.current!.state.rows.tree).length).to.equal(10 + 1);
@@ -732,7 +731,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
     });
 
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.be.greaterThan(1);
+      expect(fetchRowsSpy.mock.calls.length).to.be.greaterThan(1);
     });
 
     const cell11ChildrenCount = Number(cell11.innerText.split('(')[1].split(')')[0]);
@@ -814,7 +813,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
       throw new Error('apiRef.current.state is not defined');
     }
 
-    expect(fetchRowsSpy.callCount).to.equal(1);
+    expect(fetchRowsSpy.mock.calls.length).to.equal(1);
     await waitFor(() => {
       expect(apiRef.current!.state.rows.groupsToFetch?.length).to.be.greaterThan(0);
     });
@@ -853,7 +852,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
     await user.click(within(cell).getByRole('button'));
 
     await waitFor(() => {
-      expect(fetchRowsSpy.callCount).to.be.greaterThan(1);
+      expect(fetchRowsSpy.mock.calls.length).to.be.greaterThan(1);
     });
 
     // Collapse the first parent row

--- a/packages/x-data-grid-pro/src/tests/infiniteLoader.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/infiniteLoader.DataGridPro.test.tsx
@@ -1,16 +1,11 @@
 import * as React from 'react';
 import { act, createRenderer, waitFor } from '@mui/internal-test-utils';
 import { DataGridPro } from '@mui/x-data-grid-pro';
-import { spy, restore } from 'sinon';
 import { getColumnValues } from 'test/utils/helperFn';
 import { isJSDOM } from 'test/utils/skipIf';
-import { describe, it, expect, afterEach } from 'vitest';
+import { vi, onTestFinished, describe, it, expect } from 'vitest';
 
 describe('<DataGridPro /> - Infinite loader', () => {
-  afterEach(() => {
-    restore();
-  });
-
   const { render } = createRenderer();
 
   // Needs layout
@@ -25,7 +20,7 @@ describe('<DataGridPro /> - Infinite loader', () => {
         { id: 4, brand: 'Jordan' },
         { id: 5, brand: 'Reebok' },
       ];
-      const handleRowsScrollEnd = spy();
+      const handleRowsScrollEnd = vi.fn();
       function TestCase({ rows }: { rows: typeof baseRows }) {
         return (
           <div style={{ width: 300, height: 300 }}>
@@ -45,7 +40,7 @@ describe('<DataGridPro /> - Infinite loader', () => {
       await act(async () => virtualScroller.scrollTo({ top: 12345, behavior: 'instant' }));
 
       await waitFor(() => {
-        expect(handleRowsScrollEnd.callCount).to.equal(1);
+        expect(handleRowsScrollEnd.mock.calls.length).to.equal(1);
       });
 
       await act(async () => {
@@ -61,12 +56,12 @@ describe('<DataGridPro /> - Infinite loader', () => {
         virtualScroller.dispatchEvent(new Event('scroll'));
       });
 
-      expect(handleRowsScrollEnd.callCount).to.equal(1);
+      expect(handleRowsScrollEnd.mock.calls.length).to.equal(1);
 
       await act(async () => virtualScroller.scrollTo({ top: 12345, behavior: 'instant' }));
 
       await waitFor(() => {
-        expect(handleRowsScrollEnd.callCount).to.equal(2);
+        expect(handleRowsScrollEnd.mock.calls.length).to.equal(2);
       });
     },
   );
@@ -84,7 +79,7 @@ describe('<DataGridPro /> - Infinite loader', () => {
         { id: 5, brand: 'Reebok' },
       ];
       const initialRows = [allRows[0]];
-      const getRow = spy((id) => {
+      const getRow = vi.fn((id) => {
         return allRows.find((row) => row.id === id);
       });
 
@@ -132,13 +127,12 @@ describe('<DataGridPro /> - Infinite loader', () => {
 
       const multiplier = 2; // `setRows` is called twice for each `handleRowsScrollEnd` call
       await waitFor(() => {
-        expect(getRow.callCount).to.equal(5 * multiplier);
+        expect(getRow.mock.calls.length).to.equal(5 * multiplier);
       });
 
-      const getRowCalls = getRow.getCalls();
-      for (let callIndex = 0; callIndex < getRowCalls.length; callIndex += multiplier) {
-        const call = getRowCalls[callIndex];
-        expect(call.returnValue?.id).to.equal(callIndex / multiplier + 1);
+      const getRowResults = getRow.mock.results;
+      for (let callIndex = 0; callIndex < getRowResults.length; callIndex += multiplier) {
+        expect(getRowResults[callIndex].value?.id).to.equal(callIndex / multiplier + 1);
       }
 
       await waitFor(() => {
@@ -163,8 +157,9 @@ describe('<DataGridPro /> - Infinite loader', () => {
         bottom: [{ id: 6, brand: 'Unbranded' }],
       };
 
-      const handleRowsScrollEnd = spy();
-      const observe = spy(window.IntersectionObserver.prototype, 'observe');
+      const handleRowsScrollEnd = vi.fn();
+      const observe = vi.spyOn(window.IntersectionObserver.prototype, 'observe');
+      onTestFinished(() => observe.mockRestore());
 
       function TestCase({
         rows,
@@ -188,12 +183,12 @@ describe('<DataGridPro /> - Infinite loader', () => {
       // eslint-disable-next-line testing-library/no-container
       const virtualScroller = container.querySelector('.MuiDataGrid-virtualScroller')!;
       // on the initial render, last row is not visible and the `observe` method is not called
-      expect(observe.callCount).to.equal(0);
+      expect(observe.mock.calls.length).to.equal(0);
       // arbitrary number to make sure that the bottom of the grid window is reached.
       await act(async () => virtualScroller.scrollTo({ top: 12345, behavior: 'instant' }));
       // observer was attached
       await waitFor(() => {
-        expect(observe.callCount).to.equal(1);
+        expect(observe.mock.calls.length).to.equal(1);
       });
     },
   );

--- a/packages/x-data-grid/src/tests/export.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/export.DataGrid.test.tsx
@@ -1,11 +1,10 @@
-import { spy } from 'sinon';
-import type { SinonSpy } from 'sinon';
+import type { MockInstance } from 'vitest';
 import { DataGrid, GridToolbarExport } from '@mui/x-data-grid';
 import type { DataGridProps } from '@mui/x-data-grid';
 import { useBasicDemoData } from '@mui/x-data-grid-generator';
 import { createRenderer, screen, fireEvent } from '@mui/internal-test-utils';
 import { isJSDOM } from 'test/utils/skipIf';
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 // We need `createObjectURL` to test the downloaded value
 describe.skipIf(isJSDOM)('<DataGrid /> - Export', () => {
@@ -21,14 +20,14 @@ describe.skipIf(isJSDOM)('<DataGrid /> - Export', () => {
     );
   }
 
-  let spyCreateObjectURL: SinonSpy;
+  let spyCreateObjectURL: MockInstance;
 
   beforeEach(() => {
-    spyCreateObjectURL = spy(globalThis.URL, 'createObjectURL');
+    spyCreateObjectURL = vi.spyOn(globalThis.URL, 'createObjectURL');
   });
 
   afterEach(() => {
-    spyCreateObjectURL.restore();
+    spyCreateObjectURL.mockRestore();
   });
 
   describe('component: GridToolbar', () => {
@@ -37,8 +36,8 @@ describe.skipIf(isJSDOM)('<DataGrid /> - Export', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Export' }));
       expect(screen.queryByRole('menu')).not.to.equal(null);
       fireEvent.click(screen.getByRole('menuitem', { name: 'Download as CSV' }));
-      expect(spyCreateObjectURL.callCount).to.equal(1);
-      const csv = await spyCreateObjectURL.lastCall.firstArg.text();
+      expect(spyCreateObjectURL.mock.calls.length).to.equal(1);
+      const csv = await spyCreateObjectURL.mock.lastCall?.[0].text();
       expect(csv).to.equal(['id,Currency Pair', '0,USDGBP', '1,USDEUR', '2,GBPEUR'].join('\r\n'));
     });
 
@@ -47,8 +46,8 @@ describe.skipIf(isJSDOM)('<DataGrid /> - Export', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Export' }));
       expect(screen.queryByRole('menu')).not.to.equal(null);
       fireEvent.click(screen.getByRole('menuitem', { name: 'Download as CSV' }));
-      expect(spyCreateObjectURL.callCount).to.equal(1);
-      const csv = await spyCreateObjectURL.lastCall.firstArg.text();
+      expect(spyCreateObjectURL.mock.calls.length).to.equal(1);
+      const csv = await spyCreateObjectURL.mock.lastCall?.[0].text();
       expect(csv).to.equal(['id;Currency Pair', '0;USDGBP', '1;USDEUR', '2;GBPEUR'].join('\r\n'));
     });
 
@@ -88,8 +87,8 @@ describe.skipIf(isJSDOM)('<DataGrid /> - Export', () => {
 
       expect(screen.queryByRole('menu')).not.to.equal(null);
       fireEvent.click(screen.getByRole('menuitem', { name: 'Download as CSV' }));
-      expect(spyCreateObjectURL.callCount).to.equal(1);
-      const csv = await spyCreateObjectURL.lastCall.firstArg.text();
+      expect(spyCreateObjectURL.mock.calls.length).to.equal(1);
+      const csv = await spyCreateObjectURL.mock.lastCall?.[0].text();
 
       expect(csv).to.equal(
         [
@@ -125,8 +124,8 @@ describe.skipIf(isJSDOM)('<DataGrid /> - Export', () => {
 
       expect(screen.queryByRole('menu')).not.to.equal(null);
       fireEvent.click(screen.getByRole('menuitem', { name: 'Download as CSV' }));
-      expect(spyCreateObjectURL.callCount).to.equal(1);
-      const csv = await spyCreateObjectURL.lastCall.firstArg.text();
+      expect(spyCreateObjectURL.mock.calls.length).to.equal(1);
+      const csv = await spyCreateObjectURL.mock.lastCall?.[0].text();
 
       expect(csv).to.equal(['name', 'Name', '', '', '1234'].join('\r\n'));
     });
@@ -139,8 +138,8 @@ describe.skipIf(isJSDOM)('<DataGrid /> - Export', () => {
 
       expect(screen.queryByRole('menu')).not.to.equal(null);
       fireEvent.click(screen.getByRole('menuitem', { name: 'Download as CSV' }));
-      expect(spyCreateObjectURL.callCount).to.equal(1);
-      const csv = await spyCreateObjectURL.lastCall.firstArg.text();
+      expect(spyCreateObjectURL.mock.calls.length).to.equal(1);
+      const csv = await spyCreateObjectURL.mock.lastCall?.[0].text();
       expect(csv).to.equal(['id,Currency Pair', '0,USDGBP', '1,USDEUR', '2,GBPEUR'].join('\r\n'));
     });
 
@@ -155,8 +154,8 @@ describe.skipIf(isJSDOM)('<DataGrid /> - Export', () => {
 
       expect(screen.queryByRole('menu')).not.to.equal(null);
       fireEvent.click(screen.getByRole('menuitem', { name: 'Download as CSV' }));
-      expect(spyCreateObjectURL.callCount).to.equal(1);
-      const csv = await spyCreateObjectURL.lastCall.firstArg.text();
+      expect(spyCreateObjectURL.mock.calls.length).to.equal(1);
+      const csv = await spyCreateObjectURL.mock.lastCall?.[0].text();
       expect(csv).to.equal(['id;Currency Pair', '0;USDGBP', '1;USDEUR', '2;GBPEUR'].join('\r\n'));
     });
 

--- a/packages/x-internals/src/EventManager/EventManager.test.ts
+++ b/packages/x-internals/src/EventManager/EventManager.test.ts
@@ -1,48 +1,56 @@
-import { spy, assert as sinonAssert } from 'sinon';
-import { describe, it } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
+import type { Mock } from 'vitest';
 import { EventManager } from './EventManager';
+
+/** Vitest's invocation counter is global across mocks, so it orders calls between them. */
+function expectCallOrder(...listeners: Mock[]) {
+  // `sinon.assert.callOrder` also failed when a spy was never called.
+  listeners.forEach((listener) => expect(listener.mock.calls.length).to.be.greaterThan(0));
+  const order = listeners.map((listener) => listener.mock.invocationCallOrder[0]);
+  expect(order).to.deep.equal([...order].sort((a, b) => a - b));
+}
 
 describe('EventManager', () => {
   it('should run regular-priority event in the registration order', () => {
     const manager = new EventManager();
-    const listener1 = spy();
-    const listener2 = spy();
+    const listener1 = vi.fn();
+    const listener2 = vi.fn();
     manager.on('testEvent', listener1);
     manager.on('testEvent', listener2);
     manager.emit('testEvent');
-    sinonAssert.callOrder(listener1, listener2);
+    expectCallOrder(listener1, listener2);
   });
 
   it('should run high-priority event in the registration reversed order', () => {
     const manager = new EventManager();
-    const listener1 = spy();
-    const listener2 = spy();
+    const listener1 = vi.fn();
+    const listener2 = vi.fn();
     manager.on('testEvent', listener1, { isFirst: true });
     manager.on('testEvent', listener2, { isFirst: true });
     manager.emit('testEvent');
-    sinonAssert.callOrder(listener2, listener1);
+    expectCallOrder(listener2, listener1);
   });
 
   it('should run high-priority event before regular priority event', () => {
     const manager = new EventManager();
-    const listener1 = spy();
-    const listener2 = spy();
+    const listener1 = vi.fn();
+    const listener2 = vi.fn();
     manager.on('testEvent', listener1);
     manager.on('testEvent', listener2, { isFirst: true });
     manager.emit('testEvent');
-    sinonAssert.callOrder(listener2, listener1);
+    expectCallOrder(listener2, listener1);
   });
 
   it('should apply event un-registration even when asked after the emission', () => {
     const manager = new EventManager();
-    const listener2 = spy();
-    const listener1 = spy(() => {
+    const listener2 = vi.fn();
+    const listener1 = vi.fn(() => {
       manager.removeListener('testEvent', listener2);
     });
     manager.on('testEvent', listener1);
     manager.on('testEvent', listener2);
     manager.emit('testEvent');
-    sinonAssert.callCount(listener1, 1);
-    sinonAssert.callCount(listener2, 0);
+    expect(listener1.mock.calls.length).to.equal(1);
+    expect(listener2.mock.calls.length).to.equal(0);
   });
 });


### PR DESCRIPTION
Sixth step away from Sinon, following #23443, #23460, #23464, #23466 and #23472. Sinon goes from 22 files to 14, leaving only the fake timers and `test/setupVitest.ts`.

## The conversion itself is 1:1

`spy(obj, 'method')` maps straight to `vi.spyOn(obj, 'method')`. Both wrap the method and keep calling through, so unlike #23472's `stub` sites, none of these needs an implementation supplied.

## Restoring is the part that needed checking

Sinon registered these spies in its default sandbox, which `test/setupVitest.ts` clears after every test. That meant a site could get away with no local cleanup and still not leak. `vi.spyOn` has no such net, so I went through all ten sites:

- Eight already restored themselves, in an `afterEach` or inline, and only needed `restore()` renamed to `mockRestore()`.
- `infiniteLoader.DataGridPro` used the sandbox-wide `restore()` from Sinon in an `afterEach`. It now restores the single spy it creates.
- The cache spy in `dataSourceLazyLoader.DataGridPro` had no cleanup at all. It now restores through `onTestFinished`.

So this step still does not need `vi.restoreAllMocks()` in the shared teardown. Every site restores itself, which is the point at which that safety net stops being load-bearing.

## `sinon.assert` is gone

`EventManager.test.ts` was the only user. `assert.callOrder` has no Vitest equivalent, so it compares `mock.invocationCallOrder`, which is a global counter and therefore orders calls across separate mocks:

```ts
function expectCallOrder(...listeners: Mock[]) {
  // `sinon.assert.callOrder` also failed when a spy was never called.
  listeners.forEach((listener) => expect(listener.mock.calls.length).to.be.greaterThan(0));
  const order = listeners.map((listener) => listener.mock.invocationCallOrder[0]);
  expect(order).to.deep.equal([...order].sort((a, b) => a - b));
}
```

The call-count check is not decoration: without it, a listener that never ran would contribute `undefined` and the comparison would pass vacuously, where `assert.callOrder` failed.

## One accessor that is not about arguments

`call.returnValue` reads the call's result, so it becomes `mock.results[n].value`. Mapping it onto `mock.calls[n]` like the other call-object accessors would have compared against the arguments instead.

## Status

`typescript` and `eslint` are clean. All eight files pass: seven in the browser (111 tests) and `EventManager` in jsdom (4 tests).
