### PR TITLE
[code-infra] Gate the DataGridScrollRestoration screenshot on the horizontal restore

### DIFF
--- a/test/regressions/index.test.ts
+++ b/test/regressions/index.test.ts
@@ -38,10 +38,10 @@ interface RouteConfig {
    */
   viewport?: { width: number; height: number };
   /**
-   * Wait for these selectors before screenshotting, on top of the testcase
+   * Wait for this selector before screenshotting, on top of the testcase
    * `aria-busy` gate (which only tracks font loading, not async demo data).
    */
-  waitForSelector?: string | string[];
+  waitForSelector?: string;
 }
 
 interface RouteRule extends RouteConfig {
@@ -96,25 +96,17 @@ const TEST_RULES: RouteRule[] = [
 
   {
     test: '/test-regressions-data-grid/DataGridScrollRestoration',
-    // The grid restores its scroll to top:2000/left:2000 after an async remount.
-    // `aria-rowindex` is the absolute dataset position, so a mid-viewport row for
-    // the restored scroll (top:2000, 52px rows => row ~41 => aria-rowindex 43)
-    // only enters the DOM once the virtualizer has rendered the scrolled window.
-    // `rowheader` cells are kept mounted outside the horizontal render context at
-    // zero size, and the Commodity dataset marks one as such. Playwright only
-    // checks the first match for visibility, so exclude them to land on a cell
-    // that the virtualizer actually laid out.
-    //
-    // That first selector only proves the *vertical* restore: rows are rendered
-    // for `top: 2000` while the horizontal render context can still be empty,
-    // which paints row separators but no column headers and no cell contents.
-    // `maturityDate` sits inside the column window for `left: 2000` and outside
-    // the one for `left: 0`, so waiting for its header pins the horizontal
-    // restore too.
-    waitForSelector: [
-      '.MuiDataGrid-row[aria-rowindex="43"] .MuiDataGrid-cell:not([role="rowheader"])',
-      '.MuiDataGrid-columnHeader[data-field="maturityDate"]',
-    ],
+    // The grid restores its scroll to top:2000/left:2000 after an async remount,
+    // and the cell has to pin both axes. `aria-rowindex` is the absolute dataset
+    // position, so the row for the restored vertical scroll (top:2000, 52px rows
+    // => row ~41 => aria-rowindex 43) only enters the DOM once the virtualizer
+    // has rendered the scrolled window. Rows are rendered for that window while
+    // the horizontal render context can still be empty though, which paints row
+    // separators but no column headers and no cell contents, so pin the column
+    // too: `maturityDate` is inside the column window for left:2000 and outside
+    // the one for left:0.
+    waitForSelector:
+      '.MuiDataGrid-row[aria-rowindex="43"] .MuiDataGrid-cell[data-field="maturityDate"]',
   },
   {
     test: '/docs-data-grid-components-toolbar/GridToolbarCustom',
@@ -275,16 +267,10 @@ async function main() {
             );
 
             if (routeConfig?.waitForSelector) {
-              const selectors = Array.isArray(routeConfig.waitForSelector)
-                ? routeConfig.waitForSelector
-                : [routeConfig.waitForSelector];
-              for (const selector of selectors) {
-                // Scope the wait to this route's testcase: pooled pages keep the
-                // previous route's DOM around briefly, and a global selector could
-                // match a leftover grid instead of the one being screenshotted.
-                // eslint-disable-next-line no-await-in-loop
-                await testcase.waitForSelector(selector);
-              }
+              // Scope the wait to this route's testcase: pooled pages keep the
+              // previous route's DOM around briefly, and a global selector could
+              // match a leftover grid instead of the one being screenshotted.
+              await testcase.waitForSelector(routeConfig.waitForSelector);
             }
 
             await page.evaluate(async () => {

--- a/test/regressions/index.test.ts
+++ b/test/regressions/index.test.ts
@@ -38,10 +38,10 @@ interface RouteConfig {
    */
   viewport?: { width: number; height: number };
   /**
-   * Wait for this selector before screenshotting, on top of the testcase
+   * Wait for these selectors before screenshotting, on top of the testcase
    * `aria-busy` gate (which only tracks font loading, not async demo data).
    */
-  waitForSelector?: string;
+  waitForSelector?: string | string[];
 }
 
 interface RouteRule extends RouteConfig {
@@ -104,8 +104,17 @@ const TEST_RULES: RouteRule[] = [
     // zero size, and the Commodity dataset marks one as such. Playwright only
     // checks the first match for visibility, so exclude them to land on a cell
     // that the virtualizer actually laid out.
-    waitForSelector:
+    //
+    // That first selector only proves the *vertical* restore: rows are rendered
+    // for `top: 2000` while the horizontal render context can still be empty,
+    // which paints row separators but no column headers and no cell contents.
+    // `maturityDate` sits inside the column window for `left: 2000` and outside
+    // the one for `left: 0`, so waiting for its header pins the horizontal
+    // restore too.
+    waitForSelector: [
       '.MuiDataGrid-row[aria-rowindex="43"] .MuiDataGrid-cell:not([role="rowheader"])',
+      '.MuiDataGrid-columnHeader[data-field="maturityDate"]',
+    ],
   },
   {
     test: '/docs-data-grid-components-toolbar/GridToolbarCustom',
@@ -266,10 +275,16 @@ async function main() {
             );
 
             if (routeConfig?.waitForSelector) {
-              // Scope the wait to this route's testcase: pooled pages keep the
-              // previous route's DOM around briefly, and a global selector could
-              // match a leftover grid instead of the one being screenshotted.
-              await testcase.waitForSelector(routeConfig.waitForSelector);
+              const selectors = Array.isArray(routeConfig.waitForSelector)
+                ? routeConfig.waitForSelector
+                : [routeConfig.waitForSelector];
+              for (const selector of selectors) {
+                // Scope the wait to this route's testcase: pooled pages keep the
+                // previous route's DOM around briefly, and a global selector could
+                // match a leftover grid instead of the one being screenshotted.
+                // eslint-disable-next-line no-await-in-loop
+                await testcase.waitForSelector(selector);
+              }
             }
 
             await page.evaluate(async () => {


### PR DESCRIPTION
## Problem

Argos build 57997 (on #23517) flagged `test-regressions-data-grid/DataGridScrollRestoration` with a frame whose vertical state is pixel-identical to the baseline (rows, row separators, vertical scrollbar thumb) but whose horizontal state is empty: no column headers, no cell contents, and a much wider horizontal scrollbar thumb. The pixel diff is text plus the horizontal thumb, nothing else.

https://app.argos-ci.com/mui/mui-x/builds/57997/448966804

The route's screenshot gate was:

```
'.MuiDataGrid-row[aria-rowindex="43"] .MuiDataGrid-cell:not([role="rowheader"])'
```

That only proves the vertical restore (`top: 2000`). Row 43 is rendered for the restored vertical window regardless of where the horizontal render context is, so the harness can screenshot a frame where the columns have not been laid out yet, and Argos then treats it as a new baseline.

Measured on the live route: at `scrollLeft = 0` that selector still matches 7 elements.

## Fix

Pin the column on the same cell that already pins the row, by naming the field instead of matching any cell:

```
'.MuiDataGrid-row[aria-rowindex="43"] .MuiDataGrid-cell[data-field="maturityDate"]'
```

`maturityDate` is inside the column window for `left: 2000` and outside the one for `left: 0`, so the cell only enters the DOM once both axes have been restored. Naming the field also makes `:not([role="rowheader"])` unnecessary, since that was only there to stop Playwright from landing on the zero-size `commodity` rowheader cell.

Same approach as #22553, extended to the second axis.

## Verification

- Single route with the new gate: passes.
- Full local suite: 1535 passed. The 3 print-preview tests fail locally only because they need Linux ffmpeg/x11grab.
- The gate discriminates: at the restored scroll the selectors match `{row: 10, header: 1}`; after forcing `scrollLeft = 0` they match `{row: 7, header: 0}`.

## Notes

The blank frame did not reproduce on macOS across the full 1536-route suite and ~80 targeted runs replicating the pooled-page reuse and viewport churn. Two Data Grid hypotheses were tested with temporary fixtures and ruled out: columns arriving one tick after rows, and mounting inside a zero-width container. Both recover to `scrollLeft: 2000` / `scrollWidth: 3695`. So this PR hardens the capture gate rather than changing grid code. If the degenerate state recurs, the strict gate now makes the test time out loudly instead of silently publishing a wrong baseline.

