### PR TITLE
[ci] Grant actions: read to the flake-fix caller

### DIFF
--- a/.github/workflows/claude-flake-fix.yml
+++ b/.github/workflows/claude-flake-fix.yml
@@ -20,6 +20,7 @@ permissions: {}
 jobs:
   flake-fix:
     permissions:
+      actions: read # read this run's referenced_workflows (resolve-ref job)
       id-token: write # Anthropic WIF (triage job)
       contents: write # push the fix branch (publish job)
       pull-requests: write # open the draft PR (publish job)


### PR DESCRIPTION
The reusable flake-fix workflow's `resolve-ref` job needs `actions: read` (to read the run's `referenced_workflows`), but the caller job didn't grant it, so the workflow failed validation:

```
The nested job 'resolve-ref' is requesting 'actions: read', but is only allowed 'actions: none'.
```

Adds `actions: read` to the caller job's permissions. Follow-up to #23556.