### PR TITLE
[l10n] Add Russian (ru-RU) locale

### DIFF
--- a/docs/data/scheduler/localization/data.json
+++ b/docs/data/scheduler/localization/data.json
@@ -251,7 +251,7 @@
     "languageTag": "ru-RU",
     "importName": "ruRU",
     "localeName": "Russian",
-    "missingKeysCount": 105,
+    "missingKeysCount": 0,
     "totalKeysCount": 105,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-scheduler/src/locales/ruRU.ts"
   },

--- a/packages/x-scheduler/src/locales/ruRU.ts
+++ b/packages/x-scheduler/src/locales/ruRU.ts
@@ -6,134 +6,196 @@ import type {
 import { getSchedulerLocalization } from '../utils/getSchedulerLocalization';
 import type { SchedulerLocalization } from '../utils/getSchedulerLocalization';
 
+const weekdayNames = {
+  sunday: 'воскресенье',
+  monday: 'понедельник',
+  tuesday: 'вторник',
+  wednesday: 'среда',
+  thursday: 'четверг',
+  friday: 'пятница',
+  saturday: 'суббота',
+};
+
+const recurringWeekdayNames = {
+  sunday: 'по воскресеньям',
+  monday: 'по понедельникам',
+  tuesday: 'по вторникам',
+  wednesday: 'по средам',
+  thursday: 'по четвергам',
+  friday: 'по пятницам',
+  saturday: 'по субботам',
+};
+
+const weekOrdinalNames: Record<number, string> = {
+  1: 'первой',
+  2: 'второй',
+  3: 'третьей',
+  4: 'четвёртой',
+};
+
 const ruRUDialog: Partial<EventEditingLocaleText> = {
   // EventDialog
-  // colorPickerLabel: 'Event color',
-  // colorSectionLabel: 'Color',
-  // dateTimeSectionLabel: 'Date & time',
-  // resourceColorSectionLabel: 'Resource & color',
-  // allDayLabel: 'All Day',
-  // closeButtonAriaLabel: 'Close',
-  // closeButtonLabel: 'Close',
-  // editEventButtonAriaLabel: 'Edit event',
-  // deleteEventButtonAriaLabel: 'Delete event',
-  // eventActionsToolbarAriaLabel: 'Event actions',
-  // deleteEvent: 'Delete event',
-  // editEvent: 'Edit event',
-  // showEventDetails: 'Show details',
-  // eventContextMenuAriaLabel: 'Event actions',
-  // descriptionLabel: 'Description',
-  // endDateLabel: 'End date',
-  // endTimeLabel: 'End time',
-  // eventTitleAriaLabel: 'Event title',
-  // generalTabLabel: 'General',
-  // labelNoResource: 'No resource',
-  // labelInvalidResource: 'Invalid resource',
-  // recurrenceLabel: 'Recurrence',
-  // recurrenceNoRepeat: "Don't repeat",
-  // recurrenceCustomRepeat: 'Custom repeat rule',
-  // recurrenceDailyPresetLabel: 'Repeats daily',
-  // recurrenceDailyFrequencyLabel: 'days',
-  // recurrenceEndsLabel: 'Ends',
-  // recurrenceEndsAfterLabel: 'After',
-  // recurrenceEndsNeverLabel: 'Never',
-  // recurrenceEndsUntilLabel: 'Until',
-  // recurrenceEndsTimesLabel: 'times',
-  // recurrenceEveryLabel: 'Every',
-  // recurrenceRepeatLabel: 'Repeat',
-  // recurrenceTabLabel: 'Recurrence',
-  // recurrenceMainSelectCustomLabel: 'Recurrence',
-  // recurrenceWeeklyFrequencyLabel: 'weeks',
-  // recurrenceWeeklyPresetLabel: ({
-  //   weekdayName
-  // }) => `Repeats weekly on ${weekdayName}`,
-  // recurrenceMonthlyFrequencyLabel: 'months',
-  // recurrenceMonthlyDayOfMonthLabel: dayNumber => `Day ${dayNumber}`,
-  // recurrenceMonthlyLastWeekAriaLabel: weekDay => `${weekDay} of the last week of the month`,
-  // recurrenceMonthlyLastWeekLabel: weekDay => `${weekDay} last week`,
-  // recurrenceMonthlyPresetLabel: dayNumber => `Repeats monthly on day ${dayNumber}`,
-  // recurrenceMonthlyWeekNumberAriaLabel: (ord, weekDay) => `${weekDay} week ${ord} of the month`,
-  // recurrenceMonthlyWeekNumberLabel: (ord, weekDay) => `${weekDay} week ${ord}`,
-  // recurrenceWeeklyMonthlySpecificInputsLabel: 'On',
-  // recurrenceYearlyFrequencyLabel: 'years',
-  // recurrenceYearlyPresetLabel: date => `Repeats annually on ${date}`,
-  // noResourceAriaLabel: 'No specific resource',
-  // selectColorAriaLabel: color => `Select ${color} as event color`,
-  // resourceLabel: 'Resource',
-  // invalidDateError: 'Enter a valid date.',
-  // invalidTimeError: 'Enter a valid time.',
-  // requiredResourceError: 'A resource is required.',
-  // saveChanges: 'Save',
-  // startDateAfterEndDateError: 'End date cannot be before start date.',
-  // startDateLabel: 'Start date',
-  // startTimeAfterEndTimeError: 'End time must be after start time.',
-  // startTimeLabel: 'Start time',
+  colorPickerLabel: 'Цвет события',
+  colorSectionLabel: 'Цвет',
+  dateTimeSectionLabel: 'Дата и время',
+  resourceColorSectionLabel: 'Ресурс и цвет',
+  allDayLabel: 'Весь день',
+  closeButtonAriaLabel: 'Закрыть',
+  closeButtonLabel: 'Закрыть',
+  editEventButtonAriaLabel: 'Редактировать событие',
+  deleteEventButtonAriaLabel: 'Удалить событие',
+  eventActionsToolbarAriaLabel: 'Действия события',
+  deleteEvent: 'Удалить событие',
+  editEvent: 'Редактировать событие',
+  showEventDetails: 'Показать подробности',
+  eventContextMenuAriaLabel: 'Действия события',
+  descriptionLabel: 'Описание',
+  endDateLabel: 'Дата окончания',
+  endTimeLabel: 'Время окончания',
+  eventTitleAriaLabel: 'Название события',
+  generalTabLabel: 'Общие',
+  labelNoResource: 'Нет ресурса',
+  labelInvalidResource: 'Недопустимый ресурс',
+  recurrenceLabel: 'Повторение',
+  recurrenceNoRepeat: 'Не повторять',
+  recurrenceCustomRepeat: 'Пользовательское правило повторения',
+  recurrenceDailyPresetLabel: 'Повторяется ежедневно',
+  recurrenceDailyFrequencyLabel: 'дн.',
+  recurrenceEndsLabel: 'Заканчивается',
+  recurrenceEndsAfterLabel: 'После',
+  recurrenceEndsNeverLabel: 'Никогда',
+  recurrenceEndsUntilLabel: 'До',
+  recurrenceEndsTimesLabel: 'повт.',
+  recurrenceEveryLabel: 'Каждые',
+  recurrenceRepeatLabel: 'Повторение',
+  recurrenceTabLabel: 'Повторение',
+  recurrenceMainSelectCustomLabel: 'Повторение',
+  recurrenceWeeklyFrequencyLabel: 'нед.',
+  recurrenceWeeklyPresetLabel: ({ weekdayName }) =>
+    `Повторяется еженедельно ${recurringWeekdayNames[weekdayName]}`,
+  recurrenceMonthlyFrequencyLabel: 'мес.',
+  recurrenceMonthlyDayOfMonthLabel: (dayNumber) => `${dayNumber}-е число месяца`,
+  recurrenceMonthlyLastWeekAriaLabel: (weekDay) =>
+    `${weekdayNames[weekDay as keyof typeof weekdayNames] ?? weekDay} последней недели месяца`,
+  recurrenceMonthlyLastWeekLabel: (weekDay) => `${weekDay} последней недели`,
+  recurrenceMonthlyPresetLabel: (dayNumber) => `Повторяется ежемесячно ${dayNumber}-го числа`,
+  recurrenceMonthlyWeekNumberAriaLabel: (ord, weekDay) =>
+    `${weekdayNames[weekDay as keyof typeof weekdayNames] ?? weekDay} ${weekOrdinalNames[ord]} недели месяца`,
+  recurrenceMonthlyWeekNumberLabel: (ord, weekDay) => `${weekDay}, ${ord}-я неделя`,
+  recurrenceWeeklyMonthlySpecificInputsLabel: 'В',
+  recurrenceYearlyFrequencyLabel: 'г.',
+  recurrenceYearlyPresetLabel: (date) => `Повторяется ежегодно ${date}`,
+  noResourceAriaLabel: 'Нет конкретного ресурса',
+  selectColorAriaLabel: (color) => `Выберите ${color} в качестве цвета события`,
+  resourceLabel: 'Ресурс',
+  invalidDateError: 'Введите действительную дату',
+  invalidTimeError: 'Введите действительное время',
+  requiredResourceError: 'Требуется ресурс',
+  saveChanges: 'Сохранить',
+  startDateAfterEndDateError: 'Дата окончания не может быть раньше даты начала',
+  startDateLabel: 'Дата начала',
+  startTimeAfterEndTimeError: 'Время окончания должно быть позже времени начала',
+  startTimeLabel: 'Время начала',
+
   // RecurringScopeDialog
-  // all: 'All events',
-  // cancel: 'Cancel',
-  // confirm: 'Confirm',
-  // onlyThis: 'Only this event',
-  // radioGroupAriaLabel: 'Editing recurring events scope',
-  // thisAndFollowing: 'This and following events',
-  // title: 'Apply this change to:',
+  all: 'Все события',
+  cancel: 'Отмена',
+  confirm: 'Подтвердить',
+  onlyThis: 'Только это событие',
+  radioGroupAriaLabel: 'Редактирование повторяющихся событий',
+  thisAndFollowing: 'Это и последующие события',
+  title: 'К каким событиям применить изменение:',
 };
 
 const ruRUCalendar: Partial<Omit<EventCalendarLocaleText, keyof EventEditingLocaleText>> = {
   // ResourcesTree
-  // resourcesLabel: 'Resources',
+  resourcesLabel: 'Ресурсы',
+
   // ViewSwitcher
-  // agenda: 'Agenda',
-  // day: 'Day',
-  // month: 'Month',
-  // other: 'Other',
-  // today: 'Today',
-  // week: 'Week',
-  // time: 'Time',
-  // days: 'Days',
-  // months: 'Months',
-  // weeks: 'Weeks',
-  // years: 'Years',
+  agenda: 'Расписание',
+  day: 'День',
+  month: 'Месяц',
+  other: 'Другое',
+  today: 'Сегодня',
+  week: 'Неделя',
+  time: 'Время',
+  days: 'Дни',
+  months: 'Месяцы',
+  weeks: 'Недели',
+  years: 'Годы',
+
   // DateNavigator
-  // closeSidePanel: 'Close side panel',
-  // openSidePanel: 'Open side panel',
+  closeSidePanel: 'Закрыть боковую панель',
+  openSidePanel: 'Открыть боковую панель',
+
   // SidePanelDrawer (small screens)
-  // openMenu: 'Open menu',
+  openMenu: 'Открыть меню',
+
   // Preferences menu
-  // amPm12h: '12-hour (1:00PM)',
-  // hour24h: '24-hour (13:00)',
-  // preferencesMenu: 'Preferences',
-  // showWeekends: 'Show weekends',
-  // showEmptyDaysInAgenda: 'Show empty days',
-  // showWeekNumber: 'Show week number',
-  // timeFormat: 'Time format',
-  // viewSpecificOptions: view => `${view} view options`,
-  // startWeekOn: 'Start week on',
-  // weekdaySunday: 'Sunday',
-  // weekdayMonday: 'Monday',
-  // weekdaySaturday: 'Saturday',
+  amPm12h: '12-часовой формат (1:00PM)',
+  hour24h: '24-часовой формат (13:00)',
+  preferencesMenu: 'Настройки',
+  showWeekends: 'Показывать выходные',
+  showEmptyDaysInAgenda: 'Показывать пустые дни',
+  showWeekNumber: 'Показывать номер недели',
+  timeFormat: 'Формат времени',
+  viewSpecificOptions: (view) => {
+    const viewNames = {
+      agenda: 'Расписание',
+      day: 'День',
+      week: 'Неделя',
+      month: 'Месяц',
+    };
+    return `Настройки режима «${viewNames[view]}»`;
+  },
+  startWeekOn: 'Неделя начинается с',
+  weekdaySunday: 'Воскресенье',
+  weekdayMonday: 'Понедельник',
+  weekdaySaturday: 'Суббота',
+
   // WeekView
-  // allDay: 'All day',
-  // hiddenEvents: hiddenEventsCount => `${hiddenEventsCount} more..`,
-  // nextTimeSpan: timeSpan => `Next ${timeSpan}`,
-  // previousTimeSpan: timeSpan => `Previous ${timeSpan}`,
-  // resourceAriaLabel: resourceName => `Resource: ${resourceName}`,
-  // weekAbbreviation: 'W',
-  // weekNumberAriaLabel: weekNumber => `Week ${weekNumber}`,
+  allDay: 'Весь день',
+  hiddenEvents: (hiddenEventsCount) => `Ещё ${hiddenEventsCount}…`,
+  nextTimeSpan: (timeSpan) => {
+    const labels = {
+      agenda: 'Следующий период',
+      day: 'Следующий день',
+      week: 'Следующая неделя',
+      month: 'Следующий месяц',
+    };
+    return labels[timeSpan];
+  },
+  previousTimeSpan: (timeSpan) => {
+    const labels = {
+      agenda: 'Предыдущий период',
+      day: 'Предыдущий день',
+      week: 'Предыдущая неделя',
+      month: 'Предыдущий месяц',
+    };
+    return labels[timeSpan];
+  },
+  resourceAriaLabel: (resourceName) => `Ресурс: ${resourceName}`,
+  weekAbbreviation: 'Нед.',
+  weekNumberAriaLabel: (weekNumber) => `Неделя ${weekNumber}`,
+
   // EventItem
-  // eventItemMultiDayLabel: endDate => `Ends ${endDate}`,
+  eventItemMultiDayLabel: (endDate) => `Заканчивается ${endDate}`,
+
   // MiniCalendar
-  // miniCalendarLabel: 'Calendar',
-  // miniCalendarGoToPreviousMonth: 'Show previous month in calendar',
-  // miniCalendarGoToNextMonth: 'Show next month in calendar',
+  miniCalendarLabel: 'Календарь',
+  miniCalendarGoToPreviousMonth: 'Показать предыдущий месяц в календаре',
+  miniCalendarGoToNextMonth: 'Показать следующий месяц в календаре',
+
   // Main calendar region
-  // calendarContentAriaLabel: 'Calendar content',
+  calendarContentAriaLabel: 'Содержимое календаря',
+
   // Timeline title sub grid
-  // timelineResourceTitleHeader: 'Resource title',
+  timelineResourceTitleHeader: 'Название ресурса',
 };
 
 const ruRUTimeline: Partial<Omit<EventTimelineLocaleText, keyof EventEditingLocaleText>> = {
   // Timeline title sub grid
-  // timelineResourceTitleHeader: 'Resource title',
+  timelineResourceTitleHeader: 'Название ресурса',
 };
 
 export const ruRU: SchedulerLocalization = getSchedulerLocalization({

--- a/packages/x-scheduler/src/locales/ruRU.ts
+++ b/packages/x-scheduler/src/locales/ruRU.ts
@@ -71,8 +71,8 @@ const ruRUDialog: Partial<EventEditingLocaleText> = {
   recurrenceTabLabel: 'Повторение',
   recurrenceMainSelectCustomLabel: 'Повторение',
   recurrenceWeeklyFrequencyLabel: 'нед.',
-  recurrenceWeeklyPresetLabel: ({ weekdayName }) =>
-    `Повторяется еженедельно ${recurringWeekdayNames[weekdayName]}`,
+  recurrenceWeeklyPresetLabel: ({ weekday }) =>
+    `Повторяется еженедельно ${recurringWeekdayNames[weekday]}`,
   recurrenceMonthlyFrequencyLabel: 'мес.',
   recurrenceMonthlyDayOfMonthLabel: (dayNumber) => `${dayNumber}-е число месяца`,
   recurrenceMonthlyLastWeekAriaLabel: (weekDay) =>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

## Summary

Adds a complete Russian (`ru-RU`) locale for `@mui/x-scheduler`.

- Translates all Scheduler locale text entries.
- Updates the locale completion metadata, if applicable.



- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
