### PR TITLE
[DataGrid] Cap the pagination toolbar so the footer height is stable on mount

### DIFF
--- a/packages/x-data-grid/src/components/GridPagination.tsx
+++ b/packages/x-data-grid/src/components/GridPagination.tsx
@@ -20,6 +20,14 @@ const GridPaginationRoot = styled(NotRendered<GridSlotProps['basePagination']>, 
 })({
   maxHeight: 'calc(100% + 1px)', // border width
   flexGrow: 1,
+  // Leave room for the footer's 1px border inside its 52px minimum. Without this the
+  // toolbar's own 52px minimum plus that border makes the footer 53px on the first
+  // layout pass, and flex-shrink only reclaims the pixel once the height is definite
+  // enough for `maxHeight` above to resolve. Everything sized from the viewport
+  // height moves with that late correction.
+  '& .MuiToolbar-root': {
+    minHeight: 51,
+  },
 });
 
 function GridPagination() {

--- a/packages/x-data-grid/src/components/containers/GridFooterContainer.tsx
+++ b/packages/x-data-grid/src/components/containers/GridFooterContainer.tsx
@@ -33,7 +33,14 @@ const GridFooterContainerRoot = styled('div', {
   display: 'flex',
   justifyContent: 'space-between',
   alignItems: 'center',
-  minHeight: 52,
+  // Definite rather than a minimum, so `GridPaginationRoot`'s
+  // `maxHeight: calc(100% + 1px)` resolves on the first layout pass. With only a
+  // minimum the height is indefinite while the footer sizes to its content, that
+  // percentage cap does not apply, and the 52px tall pagination plus this 1px
+  // border makes the footer 53px until flex-shrink reclaims the pixel. Everything
+  // derived from the viewport height moves with that correction.
+  height: 52,
+  flexShrink: 0,
   borderTop: '1px solid',
 });
 

--- a/packages/x-data-grid/src/components/containers/GridFooterContainer.tsx
+++ b/packages/x-data-grid/src/components/containers/GridFooterContainer.tsx
@@ -33,14 +33,7 @@ const GridFooterContainerRoot = styled('div', {
   display: 'flex',
   justifyContent: 'space-between',
   alignItems: 'center',
-  // Definite rather than a minimum, so `GridPaginationRoot`'s
-  // `maxHeight: calc(100% + 1px)` resolves on the first layout pass. With only a
-  // minimum the height is indefinite while the footer sizes to its content, that
-  // percentage cap does not apply, and the 52px tall pagination plus this 1px
-  // border makes the footer 53px until flex-shrink reclaims the pixel. Everything
-  // derived from the viewport height moves with that correction.
-  height: 52,
-  flexShrink: 0,
+  minHeight: 52,
   borderTop: '1px solid',
 });
 


### PR DESCRIPTION
Closes #23543

## Problem

`.MuiDataGrid-footerContainer` uses `minHeight: 52` with a 1px `borderTop`, and `box-sizing` is `border-box`, so the divider has to fit inside that 52px. The `MuiToolbar-root` inside `MuiTablePagination-root` carries its own 52px minimum, so the footer's intrinsic height is 53px. `GridPaginationRoot` caps the pagination with:

```js
maxHeight: 'calc(100% + 1px)', // border width
```

but that percentage needs a definite parent height to resolve, so it does not apply while the footer is still sizing to its content. The footer is therefore 53px on the first layout pass, and flex-shrink only reclaims the pixel later.

`.MuiDataGrid-main` is `flex: 1`, so it absorbs the change and goes 285 to 286. The grid measures its container during the first pass and routes the correction through the resize debounce, so everything derived from the viewport height renders against the stale value for about 56ms after mount.

Timeline on `docs/data/data-grid/overlays/NoColumnsOverlay.js`, sampled at roughly 1ms:

| t | footer | main | overlayWrapperInner |
| --- | --- | --- | --- |
| +36ms | 53 | 285 | 229px |
| +45ms | 52 | 286 | 229px (stale) |
| +101ms | 52 | 286 | 230px |

## Fix

Cap the toolbar inside the pagination at 51px, leaving room for the footer's border inside its existing 52px minimum. The footer's intrinsic height no longer exceeds its minimum, so there is nothing for flex-shrink to reclaim and the size is correct on the first pass.

The footer keeps `minHeight`, so it still grows when its content needs more room.

## Measurements

Swept the 436 demo routes that render a grid footer, comparing master against this branch:

- routes whose footer changed size after mount: **4 on master, 0 with this change**
- routes whose settled geometry changed: **76**, of which 74 are footer 53 to 52 with `main` gaining the pixel
- the `NoColumnsOverlay` demo goes from 3 states to 1, settling at footer 52 / main 286 / overlay 230 from the first frame

Master is inconsistent today: the footer ends at 52 where the layout applies shrink pressure and 53 where it does not. This makes it uniformly 52, which is the size `maxHeight: calc(100% + 1px)` was written for. Expect Argos churn on those 74 routes.

## Approach that was dropped

The first version of this PR pinned the footer with `height: 52` and `flex-shrink: 0`. It fixed the instability with identical churn, but it also removed the footer's ability to grow, and since `.MuiDataGrid-root` is `overflow: hidden` the taller content was clipped rather than expanding. `DataGridRTLVirtualization` went from a 67.83px footer to 52px. Thanks to the review that caught it.

`flex-shrink: 0` with the existing `minHeight` was the other suggestion. It also reaches 0 unstable routes and keeps growth, but it settles every footer at 53 instead: 141 routes change rather than 76, in the direction away from what the pagination cap assumes.

Two trade-offs in the approach taken here, for the record:

- it styles a nested MUI class, and there is no other `.MuiToolbar-root` selector in the grid's styles today. If `slots.basePagination` is replaced with something that is not a MUI `TablePagination`, the rule does not apply and that grid keeps master's behaviour.
- the two routes whose footers grow shift sub-pixel, `67.83` to `67` and `52.95` to `52.31`, because the toolbar minimum moved by 1px.

## Notes

The `clientHeight` reads in `pagination.DataGrid.test.tsx` are dynamic, so they follow the new value rather than asserting a constant. I did not run the browser unit suites locally and am leaving those to CI.

Related: #23529 makes the `NoColumnsOverlay` visual test deterministic with a settle in the harness. If this lands, that settle is no longer needed for this cause and can be reverted.
