### PR TITLE
[DataGrid] Fix flex column jump when a detail panel expands

### DIFF
--- a/packages/x-data-grid-pro/src/tests/detailPanel.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/detailPanel.DataGridPro.test.tsx
@@ -705,4 +705,103 @@ describe('<DataGridPro /> - Detail panel', () => {
       color: 'yellow',
     });
   });
+
+  // https://github.com/mui/mui-x/issues/23573
+  describe('flex column width in auto-growing layouts', () => {
+    function GrowingTestCase({
+      containerStyle,
+      ...other
+    }: Partial<DataGridProProps> & { containerStyle?: React.CSSProperties }) {
+      apiRef = useGridApiRef();
+      return (
+        <div style={{ width: 400, ...containerStyle }}>
+          <DataGridPro
+            apiRef={apiRef}
+            columns={[
+              { field: 'id', width: 100 },
+              { field: 'name', flex: 1 },
+            ]}
+            rows={[
+              { id: 0, name: 'A' },
+              { id: 1, name: 'B' },
+              { id: 2, name: 'C' },
+            ]}
+            getDetailPanelContent={() => <div style={{ height: 100 }} />}
+            getDetailPanelHeight={() => 100}
+            {...other}
+          />
+        </div>
+      );
+    }
+
+    const getFlexHeader = () =>
+      document.querySelector<HTMLElement>('[role="columnheader"][data-field="name"]')!;
+
+    // Samples the flex column width on every frame, so a width change that is
+    // painted and reverted later is still observed.
+    const sampleFlexWidthPerFrame = (frames: number) =>
+      new Promise<number[]>((resolve) => {
+        const widths: number[] = [];
+        const tick = () => {
+          widths.push(getFlexHeader().offsetWidth);
+          if (widths.length >= frames) {
+            resolve(widths);
+          } else {
+            requestAnimationFrame(tick);
+          }
+        };
+        requestAnimationFrame(tick);
+      });
+
+    it.skipIf(isJSDOM)(
+      'should not shrink the flex column when expanding a detail panel in a growing layout',
+      async () => {
+        const { user } = render(<GrowingTestCase />);
+
+        await waitFor(() => {
+          expect(apiRef.current!.getRootDimensions().isReady).to.equal(true);
+        });
+        expect(apiRef.current!.getRootDimensions().hasScrollY).to.equal(false);
+        const initialWidth = getFlexHeader().offsetWidth;
+
+        await user.click(screen.getAllByRole('button', { name: 'Expand' })[0]);
+        // 15 frames cover the resize throttle window, during which the
+        // transient scrollbar reservation used to be visible.
+        const widths = await act(() => sampleFlexWidthPerFrame(15));
+
+        expect(widths, `sampled widths: ${widths.join(', ')}`).to.deep.equal(
+          widths.map(() => initialWidth),
+        );
+        expect(apiRef.current!.getRootDimensions().hasScrollY).to.equal(false);
+      },
+    );
+
+    it.skipIf(isJSDOM)(
+      'should still show the vertical scrollbar when the container cannot grow',
+      async () => {
+        // The container hugs the content exactly but has a fixed height, so the
+        // deferred scrollbar must still be committed after the expansion.
+        const { user, setProps } = render(<GrowingTestCase />);
+
+        await waitFor(() => {
+          expect(apiRef.current!.getRootDimensions().isReady).to.equal(true);
+        });
+        expect(apiRef.current!.getRootDimensions().hasScrollY).to.equal(false);
+
+        // Pin the container to its natural height: same layout, but it can no
+        // longer grow with the content.
+        const naturalHeight = document
+          .querySelector<HTMLElement>(`.${gridClasses.root}`)!
+          .getBoundingClientRect().height;
+        setProps({ containerStyle: { height: naturalHeight } });
+        expect(apiRef.current!.getRootDimensions().hasScrollY).to.equal(false);
+
+        await user.click(screen.getAllByRole('button', { name: 'Expand' })[0]);
+
+        await waitFor(() => {
+          expect(apiRef.current!.getRootDimensions().hasScrollY).to.equal(true);
+        });
+      },
+    );
+  });
 });

