### PR TITLE
[DataGrid] Keep pinned cells opaque without color-mix() support

### DIFF
--- a/packages/x-data-grid-pro/src/tests/columnPinningFallback.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/columnPinningFallback.DataGridPro.test.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import { createRenderer } from '@mui/internal-test-utils';
+import { isJSDOM } from 'test/utils/skipIf';
+import { vi, describe, it, expect } from 'vitest';
+
+// Older WebKit browsers (Safari <= 17) have no `color-mix()` support.
+// Force the fallback path: stub the feature detection, then re-import the grid
+// so its module-level `supportsColorMix` constant is computed with the stub in
+// place (the setup files already evaluated the grid modules before this file).
+// The test environment is isolated per file, so the stub cannot leak.
+const originalSupports =
+  typeof CSS !== 'undefined' && typeof CSS.supports === 'function'
+    ? (CSS.supports.bind(CSS) as (...args: string[]) => boolean)
+    : undefined;
+if (originalSupports) {
+  CSS.supports = ((...args: string[]) =>
+    args.join(' ').includes('color-mix')
+      ? false
+      : originalSupports(...args)) as typeof CSS.supports;
+}
+vi.resetModules();
+const { DataGridPro } = await import('@mui/x-data-grid-pro');
+const { useBasicDemoData } = await import('@mui/x-data-grid-generator');
+
+describe('<DataGridPro /> - Column pinning without `color-mix()` support', () => {
+  const { render } = createRenderer();
+
+  function TestCase() {
+    const data = useBasicDemoData(1, 3);
+    return (
+      <div style={{ width: 302, height: 300 }}>
+        <DataGridPro {...data} initialState={{ pinnedColumns: { left: ['id'] } }} />
+      </div>
+    );
+  }
+
+  // https://github.com/mui/mui-x/issues/18273
+  it.skipIf(!isJSDOM)('should keep pinned cells opaque on hover and selection', () => {
+    render(<TestCase />);
+
+    const css = Array.from(document.querySelectorAll('style'))
+      .map((style) => style.textContent ?? '')
+      .join('\n');
+
+    // Rules that style pinned cells in a hovered or selected row
+    const pinnedStateRules = (css.match(/[^{}]+\{[^{}]*\}/g) ?? []).filter((rule) => {
+      const selector = rule.slice(0, rule.indexOf('{'));
+      return selector.includes('cell--pinned') && /:hover|Mui-selected/.test(selector);
+    });
+    const backgroundRules = pinnedStateRules.filter((rule) => rule.includes('background-color'));
+
+    expect(backgroundRules.length).to.be.above(2);
+    backgroundRules.forEach((rule) => {
+      // A translucent fallback would let the scrolled cells behind the pinned
+      // cells bleed through
+      expect(rule).to.include('background-color:var(--DataGrid-t-cell-background-pinned)');
+      expect(rule).to.not.include('color-mix');
+    });
+  });
+});

--- a/packages/x-data-grid/src/components/containers/GridRootStyles.ts
+++ b/packages/x-data-grid/src/components/containers/GridRootStyles.ts
@@ -78,6 +78,12 @@ export const GridRootStyles = styled('div', {
     hover: vars.colors.interactive.hover,
     selected: selectedColor,
     selectedHover: selectedColor,
+    // Pinned cells cover the scrolled cells behind them, so their fallback must
+    // stay opaque. Translucent overlay colors would let those cells bleed through
+    // in browsers without `color-mix()` support (https://github.com/mui/mui-x/issues/18273).
+    pinnedHover: pinnedBackground,
+    pinnedSelected: pinnedBackground,
+    pinnedSelectedHover: pinnedBackground,
   };
 
   const hoverBackground = mix(baseBackground, hoverColor, hoverOpacity, fallbackColors.hover);
@@ -98,37 +104,32 @@ export const GridRootStyles = styled('div', {
     pinnedBackground,
     hoverColor,
     hoverOpacity,
-    fallbackColors.hover,
+    fallbackColors.pinnedHover,
   );
   const pinnedSelectedBackground = mix(
     pinnedBackground,
     selectedColor,
     selectedOpacity,
-    fallbackColors.selected,
+    fallbackColors.pinnedSelected,
   );
   const pinnedSelectedHoverBackground = mix(
     pinnedBackground,
     selectedHoverColor,
     selectedHoverOpacity,
-    fallbackColors.selectedHover,
+    fallbackColors.pinnedSelectedHover,
   );
 
   const getPinnedBackgroundStyles = (backgroundColor: string) => ({
     [`& .${c['cell--pinnedLeft']}, & .${c['cell--pinnedRight']}`]: {
       backgroundColor,
       '&.Mui-selected': {
-        backgroundColor: mix(
-          backgroundColor,
-          selectedBackground,
-          selectedOpacity,
-          fallbackColors.selected,
-        ),
+        backgroundColor: mix(backgroundColor, selectedBackground, selectedOpacity, backgroundColor),
         '&:hover': {
           backgroundColor: mix(
             backgroundColor,
             selectedHoverBackground,
             selectedHoverOpacity,
-            fallbackColors.selectedHover,
+            backgroundColor,
           ),
         },
       },


### PR DESCRIPTION
Browsers without `color-mix()` support, such as Safari 17 and older WebKit, take the fallback branch of the `mix()` helper in `GridRootStyles`.

For pinned cells, the fallback colors were the translucent hover and selection overlay colors. On row hover or selection, the pinned cells became see-through, and the cells scrolled behind them bled through.

The fallback colors for the five pinned-cell rules now keep the opaque pinned background. These browsers lose the hover and selection tint on pinned cells, but the cells stay opaque. Browsers with `color-mix()` support keep the exact same styles as before.

The regression test stubs `CSS.supports` and re-imports the grid with `vi.resetModules()`, because JSDOM supports `color-mix()` and the shared test setup evaluates the grid modules before the test file runs. This change revives the approach from #21467 by @mixelburg, which was closed by the stale bot before it could land.

Fixes #18273