### PR TITLE
[scheduler] Fix flaky timeline observer absorb

### DIFF
--- a/packages/x-scheduler-premium/src/event-timeline-premium/tests/absorbObserverFrames.test.tsx
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/tests/absorbObserverFrames.test.tsx
@@ -14,21 +14,37 @@ describe('absorbObserverFrames', () => {
     clockConfig: new Date(DEFAULT_TESTING_VISIBLE_DATE_STR),
   });
 
+  function renderTimeline() {
+    return renderSettled(
+      <EventTimelinePremium
+        resources={[{ id: 'r1', title: 'Engineering' }]}
+        events={[]}
+        visibleDate={DEFAULT_TESTING_VISIBLE_DATE}
+      />,
+    );
+  }
+
   it.skipIf(isJSDOM)(
     'should leave no observer delivery pending after a settled render',
     async () => {
-      await renderSettled(
-        <EventTimelinePremium
-          resources={[{ id: 'r1', title: 'Engineering' }]}
-          events={[]}
-          visibleDate={DEFAULT_TESTING_VISIBLE_DATE}
-        />,
-      );
+      await renderTimeline();
 
-      // Raw time outside act: an update the absorb failed to drain would land here
+      // Raw frames outside act: a delivery the absorb failed to drain would land here
       // un-acted, and the console guard fails the test with the React act warning.
-      // This has to outlast the virtualizer's `resizeThrottleMs` (100ms), because the
-      // update that escapes is the trailing edge of that throttle rather than a frame.
+      await new Promise<void>((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      });
+    },
+  );
+
+  it.skipIf(isJSDOM)(
+    'should leave no throttled dimension update pending after a settled render',
+    async () => {
+      await renderTimeline();
+
+      // A delivery also schedules a dimension update throttled by `resizeThrottleMs`
+      // (100ms), whose trailing edge rides a timer rather than a frame, so the frames
+      // above are too short to catch it. Wait past that window instead.
       await new Promise<void>((resolve) => {
         setTimeout(resolve, 250);
       });

--- a/packages/x-scheduler-premium/src/event-timeline-premium/tests/absorbObserverFrames.test.tsx
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/tests/absorbObserverFrames.test.tsx
@@ -25,10 +25,12 @@ describe('absorbObserverFrames', () => {
         />,
       );
 
-      // Raw frames outside act: a delivery the absorb failed to drain would land here
+      // Raw time outside act: an update the absorb failed to drain would land here
       // un-acted, and the console guard fails the test with the React act warning.
+      // This has to outlast the virtualizer's `resizeThrottleMs` (100ms), because the
+      // update that escapes is the trailing edge of that throttle rather than a frame.
       await new Promise<void>((resolve) => {
-        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+        setTimeout(resolve, 250);
       });
     },
   );

--- a/packages/x-scheduler-premium/src/event-timeline-premium/tests/absorbObserverFrames.test.tsx
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/tests/absorbObserverFrames.test.tsx
@@ -14,37 +14,21 @@ describe('absorbObserverFrames', () => {
     clockConfig: new Date(DEFAULT_TESTING_VISIBLE_DATE_STR),
   });
 
-  function renderTimeline() {
-    return renderSettled(
-      <EventTimelinePremium
-        resources={[{ id: 'r1', title: 'Engineering' }]}
-        events={[]}
-        visibleDate={DEFAULT_TESTING_VISIBLE_DATE}
-      />,
-    );
-  }
-
   it.skipIf(isJSDOM)(
     'should leave no observer delivery pending after a settled render',
     async () => {
-      await renderTimeline();
+      await renderSettled(
+        <EventTimelinePremium
+          resources={[{ id: 'r1', title: 'Engineering' }]}
+          events={[]}
+          visibleDate={DEFAULT_TESTING_VISIBLE_DATE}
+        />,
+      );
 
-      // Raw frames outside act: a delivery the absorb failed to drain would land here
+      // Raw time outside act: an update the absorb failed to drain would land here
       // un-acted, and the console guard fails the test with the React act warning.
-      await new Promise<void>((resolve) => {
-        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
-      });
-    },
-  );
-
-  it.skipIf(isJSDOM)(
-    'should leave no throttled dimension update pending after a settled render',
-    async () => {
-      await renderTimeline();
-
-      // A delivery also schedules a dimension update throttled by `resizeThrottleMs`
-      // (100ms), whose trailing edge rides a timer rather than a frame, so the frames
-      // above are too short to catch it. Wait past that window instead.
+      // This has to outlast the virtualizer's `resizeThrottleMs` (100ms), because the
+      // update that escapes is the trailing edge of that throttle rather than a frame.
       await new Promise<void>((resolve) => {
         setTimeout(resolve, 250);
       });

--- a/packages/x-scheduler-premium/src/event-timeline-premium/tests/absorbObserverFrames.test.tsx
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/tests/absorbObserverFrames.test.tsx
@@ -7,10 +7,37 @@ import {
   DEFAULT_TESTING_VISIBLE_DATE_STR,
 } from 'test/utils/scheduler';
 import { EventTimelinePremium } from '@mui/x-scheduler-premium/event-timeline-premium';
-import { describe, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+// Resizes itself from its own ResizeObserver, so each delivery commits React state
+// that produces the next delivery. Chains like this are what a fixed number of frames
+// cannot cover, and unlike the timeline it chains deterministically on any machine.
+function ResizingBox({
+  maximumWidth,
+  onResize,
+}: {
+  maximumWidth: number;
+  onResize?: (width: number) => void;
+}) {
+  const ref = React.useRef<HTMLDivElement>(null);
+  const [width, setWidth] = React.useState(100);
+
+  React.useLayoutEffect(() => {
+    const observer = new ResizeObserver(([entry]) => {
+      onResize?.(entry.contentRect.width);
+      if (entry.contentRect.width < maximumWidth) {
+        setWidth(entry.contentRect.width + 100);
+      }
+    });
+    observer.observe(ref.current!);
+    return () => observer.disconnect();
+  }, [maximumWidth, onResize]);
+
+  return <div ref={ref} style={{ width, height: 20 }} />;
+}
 
 describe('absorbObserverFrames', () => {
-  const { renderSettled } = createSchedulerRenderer({
+  const { render, renderSettled } = createSchedulerRenderer({
     clockConfig: new Date(DEFAULT_TESTING_VISIBLE_DATE_STR),
   });
 
@@ -34,6 +61,24 @@ describe('absorbObserverFrames', () => {
       });
     },
   );
+
+  it.skipIf(isJSDOM)('should absorb a chain of observer-driven resizes', async () => {
+    const widths: number[] = [];
+
+    await renderSettled(<ResizingBox maximumWidth={600} onResize={(w) => widths.push(w)} />);
+
+    // Every step of the chain has to land inside the drain, so the whole run is acted.
+    expect(widths).to.deep.equal([100, 200, 300, 400, 500, 600]);
+  });
+
+  it.skipIf(isJSDOM)('should throw when observer-driven layout never settles', async () => {
+    const view = render(<ResizingBox maximumWidth={Infinity} />);
+    try {
+      await expect(absorbObserverFrames()).rejects.toThrow('did not settle within');
+    } finally {
+      view.unmount();
+    }
+  });
 
   it.skipIf(isJSDOM)('should resolve while fake timers are installed', async () => {
     // Fake timers replace the global rAF; the absorb must ride the capture instead.

--- a/test/utils/scheduler/absorb-observer-frames.ts
+++ b/test/utils/scheduler/absorb-observer-frames.ts
@@ -47,6 +47,7 @@ export async function absorbObserverFrames() {
   const observer = new MutationObserver(() => {
     lastMutationAt = nativeNow();
   });
+  const startedAt = lastMutationAt;
   observer.observe(document.body, {
     subtree: true,
     childList: true,
@@ -54,8 +55,6 @@ export async function absorbObserverFrames() {
     characterData: true,
   });
   try {
-    const startedAt = nativeNow();
-    lastMutationAt = startedAt;
     // One act scope per frame, rather than one wrapping the whole drain: React 18
     // only flushes the work queued inside an act scope when that scope exits, so a
     // single long-running one would hide every update until the very end and read

--- a/test/utils/scheduler/absorb-observer-frames.ts
+++ b/test/utils/scheduler/absorb-observer-frames.ts
@@ -66,8 +66,6 @@ export async function absorbObserverFrames() {
           nativeRequestAnimationFrame!(() => resolve());
         });
       });
-      // Let the observer deliver the records for what the commit just changed.
-      await Promise.resolve();
     } while (
       nativeNow() - lastMutationAt < QUIET_WINDOW_MS &&
       nativeNow() - startedAt < MAX_DRAIN_MS

--- a/test/utils/scheduler/absorb-observer-frames.ts
+++ b/test/utils/scheduler/absorb-observer-frames.ts
@@ -60,21 +60,18 @@ export async function absorbObserverFrames() {
     // single long-running one would hide every update until the very end and read
     // as quiet throughout.
     /* eslint-disable no-await-in-loop */
-    for (;;) {
-      await act(async () => {
-        await new Promise<void>((resolve) => {
-          nativeRequestAnimationFrame!(() => resolve());
-        });
-      });
-      if (nativeNow() - lastMutationAt >= QUIET_WINDOW_MS) {
-        return;
-      }
+    while (nativeNow() - lastMutationAt < QUIET_WINDOW_MS) {
       if (nativeNow() - startedAt >= MAX_DRAIN_MS) {
         throw new Error(
           `absorbObserverFrames: the DOM did not settle within ${MAX_DRAIN_MS}ms. An ` +
             'observer-driven update is most likely resizing an observed element in a loop.',
         );
       }
+      await act(async () => {
+        await new Promise<void>((resolve) => {
+          nativeRequestAnimationFrame!(() => resolve());
+        });
+      });
     }
     /* eslint-enable no-await-in-loop */
   } finally {

--- a/test/utils/scheduler/absorb-observer-frames.ts
+++ b/test/utils/scheduler/absorb-observer-frames.ts
@@ -41,39 +41,40 @@ export async function absorbObserverFrames() {
         'the live one. A test likely leaked fake timers without restoring them.',
     );
   }
-  await act(async () => {
-    let lastMutationAt = nativeNow();
-    // Record in the callback: delivering records to it also drains the queue, so
-    // `takeRecords()` would come back empty and read as a false quiet.
-    const observer = new MutationObserver(() => {
-      lastMutationAt = nativeNow();
-    });
-    observer.observe(document.body, {
-      subtree: true,
-      childList: true,
-      attributes: true,
-      characterData: true,
-    });
-    try {
-      const startedAt = nativeNow();
-      lastMutationAt = startedAt;
-      // The frames have to be pumped one at a time: each one may produce the mutation
-      // that extends the quiet window.
-      /* eslint-disable no-await-in-loop */
-      do {
+  let lastMutationAt = nativeNow();
+  // Record in the callback: delivering records to it also drains the queue, so
+  // `takeRecords()` would come back empty and read as a false quiet.
+  const observer = new MutationObserver(() => {
+    lastMutationAt = nativeNow();
+  });
+  observer.observe(document.body, {
+    subtree: true,
+    childList: true,
+    attributes: true,
+    characterData: true,
+  });
+  try {
+    const startedAt = nativeNow();
+    lastMutationAt = startedAt;
+    // One act scope per frame, rather than one wrapping the whole drain: React 18
+    // only flushes the work queued inside an act scope when that scope exits, so a
+    // single long-running one would hide every update until the very end and read
+    // as quiet throughout.
+    /* eslint-disable no-await-in-loop */
+    do {
+      await act(async () => {
         await new Promise<void>((resolve) => {
           nativeRequestAnimationFrame!(() => resolve());
         });
-        // Let React commit what the frame produced, and the observer deliver the
-        // records for it, before testing the quiet window below.
-        await Promise.resolve();
-      } while (
-        nativeNow() - lastMutationAt < QUIET_WINDOW_MS &&
-        nativeNow() - startedAt < MAX_DRAIN_MS
-      );
-      /* eslint-enable no-await-in-loop */
-    } finally {
-      observer.disconnect();
-    }
-  });
+      });
+      // Let the observer deliver the records for what the commit just changed.
+      await Promise.resolve();
+    } while (
+      nativeNow() - lastMutationAt < QUIET_WINDOW_MS &&
+      nativeNow() - startedAt < MAX_DRAIN_MS
+    );
+    /* eslint-enable no-await-in-loop */
+  } finally {
+    observer.disconnect();
+  }
 }

--- a/test/utils/scheduler/absorb-observer-frames.ts
+++ b/test/utils/scheduler/absorb-observer-frames.ts
@@ -15,7 +15,7 @@ const nativeNow = performance.now.bind(performance);
 // edge runs on a timer rather than a frame. Waiting a fixed number of frames therefore
 // races that timer, so drain until the DOM has been still for longer than that window.
 const QUIET_WINDOW_MS = 150;
-// Upper bound so a genuinely oscillating layout fails the test instead of hanging.
+// Upper bound so a genuinely oscillating layout throws instead of hanging.
 const MAX_DRAIN_MS = 1000;
 
 /**
@@ -60,16 +60,22 @@ export async function absorbObserverFrames() {
     // single long-running one would hide every update until the very end and read
     // as quiet throughout.
     /* eslint-disable no-await-in-loop */
-    do {
+    for (;;) {
       await act(async () => {
         await new Promise<void>((resolve) => {
           nativeRequestAnimationFrame!(() => resolve());
         });
       });
-    } while (
-      nativeNow() - lastMutationAt < QUIET_WINDOW_MS &&
-      nativeNow() - startedAt < MAX_DRAIN_MS
-    );
+      if (nativeNow() - lastMutationAt >= QUIET_WINDOW_MS) {
+        return;
+      }
+      if (nativeNow() - startedAt >= MAX_DRAIN_MS) {
+        throw new Error(
+          `absorbObserverFrames: the DOM did not settle within ${MAX_DRAIN_MS}ms. An ` +
+            'observer-driven update is most likely resizing an observed element in a loop.',
+        );
+      }
+    }
     /* eslint-enable no-await-in-loop */
   } finally {
     observer.disconnect();

--- a/test/utils/scheduler/absorb-observer-frames.ts
+++ b/test/utils/scheduler/absorb-observer-frames.ts
@@ -6,12 +6,24 @@ import { vi } from 'vitest';
 const capturedRequestAnimationFrame =
   typeof requestAnimationFrame === 'function' ? requestAnimationFrame : null;
 const nativeRequestAnimationFrame = capturedRequestAnimationFrame?.bind(globalThis) ?? null;
+// Same reason as the frame capture: fake timers freeze `performance.now`, which would
+// stop the quiet window below from ever elapsing.
+const nativeNow = performance.now.bind(performance);
+
+// A ResizeObserver delivery does not settle the virtualizer on its own: it schedules a
+// dimension update throttled by `resizeThrottleMs` (100ms by default), whose trailing
+// edge runs on a timer rather than a frame. Waiting a fixed number of frames therefore
+// races that timer, so drain until the DOM has been still for longer than that window.
+const QUIET_WINDOW_MS = 150;
+// Upper bound so a genuinely oscillating layout fails the test instead of hanging.
+const MAX_DRAIN_MS = 1000;
 
 /**
- * Waits two native frames inside act, so pending ResizeObserver deliveries land as
+ * Waits inside act until the scheduler surface stops mutating the DOM, so pending
+ * ResizeObserver deliveries and the throttled dimension updates they schedule land as
  * acted updates instead of between test steps. Call it after rendering a scheduler
  * surface (prefer `renderSettled`) or after a scroll that mounts observed elements.
- * jsdom has no ResizeObserver and so no frames to absorb; there it flushes pending
+ * jsdom has no ResizeObserver and so nothing to absorb; there it flushes pending
  * microtasks inside act instead.
  */
 export async function absorbObserverFrames() {
@@ -29,11 +41,39 @@ export async function absorbObserverFrames() {
         'the live one. A test likely leaked fake timers without restoring them.',
     );
   }
-  // Two frames: one for layout, one for the delivery. A delivery chain (observer-driven
-  // state resizing an observed element) would need a third; nothing observed does today.
   await act(async () => {
-    await new Promise<void>((resolve) => {
-      nativeRequestAnimationFrame!(() => nativeRequestAnimationFrame!(() => resolve()));
+    let lastMutationAt = nativeNow();
+    // Record in the callback: delivering records to it also drains the queue, so
+    // `takeRecords()` would come back empty and read as a false quiet.
+    const observer = new MutationObserver(() => {
+      lastMutationAt = nativeNow();
     });
+    observer.observe(document.body, {
+      subtree: true,
+      childList: true,
+      attributes: true,
+      characterData: true,
+    });
+    try {
+      const startedAt = nativeNow();
+      lastMutationAt = startedAt;
+      // The frames have to be pumped one at a time: each one may produce the mutation
+      // that extends the quiet window.
+      /* eslint-disable no-await-in-loop */
+      do {
+        await new Promise<void>((resolve) => {
+          nativeRequestAnimationFrame!(() => resolve());
+        });
+        // Let React commit what the frame produced, and the observer deliver the
+        // records for it, before testing the quiet window below.
+        await Promise.resolve();
+      } while (
+        nativeNow() - lastMutationAt < QUIET_WINDOW_MS &&
+        nativeNow() - startedAt < MAX_DRAIN_MS
+      );
+      /* eslint-enable no-await-in-loop */
+    } finally {
+      observer.disconnect();
+    }
   });
 }


### PR DESCRIPTION
## Problem

`absorbObserverFrames` waited two animation frames, on the assumption that a ResizeObserver delivery settles the virtualizer. It does not, for two independent reasons:

1. **Deliveries chain.** A delivery updates dimensions, which changes layout, which produces another delivery. The old comment anticipated this ("a delivery chain would need a third [frame]; nothing observed does today") but it happens today.
2. **A timer, not a frame.** The delivery routes to `api.debouncedUpdateDimensions()` ([`virtualization.ts#L901`](https://github.com/mui/mui-x/blob/master/packages/x-virtualizer/src/features/virtualization/virtualization.ts#L901)), throttled by `resizeThrottleMs` (default `100`, never overridden by the timeline). Its trailing edge runs on a timer that no number of frames is guaranteed to cover.

Either way the `store.update` re-renders `FillerRow` outside `act`, and `vitest-fail-on-console` fails the test on React's act warning. Instrumented on a timeline render:

```
 86.0ms  throttled update scheduled   <- 2ms before the absorb returned
 88.0ms  absorb returned
170.0ms  updateDimensions executed    <- 84ms later, outside act
```

Whether it escapes depends on where the last delivery falls relative to the frame pair, which is why it only surfaced under CI load. This was the most frequent `test_browser` failure on master: **3 of the last 4** job failures (907481, 906051, 905825).

## Fix

Drain until the DOM has been still for longer than the throttle window, one `act` scope per frame.

Two details that are load-bearing and not obvious:

- **One act scope per frame, not one around the drain.** React 18 only flushes work queued inside an `act` scope when that scope exits. A single wrapping scope sees a permanently quiet DOM, exits on a false quiet, and its flush then schedules another throttled update that lands un-acted. This passed on React 19 and failed only on `test_browser_react_18`.
- **Mutations recorded in the `MutationObserver` callback, not via `takeRecords()`.** Delivering records to the callback also drains the queue, so `takeRecords()` reads as a false quiet.
- `performance.now` is captured at module load, as the file already does for `requestAnimationFrame`: fake timers freeze it and the quiet window would never elapse. The existing "should resolve while fake timers are installed" test covers this.

## Alternatives measured, and why they were rejected

The helper is more machinery than a test util usually deserves, so I measured the simpler options rather than assuming:

| Approach | React 19 | React 18 |
|---|---|---|
| `resizeThrottleMs: 0`, keep the 2-frame wait | fails 3/3 | — |
| Fixed count of per-frame act scopes, 12 frames | passes 3/3 | fails 3/3 |
| Fixed count, 20 frames | — | passes |
| Drain until quiet (this PR) | passes | passes |

Zeroing the throttle is **not** sufficient on its own: with `resizeThrottleMs: 0` the stack shows `updateDimensions` called directly from a delivery, still past the two frames — reason 1 above stands without reason 2.

A fixed frame count does work, but React 18 needs somewhere between 13 and 20 frames, so any constant sits close to the failure boundary. That is the same class of bug as the one being fixed, so the drain is adaptive with an explicit `MAX_DRAIN_MS` cap that fails loudly rather than passing on a guess.

## Test

The existing test waited two raw frames after the render — shorter than the throttle, so it only caught the escape when timing shifted. It now waits 250ms and fails reliably without the helper change.

- Without the fix: fails 3/3 on both React versions
- With the fix: passes 5/5 on both
- All four scheduler browser suites pass on React 18 and 19 (`x-scheduler`, `x-scheduler-internals`, `x-scheduler-internals-premium`, `x-scheduler-premium`)

## Cost

The quiet window puts a ~150ms floor on each `absorbObserverFrames` call. Measured on the `x-scheduler-premium` browser suite, wall clock lands between 18s and 22s against a 19s baseline — within run-to-run variance, since the drains overlap across workers.
