### PR TITLE
[DataGridPro] Fix data integrity issue in nested server data

### DIFF
--- a/packages/x-data-grid-premium/src/tests/dataSourceRowGrouping.DataGridPremium.test.tsx
+++ b/packages/x-data-grid-premium/src/tests/dataSourceRowGrouping.DataGridPremium.test.tsx
@@ -198,6 +198,71 @@ describe.skipIf(isJSDOM)('<DataGridPremium /> - Data source row grouping', () =>
     });
   });
 
+  // https://github.com/mui/mui-x/issues/23009
+  it('should keep an updated leaf row under its group', async () => {
+    const dataSource: GridDataSource = {
+      getRows: async (params: GridGetRowsParams) => {
+        if (params.groupKeys!.length === 0) {
+          const rootRows = [
+            { id: 'company-A', group: 'A', descendantCount: 2 },
+            { id: 'company-B', group: 'B', descendantCount: 0 },
+          ];
+          return { rows: rootRows, rowCount: rootRows.length };
+        }
+        if (params.groupKeys![0] === 'A') {
+          const companyChildren = [
+            { id: 'A-1', trader: 'Trader 1', descendantCount: 0 },
+            { id: 'A-2', trader: 'Trader 2', descendantCount: 0 },
+          ];
+          return { rows: companyChildren, rowCount: companyChildren.length };
+        }
+        return { rows: [], rowCount: 0 };
+      },
+      getGroupKey: (row) => row.group,
+      getChildrenCount: (row) => row.descendantCount,
+    };
+
+    function TestComponent() {
+      apiRef = useGridApiRef();
+      return (
+        <div style={{ width: 300, height: 300 }}>
+          <DataGridPremium
+            apiRef={apiRef}
+            columns={[{ field: 'company' }, { field: 'trader' }]}
+            dataSource={dataSource}
+            dataSourceCache={null}
+            disableVirtualization
+            rowGroupingModel={['company']}
+          />
+        </div>
+      );
+    }
+
+    render(<TestComponent />);
+    await waitFor(() => {
+      expect(apiRef.current!.state.rows.tree['company-A']).not.to.equal(undefined);
+    });
+
+    const getCompanyChildren = () =>
+      (apiRef.current!.state.rows.tree['company-A'] as GridGroupNode).children;
+    act(() => {
+      apiRef.current!.dataSource.fetchRows('company-A');
+    });
+    await waitFor(() => {
+      expect(getCompanyChildren()).to.deep.equal(['A-1', 'A-2']);
+    });
+
+    act(() => {
+      apiRef.current!.updateRows([{ id: 'A-1', trader: 'Trader 1 (edited)' }]);
+    });
+
+    expect(apiRef.current!.state.rows.tree['A-1'].parent).to.equal('company-A');
+    expect(getCompanyChildren()).to.deep.equal(['A-1', 'A-2']);
+    expect(
+      (apiRef.current!.state.rows.tree[GRID_ROOT_GROUP_ID] as GridGroupNode).children,
+    ).to.deep.equal(['company-A', 'company-B']);
+  });
+
   describe('Nested lazy loading', () => {
     type RowGroupingRow = {
       id: string;

--- a/packages/x-data-grid-pro/src/hooks/features/dataSource/utils.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/dataSource/utils.ts
@@ -129,7 +129,7 @@ export const getGroupKeys = (tree: GridRowTreeConfig, rowId: GridRowId) => {
   const rowNode = tree[rowId];
   let currentNodeId = rowNode.parent;
   const groupKeys: GridKeyValue[] = [];
-  while (currentNodeId && currentNodeId !== GRID_ROOT_GROUP_ID) {
+  while (currentNodeId != null && currentNodeId !== GRID_ROOT_GROUP_ID) {
     const currentNode = tree[currentNodeId] as GridGroupNode;
     groupKeys.push(currentNode.groupingKey ?? '');
     currentNodeId = currentNode.parent;

--- a/packages/x-data-grid-pro/src/hooks/features/serverSideTreeData/utils.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/serverSideTreeData/utils.ts
@@ -25,7 +25,8 @@ export function skipSorting(rowTree: GridRowTreeConfig) {
 
 /**
  * Retrieves the parent path for a row from the previous tree state.
- * Used during full tree updates to maintain correct hierarchy.
+ * Used when a row update doesn't carry explicit `groupKeys`, that is during full tree updates
+ * and partial updates coming from `apiRef.current.updateRows()`, to maintain correct hierarchy.
  *
  * Uses the parent node's `path` property, which stores the group keys
  * representing the full path to the parent (i.e. the keys used to fetch the current node).
@@ -35,7 +36,6 @@ export function getParentPath(
   treeCreationParams: GridRowTreeCreationParams,
 ): string[] {
   if (
-    treeCreationParams.updates.type !== 'full' ||
     !treeCreationParams.previousTree?.[rowId] ||
     treeCreationParams.previousTree[rowId].depth < 1
   ) {

--- a/packages/x-data-grid-pro/src/tests/dataSourceTreeData.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/dataSourceTreeData.DataGridPro.test.tsx
@@ -10,6 +10,9 @@ import type {
   GridGetRowsParams,
   GridGetRowsResponse,
   GridGroupNode,
+  GridRowId,
+  GridRowModel,
+  GridUpdateRowParams,
 } from '@mui/x-data-grid-pro';
 import { actSleep, getCell, getRow } from 'test/utils/helperFn';
 import { isJSDOM } from 'test/utils/skipIf';
@@ -858,6 +861,186 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
     // Collapse the first parent row
     await user.click(within(cell).getByRole('button'));
   });
+  // https://github.com/mui/mui-x/issues/23009
+  describe('nested row updates', () => {
+    const NESTED_DATA: Record<string, any[]> = {
+      '[]': [
+        { id: 'p1', name: 'Parent 1', website: 'p1.example', descendantCount: 3 },
+        { id: 'p2', name: 'Parent 2', website: 'p2.example', descendantCount: 0 },
+      ],
+      '["Parent 1"]': [
+        { id: 'c1', name: 'Child 1', website: 'c1.example', descendantCount: 0 },
+        { id: 'c2', name: 'Child 2', website: 'c2.example', descendantCount: 0 },
+        { id: 'c3', name: 'Child 3', website: 'c3.example', descendantCount: 0 },
+      ],
+    };
+    // The parent row has a falsy id
+    const FALSY_ID_DATA: Record<string, any[]> = {
+      '[]': [{ id: 0, name: 'Parent 0', website: 'p0.example', descendantCount: 1 }],
+      '["Parent 0"]': [{ id: 1, name: 'Child', website: 'c.example', descendantCount: 0 }],
+    };
+
+    type NestedRowsTestProps = Partial<DataGridProProps> & {
+      data?: Record<string, any[]>;
+      withUpdateRow?: boolean;
+      onGetRows?: (params: GridGetRowsParams) => void;
+    };
+
+    function NestedRowsTest(props: NestedRowsTestProps) {
+      apiRef = useGridApiRef();
+      const { data = NESTED_DATA, withUpdateRow = false, onGetRows, ...other } = props;
+
+      const dataSource: GridDataSource = React.useMemo(
+        () => ({
+          getRows: async (params: GridGetRowsParams) => {
+            onGetRows?.(params);
+            const rows = data[JSON.stringify(params.groupKeys)] ?? [];
+            return { rows, rowCount: rows.length };
+          },
+          updateRow: withUpdateRow
+            ? async (params: GridUpdateRowParams) => params.updatedRow
+            : undefined,
+          getGroupKey: (row) => row.name,
+          getChildrenCount: (row) => row.descendantCount,
+        }),
+        [data, withUpdateRow, onGetRows],
+      );
+
+      return (
+        <div style={{ width: 300, height: 300 }}>
+          <DataGridPro
+            apiRef={apiRef}
+            columns={[{ field: 'name' }, { field: 'website', editable: true }]}
+            dataSource={dataSource}
+            dataSourceCache={null}
+            treeData
+            disableVirtualization
+            {...other}
+          />
+        </div>
+      );
+    }
+
+    const getTree = () => apiRef.current!.state.rows.tree;
+    const getChildren = (id: GridRowId) => (getTree()[id] as GridGroupNode).children;
+
+    async function renderWithExpandedParent(props: NestedRowsTestProps = {}) {
+      const view = render(<NestedRowsTest {...props} />);
+      await waitFor(() => {
+        expect(getTree().p1).not.to.equal(undefined);
+      });
+      act(() => {
+        apiRef.current!.dataSource.fetchRows('p1');
+      });
+      await waitFor(() => {
+        expect(getChildren('p1')).to.deep.equal(['c1', 'c2', 'c3']);
+      });
+      return view;
+    }
+
+    async function editCell(id: GridRowId, field: string, value: string) {
+      act(() => {
+        apiRef.current!.startCellEditMode({ id, field });
+      });
+      await act(async () => {
+        await apiRef.current!.setEditCellValue({ id, field, value });
+      });
+      act(() => {
+        apiRef.current!.stopCellEditMode({ id, field });
+      });
+      await waitFor(() => {
+        expect(apiRef.current!.getRow(id)[field]).to.equal(value);
+      });
+    }
+
+    it('should keep an updated nested row under its parent', async () => {
+      await renderWithExpandedParent();
+
+      act(() => {
+        apiRef.current!.updateRows([{ id: 'c1', website: 'updated' }]);
+      });
+
+      expect(getTree().c1.parent).to.equal('p1');
+      expect(getTree().c1.depth).to.equal(1);
+      expect(getChildren('p1')).to.deep.equal(['c1', 'c2', 'c3']);
+      expect(getChildren(GRID_ROOT_GROUP_ID)).to.deep.equal(['p1', 'p2']);
+    });
+
+    it('should keep the children order after re-fetching the root and the parent following a nested row update', async () => {
+      const getRowsSpy = vi.fn();
+      await renderWithExpandedParent({ onGetRows: getRowsSpy });
+
+      act(() => {
+        apiRef.current!.updateRows([{ id: 'c1', website: 'updated' }]);
+      });
+
+      const callsBeforeRefetch = getRowsSpy.mock.calls.length;
+      act(() => {
+        apiRef.current!.dataSource.fetchRows();
+      });
+      await waitFor(() => {
+        expect(getRowsSpy.mock.calls.length).to.equal(callsBeforeRefetch + 1);
+      });
+      act(() => {
+        apiRef.current!.dataSource.fetchRows('p1');
+      });
+      await waitFor(() => {
+        expect(getRowsSpy.mock.calls.length).to.equal(callsBeforeRefetch + 2);
+      });
+      // The children re-fetch resets the edited value
+      await waitFor(() => {
+        expect(apiRef.current!.getRow('c1')?.website).to.equal('c1.example');
+      });
+
+      expect(getChildren('p1')).to.deep.equal(['c1', 'c2', 'c3']);
+      expect(getChildren(GRID_ROOT_GROUP_ID)).to.deep.equal(['p1', 'p2']);
+    });
+
+    it('should keep an edited nested row under its parent when using `processRowUpdate`', async () => {
+      const processRowUpdate = vi.fn((row: GridRowModel) => row);
+      await renderWithExpandedParent({ processRowUpdate });
+
+      await editCell('c1', 'website', 'edited');
+
+      expect(processRowUpdate.mock.calls.length).to.equal(1);
+      expect(getTree().c1.parent).to.equal('p1');
+      expect(getChildren('p1')).to.deep.equal(['c1', 'c2', 'c3']);
+    });
+
+    it('should keep an edited nested row under a parent with a falsy id when using `dataSource.updateRow`', async () => {
+      render(
+        <NestedRowsTest data={FALSY_ID_DATA} withUpdateRow defaultGroupingExpansionDepth={-1} />,
+      );
+      await waitFor(() => {
+        expect(getChildren(0)).to.deep.equal([1]);
+      });
+
+      await editCell(1, 'website', 'edited');
+
+      expect(getTree()[1].parent).to.equal(0);
+      expect(getChildren(0)).to.deep.equal([1]);
+    });
+
+    it('should fetch the children of a parent with a falsy id when expanding it', async () => {
+      const getRowsSpy = vi.fn();
+      const { user } = render(<NestedRowsTest data={FALSY_ID_DATA} onGetRows={getRowsSpy} />);
+      await waitFor(() => {
+        expect(getTree()[0]).not.to.equal(undefined);
+      });
+
+      const callsBeforeExpand = getRowsSpy.mock.calls.length;
+      await user.click(within(getCell(0, 0)).getByRole('button'));
+
+      await waitFor(() => {
+        expect(getRowsSpy.mock.calls.length).to.equal(callsBeforeExpand + 1);
+      });
+      expect(getRowsSpy.mock.calls[callsBeforeExpand][0].groupKeys).to.deep.equal(['Parent 0']);
+      await waitFor(() => {
+        expect(getChildren(0)).to.deep.equal([1]);
+      });
+    });
+  });
+
   if (SUPPORTS_ACTIVITY) {
     // https://github.com/mui/mui-x/issues/23262
     describe('Activity', () => {

--- a/packages/x-data-grid/src/hooks/features/dataSource/useGridDataSourceBase.ts
+++ b/packages/x-data-grid/src/hooks/features/dataSource/useGridDataSourceBase.ts
@@ -132,7 +132,7 @@ export const useGridDataSourceBase = <Api extends GridPrivateApiCommunity>(
         gridColumnLookupSelector(apiRef),
       );
 
-      if (parentId && parentId !== GRID_ROOT_GROUP_ID && props.signature !== 'DataGrid') {
+      if (parentId != null && parentId !== GRID_ROOT_GROUP_ID && props.signature !== 'DataGrid') {
         options.fetchRowChildren?.([parentId], [fetchParams], showChildrenLoading);
         return;
       }


### PR DESCRIPTION
Fixes #23009
Closes #23168

- Before (master at 80ee1d84): https://stackblitz.com/edit/fehgzhme
- After (fix at 8116f7c4): https://stackblitz.com/edit/jcpc3kkh

## The bug

With server-side tree data, editing a child row and reloading the data moved the edited row to the bottom of its group (or made it disappear if the children were not reloaded).

`apiRef.current.updateRows()` never carries `groupKeys`, and `getParentPath()` returned an empty path for every partial update, so a nested row updated through it got the path `[childKey]` and `updateRowTree` removed it from its parent and re-inserted it at the root. Editing reaches this path whenever the data source has no `updateRow()`: both editing hooks fall back to `updateRows()` after `processRowUpdate`. The reload then finished the job: the root refetch is itself an `updateRows()` diff that deleted the stray root row, and the next children fetch re-inserted it as a new row at the end of the group.

Server-side row grouping (Premium) calls the same helper and had the same bug.

This is not a regression: the guard has been there since #18715.

## The fix

- `getParentPath()` no longer bails out on partial updates. During a partial update `previousTree` is the live tree, so a modified nested row resolves to its parent's `path`. Explicit `groupKeys` from `updateNestedRows()` keep precedence, and rows that are not in the tree yet still land at the root as before.
- Two related bugs with a parent row whose id is `0`, found while writing the tests:
  - `getGroupKeys()` stopped walking up the tree at the falsy id, so even the `dataSource.updateRow()` path re-parented the edited child.
  - `dataSource.fetchRows(0)` was treated as a root reload, so expanding such a parent reloaded the root instead of fetching its children.

## Tests

`dataSourceTreeData.DataGridPro.test.tsx`, new `nested row updates` block (all five failed on `master`):

- should keep an updated nested row under its parent
- should keep the children order after re-fetching the root and the parent following a nested row update
- should keep an edited nested row under its parent when using `processRowUpdate`
- should keep an edited nested row under a parent with a falsy id when using `dataSource.updateRow`
- should fetch the children of a parent with a falsy id when expanding it

`dataSourceRowGrouping.DataGridPremium.test.tsx` (failed on `master`):

- should keep an updated leaf row under its group

Full `x-data-grid`, `x-data-grid-pro` and `x-data-grid-premium` suites pass in browser and jsdom mode; `tsc`, eslint and prettier are clean.

## Unchanged behaviour worth knowing

Both these behaviors are intended by design at this point. Documenting for reference:

- Editing the grouping field itself (the value returned by `getGroupKey`) still re-inserts the row at the end of its group, because its key changes.
- Inserting a brand-new nested row through the public `updateRows()` still lands at the root: only the private `updateNestedRows()` accepts `groupKeys`. A public way to pass them would be a separate feature request.

## Follow-ups (out of scope)

- With `throttleRowsMs > 0`, `updateCacheWithNewRows` stores `groupKeys` per batch, so a throttled `updateRows()` flushed by a later `updateNestedRows()` applies the later group keys to the earlier rows.
- `GridRowsPartialUpdates.idToActionLookup` is never written, so the "action already applied" branches in `updateCacheWithNewRows` are dead code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)