### PR TITLE
[DataGrid] fix quick filter dropping a pending search on parser identity change

### DIFF
--- a/packages/x-data-grid/src/components/quickFilter/QuickFilter.tsx
+++ b/packages/x-data-grid/src/components/quickFilter/QuickFilter.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import debounce from '@mui/utils/debounce';
 import useEnhancedEffect from '@mui/utils/useEnhancedEffect';
+import useEventCallback from '@mui/utils/useEventCallback';
 import useId from '@mui/utils/useId';
 import { isDeepEqual } from '@mui/x-internals/isDeepEqual';
 import { useComponentRenderer } from '@mui/x-internals/useComponentRenderer';
@@ -159,14 +160,17 @@ function QuickFilter(props: QuickFilterProps) {
     }
   }, [expandedValue]);
 
+  // Identity-stable, so that a re-render with a new `parser` does not recreate the debounced
+  // function below and clear a pending commit. See https://github.com/mui/mui-x/issues/23572.
+  const commitQuickFilterValue = useEventCallback((newValue: string) => {
+    const newQuickFilterValues = parser(newValue);
+    prevQuickFilterValuesRef.current = newQuickFilterValues;
+    apiRef.current.setQuickFilterValues(newQuickFilterValues);
+  });
+
   const setQuickFilterValueDebounced = React.useMemo(
-    () =>
-      debounce((newValue: string) => {
-        const newQuickFilterValues = parser(newValue);
-        prevQuickFilterValuesRef.current = newQuickFilterValues;
-        apiRef.current.setQuickFilterValues(newQuickFilterValues);
-      }, debounceMs),
-    [apiRef, debounceMs, parser],
+    () => debounce(commitQuickFilterValue, debounceMs),
+    [commitQuickFilterValue, debounceMs],
   );
   React.useEffect(() => setQuickFilterValueDebounced.clear, [setQuickFilterValueDebounced]);
 

--- a/packages/x-data-grid/src/tests/quickFiltering.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/quickFiltering.DataGrid.test.tsx
@@ -62,6 +62,42 @@ describe('<DataGrid /> - Quick filter', () => {
       });
     });
 
+    // https://github.com/mui/mui-x/issues/23572
+    it('should commit the pending search when a re-render recreates an inline parser during the debounce window', async () => {
+      const onFilterModelChange = vi.fn();
+
+      // The `marker` prop only exists to force re-renders through `setProps`.
+      function Test(_props: { marker: number }) {
+        return (
+          <TestCase
+            onFilterModelChange={onFilterModelChange}
+            slotProps={{
+              toolbar: {
+                quickFilterProps: {
+                  // Recreated on every render, like any inline callback prop.
+                  quickFilterParser: (searchInput: string) => [searchInput],
+                },
+              },
+            }}
+          />
+        );
+      }
+
+      const { user, setProps } = render(<Test marker={0} />);
+
+      await user.type(screen.getByRole('searchbox'), 'a');
+
+      // Re-render inside the debounce window, giving the parser a new identity.
+      setProps({ marker: 1 });
+      setProps({ marker: 2 });
+
+      await waitFor(() => {
+        expect(onFilterModelChange.mock.calls.length).to.equal(1);
+      });
+      expect(onFilterModelChange.mock.lastCall?.[0].quickFilterValues).to.deep.equal(['a']);
+      expect(getColumnValues(0)).to.deep.equal(['Adidas', 'Puma']);
+    });
+
     it('should allow to customize input splitting', async () => {
       const onFilterModelChange = vi.fn();
 


### PR DESCRIPTION
the commit logic moved into an identity-stable `commitQuickFilterValue` via `useEventCallback` (the repo's established pattern), which reads parser at commit time. The debounced function is now memoized on `[commitQuickFilterValue, debounceMs]`, so a re-render with a new inline parser no longer recreates it — and the effect cleanup no longer clears a pending commit. A genuine `debounceMs` change still recreates it deliberately, since debounce captures its delay at creation. A short comment linking #23572 guards the invariant.

Fixes #23572 