--- a/packages/x-virtualizer/src/features/dimensions.ts
+++ b/packages/x-virtualizer/src/features/dimensions.ts
@@ -178,6 +178,23 @@ function useDimensions(store: Store<BaseState>, params: ParamsWithDefaults, _api
     lastFlipTimestamp: 0,
   });
 
+  // Deferred vertical scrollbar commit. A content-height change (detail panel
+  // expansion, added rows) updates the dimensions before the root has been
+  // re-measured. When the container previously hugged the content exactly, the
+  // layout is auto-growing: the root will grow to fit and no scrollbar will
+  // appear. Reserving the scrollbar width in that window shrinks the flex
+  // columns for one paint and snaps them back after the (throttled) resize,
+  // which is visible as a jump. The flip is deferred instead, and a rAF
+  // callback checks the real overflow to commit the scrollbar when the
+  // container turned out not to grow (fixed-height layout after all).
+  // https://github.com/mui/mui-x/issues/23573
+  const scrollYDeferral = React.useRef({
+    pending: false,
+    skip: false,
+    rafId: 0,
+    confirm: () => {},
+  });
+
   const {
     layout,
     dimensions: {
@@ -276,40 +293,61 @@ function useDimensions(store: Store<BaseState>, params: ParamsWithDefaults, _api
           }
         }
 
+        const osc = scrollYOscillation.current;
+        const heightsChanged =
+          rowsMeta.currentPageTotalHeight !== osc.heights.content ||
+          rowsMeta.pinnedTopRowsTotalHeight !== osc.heights.pinnedTop ||
+          rowsMeta.pinnedBottomRowsTotalHeight !== osc.heights.pinnedBottom;
+
         // Detect vertical scrollbar oscillation — caused by stale rootSize or
         // the horizontal scrollbar's height cascading. See scrollYOscillation.
-        {
-          const osc = scrollYOscillation.current;
-          const heightsChanged =
-            rowsMeta.currentPageTotalHeight !== osc.heights.content ||
-            rowsMeta.pinnedTopRowsTotalHeight !== osc.heights.pinnedTop ||
-            rowsMeta.pinnedBottomRowsTotalHeight !== osc.heights.pinnedBottom;
+        if (heightsChanged) {
+          osc.counter = 0;
+          osc.heights = {
+            content: rowsMeta.currentPageTotalHeight,
+            pinnedTop: rowsMeta.pinnedTopRowsTotalHeight,
+            pinnedBottom: rowsMeta.pinnedBottomRowsTotalHeight,
+          };
+        }
 
-          if (heightsChanged) {
+        if (prevDimensions.isReady && hasScrollY !== prevDimensions.hasScrollY) {
+          // performance.now is monotonic; Date.now can jump (NTP, clock change).
+          const now = performance.now();
+          if (now - osc.lastFlipTimestamp > OSCILLATION_FLIP_WINDOW_MS) {
             osc.counter = 0;
-            osc.heights = {
-              content: rowsMeta.currentPageTotalHeight,
-              pinnedTop: rowsMeta.pinnedTopRowsTotalHeight,
-              pinnedBottom: rowsMeta.pinnedBottomRowsTotalHeight,
-            };
           }
+          osc.lastFlipTimestamp = now;
+          if (!heightsChanged) {
+            osc.counter += 1;
+          }
+          if (osc.counter >= 2) {
+            hasScrollY = false;
+            // Recompute hasScrollX without the vertical scrollbar's width impact,
+            // otherwise the cascade (hasScrollY → narrower viewport → hasScrollX)
+            // keeps the horizontal scrollbar/filler alive and the root keeps resizing.
+            hasScrollX = hasScrollXIfNoYScrollBar;
+          }
+        }
 
-          if (prevDimensions.isReady && hasScrollY !== prevDimensions.hasScrollY) {
-            // performance.now is monotonic; Date.now can jump (NTP, clock change).
-            const now = performance.now();
-            if (now - osc.lastFlipTimestamp > OSCILLATION_FLIP_WINDOW_MS) {
-              osc.counter = 0;
-            }
-            osc.lastFlipTimestamp = now;
-            if (!heightsChanged) {
-              osc.counter += 1;
-            }
-            if (osc.counter >= 2) {
-              hasScrollY = false;
-              // Recompute hasScrollX without the vertical scrollbar's width impact,
-              // otherwise the cascade (hasScrollY → narrower viewport → hasScrollX)
-              // keeps the horizontal scrollbar/filler alive and the root keeps resizing.
-              hasScrollX = hasScrollXIfNoYScrollBar;
+        // See scrollYDeferral. The container hugged the content on the last
+        // update, so this flip is based on a content height the root has not
+        // been re-measured against yet.
+        if (hasScrollY && !scrollYDeferral.current.skip && prevDimensions.isReady) {
+          const deferral = scrollYDeferral.current;
+          const prevHuggedContent =
+            !prevDimensions.hasScrollY &&
+            Math.abs(
+              prevDimensions.viewportOuterSize.height -
+                (prevDimensions.minimumSize.height +
+                  (prevDimensions.hasScrollX ? prevDimensions.scrollbarSize : 0)),
+            ) <= 1;
+
+          if ((heightsChanged && prevHuggedContent) || deferral.pending) {
+            hasScrollY = false;
+            hasScrollX = hasScrollXIfNoYScrollBar;
+            deferral.pending = true;
+            if (deferral.rafId === 0 && typeof requestAnimationFrame !== 'undefined') {
+              deferral.rafId = requestAnimationFrame(() => deferral.confirm());
             }
           }
         }
@@ -395,6 +433,43 @@ function useDimensions(store: Store<BaseState>, params: ParamsWithDefaults, _api
     [resizeThrottleMs, updateDimensionCallback],
   );
   React.useEffect(() => debouncedUpdateDimensions?.clear, [debouncedUpdateDimensions]);
+
+  const confirmDeferredScrollY = useEventCallback(() => {
+    const deferral = scrollYDeferral.current;
+    deferral.rafId = 0;
+    if (!deferral.pending) {
+      return;
+    }
+    deferral.pending = false;
+
+    // Layout has run at this point, so the scroller's overflow is ground
+    // truth. When the container grew to fit the content there is no overflow
+    // and the resize observer delivers the new root size. Otherwise the
+    // container is fixed-size and the scrollbar must be committed now.
+    const scroller = layout.refs.scroller.current;
+    const hasRealOverflow = scroller ? scroller.scrollHeight > scroller.clientHeight + 1 : true;
+    if (!hasRealOverflow) {
+      return;
+    }
+
+    deferral.skip = true;
+    try {
+      updateDimensionCallback();
+    } finally {
+      deferral.skip = false;
+    }
+  });
+  scrollYDeferral.current.confirm = confirmDeferredScrollY;
+
+  useLayoutEffect(() => {
+    const deferral = scrollYDeferral.current;
+    return () => {
+      if (deferral.rafId !== 0 && typeof cancelAnimationFrame !== 'undefined') {
+        cancelAnimationFrame(deferral.rafId);
+        deferral.rafId = 0;
+      }
+    };
+  }, []);
 
   useLayoutEffect(updateDimensions, [updateDimensions]);
 


### PR DESCRIPTION
Expanding a detail panel (or any content-height growth) updates the grid dimensions before the root element is re-measured. In a layout where the container grows with the content, the grid transiently predicted a vertical scrollbar, reserved its width for one paint, and snapped back after the throttled resize, so flex columns visibly jumped (#23573).

The scrollbar flip is now deferred when the previous update shows the container hugging the content exactly, which is the signature of an auto-growing layout. A `requestAnimationFrame` confirmation then reads the scroller's real overflow: if the container grew, nothing changes; if it turned out to be fixed-size, the update re-runs and commits the scrollbar. 

Fixed-height grids keep their immediate scrollbar behavior, except the pixel-exact hugging case where it now appears one frame later, covered by a dedicated test. The regression test samples the flex column width on every frame after the expansion, so the painted-then-reverted shrink cannot go unnoticed, and it fails without the fix. The `#20539`/`#22510` oscillation regression tests in the layout suite stay green.

Fixes #23573