### PR TITLE
[code-infra] Pin the only-allow version in the preinstall hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "version": "9.13.0",
   "private": true,
   "scripts": {
-    "preinstall": "npx only-allow pnpm",
+    "preinstall": "npx only-allow@1.2.2 pnpm",
     "start": "pnpm i && pnpm docs:dev",
     "docs:dev": "pnpm --filter docs dev",
     "docs:serve": "pnpm --filter docs serve",


### PR DESCRIPTION
The root `preinstall` hook runs `npx only-allow pnpm`. Because the version is unpinned, `npx` resolves and executes whatever the registry currently serves for `only-allow`, so a future release could change what runs during install with no review here.

Pin it to `only-allow@1.2.2`. Mirrors mui/material-ui#49114.
