### PR TITLE
[tree view] Measure non-pixel `itemChildrenIndentation` once per drag

### DIFF
--- a/packages/x-tree-view-pro/src/internals/plugins/itemsReordering/TreeViewItemsReorderingPlugin.test.tsx
+++ b/packages/x-tree-view-pro/src/internals/plugins/itemsReordering/TreeViewItemsReorderingPlugin.test.tsx
@@ -44,6 +44,10 @@ const buildTreeViewDragInteractions = (dataTransfer: DataTransfer) => {
   const dragEnd = createFireEvent('dragEnd');
 
   return {
+    dragStart,
+    dragEnter,
+    dragOver,
+    dragEnd,
     fullDragSequence: (
       draggedItem: HTMLElement,
       targetItem: HTMLElement,
@@ -264,6 +268,28 @@ describeTreeView<RichTreeViewProStore<any, any>>(
           ]);
         });
       });
+
+      describe('itemChildrenIndentation prop', () => {
+        it('should not measure a non-pixel indentation on every dragover event', () => {
+          const view = render({
+            items: [{ id: '1' }, { id: '2' }],
+            itemsReordering: true,
+            itemChildrenIndentation: '2rem',
+          });
+
+          const targetContent = view.getItemContent('2');
+          dragEvents.dragStart(view.getItemRoot('1'));
+          dragEvents.dragEnter(targetContent);
+          dragEvents.dragOver(targetContent);
+
+          // Measuring a non-pixel value appends a temporary element to the content element.
+          // Once measured, the following dragover events must reuse the value.
+          const appendChildSpy = vi.spyOn(targetContent, 'appendChild');
+          dragEvents.dragOver(targetContent);
+          dragEvents.dragOver(targetContent);
+          expect(appendChildSpy).not.toHaveBeenCalled();
+        });
+      });
     });
   },
 );
