### PR TITLE
[code-infra] Trial: Claude CI flake-fix caller

### DIFF
--- a/.github/workflows/claude-flake-fix.yml
+++ b/.github/workflows/claude-flake-fix.yml
@@ -1,11 +1,13 @@
 name: Claude CI flake fix
 
 # Runs mui-public's reusable flake-fix workflow against this repo's CircleCI: it triages recent
-# failures and, unless report-only, opens a draft PR proposing a fix. Dispatch-only while we try it
-# out. This repo already has the four ANTHROPIC_* variables set; Actions must also be allowed to
-# create pull requests (Settings → Actions → General).
+# failures and, unless report-only, opens a draft PR proposing a fix. Runs weekly, and can be
+# dispatched by hand. This repo already has the four ANTHROPIC_* variables set; Actions must also be
+# allowed to create pull requests (Settings → Actions → General).
 
 on:
+  schedule:
+    - cron: '0 7 * * 1' # Monday 07:00 UTC
   workflow_dispatch:
     inputs:
       report-only:

--- a/.github/workflows/claude-flake-fix.yml
+++ b/.github/workflows/claude-flake-fix.yml
@@ -1,0 +1,27 @@
+name: Claude CI flake fix
+
+# Runs mui-public's reusable flake-fix workflow against this repo's CircleCI: it triages recent
+# failures and, unless report-only, opens a draft PR proposing a fix. Dispatch-only while we try it
+# out. This repo already has the four ANTHROPIC_* variables set; Actions must also be allowed to
+# create pull requests (Settings → Actions → General).
+
+on:
+  workflow_dispatch:
+    inputs:
+      report-only:
+        description: Classify and report, but never open a PR.
+        type: boolean
+        default: false
+
+permissions: {}
+
+jobs:
+  flake-fix:
+    permissions:
+      id-token: write # Anthropic WIF (triage job)
+      contents: write # push the fix branch (publish job)
+      pull-requests: write # open the draft PR (publish job)
+      issues: write # rolling tracking issue (publish job)
+    uses: mui/mui-public/.github/workflows/claude-flake-fix.yml@c13d72d8221b544497ea5dc8cbf44eb9782bd558 # #1737
+    with:
+      report-only: ${{ inputs.report-only || false }}


### PR DESCRIPTION
Trial run of mui-public's reusable [CI flake-fix workflow](https://github.com/mui/mui-public/pull/1737) against this repo. It triages recent CircleCI failures with Claude and, unless dispatched report-only, opens a draft PR proposing a fix.

Runs weekly (Monday 07:00 UTC) and can also be dispatched by hand from the Actions tab. The four `ANTHROPIC_*` variables are already set on this repo; the only other requirement is that Actions is allowed to create pull requests (Settings → Actions → General).
