### PR TITLE
[test] Drain scheduler observer frames until the DOM settles

### DIFF
--- a/packages/x-scheduler-premium/src/event-timeline-premium/tests/absorbObserverFrames.test.tsx
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/tests/absorbObserverFrames.test.tsx
@@ -9,8 +9,32 @@ import {
 import { EventTimelinePremium } from '@mui/x-scheduler-premium/event-timeline-premium';
 import { describe, expect, it, vi } from 'vitest';
 
+function ResizingBox({
+  maximumWidth,
+  onResize,
+}: {
+  maximumWidth: number;
+  onResize?: (width: number) => void;
+}) {
+  const ref = React.useRef<HTMLDivElement>(null);
+  const [width, setWidth] = React.useState(100);
+
+  React.useLayoutEffect(() => {
+    const observer = new ResizeObserver(([entry]) => {
+      onResize?.(entry.contentRect.width);
+      if (entry.contentRect.width < maximumWidth) {
+        setWidth(entry.contentRect.width + 100);
+      }
+    });
+    observer.observe(ref.current!);
+    return () => observer.disconnect();
+  }, [maximumWidth, onResize]);
+
+  return <div ref={ref} style={{ width, height: 20 }} />;
+}
+
 describe('absorbObserverFrames', () => {
-  const { renderSettled } = createSchedulerRenderer({
+  const { render, renderSettled } = createSchedulerRenderer({
     clockConfig: new Date(DEFAULT_TESTING_VISIBLE_DATE_STR),
   });
 
@@ -38,29 +62,24 @@ describe('absorbObserverFrames', () => {
     async () => {
       const widths: number[] = [];
 
-      function ResizingBox() {
-        const ref = React.useRef<HTMLDivElement>(null);
-        const [width, setWidth] = React.useState(100);
+      await renderSettled(
+        <ResizingBox maximumWidth={600} onResize={(width) => widths.push(width)} />,
+      );
 
-        React.useLayoutEffect(() => {
-          const observer = new ResizeObserver(([entry]) => {
-            widths.push(entry.contentRect.width);
-            if (entry.contentRect.width < 300) {
-              setWidth(entry.contentRect.width + 100);
-            }
-          });
-          observer.observe(ref.current!);
-          return () => observer.disconnect();
-        }, []);
-
-        return <div ref={ref} style={{ width, height: 20 }} />;
-      }
-
-      await renderSettled(<ResizingBox />);
-
-      expect(widths).toEqual([100, 200, 300]);
+      expect(widths).toEqual([100, 200, 300, 400, 500, 600]);
     },
   );
+
+  it.skipIf(isJSDOM)('should fail when observer-driven layout never settles', async () => {
+    const view = render(<ResizingBox maximumWidth={Infinity} />);
+    try {
+      await expect(absorbObserverFrames()).rejects.toThrow(
+        'the DOM did not settle after 10 observer frame pairs',
+      );
+    } finally {
+      view.unmount();
+    }
+  });
 
   it.skipIf(isJSDOM)('should resolve while fake timers are installed', async () => {
     // Fake timers replace the global rAF; the absorb must ride the capture instead.

--- a/packages/x-scheduler-premium/src/event-timeline-premium/tests/absorbObserverFrames.test.tsx
+++ b/packages/x-scheduler-premium/src/event-timeline-premium/tests/absorbObserverFrames.test.tsx
@@ -7,7 +7,7 @@ import {
   DEFAULT_TESTING_VISIBLE_DATE_STR,
 } from 'test/utils/scheduler';
 import { EventTimelinePremium } from '@mui/x-scheduler-premium/event-timeline-premium';
-import { describe, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 describe('absorbObserverFrames', () => {
   const { renderSettled } = createSchedulerRenderer({
@@ -30,6 +30,35 @@ describe('absorbObserverFrames', () => {
       await new Promise<void>((resolve) => {
         requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
       });
+    },
+  );
+
+  it.skipIf(isJSDOM)(
+    'should absorb a resize caused by an observer-driven React update',
+    async () => {
+      const widths: number[] = [];
+
+      function ResizingBox() {
+        const ref = React.useRef<HTMLDivElement>(null);
+        const [width, setWidth] = React.useState(100);
+
+        React.useLayoutEffect(() => {
+          const observer = new ResizeObserver(([entry]) => {
+            widths.push(entry.contentRect.width);
+            if (entry.contentRect.width < 300) {
+              setWidth(entry.contentRect.width + 100);
+            }
+          });
+          observer.observe(ref.current!);
+          return () => observer.disconnect();
+        }, []);
+
+        return <div ref={ref} style={{ width, height: 20 }} />;
+      }
+
+      await renderSettled(<ResizingBox />);
+
+      expect(widths).toEqual([100, 200, 300]);
     },
   );
 

--- a/test/utils/scheduler/absorb-observer-frames.ts
+++ b/test/utils/scheduler/absorb-observer-frames.ts
@@ -32,11 +32,10 @@ export async function absorbObserverFrames() {
   // React can flush observer-driven state updates when act exits, changing layout
   // and scheduling another delivery. A second act scope absorbs that delivery;
   // waiting more frames in the first scope would leave the update batched.
-  for (let pass = 0; pass < 2; pass += 1) {
-    await act(async () => {
-      await new Promise<void>((resolve) => {
-        nativeRequestAnimationFrame!(() => nativeRequestAnimationFrame!(() => resolve()));
-      });
+  const waitForFramePair = () =>
+    new Promise<void>((resolve) => {
+      nativeRequestAnimationFrame!(() => nativeRequestAnimationFrame!(() => resolve()));
     });
-  }
+  await act(waitForFramePair);
+  await act(waitForFramePair);
 }

--- a/test/utils/scheduler/absorb-observer-frames.ts
+++ b/test/utils/scheduler/absorb-observer-frames.ts
@@ -8,7 +8,7 @@ const capturedRequestAnimationFrame =
 const nativeRequestAnimationFrame = capturedRequestAnimationFrame?.bind(globalThis) ?? null;
 
 /**
- * Waits two native frames inside act, so pending ResizeObserver deliveries land as
+ * Waits two pairs of native frames inside separate act scopes, so ResizeObserver deliveries land as
  * acted updates instead of between test steps. Call it after rendering a scheduler
  * surface (prefer `renderSettled`) or after a scroll that mounts observed elements.
  * jsdom has no ResizeObserver and so no frames to absorb; there it flushes pending
@@ -29,11 +29,14 @@ export async function absorbObserverFrames() {
         'the live one. A test likely leaked fake timers without restoring them.',
     );
   }
-  // Two frames: one for layout, one for the delivery. A delivery chain (observer-driven
-  // state resizing an observed element) would need a third; nothing observed does today.
-  await act(async () => {
-    await new Promise<void>((resolve) => {
-      nativeRequestAnimationFrame!(() => nativeRequestAnimationFrame!(() => resolve()));
+  // React can flush observer-driven state updates when act exits, changing layout
+  // and scheduling another delivery. A second act scope absorbs that delivery;
+  // waiting more frames in the first scope would leave the update batched.
+  for (let pass = 0; pass < 2; pass += 1) {
+    await act(async () => {
+      await new Promise<void>((resolve) => {
+        nativeRequestAnimationFrame!(() => nativeRequestAnimationFrame!(() => resolve()));
+      });
     });
-  });
+  }
 }

--- a/test/utils/scheduler/absorb-observer-frames.ts
+++ b/test/utils/scheduler/absorb-observer-frames.ts
@@ -8,11 +8,11 @@ const capturedRequestAnimationFrame =
 const nativeRequestAnimationFrame = capturedRequestAnimationFrame?.bind(globalThis) ?? null;
 
 /**
- * Waits two pairs of native frames inside separate act scopes, so ResizeObserver deliveries land as
- * acted updates instead of between test steps. Call it after rendering a scheduler
- * surface (prefer `renderSettled`) or after a scroll that mounts observed elements.
- * jsdom has no ResizeObserver and so no frames to absorb; there it flushes pending
- * microtasks inside act instead.
+ * Absorbs native observer frames inside act until React stops changing the DOM.
+ * Call after rendering a scheduler surface (prefer `renderSettled`) or scrolling
+ * to mount observed elements. Each pass allows React to commit observer-driven
+ * updates before waiting for the resulting layout deliveries.
+ * In jsdom, flush pending microtasks inside act without waiting for native frames.
  */
 export async function absorbObserverFrames() {
   if (typeof ResizeObserver === 'undefined' || nativeRequestAnimationFrame === null) {
@@ -29,13 +29,39 @@ export async function absorbObserverFrames() {
         'the live one. A test likely leaked fake timers without restoring them.',
     );
   }
-  // React can flush observer-driven state updates when act exits, changing layout
-  // and scheduling another delivery. A second act scope absorbs that delivery;
-  // waiting more frames in the first scope would leave the update batched.
   const waitForFramePair = () =>
     new Promise<void>((resolve) => {
       nativeRequestAnimationFrame!(() => nativeRequestAnimationFrame!(() => resolve()));
     });
-  await act(waitForFramePair);
-  await act(waitForFramePair);
+  let didMutate = false;
+  const observer = new MutationObserver(() => {
+    didMutate = true;
+  });
+  observer.observe(document.body, {
+    attributes: true,
+    childList: true,
+    characterData: true,
+    subtree: true,
+  });
+
+  async function waitForSettledDom(pass: number): Promise<void> {
+    didMutate = false;
+    // React commits at the end of each act scope; the next pass must follow it.
+    await act(waitForFramePair);
+    if (!didMutate && observer.takeRecords().length === 0) {
+      return;
+    }
+    if (pass === 10) {
+      throw new Error(
+        'absorbObserverFrames: the DOM did not settle after 10 observer frame pairs.',
+      );
+    }
+    await waitForSettledDom(pass + 1);
+  }
+
+  try {
+    await waitForSettledDom(1);
+  } finally {
+    observer.disconnect();
+  }
 }


### PR DESCRIPTION
Scheduler browser tests intermittently report React act warnings because observer-driven React commits can trigger further resize deliveries after the test helper returns. A fixed number of frame pairs does not cover longer update chains.

Wait for frame pairs in separate act scopes until a MutationObserver reports no DOM changes. Fail after ten passes if layout never settles, and always disconnect the observer. Changes are limited to the test helper and its tests.

Regression coverage uses a real ResizeObserver to resize through six widths; this fails with the previous two-pass helper. A second case checks that perpetual resizing rejects instead of hanging. Existing coverage still checks pending observer deliveries and fake timers.

Validation: all 414 scheduler-premium browser tests pass (22 skipped), the jsdom helper test passes, and scoped ESLint (including no-await-in-loop), Prettier, and scheduler-premium type checking pass. Local browser validation used cached Chromium with UTC; downloading the pinned browser timed out, so CI must confirm that version.

Latest failure: https://circleci.com/gh/mui/mui-x/908425