@@ -282,16 +308,13 @@ describe('getNewPosition util', () => {
     'move-to-parent': { parentId: null, index: 2 },
   };
 
-  const FAKE_CONTENT_ELEMENT = {} as HTMLDivElement;
-
   const COMMON_PROPERTIES = {
-    itemChildrenIndentation: 12,
+    itemChildrenIndentationPx: 12,
     validActions: ALL_ACTIONS,
     targetHeight: 100,
     targetDepth: 1,
     cursorY: 50,
     cursorX: 100,
-    contentElement: FAKE_CONTENT_ELEMENT,
   };
 
   it('should choose the "reorder-above" action when the cursor is in the top quarter of the target item', () => {

--- a/packages/x-tree-view-pro/src/internals/plugins/itemsReordering/TreeViewItemsReorderingPlugin.ts
+++ b/packages/x-tree-view-pro/src/internals/plugins/itemsReordering/TreeViewItemsReorderingPlugin.ts
@@ -3,11 +3,23 @@ import { itemsSelectors, labelSelectors } from '@mui/x-tree-view/internals';
 import type { TreeViewItemItemReorderingValidActions, TreeViewItemReorderPosition } from './types';
 import type { RichTreeViewProStore } from '../../RichTreeViewProStore/RichTreeViewProStore';
 import { itemsReorderingSelectors } from './selectors';
-import { chooseActionToApply, isAncestor, moveItemInTree } from './utils';
+import {
+  chooseActionToApply,
+  isAncestor,
+  moveItemInTree,
+  parseItemChildrenIndentation,
+} from './utils';
 import { useTreeViewItemsReorderingItemPlugin } from './itemPlugin';
 
 export class TreeViewItemsReorderingPlugin {
   private store: RichTreeViewProStore<any, any>;
+
+  /**
+   * Cached pixel value of the `itemChildrenIndentation` prop.
+   * A non-pixel value (e.g. `2rem`) can only be resolved by measuring a DOM element, which forces a synchronous layout.
+   * It is measured once per drag-and-drop operation instead of on every `dragover` event.
+   */
+  private itemChildrenIndentationPxCache: { value: string | number; px: number } | null = null;
 
   constructor(store: RichTreeViewProStore<any, any>) {
     this.store = store;
@@ -123,6 +135,10 @@ export class TreeViewItemsReorderingPlugin {
       return;
     }
 
+    // The pixel value of a non-pixel indentation depends on the environment (font size, container width, ...),
+    // so it is measured again for each new drag-and-drop operation.
+    this.itemChildrenIndentationPxCache = null;
+
     this.store.set('currentReorder', {
       targetItemId: itemId,
       draggedItemId: itemId,
@@ -187,6 +203,17 @@ export class TreeViewItemsReorderingPlugin {
     });
   };
 
+  private getItemChildrenIndentationPx = (contentElement: HTMLElement) => {
+    const value = this.store.state.itemChildrenIndentation;
+    let cache = this.itemChildrenIndentationPxCache;
+    if (cache == null || cache.value !== value) {
+      cache = { value, px: parseItemChildrenIndentation(value, contentElement) };
+      this.itemChildrenIndentationPxCache = cache;
+    }
+
+    return cache.px;
+  };
+
   /**
    * Set the new target item for the ongoing reordering.
    * The action will be determined based on the position of the cursor inside the target and the valid actions for this target.
@@ -219,13 +246,12 @@ export class TreeViewItemsReorderingPlugin {
     }
 
     const action = chooseActionToApply({
-      itemChildrenIndentation: this.store.state.itemChildrenIndentation,
+      itemChildrenIndentationPx: this.getItemChildrenIndentationPx(contentElement),
       validActions,
       targetHeight,
       targetDepth: this.store.state.itemMetaLookup[itemId].depth!,
       cursorY,
       cursorX,
-      contentElement,
     });
 
     const newPosition = action == null ? null : validActions[action]!;

--- a/packages/x-tree-view-pro/src/internals/plugins/itemsReordering/utils.ts
+++ b/packages/x-tree-view-pro/src/internals/plugins/itemsReordering/utils.ts
@@ -32,11 +32,14 @@ export const isAncestor = (
 };
 
 /**
- * Transforms a CSS string `itemChildrenIndentation` into a number representing the indentation in number.
- * @param {string | null} itemChildrenIndentation The indentation as passed to the `itemChildrenIndentation` prop.
+ * Transforms the `itemChildrenIndentation` prop into a number representing the indentation in pixels.
+ * When the value is not a pixel value (e.g. `2rem`), it is measured with a temporary DOM element,
+ * which forces a synchronous layout. Callers should cache the result instead of calling this on every event.
+ * @param {string | number} itemChildrenIndentation The indentation as passed to the `itemChildrenIndentation` prop.
  * @param {HTMLElement} contentElement The DOM element to which the indentation will be applied.
+ * @returns {number} The indentation in pixels.
  */
-const parseItemChildrenIndentation = (
+export const parseItemChildrenIndentation = (
   itemChildrenIndentation: string | number,
   contentElement: HTMLElement,
 ) => {
@@ -61,30 +64,24 @@ const parseItemChildrenIndentation = (
 };
 
 interface GetNewPositionParameters {
-  itemChildrenIndentation: string | number;
+  itemChildrenIndentationPx: number;
   validActions: TreeViewItemItemReorderingValidActions;
   targetHeight: number;
   targetDepth: number;
   cursorY: number;
   cursorX: number;
-  contentElement: HTMLDivElement;
 }
 
 export const chooseActionToApply = ({
-  itemChildrenIndentation,
+  itemChildrenIndentationPx,
   validActions,
   targetHeight,
   targetDepth,
   cursorX,
   cursorY,
-  contentElement,
 }: GetNewPositionParameters) => {
   let action: TreeViewItemsReorderingAction | null;
 
-  const itemChildrenIndentationPx = parseItemChildrenIndentation(
-    itemChildrenIndentation,
-    contentElement,
-  );
   // If we can move the item to the parent of the target, then we allocate the left offset to this action
   // Support moving to other ancestors
   if (validActions['move-to-parent'] && cursorX < itemChildrenIndentationPx * targetDepth) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Part of the Tree View performance audit (finding E2).

## Problem

- `setDragTargetItem` runs on every `dragover` event during drag and drop.
- It parsed `itemChildrenIndentation` on each call.
- For a non-pixel value like `"2rem"`, parsing creates a `div`, appends it to the content element, reads `offsetWidth`, and removes it.
- This forces a synchronous layout on every mouse move, on top of the `getBoundingClientRect` call that is already required.

## Changes

- `TreeViewItemsReorderingPlugin`: cache the pixel value of `itemChildrenIndentation`. The cache is cleared when a drag starts and invalidated if the prop value changes. A non-pixel value is now measured at most once per drag instead of once per `dragover`.
- `chooseActionToApply`: receives the pixel value as a number and no longer needs the content element.
- `parseItemChildrenIndentation`: exported so the plugin can call it.
- Tests: updated the `chooseActionToApply` tests for the new signature. Added a test that drags over an item with `itemChildrenIndentation="2rem"` and checks that repeated `dragover` events do not append to the content element. The test fails on the previous code.

## Notes

- Pixel and number values are not affected. They never needed a DOM measurement.
- The value is measured again for each new drag because a non-pixel value depends on the environment (font size, container width).
- No public API or behavior change.
