### PR TITLE
[code-infra] Let the NoColumnsOverlay demo settle before screenshotting

### DIFF
--- a/test/regressions/index.test.ts
+++ b/test/regressions/index.test.ts
@@ -24,6 +24,12 @@ const timeSensitiveSuites = [
   'RowSpanningClassSchedule',
   'ListView',
   'RowSpanningCalendar',
+  // The grid measures its container once on mount and then corrects that
+  // measurement through the resize debounce, so the overlay is one pixel short
+  // for the first ~60ms. Its content is centered, which turns that pixel into a
+  // half-pixel offset and moves the text to a different device row depending on
+  // whether the screenshot beat the correction.
+  'NoColumnsOverlay',
 ];
 
 interface RouteConfig {


### PR DESCRIPTION
## Problem

`docs-data-grid-overlays/NoColumnsOverlay.png` has been flipping between two states for months. Argos rates it flakiness 58, 8 changes over 50 builds, consistency 0%, and Argos Bot auto-ignores it. Most recent occurrence, on an unrelated PR: https://app.argos-ci.com/mui/mui-x/builds/58025/449316483

The two states differ by 879 pixels in a bounding box of `x[196-318] y[154-197]`, which is only the "No columns" / "MANAGE COLUMNS" text. The ink profile of one is the other shifted up by exactly 1px. Header, footer, borders and the pagination controls are identical.

## Cause

The grid measures its container once on mount and then corrects that measurement through the resize debounce. `viewportOuterSize.height` is 285 before the correction and 286 after it. `GridOverlayWrapper` derives its height from that value:

```js
dimensions.viewportOuterSize.height - dimensions.topContainerHeight - dimensions.bottomContainerHeight - ...
```

so `.MuiDataGrid-overlayWrapperInner` is `229px` for the first ~60ms and `230px` afterwards. Every CSS variable the grid publishes is unchanged across that transition, and the scroller is already 286px in the DOM the whole time. Only the grid's stored dimensions lag.

The overlay centers its content, so that one pixel becomes half a pixel. The button sits at `top: 178.133` before the correction and `top: 178.633` after, which puts the text on a different device row. That is the entire diff.

Measured over 6 consecutive runs, the correction lands 51-63ms after the screenshot gate opens. On CI, whether the screenshot beats it depends on machine load, which is exactly the 8-in-50 pattern.

## Fix

Add the route to `timeSensitiveSuites`, the list that already gives slow-settling routes a 100ms pause before the screenshot. 100ms clears the measured 51-63ms window. No new option, no new mechanism.

The substring also covers `NoColumnsOverlayCustom`, which renders the same overlay and has the same exposure.

## Verification

- Without the settle, the overlay is `229px` at screenshot time, the short state.
- With it, 8 consecutive runs give a `230px` overlay and byte-identical screenshots.
- The route passes through the real harness.

## Notes

This fixes the screenshot race, not the underlying behaviour. The grid still renders its overlay against a stale viewport height for one debounce window after mount, which is a real if small layout jump for users, not only for the visual tests. Fixing that means changing when the first corrected measurement is applied, which is core timing and belongs in its own PR with its own review.

## Argos

Argos reports one changed snapshot, which is this one, and the change is expected.

I originally guessed the baseline already held the settled frame and that there would be no change. That was wrong, and the direction is worth stating precisely:

| | image | text bands |
| --- | --- | --- |
| Baseline (master) | `2f69977b` | `154-164` / `188-196` |
| This PR | `6dc60940` | `155-165` / `189-197` |

This PR renders the text one pixel lower, which is the settled state: the taller 230px overlay centers its content half a pixel further down, matching the measured button top of `178.633` against `178.133`.

So the baseline master has been carrying is the premature frame, captured before the resize correction lands. Approving this change moves the baseline to the frame a user actually sees once the grid has finished measuring. The remaining 1532 snapshots are unchanged.

